### PR TITLE
Activity timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -825,7 +825,7 @@ mod test {
                                         )),
                                     }
                                 ] => {
-                                    assert_eq!(failure.message, "Activity task timedOut".to_string());
+                                    assert_eq!(failure.message, "Activity task timed out".to_string());
                                     assert_eq!(aid, &activity_id.to_string());
                                 }
                             );
@@ -878,7 +878,7 @@ mod test {
                                         )),
                                     }
                                 ] => {
-                                    assert_eq!(failure.message, "Activity task timedOut".to_string());
+                                    assert_eq!(failure.message, "Activity task timed out".to_string());
                                     assert_eq!(aid, &activity_id.to_string());
                                 }
                             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -879,7 +879,10 @@ mod test {
                 ),
                 // Activity is getting resolved right away as it has been timed out.
                 gen_assert_and_reply(
-                    &job_assert!(wf_activation_job::Variant::ResolveActivity(_)),
+                    &job_assert!(
+                        wf_activation_job::Variant::ResolveActivity(_),
+                        wf_activation_job::Variant::ResolveActivity(_)
+                    ),
                     vec![CompleteWorkflowExecution { result: None }.into()],
                 ),
             ],

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -716,7 +716,7 @@ fn new_timeout_failure(dat: &SharedState, attrs: ActivityTaskTimedOutEventAttrib
         retry_state: attrs.retry_state,
     };
     Failure {
-        message: "Activity task timedOut".to_string(),
+        message: "Activity task timed out".to_string(),
         cause: attrs.failure.map(Box::new),
         failure_info: Some(failure::FailureInfo::ActivityFailureInfo(failure_info)),
         ..Default::default()


### PR DESCRIPTION
Preview of activity timeout handling in state machines.
There is a bug when timeout happens for canceled activity in try cancel state, it would result in two activations to the lang side (one for cancellation and one for timeout).
We need to discuss and address this issue, ideally as part of this PR.
Also I think I've encountered an issue with test framework and was unable to run activity timeout after cancel test incrementally.