### PR TITLE
Buffer poll results rather than cancelling the poll for pending activations

### DIFF
--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -166,7 +166,7 @@ pub(crate) async fn poll_and_reply<'a>(
 
             core.inner
                 .complete_workflow_task(WfActivationCompletion::from_status(
-                    task_tok,
+                    task_tok.clone(),
                     reply.clone(),
                 ))
                 .await
@@ -194,7 +194,7 @@ pub(crate) async fn poll_and_reply<'a>(
                 }
                 EvictionMode::AfterEveryReply => {
                     if evictions < expected_evictions {
-                        core.inner.evict_run(&run_id);
+                        core.inner.evict_run(&task_tok);
                         evictions += 1;
                         continue 'outer;
                     }

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -126,7 +126,7 @@ pub fn hist_to_poll_resp(
     let task_token: [u8; 16] = thread_rng().gen();
     PollWorkflowTaskQueueResponse {
         history: Some(History { events: batch }),
-        workflow_execution: Some(wf.clone()),
+        workflow_execution: Some(wf),
         task_token: task_token.to_vec(),
         ..Default::default()
     }

--- a/src/pollers/mod.rs
+++ b/src/pollers/mod.rs
@@ -1,5 +1,7 @@
 mod poll_buffer;
 
+pub use poll_buffer::PollWorkflowTaskBuffer;
+
 use crate::{
     machines::ProtoCommand,
     protos::temporal::api::{

--- a/src/pollers/poll_buffer.rs
+++ b/src/pollers/poll_buffer.rs
@@ -6,13 +6,14 @@ use futures::{stream::repeat_with, Stream, StreamExt};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-struct PollWorkflowTaskBuffer {
-    buffered_polls:
-        Mutex<Box<dyn Stream<Item = pollers::Result<PollWorkflowTaskQueueResponse>> + Unpin>>,
+pub struct PollWorkflowTaskBuffer {
+    buffered_polls: Mutex<
+        Box<dyn Stream<Item = pollers::Result<PollWorkflowTaskQueueResponse>> + Unpin + Send>,
+    >,
 }
 
 impl PollWorkflowTaskBuffer {
-    pub fn new(sg: Arc<impl ServerGatewayApis + 'static>) -> Self {
+    pub fn new(sg: Arc<impl ServerGatewayApis + Send + Sync + 'static>) -> Self {
         // This is not the world's most efficient thing, but given we're wrapping IO it's unlikely
         // to be of any significance.
         let pbuff = repeat_with(move || {

--- a/src/pollers/poll_buffer.rs
+++ b/src/pollers/poll_buffer.rs
@@ -1,0 +1,84 @@
+use crate::{
+    pollers, protos::temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse,
+    ServerGatewayApis,
+};
+use futures::{stream::repeat_with, Stream, StreamExt};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+struct PollWorkflowTaskBuffer {
+    buffered_polls:
+        Mutex<Box<dyn Stream<Item = pollers::Result<PollWorkflowTaskQueueResponse>> + Unpin>>,
+}
+
+impl PollWorkflowTaskBuffer {
+    pub fn new(sg: Arc<impl ServerGatewayApis + 'static>) -> Self {
+        // This is not the world's most efficient thing, but given we're wrapping IO it's unlikely
+        // to be of any significance.
+        let pbuff = repeat_with(move || {
+            let sg = sg.clone();
+            async move { sg.poll_workflow_task().await }
+        })
+        .buffered(1);
+        Self {
+            buffered_polls: Mutex::new(Box::new(pbuff)),
+        }
+    }
+
+    // TODO: Task queue.
+    pub async fn poll_workflow_task(&self) -> pollers::Result<PollWorkflowTaskQueueResponse> {
+        let mut locked = self.buffered_polls.lock().await;
+        (*locked)
+            .next()
+            .await
+            .expect("There is always another item in the stream")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pollers::manual_mock::MockManualGateway;
+    use futures::FutureExt;
+    use std::time::Duration;
+    use tokio::{select, sync::mpsc::channel};
+
+    #[tokio::test]
+    async fn only_polls_once() {
+        let mut mock_gateway = MockManualGateway::new();
+        mock_gateway
+            .expect_poll_workflow_task()
+            .times(2)
+            .returning(move || {
+                async {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    Ok(Default::default())
+                }
+                .boxed()
+            });
+        let mock_gateway = Arc::new(mock_gateway);
+
+        let pb = PollWorkflowTaskBuffer::new(mock_gateway);
+
+        // Poll a bunch of times, "interrupting" it each time, we should only actually have polled
+        // once since the poll takes a while
+        let (interrupter_tx, mut interrupter_rx) = channel(50);
+        for _ in 0..10 {
+            interrupter_tx.send(()).await.unwrap();
+        }
+
+        let mut last_val = false;
+        for _ in 0..11 {
+            select! {
+                _ = interrupter_rx.recv() => {
+                }
+                _ = pb.poll_workflow_task() => {
+                    last_val = true;
+                }
+            }
+        }
+        assert!(last_val);
+        // Now we poll for the second time here, fulfilling our 2 times expectation
+        pb.poll_workflow_task().await.unwrap();
+    }
+}

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -84,6 +84,7 @@ impl WorkflowManager {
 pub(crate) struct NextWfActivation {
     /// Keep this private, so we can ensure task tokens are attached via [Self::finalize]
     activation: WfActivation,
+    // TODO: Becomes unneeded?
     pub more_activations_needed: bool,
 }
 
@@ -95,15 +96,12 @@ impl NextWfActivation {
         a.from_pending = from_pending;
         a
     }
-
-    pub(crate) fn get_run_id(&self) -> &str {
-        &self.activation.run_id
-    }
 }
 
 #[derive(Debug)]
 pub(crate) struct PushCommandsResult {
     pub server_commands: Vec<ProtoCommand>,
+    // TODO: Becomes unneeded?
     pub has_new_lang_jobs: bool,
 }
 
@@ -140,6 +138,7 @@ impl WorkflowManager {
         self.machines.apply_history_events(&task_hist)?;
         let activation = self.machines.get_wf_activation();
 
+        // TODO: Only increment this if there is an activation?
         self.current_wf_task_num += 1;
         let more_activations_needed = self.current_wf_task_num <= self.last_history_task_count;
         if more_activations_needed {

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -17,7 +17,7 @@ use temporal_sdk_core::protos::coresdk::{
 use temporal_sdk_core::{Core, CoreInitOptions};
 
 #[tokio::test]
-async fn long_poll_interrupted_by_new_pending_activation() {
+async fn poll_blocks_until_wft_completed() {
     let mut rng = rand::thread_rng();
     let task_q_salt: u32 = rng.gen();
     let task_q = format!("activity_cancelled_workflow_{}", task_q_salt.to_string());

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -19,7 +19,7 @@ use temporal_sdk_core::{
         workflow_completion::WfActivationCompletion,
         ActivityTaskCompletion,
     },
-    tracing_init, CompleteWfError, Core, PollWfError,
+    CompleteWfError, Core, PollWfError,
 };
 
 // TODO: These tests can get broken permanently if they break one time and the server is not
@@ -458,8 +458,6 @@ async fn started_activity_timeout() {
 
 #[tokio::test]
 async fn activity_cancellation_wait_cancellation_completed() {
-    tracing_init();
-
     let mut rng = rand::thread_rng();
     let task_q_salt: u32 = rng.gen();
     let task_q = &format!("activity_cancelled_workflow_{}", task_q_salt.to_string());
@@ -535,8 +533,6 @@ async fn activity_cancellation_wait_cancellation_completed() {
 
 #[tokio::test]
 async fn activity_cancellation_abandon() {
-    tracing_init();
-
     let mut rng = rand::thread_rng();
     let task_q_salt: u32 = rng.gen();
     let task_q = &format!("activity_cancelled_workflow_{}", task_q_salt.to_string());

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -38,7 +38,7 @@ mod integ_tests {
         fun(gw).await
     }
 
-    pub fn get_integ_server_options() -> ServerGatewayOptions {
+    pub fn get_integ_server_options(task_q: &str) -> ServerGatewayOptions {
         let temporal_server_address = match env::var("TEMPORAL_SERVICE_ADDRESS") {
             Ok(addr) => addr,
             Err(_) => "http://localhost:7233".to_owned(),
@@ -46,6 +46,7 @@ mod integ_tests {
         let url = Url::try_from(&*temporal_server_address).unwrap();
         ServerGatewayOptions {
             namespace: NAMESPACE.to_string(),
+            task_queue: task_q.to_string(),
             identity: "integ_tester".to_string(),
             worker_binary_id: "".to_string(),
             long_poll_timeout: Duration::from_secs(60),
@@ -53,8 +54,8 @@ mod integ_tests {
         }
     }
 
-    pub async fn get_integ_core() -> impl Core {
-        let gateway_opts = get_integ_server_options();
+    pub async fn get_integ_core(task_q: &str) -> impl Core {
+        let gateway_opts = get_integ_server_options(task_q);
         temporal_sdk_core::init(CoreInitOptions {
             gateway_opts,
             evict_after_pending_cleared: false,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -58,6 +58,8 @@ mod integ_tests {
         temporal_sdk_core::init(CoreInitOptions {
             gateway_opts,
             evict_after_pending_cleared: false,
+            // TODO: Configurable / sensible number
+            max_outstanding_workflow_tasks: 5,
         })
         .await
         .unwrap()

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -59,7 +59,6 @@ mod integ_tests {
         temporal_sdk_core::init(CoreInitOptions {
             gateway_opts,
             evict_after_pending_cleared: false,
-            // TODO: Configurable / sensible number
             max_outstanding_workflow_tasks: 5,
         })
         .await


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Buffer polls rather than cancelling them when a new pending activation comes in that must be handed out first. Also limit the number of concurrent workflow tasks that may be in flight at one time, and use a per-core-instance task queue rather that per-poll.

## Why?
Avoid the PA interrupt problem stated in https://github.com/temporalio/sdk-core/issues/91 without the bigger API changes in https://github.com/temporalio/sdk-core/pull/96 .

However, I'm still of the opinion the different API design is ultimately simpler

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 


2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
