### PR TITLE
Activity failure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,6 +524,14 @@ mod test {
         build_fake_core(wfid, RUN_ID, &mut t, hist_batches)
     }
 
+    #[fixture(hist_batches = &[])]
+    fn single_activity_failure_setup(hist_batches: &[usize]) -> FakeCore {
+        let wfid = "fake_wf_id";
+
+        let mut t = canned_histories::single_failed_activity("fake_activity");
+        build_fake_core(wfid, RUN_ID, &mut t, hist_batches)
+    }
+
     #[rstest(core,
     case::incremental(single_timer_setup(&[1, 2])),
     case::replay(single_timer_setup(&[2]))
@@ -566,7 +574,9 @@ mod test {
 
     #[rstest(core,
     case::incremental(single_activity_setup(&[1, 2])),
-    case::replay(single_activity_setup(&[2]))
+    case::incremental_activity_failure(single_activity_failure_setup(&[1, 2])),
+    case::replay(single_activity_setup(&[2])),
+    case::replay_activity_failure(single_activity_failure_setup(&[2]))
     )]
     fn single_activity_completion(core: FakeCore) {
         let res = core.poll_workflow_task(TASK_Q).unwrap();

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -87,7 +87,7 @@ pub(super) enum ActivityMachineCommand {
     Complete(Option<Payloads>),
     #[display(fmt = "Fail")]
     Fail(Option<Failure>),
-    #[display(fmt = "Complete")]
+    #[display(fmt = "Cancel")]
     Cancel(Option<Payloads>),
 }
 

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -222,10 +222,7 @@ impl WFMachinesAdapter for ActivityMachine {
                 activity_id: self.shared_state.attrs.activity_id.clone(),
                 result: Some(ActivityResult {
                     status: Some(activity_result::Status::Failed(ar::Failure {
-                        failure: match failure {
-                            Some(f) => Some(f.into()),
-                            None => None,
-                        },
+                        failure: failure.map(Into::into),
                     })),
                 }),
             }

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_enum_variant)]
+
 use crate::protos::coresdk::PayloadsExt;
 use crate::protos::temporal::api::failure::v1::Failure;
 use crate::protos::temporal::api::history::v1::ActivityTaskCanceledEventAttributes;

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -85,7 +85,7 @@ fsm! {
 pub(super) enum ActivityMachineCommand {
     #[display(fmt = "Complete")]
     Complete(Option<Payloads>),
-    #[display(fmt = "Complete")]
+    #[display(fmt = "Fail")]
     Fail(Option<Failure>),
     #[display(fmt = "Complete")]
     Cancel(Option<Payloads>),

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -152,6 +152,25 @@ pub mod coresdk {
         }
     }
 
+    impl From<Failure> for UserCodeFailure {
+        fn from(f: Failure) -> Self {
+            let mut r#type = "".to_string();
+            let mut non_retryable = false;
+            if let Some(FailureInfo::ApplicationFailureInfo(fi)) = f.failure_info {
+                r#type = fi.r#type;
+                non_retryable = fi.non_retryable;
+            }
+            Self {
+                message: f.message,
+                r#type,
+                source: f.source,
+                stack_trace: f.stack_trace,
+                non_retryable,
+                cause: f.cause.map(|b| Box::new((*b).into())),
+            }
+        }
+    }
+
     impl From<common::Payload> for super::temporal::api::common::v1::Payload {
         fn from(p: Payload) -> Self {
             Self {

--- a/src/test_help/canned_histories.rs
+++ b/src/test_help/canned_histories.rs
@@ -3,8 +3,9 @@ use crate::protos::temporal::api::common::v1::Payload;
 use crate::protos::temporal::api::enums::v1::{EventType, WorkflowTaskFailedCause};
 use crate::protos::temporal::api::failure::v1::Failure;
 use crate::protos::temporal::api::history::v1::{
-    history_event, ActivityTaskCompletedEventAttributes, ActivityTaskScheduledEventAttributes,
-    ActivityTaskStartedEventAttributes, TimerCanceledEventAttributes, TimerFiredEventAttributes,
+    history_event, ActivityTaskCompletedEventAttributes, ActivityTaskFailedEventAttributes,
+    ActivityTaskScheduledEventAttributes, ActivityTaskStartedEventAttributes,
+    TimerCanceledEventAttributes, TimerFiredEventAttributes,
 };
 
 ///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
@@ -195,6 +196,55 @@ pub fn single_activity(activity_id: &str) -> TestHistoryBuilder {
                 scheduled_event_id,
                 started_event_id,
                 // todo add the result payload
+                ..Default::default()
+            },
+        ),
+    );
+    t.add_workflow_task_scheduled_and_started();
+    t
+}
+
+///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+///  2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  3: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  4: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+///  5: EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+///  6: EVENT_TYPE_ACTIVITY_TASK_STARTED
+///  7: EVENT_TYPE_ACTIVITY_TASK_FAILED
+///  8: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  9: EVENT_TYPE_WORKFLOW_TASK_STARTED
+pub fn single_failed_activity(activity_id: &str) -> TestHistoryBuilder {
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    let scheduled_event_id = t.add_get_event_id(
+        EventType::ActivityTaskScheduled,
+        Some(
+            history_event::Attributes::ActivityTaskScheduledEventAttributes(
+                ActivityTaskScheduledEventAttributes {
+                    activity_id: activity_id.to_string(),
+                    ..Default::default()
+                },
+            ),
+        ),
+    );
+    let started_event_id = t.add_get_event_id(
+        EventType::ActivityTaskStarted,
+        Some(
+            history_event::Attributes::ActivityTaskStartedEventAttributes(
+                ActivityTaskStartedEventAttributes {
+                    scheduled_event_id,
+                    ..Default::default()
+                },
+            ),
+        ),
+    );
+    t.add(
+        EventType::ActivityTaskFailed,
+        history_event::Attributes::ActivityTaskFailedEventAttributes(
+            ActivityTaskFailedEventAttributes {
+                scheduled_event_id,
+                started_event_id,
                 ..Default::default()
             },
         ),

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -12,7 +12,6 @@ use std::{
     },
     time::Duration,
 };
-use temporal_sdk_core::protos::coresdk::common::RetryPolicy;
 use temporal_sdk_core::{
     protos::coresdk::{
         activity_result::{self, activity_result as act_res, ActivityResult},
@@ -122,22 +121,10 @@ fn activity_workflow() {
     create_workflow(&core, task_q, &workflow_id.to_string(), None);
     let activity_id: String = rng.gen::<u32>().to_string();
     let task = core.poll_workflow_task(task_q).unwrap();
-    core.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
-        vec![ScheduleActivity {
-            activity_id: activity_id.to_string(),
-            activity_type: "test_activity".to_string(),
-            namespace: NAMESPACE.to_owned(),
-            task_queue: task_q.to_owned(),
-            schedule_to_start_timeout: Some(Duration::from_secs(30).into()),
-            start_to_close_timeout: Some(Duration::from_secs(30).into()),
-            schedule_to_close_timeout: Some(Duration::from_secs(60).into()),
-            heartbeat_timeout: Some(Duration::from_secs(60).into()),
-            ..Default::default()
-        }
-        .into()],
-        task.task_token,
-    ))
-    .unwrap();
+    // Complete workflow task and schedule activity
+    core.complete_task(activity_completion_req(task_q, &activity_id, task))
+        .unwrap();
+    // Poll activity and verify that it's been scheduled with correct parameters
     let task = dbg!(core.poll_activity_task(task_q).unwrap());
     assert_matches!(
         task.variant,
@@ -149,12 +136,13 @@ fn activity_workflow() {
         data: b"hello ".to_vec(),
         metadata: Default::default(),
     };
+    // Complete activity successfully.
     core.complete_activity_task(
         task.task_token,
         ActivityResult::ok(response_payload.clone()),
     )
     .unwrap();
-
+    // Poll workflow task and verify that activity has succeeded.
     let task = core.poll_workflow_task(task_q).unwrap();
     assert_matches!(
         task.jobs.as_slice(),
@@ -188,22 +176,10 @@ fn activity_non_retryable_failure() {
     create_workflow(&core, task_q, &workflow_id.to_string(), None);
     let activity_id: String = rng.gen::<u32>().to_string();
     let task = core.poll_task(task_q).unwrap();
-    core.complete_task(TaskCompletion::ok_from_api_attrs(
-        vec![ScheduleActivity {
-            activity_id: activity_id.to_string(),
-            activity_type: "test_activity".to_string(),
-            namespace: NAMESPACE.to_owned(),
-            task_queue: task_q.to_owned(),
-            schedule_to_start_timeout: Some(Duration::from_secs(30).into()),
-            start_to_close_timeout: Some(Duration::from_secs(30).into()),
-            schedule_to_close_timeout: Some(Duration::from_secs(60).into()),
-            heartbeat_timeout: Some(Duration::from_secs(60).into()),
-            ..Default::default()
-        }
-        .into()],
-        task.task_token,
-    ))
-    .unwrap();
+    // Complete workflow task and schedule activity
+    core.complete_task(activity_completion_req(task_q, &activity_id, task))
+        .unwrap();
+    // Poll activity and verify that it's been scheduled with correct parameters
     let task = dbg!(core.poll_activity_task(task_q).unwrap());
     assert_matches!(
         task.get_activity_variant(),
@@ -211,6 +187,7 @@ fn activity_non_retryable_failure() {
             assert_eq!(start_activity.activity_type, "test_activity".to_string())
         }
     );
+    // Fail activity with non-retryable error
     let failure = UserCodeFailure {
         message: "activity failed".to_string(),
         non_retryable: true,
@@ -221,6 +198,7 @@ fn activity_non_retryable_failure() {
         task.task_token,
     ))
     .unwrap();
+    // Poll workflow task and verify that activity has failed.
     let task = core.poll_task(task_q).unwrap();
     assert_matches!(
         task.get_wf_jobs().as_slice(),
@@ -241,6 +219,97 @@ fn activity_non_retryable_failure() {
         task.task_token,
     ))
     .unwrap()
+}
+
+#[test]
+fn activity_retry() {
+    let mut rng = rand::thread_rng();
+    let task_q_salt: u32 = rng.gen();
+    let task_q = &format!("activity_failed_workflow_{}", task_q_salt.to_string());
+    let core = get_integ_core();
+    let workflow_id: u32 = rng.gen();
+    create_workflow(&core, task_q, &workflow_id.to_string(), None);
+    let activity_id: String = rng.gen::<u32>().to_string();
+    let task = core.poll_task(task_q).unwrap();
+    // Complete workflow task and schedule activity
+    core.complete_task(activity_completion_req(task_q, &activity_id, task))
+        .unwrap();
+    // Poll activity 1st time
+    let task = dbg!(core.poll_activity_task(task_q).unwrap());
+    assert_matches!(
+        task.get_activity_variant(),
+        Some(act_task::Variant::Start(start_activity)) => {
+            assert_eq!(start_activity.activity_type, "test_activity".to_string())
+        }
+    );
+    // Fail activity with retryable error
+    let failure = UserCodeFailure {
+        message: "activity failed".to_string(),
+        non_retryable: false,
+        ..Default::default()
+    };
+    core.complete_activity_task(TaskCompletion::fail_activity(
+        failure.clone(),
+        task.task_token,
+    ))
+    .unwrap();
+    // Poll 2nd time
+    let task = dbg!(core.poll_activity_task(task_q).unwrap());
+    assert_matches!(
+        task.get_activity_variant(),
+        Some(act_task::Variant::Start(start_activity)) => {
+            assert_eq!(start_activity.activity_type, "test_activity".to_string())
+        }
+    );
+    // Complete activity successfully
+    let response_payloads = vec![Payload {
+        data: b"hello ".to_vec(),
+        metadata: Default::default(),
+    }];
+    core.complete_activity_task(TaskCompletion::ok_activity(
+        response_payloads.clone(),
+        task.task_token,
+    ))
+    .unwrap();
+    // Poll workflow task and verify activity has succeeded.
+    let task = core.poll_task(task_q).unwrap();
+    assert_matches!(
+        task.get_wf_jobs().as_slice(),
+        [
+            WfActivationJob {
+                variant: Some(wf_activation_job::Variant::ResolveActivity(
+                    ResolveActivity {activity_id: a_id, result: Some(ActivityResult{
+                    status: Some(act_res::Status::Completed(activity_result::Success{result: r}))})}
+                )),
+            },
+        ] => {
+            assert_eq!(a_id, &activity_id);
+            assert_eq!(r, &response_payloads);
+        }
+    );
+    core.complete_task(TaskCompletion::ok_from_api_attrs(
+        vec![CompleteWorkflowExecution { result: vec![] }.into()],
+        task.task_token,
+    ))
+    .unwrap()
+}
+
+fn activity_completion_req(task_q: &String, activity_id: &String, task: Task) -> TaskCompletion {
+    WfActivationCompletion::ok_from_cmds(
+        vec![ScheduleActivity {
+            activity_id: activity_id.to_string(),
+            activity_type: "test_activity".to_string(),
+            namespace: NAMESPACE.to_owned(),
+            task_queue: task_q.to_owned(),
+            schedule_to_start_timeout: Some(Duration::from_secs(30).into()),
+            start_to_close_timeout: Some(Duration::from_secs(30).into()),
+            schedule_to_close_timeout: Some(Duration::from_secs(60).into()),
+            heartbeat_timeout: Some(Duration::from_secs(60).into()),
+            ..Default::default()
+        }
+        .into()],
+        task.task_token,
+    )
 }
 
 #[test]

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -248,11 +248,8 @@ fn activity_retry() {
         non_retryable: false,
         ..Default::default()
     };
-    core.complete_activity_task(TaskCompletion::fail_activity(
-        failure.clone(),
-        task.task_token,
-    ))
-    .unwrap();
+    core.complete_activity_task(TaskCompletion::fail_activity(failure, task.task_token))
+        .unwrap();
     // Poll 2nd time
     let task = dbg!(core.poll_activity_task(task_q).unwrap());
     assert_matches!(
@@ -294,7 +291,7 @@ fn activity_retry() {
     .unwrap()
 }
 
-fn activity_completion_req(task_q: &String, activity_id: &String, task: Task) -> TaskCompletion {
+fn activity_completion_req(task_q: &str, activity_id: &str, task: Task) -> TaskCompletion {
     WfActivationCompletion::ok_from_cmds(
         vec![ScheduleActivity {
             activity_id: activity_id.to_string(),

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -179,7 +179,7 @@ fn activity_workflow() {
 }
 
 #[test]
-fn activity_failed_workflow() {
+fn activity_non_retryable_failure() {
     let mut rng = rand::thread_rng();
     let task_q_salt: u32 = rng.gen();
     let task_q = &format!("activity_failed_workflow_{}", task_q_salt.to_string());


### PR DESCRIPTION
This change adds support for activity failure into the core sdk.
Tested in 3 variations - integ test, lib.rs top level test and state machine test.

Sample history for non-retryable failure case:
```
❯ tctl wf show --wid 1012869045

   1  WorkflowExecutionStarted    {WorkflowType:{Name:test-workflow},                           
                                  ParentInitiatedEventId:0,                                     
                                  TaskQueue:{Name:activity_failed_workflow_1964480726,          
                                  Kind:Normal}, WorkflowTaskTimeout:10s,                        
                                  Initiator:Unspecified,                                        
                                  OriginalExecutionRunId:815b9c1e-0893-491f-b35f-20b47b470c72,  
                                  FirstExecutionRunId:815b9c1e-0893-491f-b35f-20b47b470c72,     
                                  Attempt:1, FirstWorkflowTaskBackoff:0s}                       
   2  WorkflowTaskScheduled       {TaskQueue:{Name:activity_failed_workflow_1964480726,         
                                  Kind:Normal}, StartToCloseTimeout:10s, Attempt:1}             
   3  WorkflowTaskStarted         {ScheduledEventId:2, Identity:integ_tester,                   
                                  RequestId:336090d5-6cc6-4745-b25c-c1ffc2a1a382}               
   4  WorkflowTaskCompleted       {ScheduledEventId:2,                                          
                                  StartedEventId:3,                                             
                                  Identity:integ_tester}                                        
   5  ActivityTaskScheduled       {ActivityId:3202999672,                                       
                                  ActivityType:{Name:test_activity},                            
                                  Namespace:default,                                            
                                  TaskQueue:{Name:activity_failed_workflow_1964480726,          
                                  Kind:Normal}, ScheduleToCloseTimeout:1m0s,                    
                                  ScheduleToStartTimeout:30s,                                   
                                  StartToCloseTimeout:30s, HeartbeatTimeout:30s,                
                                  WorkflowTaskCompletedEventId:4,                               
                                  RetryPolicy:{InitialInterval:1s,                              
                                  BackoffCoefficient:2, MaximumInterval:1m40s,                  
                                  MaximumAttempts:0}}                                           
   6  ActivityTaskStarted         {ScheduledEventId:5, Identity:integ_tester,                   
                                  RequestId:af393dfa-86cb-493a-a5ba-bc688d2c2841,               
                                  Attempt:1}                                                    
   7  ActivityTaskFailed          {Failure:{Message:activity failed,                            
                                  FailureInfo:{ApplicationFailureInfo:{NonRetryable:true}}},    
                                  ScheduledEventId:5, StartedEventId:6,                         
                                  Identity:integ_tester, RetryState:NonRetryableFailure}        
   8  WorkflowTaskScheduled       {TaskQueue:{Name:activity_failed_workflow_1964480726,         
                                  Kind:Normal}, StartToCloseTimeout:10s, Attempt:1}             
   9  WorkflowTaskStarted         {ScheduledEventId:8, Identity:integ_tester,                   
                                  RequestId:c046f40c-dc29-4b57-8d31-f8f4737a2a3a}               
  10  WorkflowTaskCompleted       {ScheduledEventId:8,                                          
                                  StartedEventId:9,                                             
                                  Identity:integ_tester}                                        
  11  WorkflowExecutionCompleted  {WorkflowTaskCompletedEventId:10} 
```