### PR TITLE
Make pending activations interrupt long poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ let _enter = s.enter();
 
 To run the Jaeger instance:
 `docker run --rm -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest`
+Jaeger collection is off by default, you must set `TEMPORAL_ENABLE_OPENTELEMENTRY=true` in the
+environment to enable it.
 
 To show logs in the console, set the `RUST_LOG` environment variable to `temporal_sdk_core=DEBUG`
 or whatever level you desire. The env var is parsed according to tracing's 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,10 @@ pub trait Core: Send + Sync {
     /// responsibility to call the appropriate workflow code with the provided inputs. Blocks
     /// indefinitely until such work is available or [Core::shutdown] is called.
     ///
+    /// Note that it is possible to receive work from a task queue that isn't the argument you
+    /// passed if you previously polled that task queue and there is remaining work that the lang
+    /// side must do before core can respond to the server.
+    ///
     /// TODO: Examples
     async fn poll_workflow_task(&self, task_queue: &str) -> Result<WfActivation, PollWfError>;
 

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -1,0 +1,98 @@
+use crate::integ_tests::{
+    create_workflow, get_integ_core, simple_wf_tests::schedule_activity_and_timer_cmds,
+};
+use assert_matches::assert_matches;
+use rand::Rng;
+use std::sync::Arc;
+use std::time::Duration;
+use temporal_sdk_core::protos::coresdk::{
+    activity_task::activity_task as act_task,
+    workflow_activation::{wf_activation_job, FireTimer, WfActivationJob},
+    workflow_commands::{
+        ActivityCancellationType, CompleteWorkflowExecution, RequestCancelActivity,
+    },
+    workflow_completion::WfActivationCompletion,
+};
+use temporal_sdk_core::Core;
+
+#[tokio::test]
+async fn long_poll_interrupted_by_new_pending_activation() {
+    let mut rng = rand::thread_rng();
+    let task_q_salt: u32 = rng.gen();
+    let task_q = format!("activity_cancelled_workflow_{}", task_q_salt.to_string());
+    let core = Arc::new(get_integ_core().await);
+    let workflow_id: u32 = rng.gen();
+    create_workflow(&*core, &task_q, &workflow_id.to_string(), None).await;
+    let activity_id: String = rng.gen::<u32>().to_string();
+    let timer_id: String = rng.gen::<u32>().to_string();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    // Complete workflow task and schedule activity and a timer that fires immediately
+    core.complete_workflow_task(schedule_activity_and_timer_cmds(
+        &task_q,
+        &activity_id,
+        &timer_id,
+        ActivityCancellationType::TryCancel,
+        task,
+        Duration::from_secs(60),
+        Duration::from_millis(50),
+    ))
+    .await
+    .unwrap();
+    // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
+    // complete it in this test as activity is try-cancelled.
+    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
+    assert_matches!(
+        activity_task.variant,
+        Some(act_task::Variant::Start(start_activity)) => {
+            assert_eq!(start_activity.activity_type, "test_activity".to_string())
+        }
+    );
+    // Poll workflow task and verify that activity has failed.
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        [
+            WfActivationJob {
+                variant: Some(wf_activation_job::Variant::FireTimer(
+                    FireTimer { timer_id: t_id }
+                )),
+            },
+        ] => {
+            assert_eq!(t_id, &timer_id);
+        }
+    );
+
+    // Start polling again *before* we complete the WFT
+    let cc = core.clone();
+    let jh = tokio::spawn(async move {
+        let task = cc.poll_workflow_task(&task_q).await.unwrap();
+        assert_matches!(
+            task.jobs.as_slice(),
+            [WfActivationJob {
+                variant: Some(wf_activation_job::Variant::ResolveActivity(_)),
+            }]
+        );
+        cc.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
+            vec![CompleteWorkflowExecution { result: None }.into()],
+            task.task_token,
+        ))
+        .await
+        .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Then complete the (last) WFT with a request to cancel the AT, which should produce a
+    // pending activation, unblocking the (already started) poll
+    core.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
+        vec![RequestCancelActivity {
+            activity_id,
+            ..Default::default()
+        }
+        .into()],
+        task.task_token,
+    ))
+    .await
+    .unwrap();
+
+    jh.await.unwrap();
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,4 +1,62 @@
 #[cfg(test)]
 mod integ_tests {
+    use std::{convert::TryFrom, env, future::Future, sync::Arc, time::Duration};
+    use temporal_sdk_core::{Core, CoreInitOptions, ServerGatewayApis, ServerGatewayOptions};
+    use url::Url;
+
+    mod polling_tests;
     mod simple_wf_tests;
+
+    const NAMESPACE: &str = "default";
+    type GwApi = Arc<dyn ServerGatewayApis>;
+
+    pub async fn create_workflow(
+        core: &dyn Core,
+        task_q: &str,
+        workflow_id: &str,
+        wf_type: Option<&str>,
+    ) -> String {
+        with_gw(core, |gw: GwApi| async move {
+            gw.start_workflow(
+                NAMESPACE.to_owned(),
+                task_q.to_owned(),
+                workflow_id.to_owned(),
+                wf_type.unwrap_or("test-workflow").to_owned(),
+            )
+            .await
+            .unwrap()
+            .run_id
+        })
+        .await
+    }
+
+    pub async fn with_gw<F: FnOnce(GwApi) -> Fout, Fout: Future>(
+        core: &dyn Core,
+        fun: F,
+    ) -> Fout::Output {
+        let gw = core.server_gateway();
+        fun(gw).await
+    }
+
+    pub fn get_integ_server_options() -> ServerGatewayOptions {
+        let temporal_server_address = match env::var("TEMPORAL_SERVICE_ADDRESS") {
+            Ok(addr) => addr,
+            Err(_) => "http://localhost:7233".to_owned(),
+        };
+        let url = Url::try_from(&*temporal_server_address).unwrap();
+        ServerGatewayOptions {
+            namespace: NAMESPACE.to_string(),
+            identity: "integ_tester".to_string(),
+            worker_binary_id: "".to_string(),
+            long_poll_timeout: Duration::from_secs(60),
+            target_url: url,
+        }
+    }
+
+    pub async fn get_integ_core() -> impl Core {
+        let gateway_opts = get_integ_server_options();
+        temporal_sdk_core::init(CoreInitOptions { gateway_opts })
+            .await
+            .unwrap()
+    }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Pending activations need to take priority over any currently in-progress but not yet completed poll. This fixes that.

## Why?
Cancels of activities were getting lost because of the long poll

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
