### PR TITLE
Turns out [patch] doesn't apply to consumers, so, back to old way.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ prost = "0.7"
 prost-types = "0.7"
 slotmap = "1.0"
 thiserror = "1.0"
-tonic = "0.4"
 tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
@@ -35,9 +34,10 @@ url = "2.2"
 rand = "0.8.3"
 uuid = { version = "0.8.2", features = ["v4"] }
 
-[patch.crates-io]
+[dependencies.tonic]
+version = "0.4"
 # Using our fork for now which fixes grpc-timeout header getting stripped
-tonic = { git = "https://github.com/temporalio/tonic" }
+git = "https://github.com/temporalio/tonic"
 
 [dependencies.rustfsm]
 path = "fsm"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
The [patch] directive broke node sdk bridge because it doesn't apply transitively (which https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#working-with-an-unpublished-minor-version explains in a *super confusing* way, sure doesn't look transitive to me). Go back to old way. 

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
