### PR TITLE
Added randomness seed update on workflow reset

### DIFF
--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -63,8 +63,10 @@ message WFActivationJob {
         StartWorkflowTaskAttributes start_workflow = 1;
         // A timer has fired, allowing whatever was waiting on it (if anything) to proceed
         TimerFiredTaskAttributes timer_fired = 2;
+        // Workflow was reset. The randomness seed has to be updated.
+        RandomSeedUpdatedAttributes random_seed_updated = 3;
 
-        QueryWorkflowJob query_workflow = 3;
+        QueryWorkflowJob query_workflow = 4;
     }
 }
 
@@ -75,6 +77,9 @@ message StartWorkflowTaskAttributes {
     string workflow_id = 2;
     // Input to the workflow code
     temporal.api.common.v1.Payloads arguments = 3;
+    // The seed must be used to initialize the random generator used by SDK.
+    // RandomSeedUpdatedAttributes are used to deliver seed updates.
+    int64 randomness_seed = 4;
 
     // TODO: Do we need namespace here, or should that just be fetchable easily?
     //   will be others - workflow exe started attrs, etc
@@ -82,6 +87,10 @@ message StartWorkflowTaskAttributes {
 
 message TimerFiredTaskAttributes {
     string timer_id = 1;
+}
+
+message RandomSeedUpdatedAttributes {
+    int64 randomness_seed = 1;
 }
 
 message QueryWorkflowJob {

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -80,7 +80,7 @@ message StartWorkflowTaskAttributes {
     temporal.api.common.v1.Payloads arguments = 3;
     // The seed must be used to initialize the random generator used by SDK.
     // RandomSeedUpdatedAttributes are used to deliver seed updates.
-    int64 randomness_seed = 4;
+    uint64 randomness_seed = 4;
 
     // TODO: Do we need namespace here, or should that just be fetchable easily?
     //   will be others - workflow exe started attrs, etc
@@ -95,7 +95,7 @@ message TimerFiredTaskAttributes {
 }
 
 message RandomSeedUpdatedAttributes {
-    int64 randomness_seed = 1;
+    uint64 randomness_seed = 1;
 }
 
 message QueryWorkflowJob {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,13 +328,14 @@ mod test {
         machines::test_help::{build_fake_core, TestHistoryBuilder},
         protos::{
             coresdk::{
-                wf_activation_job, TaskCompletion, TimerFiredTaskAttributes, WfActivationJob,
+                wf_activation_job, RandomSeedUpdatedAttributes, StartWorkflowTaskAttributes,
+                TaskCompletion, TimerFiredTaskAttributes, WfActivationJob,
             },
             temporal::api::{
                 command::v1::{
                     CompleteWorkflowExecutionCommandAttributes, StartTimerCommandAttributes,
                 },
-                enums::v1::EventType,
+                enums::v1::{EventType, WorkflowTaskFailedCause},
                 history::v1::{history_event, TimerFiredEventAttributes},
             },
         },
@@ -558,6 +559,96 @@ mod test {
             [WfActivationJob {
                 attributes: Some(wf_activation_job::Attributes::TimerFired(_)),
             }]
+        );
+        let task_tok = res.task_token;
+        core.complete_task(TaskCompletion::ok_from_api_attrs(
+            vec![CompleteWorkflowExecutionCommandAttributes { result: None }.into()],
+            task_tok,
+        ))
+        .unwrap();
+    }
+
+    const NEW_RUN_ID: &'static str = "86E39A5F-AE31-4626-BDFE-398EE072D156";
+
+    #[test]
+    fn workflow_reset_whole_replay_test_across_wf_bridge() {
+        let s = span!(Level::DEBUG, "Test start", t = "bridge");
+        let _enter = s.enter();
+
+        let wfid = "fake_wf_id";
+        let run_id = "CA733AB0-8133-45F6-A4C1-8D375F61AE8B";
+        let timer_1_id = "timer1".to_string();
+        let task_queue = "test-task-queue";
+
+        /*
+            1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+            2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+            3: EVENT_TYPE_WORKFLOW_TASK_STARTED
+            4: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+            5: EVENT_TYPE_TIMER_STARTED
+            6: EVENT_TYPE_TIMER_FIRED
+            7: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+            8: EVENT_TYPE_WORKFLOW_TASK_STARTED
+            9: EVENT_TYPE_WORKFLOW_TASK_FAILED
+            10: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+            11: EVENT_TYPE_WORKFLOW_TASK_STARTED
+        */
+        let mut t = TestHistoryBuilder::default();
+        t.add_by_type(EventType::WorkflowExecutionStarted);
+        t.add_workflow_task();
+        let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+        t.add(
+            EventType::TimerFired,
+            history_event::Attributes::TimerFiredEventAttributes(TimerFiredEventAttributes {
+                started_event_id: timer_started_event_id,
+                timer_id: timer_1_id.clone(),
+            }),
+        );
+        t.add_workflow_task_scheduled_and_started();
+        t.add_workflow_task_failed(WorkflowTaskFailedCause::ResetWorkflow, NEW_RUN_ID);
+
+        t.add_workflow_task_scheduled_and_started();
+
+        // NOTE! What makes this a replay test is the server only responds with *one* batch here.
+        // So, server is polled once, but lang->core interactions look just like non-replay test.
+        let core = build_fake_core(wfid, run_id, &mut t, &[2]);
+
+        let res = core.poll_task(task_queue).unwrap();
+        let randomness_seed_from_start: i64;
+        assert_matches!(
+            res.get_wf_jobs().as_slice(),
+            [WfActivationJob {
+                attributes: Some(wf_activation_job::Attributes::StartWorkflow(
+                StartWorkflowTaskAttributes{randomness_seed, ..}
+                )),
+            }] => {
+            randomness_seed_from_start = *randomness_seed;
+            }
+        );
+        assert!(core.workflow_machines.get(run_id).is_some());
+
+        let task_tok = res.task_token;
+        core.complete_task(TaskCompletion::ok_from_api_attrs(
+            vec![StartTimerCommandAttributes {
+                timer_id: timer_1_id,
+                ..Default::default()
+            }
+            .into()],
+            task_tok,
+        ))
+        .unwrap();
+
+        let res = core.poll_task(task_queue).unwrap();
+        assert_matches!(
+            res.get_wf_jobs().as_slice(),
+            [WfActivationJob {
+                attributes: Some(wf_activation_job::Attributes::TimerFired(_),),
+            },
+            WfActivationJob {
+                attributes: Some(wf_activation_job::Attributes::RandomSeedUpdated(RandomSeedUpdatedAttributes{randomness_seed})),
+            }] => {
+                assert_ne!(randomness_seed_from_start, *randomness_seed)
+            }
         );
         let task_tok = res.task_token;
         core.complete_task(TaskCompletion::ok_from_api_attrs(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,9 +200,7 @@ where
             TaskCompletion {
                 variant: Some(task_completion::Variant::Activity(_)),
                 ..
-            } => {
-                unimplemented!()
-            }
+            } => unimplemented!(),
             _ => Err(CoreError::MalformedCompletion(req)),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@ mod test {
     #[test]
     fn timer_test_across_wf_bridge() {
         let wfid = "fake_wf_id";
-        let run_id = "fake_run_id";
+        let run_id = "58CE65AC-1C8C-413C-B525-6D3C5EAD62D7";
         let timer_id = "fake_timer".to_string();
         let task_queue = "test-task-queue";
 
@@ -411,7 +411,7 @@ mod test {
     #[test]
     fn parallel_timer_test_across_wf_bridge() {
         let wfid = "fake_wf_id";
-        let run_id = "fake_run_id";
+        let run_id = "9895E53E-D0A2-4E8A-A478-E6221ED2ACEB";
         let timer_1_id = "timer1".to_string();
         let timer_2_id = "timer2".to_string();
         let task_queue = "test-task-queue";
@@ -512,7 +512,7 @@ mod test {
         let _enter = s.enter();
 
         let wfid = "fake_wf_id";
-        let run_id = "fake_run_id";
+        let run_id = "CA733AB0-8133-45F6-A4C1-8D375F61AE8B";
         let timer_1_id = "timer1".to_string();
         let task_queue = "test-task-queue";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ mod test {
         let core = build_fake_core(wfid, run_id, &mut t, &[2]);
 
         let res = core.poll_task(task_queue).unwrap();
-        let randomness_seed_from_start: i64;
+        let randomness_seed_from_start: u64;
         assert_matches!(
             res.get_wf_jobs().as_slice(),
             [WfActivationJob {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ mod test {
     #[test]
     fn timer_test_across_wf_bridge() {
         let wfid = "fake_wf_id";
-        let run_id = "58CE65AC-1C8C-413C-B525-6D3C5EAD62D7";
+        let run_id = "fake_run_id";
         let timer_id = "fake_timer".to_string();
         let task_queue = "test-task-queue";
 
@@ -412,7 +412,7 @@ mod test {
     #[test]
     fn parallel_timer_test_across_wf_bridge() {
         let wfid = "fake_wf_id";
-        let run_id = "9895E53E-D0A2-4E8A-A478-E6221ED2ACEB";
+        let run_id = "fake_run_id";
         let timer_1_id = "timer1".to_string();
         let timer_2_id = "timer2".to_string();
         let task_queue = "test-task-queue";
@@ -513,7 +513,7 @@ mod test {
         let _enter = s.enter();
 
         let wfid = "fake_wf_id";
-        let run_id = "CA733AB0-8133-45F6-A4C1-8D375F61AE8B";
+        let run_id = "fake_run_id";
         let timer_1_id = "timer1".to_string();
         let task_queue = "test-task-queue";
 
@@ -568,15 +568,14 @@ mod test {
         .unwrap();
     }
 
-    const NEW_RUN_ID: &'static str = "86E39A5F-AE31-4626-BDFE-398EE072D156";
-
     #[test]
-    fn workflow_reset_whole_replay_test_across_wf_bridge() {
+    fn workflow_update_random_seed_on_workflow_reset() {
         let s = span!(Level::DEBUG, "Test start", t = "bridge");
         let _enter = s.enter();
 
         let wfid = "fake_wf_id";
         let run_id = "CA733AB0-8133-45F6-A4C1-8D375F61AE8B";
+        let original_run_id = "86E39A5F-AE31-4626-BDFE-398EE072D156";
         let timer_1_id = "timer1".to_string();
         let task_queue = "test-task-queue";
 
@@ -605,7 +604,7 @@ mod test {
             }),
         );
         t.add_workflow_task_scheduled_and_started();
-        t.add_workflow_task_failed(WorkflowTaskFailedCause::ResetWorkflow, NEW_RUN_ID);
+        t.add_workflow_task_failed(WorkflowTaskFailedCause::ResetWorkflow, original_run_id);
 
         t.add_workflow_task_scheduled_and_started();
 

--- a/src/machines/test_help/history_builder.rs
+++ b/src/machines/test_help/history_builder.rs
@@ -1,5 +1,6 @@
 use super::Result;
-use crate::protos::temporal::api::history::v1::History;
+use crate::protos::temporal::api::enums::v1::WorkflowTaskFailedCause;
+use crate::protos::temporal::api::history::v1::{History, WorkflowTaskFailedEventAttributes};
 use crate::{
     machines::{workflow_machines::WorkflowMachines, ProtoCommand},
     protos::temporal::api::{
@@ -86,6 +87,16 @@ impl TestHistoryBuilder {
             ..Default::default()
         };
         self.build_and_push_event(EventType::WorkflowTaskCompleted, attrs.into());
+    }
+
+    pub fn add_workflow_task_failed(&mut self, cause: WorkflowTaskFailedCause, new_run_id: &str) {
+        let attrs = WorkflowTaskFailedEventAttributes {
+            scheduled_event_id: self.workflow_task_scheduled_event_id,
+            cause: cause.into(),
+            new_run_id: new_run_id.into(),
+            ..Default::default()
+        };
+        self.build_and_push_event(EventType::WorkflowTaskFailed, attrs.into());
     }
 
     pub fn as_history(&self) -> History {

--- a/src/machines/test_help/history_builder.rs
+++ b/src/machines/test_help/history_builder.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use anyhow::bail;
 use std::time::SystemTime;
+use uuid::Uuid;
 
 #[derive(Default, Debug)]
 pub struct TestHistoryBuilder {
@@ -153,9 +154,11 @@ impl TestHistoryBuilder {
 
 fn default_attribs(et: EventType) -> Result<Attributes> {
     Ok(match et {
-        EventType::WorkflowExecutionStarted => {
-            WorkflowExecutionStartedEventAttributes::default().into()
+        EventType::WorkflowExecutionStarted => WorkflowExecutionStartedEventAttributes {
+            original_execution_run_id: Uuid::new_v4().to_string(),
+            ..Default::default()
         }
+        .into(),
         EventType::WorkflowTaskScheduled => WorkflowTaskScheduledEventAttributes::default().into(),
         EventType::TimerStarted => TimerStartedEventAttributes::default().into(),
         _ => bail!("Don't know how to construct default attrs for {:?}", et),

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -227,9 +227,7 @@ impl WFMachinesAdapter for TimerMachine {
                 timer_id: self.shared_state.timer_attributes.timer_id.clone(),
             }
             .into()]),
-            TimerMachineCommand::AddCommand(_) => {
-                unreachable!()
-            }
+            TimerMachineCommand::AddCommand(_) => unreachable!(),
         }
     }
 }

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -413,8 +413,6 @@ mod test {
         let _enter = s.enter();
 
         let (t, mut state_machines) = workflow_reset_hist;
-        let initial_seed = state_machines.randomness_seed;
-        assert!(initial_seed > 0);
         let commands = t
             .handle_workflow_task_take_cmds(&mut state_machines, Some(2))
             .unwrap();
@@ -424,7 +422,6 @@ mod test {
             commands[0].command_type,
             CommandType::CompleteWorkflowExecution as i32
         );
-        assert_ne!(initial_seed, state_machines.randomness_seed);
     }
 
     #[rstest]
@@ -433,7 +430,6 @@ mod test {
         let _enter = s.enter();
 
         let (t, mut state_machines) = workflow_reset_hist;
-        let initial_seed = state_machines.randomness_seed;
         let commands = t
             .handle_workflow_task_take_cmds(&mut state_machines, Some(1))
             .unwrap();
@@ -452,6 +448,5 @@ mod test {
             commands[0].command_type,
             CommandType::CompleteWorkflowExecution as i32
         );
-        assert_ne!(initial_seed, state_machines.randomness_seed);
     }
 }

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -287,8 +287,11 @@ mod test {
         });
 
         let mut t = TestHistoryBuilder::default();
-        let mut state_machines =
-            WorkflowMachines::new("wfid".to_string(), "runid".to_string(), Box::new(twd));
+        let mut state_machines = WorkflowMachines::new(
+            "wfid".to_string(),
+            "54619485-18AC-4970-9BF2-D24F875F7816".to_string(),
+            Box::new(twd),
+        );
 
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_workflow_task();
@@ -346,6 +349,8 @@ mod test {
         );
     }
 
+    const NEW_RUN_ID: &'static str = "86E39A5F-AE31-4626-BDFE-398EE072D156";
+
     #[fixture]
     fn workflow_reset_hist() -> (TestHistoryBuilder, WorkflowMachines) {
         /*
@@ -377,8 +382,11 @@ mod test {
         });
 
         let mut t = TestHistoryBuilder::default();
-        let mut state_machines =
-            WorkflowMachines::new("wfid".to_string(), "runid".to_string(), Box::new(twd));
+        let mut state_machines = WorkflowMachines::new(
+            "wfid".to_string(),
+            "54619485-18AC-4970-9BF2-D24F875F7816".to_string(),
+            Box::new(twd),
+        );
 
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_workflow_task();
@@ -391,7 +399,7 @@ mod test {
             }),
         );
         t.add_workflow_task_scheduled_and_started();
-        t.add_workflow_task_failed(WorkflowTaskFailedCause::ResetWorkflow, "runId2");
+        t.add_workflow_task_failed(WorkflowTaskFailedCause::ResetWorkflow, NEW_RUN_ID);
 
         t.add_workflow_task_scheduled_and_started();
 
@@ -405,6 +413,8 @@ mod test {
         let _enter = s.enter();
 
         let (t, mut state_machines) = workflow_reset_hist;
+        let initial_seed = state_machines.randomness_seed;
+        assert!(initial_seed > 0);
         let commands = t
             .handle_workflow_task_take_cmds(&mut state_machines, Some(2))
             .unwrap();
@@ -414,7 +424,7 @@ mod test {
             commands[0].command_type,
             CommandType::CompleteWorkflowExecution as i32
         );
-        assert_eq!("runId2", state_machines.run_id);
+        assert_ne!(initial_seed, state_machines.randomness_seed);
     }
 
     #[rstest]
@@ -423,7 +433,7 @@ mod test {
         let _enter = s.enter();
 
         let (t, mut state_machines) = workflow_reset_hist;
-
+        let initial_seed = state_machines.randomness_seed;
         let commands = t
             .handle_workflow_task_take_cmds(&mut state_machines, Some(1))
             .unwrap();
@@ -442,6 +452,6 @@ mod test {
             commands[0].command_type,
             CommandType::CompleteWorkflowExecution as i32
         );
-        assert_eq!("runId2", state_machines.run_id);
+        assert_ne!(initial_seed, state_machines.randomness_seed);
     }
 }

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -237,7 +237,6 @@ impl WFMachinesAdapter for TimerMachine {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::protos::temporal::api::enums::v1::WorkflowTaskFailedCause;
     use crate::{
         machines::{
             complete_workflow_state_machine::complete_workflow,
@@ -247,6 +246,7 @@ mod test {
         },
         protos::temporal::api::{
             command::v1::CompleteWorkflowExecutionCommandAttributes,
+            enums::v1::WorkflowTaskFailedCause,
             history::v1::{
                 TimerFiredEventAttributes, WorkflowExecutionCanceledEventAttributes,
                 WorkflowExecutionSignaledEventAttributes, WorkflowExecutionStartedEventAttributes,
@@ -322,6 +322,7 @@ mod test {
         let commands = t
             .handle_workflow_task_take_cmds(&mut state_machines, Some(2))
             .unwrap();
+        dbg!(state_machines.get_wf_activation());
         assert_eq!(commands.len(), 1);
         assert_eq!(
             commands[0].command_type,
@@ -407,6 +408,7 @@ mod test {
         let commands = t
             .handle_workflow_task_take_cmds(&mut state_machines, Some(2))
             .unwrap();
+
         assert_eq!(commands.len(), 1);
         assert_eq!(
             commands[0].command_type,
@@ -427,11 +429,14 @@ mod test {
             .unwrap();
         dbg!(&commands);
         dbg!(state_machines.get_wf_activation());
+
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].command_type, CommandType::StartTimer as i32);
         let commands = t
             .handle_workflow_task_take_cmds(&mut state_machines, Some(2))
             .unwrap();
+        dbg!(state_machines.get_wf_activation());
+
         assert_eq!(commands.len(), 1);
         assert_eq!(
             commands[0].command_type,

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -406,47 +406,4 @@ mod test {
         assert_eq!(2, t.as_history().get_workflow_task_count(None).unwrap());
         (t, state_machines)
     }
-
-    #[rstest]
-    fn test_reset_workflow_path_full(workflow_reset_hist: (TestHistoryBuilder, WorkflowMachines)) {
-        let s = span!(Level::DEBUG, "Test start", t = "full");
-        let _enter = s.enter();
-
-        let (t, mut state_machines) = workflow_reset_hist;
-        let commands = t
-            .handle_workflow_task_take_cmds(&mut state_machines, Some(2))
-            .unwrap();
-
-        assert_eq!(commands.len(), 1);
-        assert_eq!(
-            commands[0].command_type,
-            CommandType::CompleteWorkflowExecution as i32
-        );
-    }
-
-    #[rstest]
-    fn test_reset_workflow_inc(workflow_reset_hist: (TestHistoryBuilder, WorkflowMachines)) {
-        let s = span!(Level::DEBUG, "Test start", t = "inc");
-        let _enter = s.enter();
-
-        let (t, mut state_machines) = workflow_reset_hist;
-        let commands = t
-            .handle_workflow_task_take_cmds(&mut state_machines, Some(1))
-            .unwrap();
-        dbg!(&commands);
-        dbg!(state_machines.get_wf_activation());
-
-        assert_eq!(commands.len(), 1);
-        assert_eq!(commands[0].command_type, CommandType::StartTimer as i32);
-        let commands = t
-            .handle_workflow_task_take_cmds(&mut state_machines, Some(2))
-            .unwrap();
-        dbg!(state_machines.get_wf_activation());
-
-        assert_eq!(commands.len(), 1);
-        assert_eq!(
-            commands[0].command_type,
-            CommandType::CompleteWorkflowExecution as i32
-        );
-    }
 }

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -461,7 +461,7 @@ impl WorkflowMachines {
     }
 }
 
-fn uuid_to_randomness_seed(run_id: &str) -> i64 {
+pub(super) fn uuid_to_randomness_seed(run_id: &str) -> i64 {
     let uuid = Uuid::parse_str(run_id).unwrap();
     let fields = uuid.as_fields();
     let b0 = fields.0 as i64;

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -461,7 +461,7 @@ impl WorkflowMachines {
     }
 }
 
-pub(super) fn uuid_to_randomness_seed(run_id: &str) -> Result<i64> {
+fn uuid_to_randomness_seed(run_id: &str) -> Result<i64> {
     let uuid = Uuid::parse_str(run_id).map_err(|e| WFMachinesError::Underlying(e.into()))?;
     let fields = uuid.as_fields();
     let b0 = fields.0 as i64;

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -76,6 +76,9 @@ pub(super) enum WorkflowTrigger {
         task_started_event_id: i64,
         time: SystemTime,
     },
+    UpdateRunIdOnWorkflowReset {
+        run_id: String,
+    },
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -409,6 +412,9 @@ impl WorkflowMachines {
                     time,
                 } => {
                     self.task_started(task_started_event_id, time);
+                }
+                WorkflowTrigger::UpdateRunIdOnWorkflowReset { run_id: new_run_id } => {
+                    self.run_id = new_run_id;
                 }
             }
         }

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -301,7 +301,7 @@ impl WorkflowMachines {
                             arguments: attrs.input.clone(),
                             randomness_seed: uuid_to_randomness_seed(
                                 &attrs.original_execution_run_id,
-                            ),
+                            )?,
                         }
                         .into(),
                     );
@@ -424,7 +424,7 @@ impl WorkflowMachines {
                     self.outgoing_wf_activation_jobs.push_back(
                         wf_activation_job::Attributes::RandomSeedUpdated(
                             RandomSeedUpdatedAttributes {
-                                randomness_seed: uuid_to_randomness_seed(&new_run_id),
+                                randomness_seed: uuid_to_randomness_seed(&new_run_id)?,
                             },
                         ),
                     );
@@ -461,12 +461,12 @@ impl WorkflowMachines {
     }
 }
 
-pub(super) fn uuid_to_randomness_seed(run_id: &str) -> i64 {
-    let uuid = Uuid::parse_str(run_id).unwrap();
+pub(super) fn uuid_to_randomness_seed(run_id: &str) -> Result<i64> {
+    let uuid = Uuid::parse_str(run_id).map_err(|e| WFMachinesError::Underlying(e.into()))?;
     let fields = uuid.as_fields();
     let b0 = fields.0 as i64;
     let b32 = fields.1 as i64 >> 32;
     let b48 = fields.2 as i64 >> 48;
     let seed: i64 = b0 + b32 + b48;
-    seed
+    Ok(seed)
 }

--- a/src/machines/workflow_task_state_machine.rs
+++ b/src/machines/workflow_task_state_machine.rs
@@ -115,8 +115,6 @@ impl TryFrom<HistoryEvent> for WorkflowTaskMachineEvents {
                 })?;
 
                 Self::WorkflowTaskFailed(WFTFailedDat {
-                    // TODO(maxim): How to avoid clone of attributes. We need to borrow e for the
-                    // MalformedEvent down there. But forcing clone just for that doesn't make sense.
                     new_run_id: match attributes {
                         WorkflowTaskFailedEventAttributes(a) => {
                             let cause = WorkflowTaskFailedCause::from_i32(a.cause);

--- a/src/machines/workflow_task_state_machine.rs
+++ b/src/machines/workflow_task_state_machine.rs
@@ -13,8 +13,10 @@ use crate::{
     },
 };
 use rustfsm::{fsm, TransitionResult};
+use std::panic::resume_unwind;
 use std::{convert::TryFrom, time::SystemTime};
 use tracing::Level;
+use uuid::Uuid;
 
 fsm! {
     pub(super) name WorkflowTaskMachine;


### PR DESCRIPTION
On workflow reset a `WorkflowTaskFailed` with `WORKFLOW_TASK_FAILED_CAUSE_RESET_WORKFLOW` cause is written to the history. It contains a new run-id. The new run-id must be used for random seed at this point to avoid producing duplicated UUIDs and random values.

[Here is ](https://github.com/temporalio/sdk-java/blob/30420212a26283cf7cbe6339512058a3186074e8/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowTaskStateMachine.java#L124) the relevant Java code.