### PR TITLE
Single threaded workflows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,7 @@ mod test {
             },
         },
     };
+    use std::time::Duration;
 
     #[test]
     fn single_timer_test_across_wf_bridge() {
@@ -544,4 +545,30 @@ mod test {
         ))
         .unwrap();
     }
+
+    // #[test]
+    // fn test_cpu() {
+    //     let wfid = "fake_wf_id";
+    //     let run_id = "fake_run_id";
+    //     let timer_1_id = "timer1".to_string();
+    //     let task_queue = "test-task-queue";
+    //
+    //     let mut t = TestHistoryBuilder::default();
+    //     t.add_by_type(EventType::WorkflowExecutionStarted);
+    //     t.add_workflow_task();
+    //     let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    //     t.add(
+    //         EventType::TimerFired,
+    //         history_event::Attributes::TimerFiredEventAttributes(TimerFiredEventAttributes {
+    //             started_event_id: timer_started_event_id,
+    //             timer_id: timer_1_id.clone(),
+    //         }),
+    //     );
+    //     t.add_workflow_task_scheduled_and_started();
+    //     // NOTE! What makes this a replay test is the server only responds with *one* batch here.
+    //     // So, server is polled once, but lang->core interactions look just like non-replay test.
+    //     let core = build_fake_core(wfid, run_id, &mut t, &[2]);
+    //
+    //     std::thread::sleep(Duration::from_secs(10000000));
+    // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,11 @@ use crate::{
 };
 use crossbeam::queue::SegQueue;
 use dashmap::DashMap;
-use std::fmt::Debug;
-use std::{convert::TryInto, sync::mpsc::SendError, sync::Arc};
+use std::{
+    convert::TryInto,
+    fmt::Debug,
+    sync::{mpsc::SendError, Arc},
+};
 use tokio::runtime::Runtime;
 use tonic::codegen::http::uri::InvalidUri;
 use tracing::Level;
@@ -381,7 +384,6 @@ mod test {
             task_tok,
         ))
         .unwrap();
-        dbg!("Done!!!!");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,6 @@ mod test {
             },
         },
     };
-    use std::time::Duration;
 
     #[test]
     fn single_timer_test_across_wf_bridge() {
@@ -545,30 +544,4 @@ mod test {
         ))
         .unwrap();
     }
-
-    // #[test]
-    // fn test_cpu() {
-    //     let wfid = "fake_wf_id";
-    //     let run_id = "fake_run_id";
-    //     let timer_1_id = "timer1".to_string();
-    //     let task_queue = "test-task-queue";
-    //
-    //     let mut t = TestHistoryBuilder::default();
-    //     t.add_by_type(EventType::WorkflowExecutionStarted);
-    //     t.add_workflow_task();
-    //     let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-    //     t.add(
-    //         EventType::TimerFired,
-    //         history_event::Attributes::TimerFiredEventAttributes(TimerFiredEventAttributes {
-    //             started_event_id: timer_started_event_id,
-    //             timer_id: timer_1_id.clone(),
-    //         }),
-    //     );
-    //     t.add_workflow_task_scheduled_and_started();
-    //     // NOTE! What makes this a replay test is the server only responds with *one* batch here.
-    //     // So, server is polled once, but lang->core interactions look just like non-replay test.
-    //     let core = build_fake_core(wfid, run_id, &mut t, &[2]);
-    //
-    //     std::thread::sleep(Duration::from_secs(10000000));
-    // }
 }

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -66,8 +66,8 @@ pub(crate) fn build_fake_core(
     CoreSDK {
         runtime,
         server_gateway: Arc::new(mock_gateway),
-        workflow_machines: DashMap::new(),
-        workflow_task_tokens: DashMap::new(),
+        workflow_machines: Default::default(),
+        workflow_task_tokens: Default::default(),
         pending_activations: Default::default(),
     }
 }

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -6,6 +6,7 @@ mod workflow_driver;
 pub(crate) use history_builder::TestHistoryBuilder;
 pub(super) use workflow_driver::{CommandSender, TestWFCommand, TestWorkflowDriver};
 
