### PR TITLE
Activity heartbeat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ prost = "0.7"
 prost-types = "0.7"
 slotmap = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot"] }
+# For the full list of tokio features and what they enable see https://docs.rs/tokio/1.5.0/tokio/#feature-flags
+tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "time"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.12"

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -16,7 +16,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 
-// A request as given to [crate::Core::send_activity_heartbeat]
+// A request as given to [crate::Core::record_activity_heartbeat]
 message ActivityHeartbeat {
     ActivityId activity_id = 1;
     repeated common.Payload details = 2;

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -18,24 +18,8 @@ import "google/protobuf/empty.proto";
 
 // A request as given to [crate::Core::record_activity_heartbeat]
 message ActivityHeartbeat {
-    ActivityId activity_id = 1;
+    bytes task_token = 1;
     repeated common.Payload details = 2;
-}
-
-message ActivityId {
-    oneof id {
-        bytes task_token = 1;
-        ManualCompletionActivityTaskToken manual_completion_task_token = 2;
-    }
-}
-
-message ManualCompletionActivityTaskToken {
-    common.WorkflowExecution workflow_execution = 1;
-    string activity_id = 2;
-}
-
-message RecordActivityHeartbeatResponse {
-    bool cancel_requested = 1;
 }
 
 // A request as given to [crate::Core::complete_activity_task]

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -20,6 +20,7 @@ import "google/protobuf/empty.proto";
 message ActivityHeartbeat {
     bytes task_token = 1;
     repeated common.Payload details = 2;
+    google.protobuf.Duration heartbeat_timeout = 3;
 }
 
 // A request as given to [crate::Core::complete_activity_task]

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -18,8 +18,24 @@ import "google/protobuf/empty.proto";
 
 // A request as given to [crate::Core::send_activity_heartbeat]
 message ActivityHeartbeat {
-    string activity_id = 1;
+    ActivityId activity_id = 1;
     repeated common.Payload details = 2;
+}
+
+message ActivityId {
+    oneof id {
+        bytes task_token = 1;
+        ManualCompletionActivityTaskToken manual_completion_task_token = 2;
+    }
+}
+
+message ManualCompletionActivityTaskToken {
+    common.WorkflowExecution workflow_execution = 1;
+    string activity_id = 2;
+}
+
+message RecordActivityHeartbeatResponse {
+    bool cancel_requested = 1;
 }
 
 // A request as given to [crate::Core::complete_activity_task]

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -80,8 +80,7 @@ impl ActivityHeartbeatManager {
         // 2. join the futures and for any future that becomes ready:
         // - send heartbeat details to the server (if any)
         // - clear details from the local cache
-        // - schedule next task
-        //in case if heartbeat has been sent
+        // - schedule next task in case if heartbeat has been sent, otherwise clear task token from scheduled_heartbeats
         unimplemented!()
     }
 }

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -292,7 +292,7 @@ mod test {
             heartbeat_timeout: Some(Duration::from_millis(1000).into()),
         }) {
             Ok(_) => {
-                assert!(false, "heartbeat should not be recorded after the shutdown")
+                unreachable!("heartbeat should not be recorded after the shutdown")
             }
             Err(e) => {
                 matches!(e, ActivityHeartbeatError::ShuttingDown);
@@ -319,7 +319,7 @@ mod test {
             heartbeat_timeout: None,
         }) {
             Ok(_) => {
-                assert!(false, "heartbeat should not be recorded without timeout")
+                unreachable!("heartbeat should not be recorded without timeout")
             }
             Err(e) => {
                 matches!(e, ActivityHeartbeatError::HeartbeatTimeoutNotSet);

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -106,7 +106,8 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatProcessor<S
         let details = self.heartbeat_rx.borrow().clone();
         let _ = self
             .server_gateway
-            .record_activity_heartbeat(self.task_token.clone(), details.into_payloads());
+            .record_activity_heartbeat(self.task_token.clone(), details.into_payloads())
+            .await;
         loop {
             sleep(self.delay).await;
             let stop = select! {
@@ -123,10 +124,9 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatProcessor<S
                 }
                 _ = self.heartbeat_rx.changed() => {
                     // Received new heartbeat details.
-                    let details = self.heartbeat_rx.borrow();
-                    // TODO see if we can get rid of cloning details.
+                    let details = self.heartbeat_rx.borrow().clone();
                     let _ = self.server_gateway
-                        .record_activity_heartbeat(self.task_token.clone(), details.clone().into_payloads());
+                        .record_activity_heartbeat(self.task_token.clone(), details.into_payloads()).await;
                     false
                 }
             };

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -46,7 +46,10 @@ impl ActivityHeartbeatManager {
         self.heartbeat_details
             .insert(heartbeat.task_token.clone(), heartbeat.details);
 
-        if !self.scheduled_heartbeats.contains(&heartbeat.task_token) {
+        if self
+            .scheduled_heartbeats
+            .insert(heartbeat.task_token.clone())
+        {
             let initial_delay = time::Duration::from_millis(0);
             let heartbeat_timeout: time::Duration = heartbeat
                 .heartbeat_timeout

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -1,0 +1,84 @@
+use crate::errors::ActivityHeartbeatError;
+use crate::protos::coresdk::{common, ActivityHeartbeat};
+use crate::ServerGatewayApis;
+use crossbeam::channel::{bounded, unbounded, Receiver, Select, Sender, TryRecvError};
+use dashmap::{DashMap, DashSet};
+use futures::FutureExt;
+use std::convert::TryInto;
+use std::future::Future;
+use std::ops::Div;
+use std::sync::Arc;
+use std::{thread, time};
+use tokio::time::{sleep, Sleep};
+
+pub(crate) struct ActivityHeartbeatManager {
+    /// Core will aggregate activity heartbeats and send them to the server periodically.
+    /// This map contains latest heartbeat details for each activity that reported them.
+    heartbeat_details: DashMap<Vec<u8>, Vec<common::Payload>>,
+
+    scheduled_heartbeats: DashSet<Vec<u8>>,
+
+    heartbeat_tx: Sender<ActivityHeartbeatTask>,
+
+    shutdown_tx: Sender<bool>,
+}
+
+struct ActivityHeartbeatTask {
+    task_token: Vec<u8>,
+    next_delay: time::Duration,
+    trigger: Sleep,
+}
+
+impl ActivityHeartbeatManager {
+    pub fn new() -> Self {
+        let (heartbeat_tx, heartbeat_rx) = unbounded::<ActivityHeartbeatTask>();
+        let (shutdown_tx, shutdown_rx) = bounded(1);
+        thread::spawn(move || Self::processor(heartbeat_rx, shutdown_rx));
+        Self {
+            heartbeat_details: Default::default(),
+            scheduled_heartbeats: Default::default(),
+            heartbeat_tx,
+            shutdown_tx,
+        }
+    }
+
+    pub fn record(&self, heartbeat: ActivityHeartbeat) -> Result<(), ActivityHeartbeatError> {
+        self.heartbeat_details
+            .insert(heartbeat.task_token.clone(), heartbeat.details);
+
+        if !self.scheduled_heartbeats.contains(&heartbeat.task_token) {
+            let initial_delay = time::Duration::from_millis(0);
+            let heartbeat_timeout: time::Duration = heartbeat
+                .heartbeat_timeout
+                .ok_or(ActivityHeartbeatError::HeartbeatTimeoutNotSet)?
+                .try_into()
+                .or(Err(ActivityHeartbeatError::InvalidHeartbeatTimeout))?;
+            let next_delay = heartbeat_timeout.div(2);
+
+            self.heartbeat_tx
+                .send(ActivityHeartbeatTask {
+                    task_token: heartbeat.task_token,
+                    next_delay,
+                    trigger: sleep(initial_delay),
+                })
+                .expect("failed to send activity task into the channel");
+        };
+
+        Ok(())
+    }
+
+    pub fn shutdown(&self) {
+        self.shutdown_tx.send(true);
+    }
+
+    fn processor(heartbeat_rx: Receiver<ActivityHeartbeatTask>, shutdown_rx: Receiver<bool>) {
+        // TODO this function should:
+        // 1. consume heartbeat tasks
+        // 2. join the futures and for any future that becomes ready:
+        // - send heartbeat details to the server (if any)
+        // - clear details from the local cache
+        // - schedule next task
+        //in case if heartbeat has been sent
+        unimplemented!()
+    }
+}

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -297,6 +297,7 @@ mod test {
         hm.shutdown().await;
     }
 
+    /// Recording new heartbeats after shutdown is not allowed, and will result in error.
     #[tokio::test]
     async fn record_after_shutdown() {
         let mut mock_gateway = MockServerGatewayApis::new();

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -162,26 +162,22 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatProcessor<S
     async fn run(mut self) {
         // Each processor is initialized with heartbeat payloads, first thing we need to do is send it out.
         let details = self.heartbeat_rx.borrow().clone();
-        dbg!("sending heartbeat first time");
         let _ = self
             .server_gateway
             .record_activity_heartbeat(self.task_token.clone(), details.into_payloads())
             .await;
         loop {
-            dbg!("waiting...");
             sleep(self.delay).await;
             let stop = select! {
                 _ = self.shutdown_rx.changed() => {
                     // Shutting down core, need to break the loop. Previous details has been sent,
                     // so there is nothing else to do.
-                    dbg!("shutting down");
                     true
                 }
                 _ = sleep(self.delay) => {
                     // Timed out while waiting for the next heartbeat.
                     // We waited 2 * delay in total, where delay is 1/2 of the activity heartbeat timeout.
                     // This means that activity has either timed out or completed by now.
-                    dbg!("timed out waiting");
                     true
                 }
                 _ = self.heartbeat_rx.changed() => {
@@ -189,7 +185,6 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatProcessor<S
                     let details = self.heartbeat_rx.borrow().clone();
                     let _ = self.server_gateway
                         .record_activity_heartbeat(self.task_token.clone(), details.into_payloads()).await;
-                    dbg!("sending heartbeat after delay");
                     false
                 }
             };

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -86,6 +86,7 @@ impl ActivityHeartbeatManagerHandle {
 }
 
 impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatManager<SG> {
+    #![allow(clippy::new_ret_no_self)]
     pub fn new(sg: Arc<SG>) -> ActivityHeartbeatManagerHandle {
         let (shutdown_tx, shutdown_rx) = channel(false);
         let (heartbeat_tx, heartbeat_rx) = unbounded_channel();
@@ -206,7 +207,7 @@ mod test {
             .times(2);
         let hm = ActivityHeartbeatManager::new(Arc::new(mock_gateway));
         let fake_task_token = vec![1, 2, 3];
-        for i in 0..30 {
+        for i in 0u8..30 {
             sleep(Duration::from_millis(10)).await;
             hm.record(ActivityHeartbeat {
                 task_token: fake_task_token.clone(),

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -39,6 +39,7 @@ struct ActivityHeartbeatProcessorHandle {
     join_handle: JoinHandle<()>,
 }
 
+/// Heartbeat processor, that aggregates and periodically sends heartbeat requests for a single activity to the server.
 struct ActivityHeartbeatProcessor<SG> {
     task_token: Vec<u8>,
     delay: time::Duration,

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -2,21 +2,16 @@ use crate::errors::ActivityHeartbeatError;
 use crate::protos::coresdk::PayloadsExt;
 use crate::protos::coresdk::{common, ActivityHeartbeat};
 use crate::ServerGatewayApis;
-use dashmap::mapref::one::Ref;
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use futures::future::join_all;
-use futures::FutureExt;
-use std::borrow::BorrowMut;
-use std::collections::hash_map::RandomState;
 use std::convert::TryInto;
-use std::future::Future;
 use std::ops::Div;
 use std::sync::Arc;
-use std::{thread, time};
+use std::time;
 use tokio::select;
 use tokio::sync::watch::{channel, Receiver, Sender};
 use tokio::task::JoinHandle;
-use tokio::time::{sleep, Sleep};
+use tokio::time::sleep;
 
 pub(crate) struct ActivityHeartbeatManager<SG> {
     /// Core will aggregate activity heartbeats and send them to the server periodically.

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -3,7 +3,6 @@ use crate::protos::coresdk::PayloadsExt;
 use crate::protos::coresdk::{common, ActivityHeartbeat};
 use crate::ServerGatewayApis;
 use dashmap::DashMap;
-use futures::future::join_all;
 use std::convert::TryInto;
 use std::ops::Div;
 use std::sync::Arc;
@@ -158,7 +157,8 @@ mod test {
                     data: vec![i],
                 }],
                 heartbeat_timeout: Some(Duration::from_millis(1000).into()),
-            });
+            })
+            .expect("hearbeat recording should not fail");
         }
         sleep(Duration::from_secs(1)).await;
         hm.shutdown().await;

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -1,0 +1,3 @@
+mod activity_heartbeat_manager;
+
+pub(crate) use activity_heartbeat_manager::ActivityHeartbeatManager;

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -1,3 +1,4 @@
 mod activity_heartbeat_manager;
 
 pub(crate) use activity_heartbeat_manager::ActivityHeartbeatManager;
+pub(crate) use activity_heartbeat_manager::ActivityHeartbeatManagerHandle;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -151,4 +151,6 @@ pub enum ActivityHeartbeatError {
     HeartbeatTimeoutNotSet,
     #[error("Heartbeat request must contain valid heartbeat timeout.")]
     InvalidHeartbeatTimeout,
+    #[error("New heartbeat requests are not accepted while shutting down")]
+    ShuttingDown,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -143,3 +143,9 @@ pub enum CompleteActivityError {
     #[error("Unhandled error when calling the temporal server: {0:?}")]
     TonicError(#[from] tonic::Status),
 }
+
+/// Errors thrown by [crate::Core::record_activity_heartbeat] and [crate::Core::get_last_activity_heartbeat]
+#[derive(thiserror::Error, Debug)]
+pub enum ActivityHeartbeatError {
+    // TODO populate
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -147,5 +147,8 @@ pub enum CompleteActivityError {
 /// Errors thrown by [crate::Core::record_activity_heartbeat] and [crate::Core::get_last_activity_heartbeat]
 #[derive(thiserror::Error, Debug)]
 pub enum ActivityHeartbeatError {
-    // TODO populate
+    #[error("Heartbeat request must contain heartbeat timeout.")]
+    HeartbeatTimeoutNotSet,
+    #[error("Heartbeat request must contain valid heartbeat timeout.")]
+    InvalidHeartbeatTimeout,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -153,4 +153,6 @@ pub enum ActivityHeartbeatError {
     InvalidHeartbeatTimeout,
     #[error("New heartbeat requests are not accepted while shutting down")]
     ShuttingDown,
+    #[error("Unable to dispatch heartbeat.")]
+    SendError,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1278,7 +1278,7 @@ mod test {
         let res = single_timer_setup.inner.poll_workflow_task().await.unwrap();
         assert_eq!(res.jobs.len(), 1);
 
-        single_timer_setup.inner.shutdown();
+        single_timer_setup.inner.shutdown().await;
         assert_matches!(
             single_timer_setup
                 .inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,7 +407,7 @@ impl<WP: ServerGatewayApis + Send + Sync + 'static> CoreSDK<WP> {
             shutdown_notify: Notify::new(),
             workflow_task_complete_notify: Notify::new(),
             activity_task_complete_notify: Notify::new(),
-            activity_heartbeat_manager: ActivityHeartbeatManager::new(),
+            activity_heartbeat_manager: ActivityHeartbeatManager::new(), // todo pass server gateway
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,12 +120,12 @@ pub trait Core: Send + Sync {
     /// Returns core's instance of the [ServerGatewayApis] implementor it is using.
     fn server_gateway(&self) -> Arc<dyn ServerGatewayApis>;
 
-    /// Eventually ceases all polling of the server. [Core::poll_workflow_task] should be called
-    /// until it returns [PollWfError::ShutDown] to ensure that any workflows which are still
-    /// undergoing replay have an opportunity to finish. This means that the lang sdk will need to
-    /// call [Core::complete_workflow_task] for those workflows until they are done. At that point,
-    /// the lang SDK can end the process, or drop the [Core] instance, which will close the
-    /// connection.
+    /// Initiates async shutdown procedure, eventually ceases all polling of the server.
+    /// [Core::poll_workflow_task] should be called until it returns [PollWfError::ShutDown]
+    /// to ensure that any workflows which are still undergoing replay have an opportunity to finish.
+    /// This means that the lang sdk will need to call [Core::complete_workflow_task] for those
+    /// workflows until they are done. At that point, the lang SDK can end the process,
+    /// or drop the [Core] instance, which will close the connection.
     async fn shutdown(&self);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,7 +407,7 @@ impl<WP: ServerGatewayApis + Send + Sync + 'static> CoreSDK<WP> {
             shutdown_notify: Notify::new(),
             workflow_task_complete_notify: Notify::new(),
             activity_task_complete_notify: Notify::new(),
-            activity_heartbeat_manager: ActivityHeartbeatManager::new(sg), // todo pass server gateway
+            activity_heartbeat_manager: ActivityHeartbeatManager::new(sg.clone()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,14 +400,14 @@ impl<WP: ServerGatewayApis + Send + Sync + 'static> CoreSDK<WP> {
             workflow_task_tokens: Default::default(),
             workflows_last_task_failed: Default::default(),
             outstanding_workflow_tasks: Default::default(),
-            wf_task_poll_buffer: PollWorkflowTaskBuffer::new(sg),
+            wf_task_poll_buffer: PollWorkflowTaskBuffer::new(sg.clone()),
             pending_activations: Default::default(),
             outstanding_activity_tasks: Default::default(),
             shutdown_requested: AtomicBool::new(false),
             shutdown_notify: Notify::new(),
             workflow_task_complete_notify: Notify::new(),
             activity_task_complete_notify: Notify::new(),
-            activity_heartbeat_manager: ActivityHeartbeatManager::new(sg.clone()),
+            activity_heartbeat_manager: ActivityHeartbeatManager::new(sg),
         }
     }
 

--- a/src/pollers/mod.rs
+++ b/src/pollers/mod.rs
@@ -2,6 +2,10 @@ mod poll_buffer;
 
 pub use poll_buffer::PollWorkflowTaskBuffer;
 
+use crate::protos::temporal::api::workflowservice::v1::{
+    RecordActivityTaskHeartbeatByIdRequest, RecordActivityTaskHeartbeatByIdResponse,
+    RecordActivityTaskHeartbeatRequest, RecordActivityTaskHeartbeatResponse,
+};
 use crate::{
     machines::ProtoCommand,
     protos::temporal::api::{
@@ -135,6 +139,27 @@ pub trait ServerGatewayApis {
         task_token: Vec<u8>,
         result: Option<Payloads>,
     ) -> Result<RespondActivityTaskCompletedResponse>;
+
+    /// Report activity task heartbeat by sending details to the server. `task_token` contains activity
+    /// identifier that would've been received from [crate::Core::poll_activity_task] API.
+    /// `result` contains `cancel_requested` flag, which if set to true indicates that activity has been cancelled.
+    async fn record_activity_heartbeat(
+        &self,
+        task_token: Vec<u8>,
+        details: Option<Payloads>,
+    ) -> Result<RecordActivityTaskHeartbeatResponse>;
+
+    /// Report activity task heartbeat by sending details to the server. This function should only be used
+    /// when task token is not available, such as in case of manual completion, otherwise use `record_activity_heartbeat`.
+    /// `activity_id`, `workflow_id` and `run_id` must be set to respective IDs of activity, workflow and workflow run.
+    /// `result` contains `cancel_requested` flag, which if set to true indicates that activity has been cancelled.
+    async fn record_activity_heartbeat_by_id(
+        &self,
+        activity_id: String,
+        workflow_id: String,
+        run_id: String,
+        details: Option<Payloads>,
+    ) -> Result<RecordActivityTaskHeartbeatByIdResponse>;
 
     /// Cancel activity task by sending response to the server. `task_token` contains activity
     /// identifier that would've been received from [crate::Core::poll_activity_task] API. `details`
@@ -282,6 +307,46 @@ impl ServerGatewayApis for ServerGateway {
             .respond_activity_task_completed(RespondActivityTaskCompletedRequest {
                 task_token,
                 result,
+                identity: self.opts.identity.clone(),
+                namespace: self.opts.namespace.clone(),
+            })
+            .await?
+            .into_inner())
+    }
+
+    async fn record_activity_heartbeat(
+        &self,
+        task_token: Vec<u8>,
+        details: Option<Payloads>,
+    ) -> Result<RecordActivityTaskHeartbeatResponse> {
+        Ok(self
+            .service
+            .clone()
+            .record_activity_task_heartbeat(RecordActivityTaskHeartbeatRequest {
+                task_token,
+                details,
+                identity: self.opts.identity.clone(),
+                namespace: self.opts.namespace.clone(),
+            })
+            .await?
+            .into_inner())
+    }
+
+    async fn record_activity_heartbeat_by_id(
+        &self,
+        activity_id: String,
+        workflow_id: String,
+        run_id: String,
+        details: Option<Payloads>,
+    ) -> Result<RecordActivityTaskHeartbeatByIdResponse> {
+        Ok(self
+            .service
+            .clone()
+            .record_activity_task_heartbeat_by_id(RecordActivityTaskHeartbeatByIdRequest {
+                activity_id,
+                details,
+                workflow_id,
+                run_id,
                 identity: self.opts.identity.clone(),
                 namespace: self.opts.namespace.clone(),
             })

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -903,7 +903,7 @@ async fn shutdown_aborts_actively_blocked_poll() {
         core.poll_workflow_task().await.unwrap_err(),
         PollWfError::ShutDown
     );
-    let _ = handle.await;
+    handle.await.unwrap();
     // Ensure double-shutdown doesn't explode
     core.shutdown().await;
     assert_matches!(


### PR DESCRIPTION
Implementation of activity heartbeat in the core SDK, which allows lang-side activities to send heartbeat requests rapidly without hitting server on every request. This is possibly because core would aggregate heartbeat requests for up to 1/2 of heartbeat timeout before sending them to the server. Note that first heartbeat request will be sent immediately if core hasn't seen request for the same task token within 1/2 of the heartbet timeout, this means that first heartbeat request for each activity will be sent immediately. Upon shutdown new heartbeat requests will not be recorded and errors will be returned to the core. Outstanding requests will be drained and sent to the server.