### PR TITLE
Show fsm coverage

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,9 +35,10 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "cargo tarpaulin --out Html --workspace"
+    command: "cargo tarpaulin --out Html --workspace && cargo test -- --include-ignored"
     artifact_paths:
       - "tarpaulin-report.html"
+      - "machine_coverage/*"
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.0.0:

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ Cargo.lock
 src/protos/*.rs
 !src/protos/mod.rs
 /tarpaulin-report.html
+/machine_coverage/
 /.cargo/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ prost = "0.7"
 prost-types = "0.7"
 slotmap = "1.0"
 thiserror = "1.0"
+tonic = "0.4"
 tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
@@ -34,11 +35,9 @@ url = "2.2"
 rand = "0.8.3"
 uuid = { version = "0.8.2", features = ["v4"] }
 
-[dependencies.tonic]
-version = "0.4"
-#path = "../tonic/tonic"
+[patch.crates-io]
 # Using our fork for now which fixes grpc-timeout header getting stripped
-git = "https://github.com/temporalio/tonic"
+tonic = { git = "https://github.com/temporalio/tonic" }
 
 [dependencies.rustfsm]
 path = "fsm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ path = "fsm"
 assert_matches = "1.4"
 mockall = "0.9"
 rstest = "0.7"
+lazy_static = "1.4"
 
 [build-dependencies]
 tonic-build = "0.4"

--- a/fsm/state_machine_procmacro/src/lib.rs
+++ b/fsm/state_machine_procmacro/src/lib.rs
@@ -200,13 +200,15 @@ impl Parse for StateMachineDefinition {
         // Parse visibility if present
         let visibility = input.parse()?;
         // parse the state machine name, command type, and error type
-        let (name, command_type, error_type, shared_state_type) = parse_machine_types(&input).map_err(|mut e| {
-            e.combine(Error::new(
-                e.span(),
-                "The fsm definition should begin with `name MachineName; command CommandType; error ErrorType;` optionally followed by `shared_state SharedStateType;`",
-            ));
-            e
-        })?;
+        let (name, command_type, error_type, shared_state_type) = parse_machine_types(&input)
+            .map_err(|mut e| {
+                e.combine(Error::new(
+                    e.span(),
+                    "The fsm definition should begin with `name MachineName; command CommandType; \
+                    error ErrorType;` optionally followed by `shared_state SharedStateType;`",
+                ));
+                e
+            })?;
         // Then the state machine definition is simply a sequence of transitions separated by
         // semicolons
         let transitions: Punctuated<Transition, Token![;]> =
@@ -335,15 +337,7 @@ impl StateMachineDefinition {
     fn codegen(&self) -> TokenStream {
         let visibility = self.visibility.clone();
         // First extract all of the states into a set, and build the enum's insides
-        let states: HashSet<_> = self
-            .transitions
-            .iter()
-            .flat_map(|t| {
-                let mut states = t.to.clone();
-                states.push(t.from.clone());
-                states
-            })
-            .collect();
+        let states = self.all_states();
         let state_variants = states.iter().map(|s| {
             let statestr = s.to_string();
             quote! {
@@ -529,6 +523,8 @@ impl StateMachineDefinition {
             }
         }).collect();
 
+        let viz_str = self.visualize();
+
         let trait_impl = quote! {
             impl ::rustfsm::StateMachine for #name {
                 type Error = #err_type;
@@ -566,11 +562,14 @@ impl StateMachineDefinition {
                 fn from_parts(shared: Self::SharedState, state: Self::State) -> Self {
                     Self { shared_state: shared, state }
                 }
+
+                fn visualizer() -> &'static str {
+                    #viz_str
+                }
             }
         };
 
         let output = quote! {
-
             #transition_type_alias
             #machine_struct
             #states_enum
@@ -581,6 +580,37 @@ impl StateMachineDefinition {
         };
 
         output.into()
+    }
+
+    fn all_states(&self) -> HashSet<Ident> {
+        self.transitions
+            .iter()
+            .flat_map(|t| {
+                let mut states = t.to.clone();
+                states.push(t.from.clone());
+                states
+            })
+            .collect()
+    }
+
+    fn visualize(&self) -> String {
+        let transitions: Vec<String> = self
+            .transitions
+            .iter()
+            .flat_map(|t| {
+                t.to.iter()
+                    .map(move |d| format!("{} --> {}: {}", t.from, d, t.event.ident))
+            })
+            // Add all final state transitions
+            .chain(
+                self.all_states()
+                    .iter()
+                    .filter(|s| self.is_final_state(s))
+                    .map(|s| format!("{} --> [*]", s)),
+            )
+            .collect();
+        let transitions = transitions.join("\n");
+        format!("@startuml\n{}\n@enduml", transitions)
     }
 }
 

--- a/fsm/state_machine_trait/src/lib.rs
+++ b/fsm/state_machine_trait/src/lib.rs
@@ -1,5 +1,7 @@
-use std::error::Error;
-use std::fmt::{Debug, Display, Formatter};
+use std::{
+    error::Error,
+    fmt::{Debug, Display, Formatter},
+};
 
 /// This trait defines a state machine (more formally, a [finite state
 /// transducer](https://en.wikipedia.org/wiki/Finite-state_transducer)) which accepts events (the
@@ -70,6 +72,9 @@ pub trait StateMachine: Sized {
 
     /// Given the shared data and new state, create a new instance.
     fn from_parts(shared: Self::SharedState, state: Self::State) -> Self;
+
+    /// Return a PlantUML definition of the fsm that can be used to visualize it
+    fn visualizer() -> &'static str;
 }
 
 /// The error returned by [StateMachine]s when handling events

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -37,8 +37,6 @@ use crate::{
 use rustfsm::{fsm, MachineError, StateMachine, TransitionResult};
 use std::convert::{TryFrom, TryInto};
 
-// Schedule / cancel are "explicit events" (imperative rather than past events?)
-
 fsm! {
     pub(super) name ActivityMachine;
     command ActivityMachineCommand;

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -779,4 +779,10 @@ mod test {
             ]
         )
     }
+
+    #[test]
+    fn viz() {
+        let viz = ActivityMachine::visualizer();
+        println!("{}", viz);
+    }
 }

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     machines::{
-        workflow_machines::MachineResponse, Cancellable, NewMachineWithCommand, WFMachinesAdapter,
-        WFMachinesError,
+        workflow_machines::MachineResponse, Cancellable, NewMachineWithCommand, OnEventWrapper,
+        WFMachinesAdapter, WFMachinesError,
     },
     protos::{
         coresdk::{
@@ -120,7 +120,7 @@ impl ActivityMachine {
                 ..Default::default()
             },
         };
-        s.on_event_mut(ActivityMachineEvents::Schedule)
+        OnEventWrapper::on_event_mut(&mut s, ActivityMachineEvents::Schedule)
             .expect("Scheduling activities doesn't fail");
         let cmd = Command {
             command_type: CommandType::ScheduleActivityTask as i32,
@@ -262,7 +262,7 @@ impl Cancellable for ActivityMachine {
             ActivityCancellationType::Abandon => ActivityMachineEvents::Abandon,
             _ => ActivityMachineEvents::Cancel,
         };
-        let vec = self.on_event_mut(event)?;
+        let vec = OnEventWrapper::on_event_mut(self, event)?;
         let res = vec
             .into_iter()
             .flat_map(|amc| match amc {

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -777,10 +777,4 @@ mod test {
             ]
         )
     }
-
-    #[test]
-    fn viz() {
-        let viz = ActivityMachine::visualizer();
-        println!("{}", viz);
-    }
 }

--- a/src/machines/complete_workflow_state_machine.rs
+++ b/src/machines/complete_workflow_state_machine.rs
@@ -1,7 +1,7 @@
 use crate::{
     machines::{
-        workflow_machines::MachineResponse, Cancellable, NewMachineWithCommand, WFMachinesAdapter,
-        WFMachinesError,
+        workflow_machines::MachineResponse, Cancellable, NewMachineWithCommand, OnEventWrapper,
+        WFMachinesAdapter, WFMachinesError,
     },
     protos::{
         coresdk::workflow_commands::CompleteWorkflowExecution,

--- a/src/machines/complete_workflow_state_machine.rs
+++ b/src/machines/complete_workflow_state_machine.rs
@@ -53,14 +53,14 @@ impl CompleteWorkflowMachine {
             state: Created {}.into(),
             shared_state: attribs,
         };
-        let cmd = match s
-            .on_event_mut(CompleteWorkflowMachineEvents::Schedule)
-            .expect("Scheduling complete wf machines doesn't fail")
-            .pop()
-        {
-            Some(CompleteWFCommand::AddCommand(c)) => c,
-            _ => panic!("complete wf machine on_schedule must produce command"),
-        };
+        let cmd =
+            match OnEventWrapper::on_event_mut(&mut s, CompleteWorkflowMachineEvents::Schedule)
+                .expect("Scheduling complete wf machines doesn't fail")
+                .pop()
+            {
+                Some(CompleteWFCommand::AddCommand(c)) => c,
+                _ => panic!("complete wf machine on_schedule must produce command"),
+            };
         (s, cmd)
     }
 }

--- a/src/machines/complete_workflow_state_machine.rs
+++ b/src/machines/complete_workflow_state_machine.rs
@@ -12,7 +12,7 @@ use crate::{
         },
     },
 };
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{fsm, TransitionResult};
 use std::convert::TryFrom;
 
 fsm! {

--- a/src/machines/fail_workflow_state_machine.rs
+++ b/src/machines/fail_workflow_state_machine.rs
@@ -1,9 +1,9 @@
-use crate::protos::coresdk::workflow_commands::FailWorkflowExecution;
 use crate::{
     machines::{
-        workflow_machines::MachineResponse, Cancellable, NewMachineWithCommand, ProtoCommand,
-        WFMachinesAdapter, WFMachinesError,
+        workflow_machines::MachineResponse, Cancellable, NewMachineWithCommand, OnEventWrapper,
+        ProtoCommand, WFMachinesAdapter, WFMachinesError,
     },
+    protos::coresdk::workflow_commands::FailWorkflowExecution,
     protos::temporal::api::enums::v1::CommandType,
     protos::temporal::api::enums::v1::EventType,
     protos::temporal::api::history::v1::HistoryEvent,

--- a/src/machines/fail_workflow_state_machine.rs
+++ b/src/machines/fail_workflow_state_machine.rs
@@ -8,7 +8,7 @@ use crate::{
     protos::temporal::api::enums::v1::EventType,
     protos::temporal::api::history::v1::HistoryEvent,
 };
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{fsm, TransitionResult};
 use std::convert::TryFrom;
 
 fsm! {

--- a/src/machines/fail_workflow_state_machine.rs
+++ b/src/machines/fail_workflow_state_machine.rs
@@ -46,8 +46,7 @@ impl FailWorkflowMachine {
             state: Created {}.into(),
             shared_state: attribs,
         };
-        let cmd = match s
-            .on_event_mut(FailWorkflowMachineEvents::Schedule)
+        let cmd = match OnEventWrapper::on_event_mut(&mut s, FailWorkflowMachineEvents::Schedule)
             .expect("Scheduling fail wf machines doesn't fail")
             .pop()
         {

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -121,10 +121,15 @@ trait TemporalStateMachine: CheckStateMachineInFinal + Send {
 
 impl<SM> TemporalStateMachine for SM
 where
-    SM: StateMachine + CheckStateMachineInFinal + WFMachinesAdapter + Cancellable + Clone + Send,
+    SM: StateMachine
+        + CheckStateMachineInFinal
+        + WFMachinesAdapter
+        + Cancellable
+        + OnEventWrapper
+        + Clone
+        + Send,
     <SM as StateMachine>::Event: TryFrom<HistoryEvent>,
     <SM as StateMachine>::Event: TryFrom<CommandType>,
-    // TODO: Can't make this condidional?
     <SM as StateMachine>::Event: Display,
     WFMachinesError: From<<<SM as StateMachine>::Event as TryFrom<HistoryEvent>>::Error>,
     <SM as StateMachine>::Command: Debug + Display,
@@ -143,7 +148,7 @@ where
             "handling command"
         );
         if let Ok(converted_command) = command_type.try_into() {
-            match self.on_event_mut(converted_command) {
+            match OnEventWrapper::on_event_mut(self, converted_command) {
                 Ok(_c) => Ok(()),
                 Err(MachineError::InvalidTransition) => {
                     Err(WFMachinesError::UnexpectedCommand(command_type))
@@ -168,21 +173,8 @@ where
         );
         let converted_event: <Self as StateMachine>::Event = event.clone().try_into()?;
 
-        #[cfg(test)]
-        let from_state = self.state().to_string();
-        #[cfg(test)]
-        let converted_event_str = converted_event.to_string();
-
-        match self.on_event_mut(converted_event) {
+        match OnEventWrapper::on_event_mut(self, converted_event) {
             Ok(c) => {
-                #[cfg(test)]
-                add_coverage(
-                    self.name().to_owned(),
-                    from_state,
-                    self.state().to_string(),
-                    converted_event_str,
-                );
-
                 if !c.is_empty() {
                     debug!(commands = %c.display(), state = %self.state(),
                            "Machine produced commands");
@@ -268,6 +260,46 @@ trait Cancellable: StateMachine {
     fn was_cancelled_before_sent_to_server(&self) -> bool {
         false
     }
+}
+
+/// We need to wrap calls to [StateMachine::on_event_mut] to track coverage, or anything else
+/// we'd like to do on every call.
+pub(crate) trait OnEventWrapper: StateMachine
+where
+    <Self as StateMachine>::State: Display,
+    <Self as StateMachine>::Event: Display,
+    Self: Clone,
+{
+    fn on_event_mut(
+        &mut self,
+        event: Self::Event,
+    ) -> Result<Vec<Self::Command>, MachineError<Self::Error>> {
+        #[cfg(test)]
+        let from_state = self.state().to_string();
+        #[cfg(test)]
+        let converted_event_str = event.to_string();
+
+        let res = StateMachine::on_event_mut(self, event);
+        if let Ok(_) = &res {
+            #[cfg(test)]
+            add_coverage(
+                self.name().to_owned(),
+                from_state,
+                self.state().to_string(),
+                converted_event_str,
+            );
+        }
+        res
+    }
+}
+
+impl<SM> OnEventWrapper for SM
+where
+    SM: StateMachine,
+    <Self as StateMachine>::State: Display,
+    <Self as StateMachine>::Event: Display,
+    Self: Clone,
+{
 }
 
 #[derive(Debug)]

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -280,7 +280,7 @@ where
         let converted_event_str = event.to_string();
 
         let res = StateMachine::on_event_mut(self, event);
-        if let Ok(_) = &res {
+        if res.is_ok() {
             #[cfg(test)]
             add_coverage(
                 self.name().to_owned(),

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -34,7 +34,6 @@ pub(crate) mod test_help;
 
 pub(crate) use workflow_machines::{WFMachinesError, WorkflowMachines};
 
-use crate::machines::test_help::add_coverage;
 use crate::{
     core_tracing::VecDisplayer,
     machines::workflow_machines::MachineResponse,
@@ -52,6 +51,9 @@ use std::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display},
 };
+
+#[cfg(test)]
+use crate::machines::test_help::add_coverage;
 
 pub(crate) type ProtoCommand = Command;
 

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -2,9 +2,11 @@ type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 
 mod async_workflow_driver;
 mod history_builder;
+mod transition_coverage;
 
 pub(super) use async_workflow_driver::{CommandSender, TestWorkflowDriver};
 pub(crate) use history_builder::TestHistoryBuilder;
+pub(crate) use transition_coverage::add_coverage;
 
 use crate::{
     pollers::MockServerGatewayApis,

--- a/src/machines/test_help/transition_coverage.rs
+++ b/src/machines/test_help/transition_coverage.rs
@@ -1,0 +1,35 @@
+use dashmap::{mapref::entry::Entry, DashMap, DashSet};
+
+// During test we want to know about which transitions we've covered in state machines
+lazy_static::lazy_static! {
+    static ref COVERED_TRANSITIONS: DashMap<String, DashSet<CoveredTransition>>
+        = DashMap::new();
+}
+
+#[derive(Eq, PartialEq, Hash, Debug)]
+struct CoveredTransition {
+    from_state: String,
+    to_state: String,
+    event: String,
+}
+
+pub fn add_coverage(machine_name: String, from_state: String, to_state: String, event: String) {
+    let ct = CoveredTransition {
+        from_state,
+        to_state,
+        event,
+    };
+    match COVERED_TRANSITIONS.entry(machine_name) {
+        Entry::Occupied(o) => {
+            o.get().insert(ct);
+        }
+        Entry::Vacant(v) => {
+            v.insert({
+                let ds = DashSet::new();
+                ds.insert(ct);
+                ds
+            });
+        }
+    }
+    dbg!(&*COVERED_TRANSITIONS);
+}

--- a/src/machines/test_help/transition_coverage.rs
+++ b/src/machines/test_help/transition_coverage.rs
@@ -66,6 +66,7 @@ fn spawn_save_coverage_at_end() -> SyncSender<(String, CoveredTransition)> {
 #[cfg(test)]
 mod machine_coverage_report {
     use super::*;
+    use crate::machines::fail_workflow_state_machine::FailWorkflowMachine;
     use crate::machines::{
         activity_state_machine::ActivityMachine,
         complete_workflow_state_machine::CompleteWorkflowMachine,
@@ -101,6 +102,7 @@ mod machine_coverage_report {
         let mut timer = TimerMachine::visualizer().to_owned();
         let mut complete_wf = CompleteWorkflowMachine::visualizer().to_owned();
         let mut wf_task = WorkflowTaskMachine::visualizer().to_owned();
+        let mut fail_wf = FailWorkflowMachine::visualizer().to_owned();
 
         // This isn't at all efficient but doesn't need to be.
         // Replace transitions in the vizzes with green color if they are covered.
@@ -111,6 +113,7 @@ mod machine_coverage_report {
                 "TimerMachine" => cover_transitions(&mut timer, coverage),
                 "CompleteWorkflowMachine" => cover_transitions(&mut complete_wf, coverage),
                 "WorkflowTaskMachine" => cover_transitions(&mut wf_task, coverage),
+                "FailWorkflowMachine" => cover_transitions(&mut fail_wf, coverage),
                 m => panic!("Unknown machine {}", m),
             }
         }

--- a/src/machines/test_help/transition_coverage.rs
+++ b/src/machines/test_help/transition_coverage.rs
@@ -118,6 +118,8 @@ mod machine_coverage_report {
             }
         }
         println!("{}", activity);
+        println!("{}", timer);
+        println!("{}", wf_task);
     }
 
     fn cover_transitions(viz: &mut String, cov: &DashSet<CoveredTransition>) {

--- a/src/machines/test_help/transition_coverage.rs
+++ b/src/machines/test_help/transition_coverage.rs
@@ -75,8 +75,9 @@ mod machine_coverage_report {
     // it'll just get abandoned.
     #[test]
     fn reporter() {
-        // Need to wait a bit for the thread handle to be initialized
-        std::thread::sleep(Duration::from_millis(200));
+        // Make sure thread handle exists
+        &*COVERAGE_SENDER;
+        // Join it
         THREAD_HANDLE
             .lock()
             .unwrap()

--- a/src/machines/test_help/transition_coverage.rs
+++ b/src/machines/test_help/transition_coverage.rs
@@ -58,7 +58,6 @@ fn spawn_save_coverage_at_end() -> SyncSender<(String, CoveredTransition)> {
                 }
             }
         }
-        dbg!(&*COVERED_TRANSITIONS);
     });
     *THREAD_HANDLE.lock().unwrap() = Some(handle);
     tx
@@ -67,14 +66,25 @@ fn spawn_save_coverage_at_end() -> SyncSender<(String, CoveredTransition)> {
 #[cfg(test)]
 mod machine_coverage_report {
     use super::*;
+    use crate::machines::{
+        activity_state_machine::ActivityMachine,
+        complete_workflow_state_machine::CompleteWorkflowMachine,
+        timer_state_machine::TimerMachine, workflow_task_state_machine::WorkflowTaskMachine,
+    };
+    use rustfsm::StateMachine;
 
     // This "test" needs to exist so that we have a way to join the spawned thread. Otherwise
     // it'll just get abandoned.
     #[test]
+    // Use `cargo test -- --include-ignored` to run this. We don't want to bother with it by default
+    // because it takes a minimum of a second.
+    #[ignore]
     fn reporter() {
         // Make sure thread handle exists
         #[allow(clippy::no_effect)] // Haha clippy, you'd be wrong here.
-        &*COVERAGE_SENDER;
+        {
+            &*COVERAGE_SENDER;
+        }
         // Join it
         THREAD_HANDLE
             .lock()
@@ -83,5 +93,43 @@ mod machine_coverage_report {
             .unwrap()
             .join()
             .unwrap();
+
+        dbg!(&*COVERED_TRANSITIONS);
+
+        // Gather visualizations for all machines
+        let mut activity = ActivityMachine::visualizer().to_owned();
+        let mut timer = TimerMachine::visualizer().to_owned();
+        let mut complete_wf = CompleteWorkflowMachine::visualizer().to_owned();
+        let mut wf_task = WorkflowTaskMachine::visualizer().to_owned();
+
+        // This isn't at all efficient but doesn't need to be.
+        // Replace transitions in the vizzes with green color if they are covered.
+        for item in COVERED_TRANSITIONS.iter() {
+            let (machine, coverage) = item.pair();
+            match machine.as_ref() {
+                "ActivityMachine" => cover_transitions(&mut activity, coverage),
+                "TimerMachine" => cover_transitions(&mut timer, coverage),
+                "CompleteWorkflowMachine" => cover_transitions(&mut complete_wf, coverage),
+                "WorkflowTaskMachine" => cover_transitions(&mut wf_task, coverage),
+                m => panic!("Unknown machine {}", m),
+            }
+        }
+        println!("{}", activity);
+    }
+
+    fn cover_transitions(viz: &mut String, cov: &DashSet<CoveredTransition>) {
+        for trans in cov.iter() {
+            let find_line = format!(
+                "{} --> {}: {}",
+                trans.from_state, trans.to_state, trans.event
+            );
+            if let Some(start) = viz.find(&find_line) {
+                let new_line = format!(
+                    "{} -[#blue]-> {}: {}",
+                    trans.from_state, trans.to_state, trans.event
+                );
+                viz.replace_range(start..start + find_line.len(), &new_line);
+            }
+        }
     }
 }

--- a/src/machines/test_help/transition_coverage.rs
+++ b/src/machines/test_help/transition_coverage.rs
@@ -1,9 +1,25 @@
+//! Look, I'm not happy about the code in here, and you shouldn't be either. This is all an awful,
+//! dirty hack to work around the fact that there's no such thing as "run this after all unit tests"
+//! in stable Rust. Don't do the things in here. They're bad. This is test only code, and should
+//! never ever be removed from behind `#[cfg(test)]` compilation.
+
 use dashmap::{mapref::entry::Entry, DashMap, DashSet};
+use std::{
+    sync::{
+        mpsc::{sync_channel, SyncSender},
+        Mutex,
+    },
+    thread::JoinHandle,
+    time::Duration,
+};
 
 // During test we want to know about which transitions we've covered in state machines
 lazy_static::lazy_static! {
     static ref COVERED_TRANSITIONS: DashMap<String, DashSet<CoveredTransition>>
         = DashMap::new();
+    static ref COVERAGE_SENDER: SyncSender<(String, CoveredTransition)> =
+        spawn_save_coverage_at_end();
+    static ref THREAD_HANDLE: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
 }
 
 #[derive(Eq, PartialEq, Hash, Debug)]
@@ -19,17 +35,54 @@ pub fn add_coverage(machine_name: String, from_state: String, to_state: String, 
         to_state,
         event,
     };
-    match COVERED_TRANSITIONS.entry(machine_name) {
-        Entry::Occupied(o) => {
-            o.get().insert(ct);
+    COVERAGE_SENDER.send((machine_name, ct)).unwrap();
+}
+
+fn spawn_save_coverage_at_end() -> SyncSender<(String, CoveredTransition)> {
+    let (tx, rx) = sync_channel(1000);
+    let handle = std::thread::spawn(move || {
+        loop {
+            // Assume that, if the entire program hasn't run a state machine transition in the
+            // last second that we are probably done running all the tests. This is to avoid
+            // needing to instrument every single test.
+            match rx.recv_timeout(Duration::from_secs(1)) {
+                Ok((machine_name, ct)) => match COVERED_TRANSITIONS.entry(machine_name) {
+                    Entry::Occupied(o) => {
+                        o.get().insert(ct);
+                    }
+                    Entry::Vacant(v) => {
+                        v.insert({
+                            let ds = DashSet::new();
+                            ds.insert(ct);
+                            ds
+                        });
+                    }
+                },
+                Err(_) => break,
+            }
         }
-        Entry::Vacant(v) => {
-            v.insert({
-                let ds = DashSet::new();
-                ds.insert(ct);
-                ds
-            });
-        }
+        dbg!(&*COVERED_TRANSITIONS);
+    });
+    *THREAD_HANDLE.lock().unwrap() = Some(handle);
+    tx
+}
+
+#[cfg(test)]
+mod machine_coverage_report {
+    use super::*;
+
+    // This "test" needs to exist so that we have a way to join the spawned thread. Otherwise
+    // it'll just get abandoned.
+    #[test]
+    fn reporter() {
+        // Need to wait a bit for the thread handle to be initialized
+        std::thread::sleep(Duration::from_millis(200));
+        THREAD_HANDLE
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap()
+            .join()
+            .unwrap();
     }
-    dbg!(&*COVERED_TRANSITIONS);
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Only when compiled for test, we collect coverage info about which state machine transitions have been hit and turn it into nice little state diagrams with colored lines.

## Why?
Much easier to tell where we have coverage gaps while testing state machines

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
