### PR TITLE
Better encapsulate DrivenWorkflow concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Cargo.lock
 src/protos/*.rs
 !src/protos/mod.rs
 /tarpaulin-report.html
+/.cargo/

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -297,8 +297,11 @@ mod test {
         });
 
         let t = canned_histories::single_timer("timer1");
-        let state_machines =
-            WorkflowMachines::new("wfid".to_string(), "runid".to_string(), Box::new(twd));
+        let state_machines = WorkflowMachines::new(
+            "wfid".to_string(),
+            "runid".to_string(),
+            Box::new(twd).into(),
+        );
 
         assert_eq!(2, t.as_history().get_workflow_task_count(None).unwrap());
         (t, state_machines)
@@ -355,8 +358,11 @@ mod test {
         });
 
         let t = canned_histories::single_timer("badid");
-        let mut state_machines =
-            WorkflowMachines::new("wfid".to_string(), "runid".to_string(), Box::new(twd));
+        let mut state_machines = WorkflowMachines::new(
+            "wfid".to_string(),
+            "runid".to_string(),
+            Box::new(twd).into(),
+        );
 
         assert!(t
             .handle_workflow_task_take_cmds(&mut state_machines, None)
@@ -392,8 +398,11 @@ mod test {
         });
 
         let t = canned_histories::cancel_timer("wait_timer", "cancel_timer");
-        let state_machines =
-            WorkflowMachines::new("wfid".to_string(), "runid".to_string(), Box::new(twd));
+        let state_machines = WorkflowMachines::new(
+            "wfid".to_string(),
+            "runid".to_string(),
+            Box::new(twd).into(),
+        );
         (t, state_machines)
     }
 
@@ -461,8 +470,11 @@ mod test {
         t.add_full_wf_task();
         t.add_workflow_execution_completed();
 
-        let mut state_machines =
-            WorkflowMachines::new("wfid".to_string(), "runid".to_string(), Box::new(twd));
+        let mut state_machines = WorkflowMachines::new(
+            "wfid".to_string(),
+            "runid".to_string(),
+            Box::new(twd).into(),
+        );
 
         let commands = t
             .handle_workflow_task_take_cmds(&mut state_machines, None)

--- a/src/workflow/bridge.rs
+++ b/src/workflow/bridge.rs
@@ -1,8 +1,6 @@
 use crate::{
-    machines::{ActivationListener, DrivenWorkflow, WFCommand},
-    protos::temporal::api::history::v1::WorkflowExecutionCanceledEventAttributes,
-    protos::temporal::api::history::v1::WorkflowExecutionSignaledEventAttributes,
-    protos::temporal::api::history::v1::WorkflowExecutionStartedEventAttributes,
+    machines::WFCommand,
+    workflow::{ActivationListener, WorkflowFetcher},
 };
 use std::sync::mpsc::{self, Receiver, Sender};
 
@@ -11,8 +9,6 @@ use std::sync::mpsc::{self, Receiver, Sender};
 /// output from calls to [DrivenWorkflow] and offering them to [CoreSDKService]
 #[derive(Debug)]
 pub(crate) struct WorkflowBridge {
-    // does wf id belong in here?
-    started_attrs: Option<WorkflowExecutionStartedEventAttributes>,
     incoming_commands: Receiver<Vec<WFCommand>>,
 }
 
@@ -22,7 +18,6 @@ impl WorkflowBridge {
         let (tx, rx) = mpsc::channel();
         (
             Self {
-                started_attrs: None,
                 incoming_commands: rx,
             },
             tx,
@@ -30,26 +25,13 @@ impl WorkflowBridge {
     }
 }
 
-impl DrivenWorkflow for WorkflowBridge {
-    fn start(&mut self, attribs: WorkflowExecutionStartedEventAttributes) {
-        debug!(attribs = ?attribs, "wf bridge start");
-        self.started_attrs = Some(attribs);
-    }
-
+impl WorkflowFetcher for WorkflowBridge {
     fn fetch_workflow_iteration_output(&mut self) -> Vec<WFCommand> {
         let in_cmds = self.incoming_commands.try_recv();
 
         let in_cmds = in_cmds.unwrap_or_else(|_| vec![WFCommand::NoCommandsFromLang]);
         debug!(in_cmds = ?in_cmds, "wf bridge iteration fetch");
         in_cmds
-    }
-
-    fn signal(&mut self, _attribs: WorkflowExecutionSignaledEventAttributes) {
-        unimplemented!()
-    }
-
-    fn cancel(&mut self, _attribs: WorkflowExecutionCanceledEventAttributes) {
-        unimplemented!()
     }
 }
 

--- a/src/workflow/driven_workflow.rs
+++ b/src/workflow/driven_workflow.rs
@@ -1,0 +1,71 @@
+use crate::{
+    machines::WFCommand,
+    protos::coresdk::wf_activation_job,
+    protos::temporal::api::history::v1::{
+        WorkflowExecutionCanceledEventAttributes, WorkflowExecutionSignaledEventAttributes,
+        WorkflowExecutionStartedEventAttributes,
+    },
+};
+
+/// Abstracts away the concept of an actual workflow implementation
+///
+/// TODO: More
+pub struct DrivenWorkflow {
+    started_attrs: Option<WorkflowExecutionStartedEventAttributes>,
+    fetcher: Box<dyn WorkflowFetcher>,
+}
+
+impl<WF> From<Box<WF>> for DrivenWorkflow
+where
+    WF: WorkflowFetcher + 'static,
+{
+    fn from(wf: Box<WF>) -> Self {
+        Self {
+            started_attrs: None,
+            fetcher: wf,
+        }
+    }
+}
+
+impl DrivenWorkflow {
+    /// Start the workflow
+    pub fn start(&mut self, attribs: WorkflowExecutionStartedEventAttributes) {}
+
+    /// Signal the workflow
+    fn signal(&mut self, attribs: WorkflowExecutionSignaledEventAttributes) {}
+
+    /// Cancel the workflow
+    fn cancel(&mut self, attribs: WorkflowExecutionCanceledEventAttributes) {}
+}
+
+impl WorkflowFetcher for DrivenWorkflow {
+    fn fetch_workflow_iteration_output(&mut self) -> Vec<WFCommand> {
+        self.fetcher.fetch_workflow_iteration_output()
+    }
+}
+
+impl ActivationListener for DrivenWorkflow {
+    fn on_activation_job(&mut self, a: &wf_activation_job::Variant) {
+        self.fetcher.on_activation_job(a)
+    }
+}
+
+/// Implementors of this trait represent a way to fetch output from executing/iterating some
+/// workflow code (or a mocked workflow).
+pub trait WorkflowFetcher: ActivationListener + Send {
+    /// Obtain any output from the workflow's recent execution(s). Because the lang sdk is
+    /// responsible for calling workflow code as a result of receiving tasks from
+    /// [crate::Core::poll_task], we cannot directly iterate it here. Thus implementations of this
+    /// trait are expected to either buffer output or otherwise produce it on demand when this
+    /// function is called.
+    ///
+    /// In the case of the real [WorkflowBridge] implementation, commands are simply pulled from
+    /// a buffer that the language side sinks into when it calls [crate::Core::complete_task]
+    fn fetch_workflow_iteration_output(&mut self) -> Vec<WFCommand>;
+}
+
+/// Allows observers to listen to newly generated outgoing activation jobs. Used for testing, where
+/// some activations must be handled before outgoing commands are issued to avoid deadlocking.
+pub trait ActivationListener {
+    fn on_activation_job(&mut self, _activation: &wf_activation_job::Variant) {}
+}

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -1,8 +1,10 @@
 mod bridge;
 mod concurrency_manager;
+mod driven_workflow;
 
 pub(crate) use bridge::WorkflowBridge;
 pub(crate) use concurrency_manager::WorkflowConcurrencyManager;
+pub(crate) use driven_workflow::{ActivationListener, DrivenWorkflow, WorkflowFetcher};
 
 use crate::{
     machines::{ProtoCommand, WFCommand, WorkflowMachines},
@@ -88,7 +90,7 @@ impl WorkflowManager {
         };
 
         let (wfb, cmd_sink) = WorkflowBridge::new();
-        let state_machines = WorkflowMachines::new(we.workflow_id, we.run_id, Box::new(wfb));
+        let state_machines = WorkflowMachines::new(we.workflow_id, we.run_id, Box::new(wfb).into());
         Ok(Self {
             machines: state_machines,
             command_sink: cmd_sink,


### PR DESCRIPTION
This pushes the outgoing jobs queue inside of a new DrivenWorkflow struct which replaces the old trait, and better represents the concepts of needing to fetch from some external workflow code and send it jobs.

This will make sending signals and cancelling much more obvious. 