### PR TITLE
Make activity task usable

### DIFF
--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -73,6 +73,8 @@ message WFActivationJob {
         CancelWorkflow cancel_workflow = 6;
         // A request to signal the workflow was received.
         SignalWorkflow signal_workflow = 7;
+        // An activity was resolved with, result could be completed, failed or cancelled
+        ResolveActivity resolve_activity = 8;
     }
 }
 
@@ -93,6 +95,11 @@ message StartWorkflow {
 
 message FireTimer {
     string timer_id = 1;
+}
+
+message ResolveActivity {
+    string activity_id = 1;
+    ActivityResult result = 2;
 }
 
 message CancelTimer {
@@ -213,7 +220,6 @@ message WFActivationFailure {
 }
 
 message ActivityTaskCancelation {
-    temporal.api.common.v1.Payloads details = 1;
 }
 
 message ActivityTaskSuccess {

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -183,6 +183,7 @@ message WFActivationCompletion {
     }
 }
 
+/// Used to report activity completion to core and to resolve the activity in a workflow activtion
 message ActivityResult {
     oneof status {
         ActivityTaskSuccess completed = 1;
@@ -191,6 +192,7 @@ message ActivityResult {
     }
 }
 
+/// Request cancellation of an activity from a workflow
 message RequestActivityCancellation {
     string activity_id = 1;
     string reason = 2;
@@ -225,14 +227,17 @@ message WFActivationFailure {
     // Other bits from RespondWorkflowTaskFailedRequest as needed
 }
 
+/// Used in ActivityResult to report cancellation
 message ActivityTaskCancelation {
 }
 
+/// Used in ActivityResult to report successful completion
 message ActivityTaskSuccess {
     temporal.api.common.v1.Payloads result = 1;
     // Other bits from RespondActivityTaskCompletedRequest as needed
 }
 
+/// Used in ActivityResult to report failure
 message ActivityTaskFailure {
     temporal.api.failure.v1.Failure failure = 1;
     // Other bits from RespondActivityTaskFailedRequest as needed

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -193,6 +193,7 @@ message ActivityResult {
 
 message RequestActivityCancellation {
     string activity_id = 1;
+    string reason = 2;
 }
 
 message CoreCommand {

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -191,9 +191,14 @@ message ActivityResult {
     }
 }
 
+message RequestActivityCancellation {
+    string activity_id = 1;
+}
+
 message CoreCommand {
     oneof variant {
-        temporal.api.query.v1.WorkflowQueryResult query_result = 1;
+        temporal.api.query.v1.WorkflowQueryResult respond_to_query = 1;
+        RequestActivityCancellation request_activity_cancellation = 2;
     }
 }
 

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -7,6 +7,7 @@ package coresdk;
 // and adding the "api_upstream" subdir as an include path.
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "dependencies/gogoproto/gogo.proto";
 import "temporal/api/workflowservice/v1/request_response.proto";
@@ -116,7 +117,29 @@ message SignalWorkflow {
 }
 
 message StartActivity {
-    // TODO: add attributes
+    string workflow_namespace = 1;
+    temporal.api.common.v1.WorkflowType workflow_type = 2;
+    temporal.api.common.v1.WorkflowExecution workflow_execution = 3;
+    temporal.api.common.v1.ActivityType activity_type = 4;
+    temporal.api.common.v1.Header header = 5;
+    temporal.api.common.v1.Payloads input = 6;
+    temporal.api.common.v1.Payloads heartbeat_details = 7;
+    google.protobuf.Timestamp scheduled_time = 8 [(gogoproto.stdtime) = true];
+    google.protobuf.Timestamp current_attempt_scheduled_time = 9 [(gogoproto.stdtime) = true];
+    google.protobuf.Timestamp started_time = 10 [(gogoproto.stdtime) = true];
+    int32 attempt = 11;
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    google.protobuf.Duration schedule_to_close_timeout = 12 [(gogoproto.stdduration) = true];
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    google.protobuf.Duration start_to_close_timeout = 13 [(gogoproto.stdduration) = true];
+    google.protobuf.Duration heartbeat_timeout = 14 [(gogoproto.stdduration) = true];
+    // This is an actual retry policy the service uses.
+    // It can be different from the one provided (or not) during activity scheduling
+    // as the service can override the provided one in case its values are not specified
+    // or exceed configured system limits.
+    temporal.api.common.v1.RetryPolicy retry_policy = 15;
 }
 
 message CancelActivity {
@@ -124,11 +147,12 @@ message CancelActivity {
 }
 
 message ActivityTask {
+    string activity_id = 1;
     oneof job {
         // Start activity execution.
-        StartActivity start = 1;
+        StartActivity start = 2;
         // Attempt to cancel activity execution.
-        CancelActivity cancel = 2;
+        CancelActivity cancel = 3;
     }
 }
 


### PR DESCRIPTION
StartActivity attributes were pasted from https://github.com/temporalio/api/blob/dfdf839e185089b000dd8613bfea57375088f88a/temporal/api/workflowservice/v1/request_response.proto#L236

I'm not sure if this was the right decision but it's convenient to use.