### PR TITLE
Auto-translate all Java FSMs to Rust

### DIFF
--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -9,12 +9,12 @@ fsm! {
 
     ScheduleCommandCreated --(CommandScheduleActivityTask) --> ScheduleCommandCreated;
     ScheduleCommandCreated
-      --(ActivityTaskScheduled, on_activity_task_scheduled) --> ScheduleEventRecorded;
+      --(ActivityTaskScheduled, on_activity_task_scheduled) --> ScheduledEventRecorded;
     ScheduleCommandCreated --(Cancel, on_canceled) --> Canceled;
 
-    ScheduleEventRecorded --(ActivityTaskStarted, on_task_started) --> Started;
-    ScheduleEventRecorded --(ActivityTaskTimedOut, on_task_timed_out) --> TimedOut;
-    ScheduleEventRecorded --(Cancel, on_canceled) --> ScheduledActivityCancelCommandCreated;
+    ScheduledEventRecorded --(ActivityTaskStarted, on_task_started) --> Started;
+    ScheduledEventRecorded --(ActivityTaskTimedOut, on_task_timed_out) --> TimedOut;
+    ScheduledEventRecorded --(Cancel, on_canceled) --> ScheduledActivityCancelCommandCreated;
 
     Started --(ActivityTaskCompleted, on_activity_task_completed) --> Completed;
     Started --(ActivityTaskFailed, on_activity_task_failed) --> Failed;
@@ -68,7 +68,7 @@ impl ScheduleCommandCreated {
     pub fn on_activity_task_scheduled(self) -> ActivityMachineTransition {
         // set initial command event id
         //  this.initialCommandEventId = currentEvent.getEventId();
-        ActivityMachineTransition::default::<ScheduleEventRecorded>()
+        ActivityMachineTransition::default::<ScheduledEventRecorded>()
     }
     pub fn on_canceled(self) -> ActivityMachineTransition {
         // cancelCommandNotifyCanceled
@@ -77,8 +77,8 @@ impl ScheduleCommandCreated {
 }
 
 #[derive(Default)]
-pub struct ScheduleEventRecorded {}
-impl ScheduleEventRecorded {
+pub struct ScheduledEventRecorded {}
+impl ScheduledEventRecorded {
     pub fn on_task_started(self) -> ActivityMachineTransition {
         // setStartedCommandEventId
         ActivityMachineTransition::default::<Started>()

--- a/src/machines/cancel_external_state_machine.rs
+++ b/src/machines/cancel_external_state_machine.rs
@@ -1,0 +1,43 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	CancelExternalMachine, CancelExternalCommand, CancelExternalMachineError
+
+	Created --(Schedule, on_schedule) --> RequestCancelExternalCommandCreated;
+
+	RequestCancelExternalCommandCreated --(CommandRequestCancelExternalWorkflowExecution) --> RequestCancelExternalCommandCreated;
+	RequestCancelExternalCommandCreated --(RequestCancelExternalWorkflowExecutionInitiated, on_request_cancel_external_workflow_execution_initiated) --> RequestCancelExternalCommandRecorded;
+
+	RequestCancelExternalCommandRecorded --(ExternalWorkflowExecutionCancelRequested, on_external_workflow_execution_cancel_requested) --> CancelRequested;
+	RequestCancelExternalCommandRecorded --(RequestCancelExternalWorkflowExecutionFailed, on_request_cancel_external_workflow_execution_failed) --> RequestCancelFailed;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CancelExternalMachineError {}
+pub enum CancelExternalCommand {}
+
+#[derive(Default)]
+pub struct CancelRequested {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> CancelExternalMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct RequestCancelExternalCommandCreated {}
+impl RequestCancelExternalCommandCreated {
+	pub fn on_request_cancel_external_workflow_execution_initiated(self) -> CancelExternalMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct RequestCancelExternalCommandRecorded {}
+impl RequestCancelExternalCommandRecorded {
+	pub fn on_external_workflow_execution_cancel_requested(self) -> CancelExternalMachineTransition { unimplemented!() }
+	pub fn on_request_cancel_external_workflow_execution_failed(self) -> CancelExternalMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct RequestCancelFailed {}
+

--- a/src/machines/cancel_workflow_state_machine.rs
+++ b/src/machines/cancel_workflow_state_machine.rs
@@ -1,0 +1,30 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	CancelWorkflowMachine, CancelWorkflowCommand, CancelWorkflowMachineError
+
+	CancelWorkflowCommandCreated --(CommandCancelWorkflowExecution) --> CancelWorkflowCommandCreated;
+	CancelWorkflowCommandCreated --(WorkflowExecutionCanceled, on_workflow_execution_canceled) --> CancelWorkflowCommandRecorded;
+
+	Created --(Schedule, on_schedule) --> CancelWorkflowCommandCreated;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CancelWorkflowMachineError {}
+pub enum CancelWorkflowCommand {}
+
+#[derive(Default)]
+pub struct CancelWorkflowCommandCreated {}
+impl CancelWorkflowCommandCreated {
+	pub fn on_workflow_execution_canceled(self) -> CancelWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct CancelWorkflowCommandRecorded {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> CancelWorkflowMachineTransition { unimplemented!() }
+}
+

--- a/src/machines/child_workflow_state_machine.rs
+++ b/src/machines/child_workflow_state_machine.rs
@@ -1,0 +1,73 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	ChildWorkflowMachine, ChildWorkflowCommand, ChildWorkflowMachineError
+
+	Created --(Schedule, on_schedule) --> StartCommandCreated;
+
+	Started --(ChildWorkflowExecutionCompleted, on_child_workflow_execution_completed) --> Completed;
+	Started --(ChildWorkflowExecutionFailed, on_child_workflow_execution_failed) --> Failed;
+	Started --(ChildWorkflowExecutionTimedOut, on_child_workflow_execution_timed_out) --> TimedOut;
+	Started --(ChildWorkflowExecutionCanceled, on_child_workflow_execution_canceled) --> Canceled;
+	Started --(ChildWorkflowExecutionTerminated, on_child_workflow_execution_terminated) --> Terminated;
+
+	StartCommandCreated --(CommandStartChildWorkflowExecution) --> StartCommandCreated;
+	StartCommandCreated --(StartChildWorkflowExecutionInitiated, on_start_child_workflow_execution_initiated) --> StartEventRecorded;
+	StartCommandCreated --(Cancel, on_cancel) --> Canceled;
+
+	StartEventRecorded --(ChildWorkflowExecutionStarted, on_child_workflow_execution_started) --> Started;
+	StartEventRecorded --(StartChildWorkflowExecutionFailed, on_start_child_workflow_execution_failed) --> StartFailed;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ChildWorkflowMachineError {}
+pub enum ChildWorkflowCommand {}
+
+#[derive(Default)]
+pub struct Canceled {}
+
+#[derive(Default)]
+pub struct Completed {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Failed {}
+
+#[derive(Default)]
+pub struct StartCommandCreated {}
+impl StartCommandCreated {
+	pub fn on_start_child_workflow_execution_initiated(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+	pub fn on_cancel(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct StartEventRecorded {}
+impl StartEventRecorded {
+	pub fn on_child_workflow_execution_started(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+	pub fn on_start_child_workflow_execution_failed(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct StartFailed {}
+
+#[derive(Default)]
+pub struct Started {}
+impl Started {
+	pub fn on_child_workflow_execution_completed(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+	pub fn on_child_workflow_execution_failed(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+	pub fn on_child_workflow_execution_timed_out(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+	pub fn on_child_workflow_execution_canceled(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+	pub fn on_child_workflow_execution_terminated(self) -> ChildWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Terminated {}
+
+#[derive(Default)]
+pub struct TimedOut {}
+

--- a/src/machines/complete_workflow_state_machine.rs
+++ b/src/machines/complete_workflow_state_machine.rs
@@ -1,0 +1,30 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	CompleteWorkflowMachine, CompleteWorkflowCommand, CompleteWorkflowMachineError
+
+	CompleteWorkflowCommandCreated --(CommandCompleteWorkflowExecution) --> CompleteWorkflowCommandCreated;
+	CompleteWorkflowCommandCreated --(WorkflowExecutionCompleted, on_workflow_execution_completed) --> CompleteWorkflowCommandRecorded;
+
+	Created --(Schedule, on_schedule) --> CompleteWorkflowCommandCreated;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CompleteWorkflowMachineError {}
+pub enum CompleteWorkflowCommand {}
+
+#[derive(Default)]
+pub struct CompleteWorkflowCommandCreated {}
+impl CompleteWorkflowCommandCreated {
+	pub fn on_workflow_execution_completed(self) -> CompleteWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct CompleteWorkflowCommandRecorded {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> CompleteWorkflowMachineTransition { unimplemented!() }
+}
+

--- a/src/machines/continue_as_new_workflow_state_machine.rs
+++ b/src/machines/continue_as_new_workflow_state_machine.rs
@@ -1,0 +1,30 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	ContinueAsNewWorkflowMachine, ContinueAsNewWorkflowCommand, ContinueAsNewWorkflowMachineError
+
+	ContinueAsNewWorkflowCommandCreated --(CommandContinueAsNewWorkflowExecution) --> ContinueAsNewWorkflowCommandCreated;
+	ContinueAsNewWorkflowCommandCreated --(WorkflowExecutionContinuedAsNew, on_workflow_execution_continued_as_new) --> ContinueAsNewWorkflowCommandRecorded;
+
+	Created --(Schedule, on_schedule) --> ContinueAsNewWorkflowCommandCreated;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ContinueAsNewWorkflowMachineError {}
+pub enum ContinueAsNewWorkflowCommand {}
+
+#[derive(Default)]
+pub struct ContinueAsNewWorkflowCommandCreated {}
+impl ContinueAsNewWorkflowCommandCreated {
+	pub fn on_workflow_execution_continued_as_new(self) -> ContinueAsNewWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct ContinueAsNewWorkflowCommandRecorded {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> ContinueAsNewWorkflowMachineTransition { unimplemented!() }
+}
+

--- a/src/machines/fail_workflow_state_machine.rs
+++ b/src/machines/fail_workflow_state_machine.rs
@@ -1,0 +1,30 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	FailWorkflowMachine, FailWorkflowCommand, FailWorkflowMachineError
+
+	Created --(Schedule, on_schedule) --> FailWorkflowCommandCreated;
+
+	FailWorkflowCommandCreated --(CommandFailWorkflowExecution) --> FailWorkflowCommandCreated;
+	FailWorkflowCommandCreated --(WorkflowExecutionFailed, on_workflow_execution_failed) --> FailWorkflowCommandRecorded;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FailWorkflowMachineError {}
+pub enum FailWorkflowCommand {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> FailWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct FailWorkflowCommandCreated {}
+impl FailWorkflowCommandCreated {
+	pub fn on_workflow_execution_failed(self) -> FailWorkflowMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct FailWorkflowCommandRecorded {}
+

--- a/src/machines/local_activity_state_machine.rs
+++ b/src/machines/local_activity_state_machine.rs
@@ -1,0 +1,75 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	LocalActivityMachine, LocalActivityCommand, LocalActivityMachineError
+
+	Created --(CheckExecutionState, on_check_execution_state) --> Replaying;
+	Created --(CheckExecutionState, on_check_execution_state) --> Executing;
+
+	Executing --(Schedule, on_schedule) --> RequestPrepared;
+
+	MarkerCommandCreated --(CommandRecordMarker, on_command_record_marker) --> ResultNotified;
+
+	Replaying --(Schedule) --> WaitingMarkerEvent;
+
+	RequestPrepared --(MarkAsSent) --> RequestSent;
+
+	RequestSent --(NonReplayWorkflowTaskStarted) --> RequestSent;
+	RequestSent --(HandleResult, on_handle_result) --> MarkerCommandCreated;
+
+	ResultNotified --(MarkerRecorded, on_marker_recorded) --> MarkerCommandRecorded;
+
+	WaitingMarkerEvent --(MarkerRecorded, on_marker_recorded) --> MarkerCommandRecorded;
+	WaitingMarkerEvent --(NonReplayWorkflowTaskStarted, on_non_replay_workflow_task_started) --> RequestPrepared;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum LocalActivityMachineError {}
+pub enum LocalActivityCommand {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_check_execution_state(self) -> LocalActivityMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Executing {}
+impl Executing {
+	pub fn on_schedule(self) -> LocalActivityMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct MarkerCommandCreated {}
+impl MarkerCommandCreated {
+	pub fn on_command_record_marker(self) -> LocalActivityMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct MarkerCommandRecorded {}
+
+#[derive(Default)]
+pub struct Replaying {}
+
+#[derive(Default)]
+pub struct RequestPrepared {}
+
+#[derive(Default)]
+pub struct RequestSent {}
+impl RequestSent {
+	pub fn on_handle_result(self) -> LocalActivityMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct ResultNotified {}
+impl ResultNotified {
+	pub fn on_marker_recorded(self) -> LocalActivityMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct WaitingMarkerEvent {}
+impl WaitingMarkerEvent {
+	pub fn on_marker_recorded(self) -> LocalActivityMachineTransition { unimplemented!() }
+	pub fn on_non_replay_workflow_task_started(self) -> LocalActivityMachineTransition { unimplemented!() }
+}
+

--- a/src/machines/mutable_side_effect_state_machine.rs
+++ b/src/machines/mutable_side_effect_state_machine.rs
@@ -1,0 +1,82 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	MutableSideEffectMachine, MutableSideEffectCommand, MutableSideEffectMachineError
+
+	Created --(CheckExecutionState, on_check_execution_state) --> Replaying;
+	Created --(CheckExecutionState, on_check_execution_state) --> Executing;
+
+	Executing --(Schedule, on_schedule) --> MarkerCommandCreated;
+	Executing --(Schedule, on_schedule) --> Skipped;
+
+	MarkerCommandCreated --(CommandRecordMarker, on_command_record_marker) --> ResultNotified;
+
+	MarkerCommandCreatedReplaying --(CommandRecordMarker) --> ResultNotifiedReplaying;
+
+	Replaying --(Schedule, on_schedule) --> MarkerCommandCreatedReplaying;
+
+	ResultNotified --(MarkerRecorded, on_marker_recorded) --> MarkerCommandRecorded;
+
+	ResultNotifiedReplaying --(NonMatchingEvent, on_non_matching_event) --> SkippedNotified;
+	ResultNotifiedReplaying --(MarkerRecorded, on_marker_recorded) --> MarkerCommandRecorded;
+	ResultNotifiedReplaying --(MarkerRecorded, on_marker_recorded) --> SkippedNotified;
+
+	Skipped --(CommandRecordMarker, on_command_record_marker) --> SkippedNotified;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MutableSideEffectMachineError {}
+pub enum MutableSideEffectCommand {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_check_execution_state(self) -> MutableSideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Executing {}
+impl Executing {
+	pub fn on_schedule(self) -> MutableSideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct MarkerCommandCreated {}
+impl MarkerCommandCreated {
+	pub fn on_command_record_marker(self) -> MutableSideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct MarkerCommandCreatedReplaying {}
+
+#[derive(Default)]
+pub struct MarkerCommandRecorded {}
+
+#[derive(Default)]
+pub struct Replaying {}
+impl Replaying {
+	pub fn on_schedule(self) -> MutableSideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct ResultNotified {}
+impl ResultNotified {
+	pub fn on_marker_recorded(self) -> MutableSideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct ResultNotifiedReplaying {}
+impl ResultNotifiedReplaying {
+	pub fn on_non_matching_event(self) -> MutableSideEffectMachineTransition { unimplemented!() }
+	pub fn on_marker_recorded(self) -> MutableSideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Skipped {}
+impl Skipped {
+	pub fn on_command_record_marker(self) -> MutableSideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct SkippedNotified {}
+

--- a/src/machines/side_effect_state_machine.rs
+++ b/src/machines/side_effect_state_machine.rs
@@ -1,0 +1,51 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	SideEffectMachine, SideEffectCommand, SideEffectMachineError
+
+	Created --(Schedule, on_schedule) --> MarkerCommandCreated;
+	Created --(Schedule, on_schedule) --> MarkerCommandCreatedReplaying;
+
+	MarkerCommandCreated --(CommandRecordMarker, on_command_record_marker) --> ResultNotified;
+
+	MarkerCommandCreatedReplaying --(CommandRecordMarker) --> ResultNotifiedReplaying;
+
+	ResultNotified --(MarkerRecorded, on_marker_recorded) --> MarkerCommandRecorded;
+
+	ResultNotifiedReplaying --(MarkerRecorded, on_marker_recorded) --> MarkerCommandRecorded;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum SideEffectMachineError {}
+pub enum SideEffectCommand {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> SideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct MarkerCommandCreated {}
+impl MarkerCommandCreated {
+	pub fn on_command_record_marker(self) -> SideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct MarkerCommandCreatedReplaying {}
+
+#[derive(Default)]
+pub struct MarkerCommandRecorded {}
+
+#[derive(Default)]
+pub struct ResultNotified {}
+impl ResultNotified {
+	pub fn on_marker_recorded(self) -> SideEffectMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct ResultNotifiedReplaying {}
+impl ResultNotifiedReplaying {
+	pub fn on_marker_recorded(self) -> SideEffectMachineTransition { unimplemented!() }
+}
+

--- a/src/machines/signal_external_state_machine.rs
+++ b/src/machines/signal_external_state_machine.rs
@@ -1,0 +1,49 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	SignalExternalMachine, SignalExternalCommand, SignalExternalMachineError
+
+	Created --(Schedule, on_schedule) --> SignalExternalCommandCreated;
+
+	SignalExternalCommandCreated --(CommandSignalExternalWorkflowExecution) --> SignalExternalCommandCreated;
+	SignalExternalCommandCreated --(Cancel, on_cancel) --> Canceled;
+	SignalExternalCommandCreated --(SignalExternalWorkflowExecutionInitiated, on_signal_external_workflow_execution_initiated) --> SignalExternalCommandRecorded;
+
+	SignalExternalCommandRecorded --(Cancel) --> SignalExternalCommandRecorded;
+	SignalExternalCommandRecorded --(ExternalWorkflowExecutionSignaled, on_external_workflow_execution_signaled) --> Signaled;
+	SignalExternalCommandRecorded --(SignalExternalWorkflowExecutionFailed, on_signal_external_workflow_execution_failed) --> Failed;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum SignalExternalMachineError {}
+pub enum SignalExternalCommand {}
+
+#[derive(Default)]
+pub struct Canceled {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> SignalExternalMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Failed {}
+
+#[derive(Default)]
+pub struct SignalExternalCommandCreated {}
+impl SignalExternalCommandCreated {
+	pub fn on_cancel(self) -> SignalExternalMachineTransition { unimplemented!() }
+	pub fn on_signal_external_workflow_execution_initiated(self) -> SignalExternalMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct SignalExternalCommandRecorded {}
+impl SignalExternalCommandRecorded {
+	pub fn on_external_workflow_execution_signaled(self) -> SignalExternalMachineTransition { unimplemented!() }
+	pub fn on_signal_external_workflow_execution_failed(self) -> SignalExternalMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Signaled {}
+

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -3,19 +3,19 @@ use rustfsm::{fsm, TransitionResult};
 fsm! {
     TimerMachine, TimerCommand, TimerMachineError
 
-    Created --(Schedule, on_schedule)--> StartCommandCreated;
+    CancelTimerCommandCreated --(Cancel) --> CancelTimerCommandCreated;
+    CancelTimerCommandCreated --(CommandCancelTimer, on_command_cancel_timer) --> CancelTimerCommandSent;
+
+    CancelTimerCommandSent --(TimerCanceled, on_timer_canceled) --> Canceled;
+
+    Created --(Schedule, on_schedule) --> StartCommandCreated;
 
     StartCommandCreated --(CommandStartTimer) --> StartCommandCreated;
     StartCommandCreated --(TimerStarted, on_timer_started) --> StartCommandRecorded;
     StartCommandCreated --(Cancel, on_cancel) --> Canceled;
 
-    StartCommandRecorded --(TimerFired, on_fired) --> Fired;
+    StartCommandRecorded --(TimerFired, on_timer_fired) --> Fired;
     StartCommandRecorded --(Cancel, on_cancel) --> CancelTimerCommandCreated;
-
-    CancelTimerCommandCreated --(Cancel) --> CancelTimerCommandCreated;
-    CancelTimerCommandCreated --(CommandTypeCancelTimer, on_cancel) --> CancelTimerCommandSent;
-
-    CancelTimerCommandSent --(TimerCanceled) --> Canceled;
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -23,60 +23,53 @@ pub enum TimerMachineError {}
 pub enum TimerCommand {}
 
 #[derive(Default)]
+pub struct CancelTimerCommandCreated {}
+impl CancelTimerCommandCreated {
+    pub fn on_command_cancel_timer(self) -> TimerMachineTransition {
+        unimplemented!()
+    }
+}
+
+#[derive(Default)]
+pub struct CancelTimerCommandSent {}
+impl CancelTimerCommandSent {
+    pub fn on_timer_canceled(self) -> TimerMachineTransition {
+        unimplemented!()
+    }
+}
+
+#[derive(Default)]
+pub struct Canceled {}
+
+#[derive(Default)]
 pub struct Created {}
 impl Created {
     pub fn on_schedule(self) -> TimerMachineTransition {
-        // would add command here
-        TimerMachineTransition::default::<StartCommandCreated>()
+        unimplemented!()
     }
 }
+
+#[derive(Default)]
+pub struct Fired {}
 
 #[derive(Default)]
 pub struct StartCommandCreated {}
 impl StartCommandCreated {
     pub fn on_timer_started(self) -> TimerMachineTransition {
-        TimerMachineTransition::default::<StartCommandRecorded>()
+        unimplemented!()
     }
     pub fn on_cancel(self) -> TimerMachineTransition {
-        TimerMachineTransition::default::<Canceled>()
+        unimplemented!()
     }
 }
 
 #[derive(Default)]
 pub struct StartCommandRecorded {}
 impl StartCommandRecorded {
+    pub fn on_timer_fired(self) -> TimerMachineTransition {
+        unimplemented!()
+    }
     pub fn on_cancel(self) -> TimerMachineTransition {
-        TimerMachineTransition::default::<CancelTimerCommandCreated>()
+        unimplemented!()
     }
-    pub fn on_fired(self) -> TimerMachineTransition {
-        TimerMachineTransition::default::<Fired>()
-    }
-}
-
-#[derive(Default)]
-pub struct CancelTimerCommandCreated {}
-impl CancelTimerCommandCreated {
-    pub fn on_cancel(self) -> TimerMachineTransition {
-        TimerMachineTransition::default::<Canceled>()
-    }
-}
-
-#[derive(Default)]
-pub struct CancelTimerCommandSent {}
-
-#[derive(Default)]
-pub struct Fired {}
-
-#[derive(Default)]
-pub struct Canceled {}
-impl From<CancelTimerCommandSent> for Canceled {
-    fn from(_: CancelTimerCommandSent) -> Self {
-        Canceled::default()
-    }
-}
-
-#[cfg(test)]
-mod activity_machine_tests {
-    #[test]
-    fn test() {}
 }

--- a/src/machines/upsert_search_attributes_state_machine.rs
+++ b/src/machines/upsert_search_attributes_state_machine.rs
@@ -1,0 +1,30 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	UpsertSearchAttributesMachine, UpsertSearchAttributesCommand, UpsertSearchAttributesMachineError
+
+	Created --(Schedule, on_schedule) --> UpsertCommandCreated;
+
+	UpsertCommandCreated --(CommandUpsertWorkflowSearchAttributes) --> UpsertCommandCreated;
+	UpsertCommandCreated --(UpsertWorkflowSearchAttributes, on_upsert_workflow_search_attributes) --> UpsertCommandRecorded;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum UpsertSearchAttributesMachineError {}
+pub enum UpsertSearchAttributesCommand {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_schedule(self) -> UpsertSearchAttributesMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct UpsertCommandCreated {}
+impl UpsertCommandCreated {
+	pub fn on_upsert_workflow_search_attributes(self) -> UpsertSearchAttributesMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct UpsertCommandRecorded {}
+

--- a/src/machines/version_state_machine.rs
+++ b/src/machines/version_state_machine.rs
@@ -1,0 +1,82 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	VersionMachine, VersionCommand, VersionMachineError
+
+	Created --(CheckExecutionState, on_check_execution_state) --> Replaying;
+	Created --(CheckExecutionState, on_check_execution_state) --> Executing;
+
+	Executing --(Schedule, on_schedule) --> MarkerCommandCreated;
+	Executing --(Schedule, on_schedule) --> Skipped;
+
+	MarkerCommandCreated --(CommandRecordMarker, on_command_record_marker) --> ResultNotified;
+
+	MarkerCommandCreatedReplaying --(CommandRecordMarker) --> ResultNotifiedReplaying;
+
+	Replaying --(Schedule, on_schedule) --> MarkerCommandCreatedReplaying;
+
+	ResultNotified --(MarkerRecorded, on_marker_recorded) --> MarkerCommandRecorded;
+
+	ResultNotifiedReplaying --(NonMatchingEvent, on_non_matching_event) --> SkippedNotified;
+	ResultNotifiedReplaying --(MarkerRecorded, on_marker_recorded) --> MarkerCommandRecorded;
+	ResultNotifiedReplaying --(MarkerRecorded, on_marker_recorded) --> SkippedNotified;
+
+	Skipped --(CommandRecordMarker, on_command_record_marker) --> SkippedNotified;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum VersionMachineError {}
+pub enum VersionCommand {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_check_execution_state(self) -> VersionMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Executing {}
+impl Executing {
+	pub fn on_schedule(self) -> VersionMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct MarkerCommandCreated {}
+impl MarkerCommandCreated {
+	pub fn on_command_record_marker(self) -> VersionMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct MarkerCommandCreatedReplaying {}
+
+#[derive(Default)]
+pub struct MarkerCommandRecorded {}
+
+#[derive(Default)]
+pub struct Replaying {}
+impl Replaying {
+	pub fn on_schedule(self) -> VersionMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct ResultNotified {}
+impl ResultNotified {
+	pub fn on_marker_recorded(self) -> VersionMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct ResultNotifiedReplaying {}
+impl ResultNotifiedReplaying {
+	pub fn on_non_matching_event(self) -> VersionMachineTransition { unimplemented!() }
+	pub fn on_marker_recorded(self) -> VersionMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Skipped {}
+impl Skipped {
+	pub fn on_command_record_marker(self) -> VersionMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct SkippedNotified {}
+

--- a/src/machines/workflow_task_state_machine.rs
+++ b/src/machines/workflow_task_state_machine.rs
@@ -1,0 +1,49 @@
+use rustfsm::{fsm, TransitionResult};
+
+fsm! {
+	WorkflowTaskMachine, WorkflowTaskCommand, WorkflowTaskMachineError
+
+	Created --(WorkflowTaskScheduled, on_workflow_task_scheduled) --> Scheduled;
+
+	Scheduled --(WorkflowTaskStarted, on_workflow_task_started) --> Started;
+	Scheduled --(WorkflowTaskTimedOut, on_workflow_task_timed_out) --> TimedOut;
+
+	Started --(WorkflowTaskCompleted, on_workflow_task_completed) --> Completed;
+	Started --(WorkflowTaskFailed, on_workflow_task_failed) --> Failed;
+	Started --(WorkflowTaskTimedOut, on_workflow_task_timed_out) --> TimedOut;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum WorkflowTaskMachineError {}
+pub enum WorkflowTaskCommand {}
+
+#[derive(Default)]
+pub struct Completed {}
+
+#[derive(Default)]
+pub struct Created {}
+impl Created {
+	pub fn on_workflow_task_scheduled(self) -> WorkflowTaskMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Failed {}
+
+#[derive(Default)]
+pub struct Scheduled {}
+impl Scheduled {
+	pub fn on_workflow_task_started(self) -> WorkflowTaskMachineTransition { unimplemented!() }
+	pub fn on_workflow_task_timed_out(self) -> WorkflowTaskMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct Started {}
+impl Started {
+	pub fn on_workflow_task_completed(self) -> WorkflowTaskMachineTransition { unimplemented!() }
+	pub fn on_workflow_task_failed(self) -> WorkflowTaskMachineTransition { unimplemented!() }
+	pub fn on_workflow_task_timed_out(self) -> WorkflowTaskMachineTransition { unimplemented!() }
+}
+
+#[derive(Default)]
+pub struct TimedOut {}
+


### PR DESCRIPTION
I modified the UML generator in the Java code to do this. It was pretty nasty one-time code, but got the job done for creating these skeletons. No translating by hand! :tada: 