### PR TITLE
Target c5-2xl workers in builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,6 +25,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
+      aws:instance-type: "c5a.2xlarge"
     command: "cargo clippy --workspace --all-features --all-targets -- -D warnings && cargo clippy --test integ_tests --all-features -- --D warnings"
     timeout_in_minutes: 15
     plugins:
@@ -35,6 +36,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
+      aws:instance-type: "c5a.2xlarge"
     command: "cargo tarpaulin --out Html --workspace && cargo test -- --include-ignored"
     artifact_paths:
       - "tarpaulin-report.html"
@@ -48,6 +50,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
+      aws:instance-type: "c5a.2xlarge"
     command: "cargo test --test integ_tests"
     timeout_in_minutes: 15
     plugins:


### PR DESCRIPTION
We have t3-s workers in the mix, alongside c5-s, core builds time out on t3s, this PR sets configuration that should target c5-s for build/test/lint