+use crate::workflow::WorkflowConcurrencyManager;
 use crate::{
     pollers::MockServerGateway,
     protos::temporal::api::common::v1::WorkflowExecution,
@@ -15,7 +16,6 @@ use crate::{
     },
     CoreSDK,
 };
-use dashmap::DashMap;
 use rand::{thread_rng, Rng};
 use std::{collections::VecDeque, sync::Arc};
 use tokio::runtime::Runtime;
@@ -66,7 +66,7 @@ pub(crate) fn build_fake_core(
     CoreSDK {
         runtime,
         server_gateway: Arc::new(mock_gateway),
-        workflow_machines: Default::default(),
+        workflow_machines: WorkflowConcurrencyManager::new(),
         workflow_task_tokens: Default::default(),
         pending_activations: Default::default(),
     }

--- a/src/workflow/concurrency_manager.rs
+++ b/src/workflow/concurrency_manager.rs
@@ -179,6 +179,7 @@ impl WorkflowConcurrencyManager {
     ///
     /// # Panics
     /// If the workflow machine thread panicked
+    #[allow(unused)] // TODO: Will be used when other shutdown PR is merged
     pub fn shutdown(self) {
         self.shutdown_flag.store(true, Ordering::Relaxed);
         self.wf_thread

--- a/src/workflow/concurrency_manager.rs
+++ b/src/workflow/concurrency_manager.rs
@@ -1,0 +1,51 @@
+use crate::{
+    machines::ProtoCommand,
+    workflow::{NextWfActivation, WfManagerProtected, WorkflowManager},
+    CoreError, Result,
+};
+use crossbeam::channel::Sender;
+use dashmap::DashMap;
+
+type MachineSender = Sender<Box<dyn FnOnce(&mut WfManagerProtected) -> Result<()> + Send>>;
+
+// TODO: If can't be totally generic, could do enum of Fn's with defined responses
+/// Responses that workflow machines can respond with from their thread
+enum WfMgrResponse {
+    Nothing,
+    Activation(NextWfActivation),
+    Commands(Vec<ProtoCommand>),
+}
+
+#[derive(Default)]
+pub(crate) struct WorkflowConcurrencyManager {
+    machines: DashMap<String, MachineSender>,
+}
+
+impl WorkflowConcurrencyManager {
+    pub fn exists(&self, run_id: &str) -> bool {
+        self.machines.contains_key(run_id)
+    }
+
+    pub fn create_or_update(&self, run_id: &str) -> Result<NextWfActivation> {
+        unimplemented!()
+    }
+
+    /// Access a workflow manager to do something with it. Ideally, the return type could be generic
+    /// but in practice I couldn't find a way to do it. If we need more and more response types,
+    /// it's worth trying again.
+    pub fn access<F, Fout>(&self, run_id: &str, mutator: F) -> Result<Fout>
+    where
+        F: FnOnce(&mut WfManagerProtected) -> Result<Fout>,
+        F: Send,
+    {
+        if let Some(m) = self.machines.get(run_id) {
+            // m.value().send(Box::new(mutator)).unwrap();
+            unimplemented!()
+        } else {
+            Err(CoreError::MissingMachines(run_id.to_string()))
+        }
+    }
+}
+
+trait BeSendSync: Send + Sync {}
+impl BeSendSync for WorkflowConcurrencyManager {}

--- a/src/workflow/concurrency_manager.rs
+++ b/src/workflow/concurrency_manager.rs
@@ -1,4 +1,4 @@
-//! Ultimately it would be nice to make this generic and push it out into it's own crate but
+//! Ultimately it would be nice to make this generic and push it out into its own crate but
 //! doing so is nontrivial
 
 use crate::{
@@ -151,7 +151,7 @@ impl WorkflowConcurrencyManager {
                 break;
             } else if index == 1 {
                 // If there's a message ready on the creation channel, make a new machine
-                // and put it's receiver into the list, replying with the machine's activation and
+                // and put its receiver into the list, replying with the machine's activation and
                 // a channel to send requests to it, or an error otherwise.
                 let maybe_create_chan_msg = create_rcv.try_recv();
                 let should_break = WorkflowConcurrencyManager::handle_creation_message(
@@ -162,7 +162,7 @@ impl WorkflowConcurrencyManager {
                     break;
                 }
             } else {
-                // If there's a message ready on the creation channel, make a new machine
+                // If we're here, a request to access a workflow manager is ready.
 
                 // We must subtract two to account for the shutdown and creation channels reads
                 // being the first two operations in the select

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -19,10 +19,7 @@ use crate::{
     protosext::HistoryInfo,
     CoreError, Result,
 };
-use std::{
-    ops::DerefMut,
-    sync::{mpsc::Sender, Arc, Mutex},
-};
+use std::sync::mpsc::Sender;
 use tracing::Level;
 
 /// Implementors can provide new workflow tasks to the SDK. The connection to the server is the real
@@ -63,13 +60,9 @@ pub trait StartWorkflowExecutionApi {
     ) -> Result<StartWorkflowExecutionResponse>;
 }
 
-/// Manages concurrent access to an instance of a [WorkflowMachines], which is not thread-safe,
-/// as well as other data associated with that specific workflow run.
+/// Manages an instance of a [WorkflowMachines], which is not thread-safe, as well as other data
+/// associated with that specific workflow run.
 pub(crate) struct WorkflowManager {
-    data: Arc<Mutex<WfManagerProtected>>,
-}
-/// Inner data for [WorkflowManager]
-pub(crate) struct WfManagerProtected {
     pub machines: WorkflowMachines,
     pub command_sink: Sender<Vec<WFCommand>>,
     /// The last recorded history we received from the server for this workflow run. This must be
@@ -99,36 +92,24 @@ impl WorkflowManager {
 
         let (wfb, cmd_sink) = WorkflowBridge::new();
         let state_machines = WorkflowMachines::new(we.workflow_id, we.run_id, Box::new(wfb));
-        let protected = WfManagerProtected {
+        Ok(Self {
             machines: state_machines,
             command_sink: cmd_sink,
             last_history_task_count: history.get_workflow_task_count(None)?,
             last_history_from_server: history,
             current_wf_task_num: 1,
             _temp: std::rc::Rc::new(8),
-        };
-        Ok(Self {
-            data: Arc::new(Mutex::new(protected)),
         })
-    }
-
-    pub fn lock(&self) -> Result<impl DerefMut<Target = WfManagerProtected> + '_> {
-        Ok(self.data.lock().map_err(|_| {
-            CoreError::LockPoisoned(
-                "A workflow manager lock was poisoned. This should be impossible since they \
-                are run on one thread."
-                    .to_string(),
-            )
-        })?)
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct NextWfActivation {
     pub activation: Option<WfActivation>,
     pub more_activations_needed: bool,
 }
 
-impl WfManagerProtected {
+impl WorkflowManager {
     /// Given history that was just obtained from the server, pipe it into this workflow's machines.
     ///
     /// Should only be called when a workflow has caught up on replay. It will return a workflow

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -72,8 +72,6 @@ pub(crate) struct WorkflowManager {
     last_history_task_count: usize,
     /// The current workflow task number this run is on. Starts at one and monotonically increases.
     current_wf_task_num: usize,
-
-    _temp: std::rc::Rc<u8>,
 }
 
 impl WorkflowManager {
@@ -98,7 +96,6 @@ impl WorkflowManager {
             last_history_task_count: history.get_workflow_task_count(None)?,
             last_history_from_server: history,
             current_wf_task_num: 1,
-            _temp: std::rc::Rc::new(8),
         })
     }
 }

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -106,8 +106,9 @@ fn parallel_timer_workflow() {
         task.task_token,
     ))
     .unwrap();
-    // Wait long enough for both timers to complete
-    std::thread::sleep(Duration::from_millis(1000));
+    // Wait long enough for both timers to complete. Server seems to be a bit weird about actually
+    // sending both of these in one go, so we need to wait longer than you would expect.
+    std::thread::sleep(Duration::from_millis(1500));
     let task = core.poll_task(task_q).unwrap();
     assert_matches!(
         task.get_wf_jobs().as_slice(),


### PR DESCRIPTION
This implements some rather complex (but well encapsulated) concurrency management code to ensure that the workflow machines can be written without needing to be `Send` or `Sync`.

Left to do
- [x] Document
- [x] Clean up unwraps
- [x] Unit tests for concurrency manager itself