### PR TITLE
Evict workflows after completing a workflow task

### DIFF
--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -22,6 +22,8 @@ message WFActivation {
     string run_id = 3;
     /// The things to do upon activating the workflow
     repeated WFActivationJob jobs = 4;
+    /// True if this activation was internally generated rather than from the server
+    bool from_pending = 5;
 }
 
 message WFActivationJob {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -800,7 +800,6 @@ mod test {
     #[rstest(hist_batches, case::incremental(&[1, 2]), case::replay(&[2]))]
     #[tokio::test]
     async fn scheduled_activity_cancellation_try_cancel(hist_batches: &[usize]) {
-        tracing_init();
         let wfid = "fake_wf_id";
         let activity_id = "fake_activity";
         let signal_id = "signal";
@@ -1062,8 +1061,6 @@ mod test {
     #[rstest(hist_batches, case::incremental(&[1, 2, 3, 4]), case::replay(&[4]))]
     #[tokio::test]
     async fn scheduled_activity_cancellation_wait_for_cancellation(hist_batches: &[usize]) {
-        tracing_init();
-
         let wfid = "fake_wf_id";
         let activity_id = "fake_activity";
         let signal_id = "signal";
@@ -1340,8 +1337,6 @@ mod test {
         #[case] batches: &[usize],
         #[case] evict: EvictionMode,
     ) {
-        tracing_init();
-
         let wfid = "fake_wf_id";
         let timer_id = "timer";
 

--- a/src/machines/test_help/history_builder.rs
+++ b/src/machines/test_help/history_builder.rs
@@ -183,6 +183,12 @@ impl TestHistoryBuilder {
         HistoryInfo::new_from_events(&self.events, Some(to_wf_task_num))
     }
 
+    /// Iterates over the events in this builder to return a [HistoryInfo] representing *all*
+    /// events in the history
+    pub(crate) fn get_full_history_info(&self) -> Result<HistoryInfo, HistoryInfoError> {
+        HistoryInfo::new_from_events(&self.events, None)
+    }
+
     fn build_and_push_event(&mut self, event_type: EventType, attribs: Attributes) {
         self.current_event_id += 1;
         let evt = HistoryEvent {

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -117,17 +117,12 @@ pub(crate) async fn poll_and_reply<'a>(
     let mut run_id = "".to_string();
     let mut evictions = 0;
     let expected_evictions = expect_and_reply.len() - 1;
-    // Counts how many times we have reset the expect/reply iterator
     let mut performed_wft_calls = 0;
 
     'outer: loop {
         let expect_iter = expect_and_reply.iter();
-        warn!("replaying expectations");
 
         for interaction in expect_iter {
-            warn!("Interaction loop");
-            dbg!(&performed_wft_calls);
-            dbg!(&core.expected_wft_calls);
             let (asserter, reply) = interaction;
             let res = core.inner.poll_workflow_task(task_queue).await.unwrap();
             if !res.from_pending {
@@ -151,8 +146,6 @@ pub(crate) async fn poll_and_reply<'a>(
 
             let last_complete_was_failure = !reply.is_success();
 
-            dbg!(&performed_wft_calls);
-            dbg!(&core.expected_wft_calls);
             match eviction_mode {
                 EvictionMode::Sticky => unimplemented!(),
                 EvictionMode::NotSticky => {
@@ -164,7 +157,6 @@ pub(crate) async fn poll_and_reply<'a>(
                         && !core.inner.pending_activations.has_pending(&res.run_id)
                         && !last_complete_was_failure
                     {
-                        warn!("Nosticky not done");
                         continue 'outer;
                     }
                 }

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -52,6 +52,17 @@ pub(crate) fn build_fake_core(
         run_id: run_id.to_string(),
     });
 
+    let full_hist_info = t.get_full_history_info().unwrap();
+    // Ensure no response batch is trying to return more tasks than the history contains
+    for rb_wf_num in response_batches {
+        assert!(
+            *rb_wf_num <= full_hist_info.wf_task_count,
+            "Wf task count {} is not <= total task count {}",
+            rb_wf_num,
+            full_hist_info.wf_task_count
+        );
+    }
+
     let responses: Vec<_> = response_batches
         .iter()
         .map(|to_task_num| {

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -46,6 +46,8 @@ pub(crate) struct WorkflowMachines {
     /// The event id of the started event of the last successfully executed workflow task
     previous_started_event_id: i64,
     /// True if the workflow is replaying from history
+    /// TODO: This seems wrong when I try to use it in contexts I expect it to return true, and
+    ///   is currently unused, but some unimplemented state machines need it so kept for now.
     replaying: bool,
     /// Workflow identifier
     pub workflow_id: String,
@@ -418,6 +420,7 @@ impl WorkflowMachines {
                 run_id: self.run_id.clone(),
                 jobs,
                 task_token: vec![],
+                from_pending: false,
             })
         }
     }

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -24,7 +24,17 @@ pub mod coresdk {
         include!("coresdk.workflow_activation.rs");
     }
     pub mod workflow_completion {
+        use crate::protos::coresdk::workflow_completion::wf_activation_completion::Status;
         include!("coresdk.workflow_completion.rs");
+
+        impl wf_activation_completion::Status {
+            pub fn is_success(&self) -> bool {
+                match &self {
+                    Status::Successful(_) => true,
+                    Status::Failed(_) => false,
+                }
+            }
+        }
     }
     pub mod workflow_commands {
         include!("coresdk.workflow_commands.rs");

--- a/src/protosext/history_info.rs
+++ b/src/protosext/history_info.rs
@@ -10,6 +10,7 @@ pub(crate) struct HistoryInfo {
     // This needs to stay private so the struct can't be instantiated outside of the constructor,
     // which enforces some invariants regarding history structure that need to be upheld.
     events: Vec<HistoryEvent>,
+    pub wf_task_count: usize,
 }
 
 type Result<T, E = HistoryInfoError> = std::result::Result<T, E>;
@@ -42,7 +43,7 @@ impl HistoryInfo {
         let to_wf_task_num = to_wf_task_num.unwrap_or(usize::MAX);
         let mut workflow_task_started_event_id = 0;
         let mut previous_started_event_id = 0;
-        let mut count = 0;
+        let mut wf_task_count = 0;
         let mut history = events.iter().peekable();
         let mut events = vec![];
 
@@ -68,12 +69,13 @@ impl HistoryInfo {
                             workflow_task_started_event_id,
                         });
                     }
-                    count += 1;
-                    if count == to_wf_task_num || next_event.is_none() {
+                    wf_task_count += 1;
+                    if wf_task_count == to_wf_task_num || next_event.is_none() {
                         return Ok(Self {
                             previous_started_event_id,
                             workflow_task_started_event_id,
                             events,
+                            wf_task_count,
                         });
                     }
                 } else if next_event.is_some() && !next_is_failed_or_timeout {
@@ -87,6 +89,7 @@ impl HistoryInfo {
                         previous_started_event_id,
                         workflow_task_started_event_id,
                         events,
+                        wf_task_count,
                     });
                 }
                 // No more events

--- a/src/test_help/canned_histories.rs
+++ b/src/test_help/canned_histories.rs
@@ -465,6 +465,7 @@ pub fn started_activity_timeout(activity_id: &str) -> TestHistoryBuilder {
 /// 7: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
 /// 8: EVENT_TYPE_WORKFLOW_TASK_STARTED
 /// 9: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+/// 11: EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
 pub fn cancel_scheduled_activity_abandon(activity_id: &str, signal_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
@@ -488,6 +489,7 @@ pub fn cancel_scheduled_activity_abandon(activity_id: &str, signal_id: &str) -> 
         }],
     );
     t.add_full_wf_task();
+    t.add_workflow_execution_completed();
     t
 }
 
@@ -501,6 +503,7 @@ pub fn cancel_scheduled_activity_abandon(activity_id: &str, signal_id: &str) -> 
 /// 8: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
 /// 9: EVENT_TYPE_WORKFLOW_TASK_STARTED
 /// 10: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+/// 11: EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
 pub fn cancel_started_activity_abandon(activity_id: &str, signal_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
@@ -535,6 +538,7 @@ pub fn cancel_started_activity_abandon(activity_id: &str, signal_id: &str) -> Te
         }],
     );
     t.add_full_wf_task();
+    t.add_workflow_execution_completed();
     t
 }
 

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -89,9 +89,10 @@ pub(crate) struct NextWfActivation {
 
 impl NextWfActivation {
     /// Attach a task token to the activation so it can be sent out to the lang sdk
-    pub(crate) fn finalize(self, task_token: Vec<u8>) -> WfActivation {
+    pub(crate) fn finalize(self, task_token: Vec<u8>, from_pending: bool) -> WfActivation {
         let mut a = self.activation;
         a.task_token = task_token;
+        a.from_pending = from_pending;
         a
     }
 

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -1107,21 +1107,3 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     .await
     .unwrap();
 }
-
-#[tokio::test]
-async fn long_poll_timeout_is_retried() {
-    let mut gateway_opts = get_integ_server_options();
-    // Server whines unless long poll > 2 seconds
-    gateway_opts.long_poll_timeout = Duration::from_secs(3);
-    let core = temporal_sdk_core::init(CoreInitOptions { gateway_opts })
-        .await
-        .unwrap();
-    // Should block for more than 3 seconds, since we internally retry long poll
-    let (tx, rx) = unbounded();
-    tokio::spawn(async move {
-        core.poll_workflow_task("some_task_q").await.unwrap();
-        tx.send(())
-    });
-    let err = rx.recv_timeout(Duration::from_secs(4)).unwrap_err();
-    assert_matches!(err, RecvTimeoutError::Timeout);
-}

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -1,8 +1,5 @@
-use crate::integ_tests::{
-    create_workflow, get_integ_core, get_integ_server_options, with_gw, GwApi, NAMESPACE,
-};
+use crate::integ_tests::{create_workflow, get_integ_core, with_gw, GwApi, NAMESPACE};
 use assert_matches::assert_matches;
-use crossbeam::channel::{unbounded, RecvTimeoutError};
 use futures::{channel::mpsc::UnboundedReceiver, future, SinkExt, StreamExt};
 use rand::{self, Rng};
 use std::{collections::HashMap, sync::Arc, time::Duration};
@@ -22,7 +19,7 @@ use temporal_sdk_core::{
         workflow_completion::WfActivationCompletion,
         ActivityTaskCompletion,
     },
-    tracing_init, CompleteWfError, Core, CoreInitOptions, PollWfError,
+    tracing_init, CompleteWfError, Core, PollWfError,
 };
 
 // TODO: These tests can get broken permanently if they break one time and the server is not
@@ -81,7 +78,7 @@ async fn activity_workflow() {
     .await
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
-    let task = dbg!(core.poll_activity_task(task_q).await.unwrap());
+    let task = core.poll_activity_task(task_q).await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -145,7 +142,7 @@ async fn activity_non_retryable_failure() {
     .await
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
-    let task = dbg!(core.poll_activity_task(task_q).await.unwrap());
+    let task = core.poll_activity_task(task_q).await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -241,7 +238,7 @@ async fn activity_retry() {
     .await
     .unwrap();
     // Poll 2nd time
-    let task = dbg!(core.poll_activity_task(task_q).await.unwrap());
+    let task = core.poll_activity_task(task_q).await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -689,7 +686,7 @@ async fn timer_cancel_workflow() {
     ))
     .await
     .unwrap();
-    let task = dbg!(core.poll_workflow_task(task_q).await.unwrap());
+    let task = core.poll_workflow_task(task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
         vec![
             CancelTimer {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -55,8 +55,11 @@ mod integ_tests {
 
     pub async fn get_integ_core() -> impl Core {
         let gateway_opts = get_integ_server_options();
-        temporal_sdk_core::init(CoreInitOptions { gateway_opts })
-            .await
-            .unwrap()
+        temporal_sdk_core::init(CoreInitOptions {
+            gateway_opts,
+            evict_after_pending_cleared: false,
+        })
+        .await
+        .unwrap()
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Workflows are evicted from the cache as soon as they have no more pending activations

## Why?
Until real sticky task queues are implemented, and we have a proper LRU eviction policy, we need some way to make sure workers don't eat up memory forever, and this is equivalent to the "non sticky" queues in existing SDKs.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
