### PR TITLE
Extend protocol to support activities

### DIFF
--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -115,9 +115,15 @@ message SignalWorkflow {
     temporal.api.history.v1.WorkflowExecutionSignaledEventAttributes signal = 1;
 }
 
+message CancelActivity {
+    string activity_id = 1;
+}
+
 message ActivityTask {
-    // Original task from temporal service
-    temporal.api.workflowservice.v1.PollActivityTaskQueueResponse original = 1;
+    oneof variant {
+        temporal.api.workflowservice.v1.PollActivityTaskQueueResponse start_activity = 1;
+        CancelActivity cancel_activity = 2;
+    }
 }
 
 
@@ -175,12 +181,30 @@ message WFActivationFailure {
     // Other bits from RespondWorkflowTaskFailedRequest as needed
 }
 
-message ActivityTaskSuccess {
+message ActivityTaskCompleted {
     temporal.api.common.v1.Payloads result = 1;
     // Other bits from RespondActivityTaskCompletedRequest as needed
+}
+
+message ActivityTaskCancelled {
+    temporal.api.common.v1.Payloads details = 1;
+}
+
+message ActivityTaskSuccess {
+    oneof variant {
+        ActivityTaskCompleted completed = 1;
+        ActivityTaskCancelled cancelled = 2;
+    }
 }
 
 message ActivityTaskFailure {
     temporal.api.failure.v1.Failure failure = 1;
     // Other bits from RespondActivityTaskFailedRequest as needed
 }
+
+// A request as given to [crate::Core::send_activity_heartbeat]
+message ActivityHeartbeat {
+    string activity_id = 1;
+    temporal.api.common.v1.Payloads details = 2;
+}
+

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -115,14 +115,20 @@ message SignalWorkflow {
     temporal.api.history.v1.WorkflowExecutionSignaledEventAttributes signal = 1;
 }
 
+message StartActivity {
+    // TODO: add attributes
+}
+
 message CancelActivity {
-    string activity_id = 1;
+    // TODO: add attributes
 }
 
 message ActivityTask {
-    oneof variant {
-        temporal.api.workflowservice.v1.PollActivityTaskQueueResponse start_activity = 1;
-        CancelActivity cancel_activity = 2;
+    oneof job {
+        // Start activity execution.
+        StartActivity start = 1;
+        // Attempt to cancel activity execution.
+        CancelActivity cancel = 2;
     }
 }
 
@@ -135,7 +141,7 @@ message TaskCompletion {
         // Complete a workflow task
         WFActivationCompletion workflow = 2;
         // Complete an activity task
-        ActivityTaskCompletion activity = 3;
+        ActivityResult activity = 3;
     }
 }
 
@@ -146,10 +152,11 @@ message WFActivationCompletion {
     }
 }
 
-message ActivityTaskCompletion {
+message ActivityResult {
     oneof status {
-        ActivityTaskSuccess successful = 1;
-        ActivityTaskFailure failed = 2;
+        ActivityTaskSuccess completed = 1;
+        ActivityTaskCancelation canceled = 2;
+        ActivityTaskFailure failed = 3;
     }
 }
 
@@ -181,20 +188,13 @@ message WFActivationFailure {
     // Other bits from RespondWorkflowTaskFailedRequest as needed
 }
 
-message ActivityTaskCompleted {
-    temporal.api.common.v1.Payloads result = 1;
-    // Other bits from RespondActivityTaskCompletedRequest as needed
-}
-
-message ActivityTaskCancelled {
+message ActivityTaskCancelation {
     temporal.api.common.v1.Payloads details = 1;
 }
 
 message ActivityTaskSuccess {
-    oneof variant {
-        ActivityTaskCompleted completed = 1;
-        ActivityTaskCancelled cancelled = 2;
-    }
+    temporal.api.common.v1.Payloads result = 1;
+    // Other bits from RespondActivityTaskCompletedRequest as needed
 }
 
 message ActivityTaskFailure {
@@ -207,4 +207,3 @@ message ActivityHeartbeat {
     string activity_id = 1;
     temporal.api.common.v1.Payloads details = 2;
 }
-


### PR DESCRIPTION
I'm not sure if we should keep the name `ActivityTask` it might be a bit confusing.
I'm considering changing `activity_id` to just `id` because it should be obvious which ID we mean in the message context.
Not sure if we should wrap `PollActivityTaskQueueResponse` with a `StartActivity` message.
