### PR TITLE
Return evictions to lang and also combine pending activity jobs

### DIFF
--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -42,6 +42,13 @@ message WFActivationJob {
         SignalWorkflow signal_workflow = 7;
         /// An activity was resolved with, result could be completed, failed or cancelled
         ResolveActivity resolve_activity = 8;
+
+        /// Remove the workflow identified by the [WFActivation] containing this job from the cache
+        /// after performing the activation.
+        ///
+        /// If other job variant are present in the list, this variant must be the last job in the
+        /// job list. The actual value is irrelevant, and should always be true.
+        bool remove_from_cache = 50;
     }
 }
 

--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -44,8 +44,9 @@ message WFActivationJob {
         /// Remove the workflow identified by the [WFActivation] containing this job from the cache
         /// after performing the activation.
         ///
-        /// If other job variant are present in the list, this variant must be the last job in the
-        /// job list. The actual value is irrelevant, and should always be true.
+        /// If other job variant are present in the list, this variant will be the last job in the
+        /// job list. The boolean value is irrelevant, since the variant type is what matters. It
+        /// will be set to true if this is the variant.
         bool remove_from_cache = 50;
     }
 }

--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -22,8 +22,6 @@ message WFActivation {
     string run_id = 3;
     /// The things to do upon activating the workflow
     repeated WFActivationJob jobs = 4;
-    /// True if this activation was internally generated rather than from the server
-    bool from_pending = 5;
 }
 
 message WFActivationJob {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,9 +430,8 @@ impl<WP: ServerGatewayApis + Send + Sync + 'static> CoreSDK<WP> {
         &self,
         next_a: NextWfActivation,
         task_token: Vec<u8>,
-        from_pending: bool,
     ) -> WfActivation {
-        next_a.finalize(task_token, from_pending)
+        next_a.finalize(task_token)
     }
 
     /// Given a wf task from the server, prepare an activation (if there is one) to be sent to lang
@@ -453,7 +452,7 @@ impl<WP: ServerGatewayApis + Send + Sync + 'static> CoreSDK<WP> {
         let next_activation = self.instantiate_or_update_workflow(work)?;
 
         if let Some(na) = next_activation {
-            return Ok(Some(self.finalize_next_activation(na, task_token, false)));
+            return Ok(Some(self.finalize_next_activation(na, task_token)));
         }
         Ok(None)
     }
@@ -628,11 +627,8 @@ impl<WP: ServerGatewayApis + Send + Sync + 'static> CoreSDK<WP> {
         if let Some(next_activation) =
             self.access_wf_machine(run_id, move |mgr| mgr.get_next_activation())?
         {
-            self.pending_activations.push(self.finalize_next_activation(
-                next_activation,
-                task_token,
-                true,
-            ));
+            self.pending_activations
+                .push(self.finalize_next_activation(next_activation, task_token));
         }
         self.workflow_task_complete_notify.notify_one();
         Ok(())

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -420,7 +420,6 @@ impl WorkflowMachines {
                 run_id: self.run_id.clone(),
                 jobs,
                 task_token: vec![],
-                from_pending: false,
             })
         }
     }

--- a/src/pending_activations.rs
+++ b/src/pending_activations.rs
@@ -122,7 +122,7 @@ mod tests {
             ..Default::default()
         });
         pas.push(WfActivation {
-            run_id: rid.clone(),
+            run_id: rid,
             task_token: vec![9],
             ..Default::default()
         });

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -31,6 +31,17 @@ pub mod coresdk {
     }
     pub mod workflow_activation {
         include!("coresdk.workflow_activation.rs");
+        pub fn create_evict_activation(task_token: Vec<u8>, run_id: String) -> WfActivation {
+            WfActivation {
+                task_token,
+                timestamp: None,
+                run_id,
+                jobs: vec![WfActivationJob::from(
+                    wf_activation_job::Variant::RemoveFromCache(true),
+                )],
+                from_pending: true,
+            }
+        }
     }
     pub mod workflow_completion {
         use crate::protos::coresdk::workflow_completion::wf_activation_completion::Status;

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -39,7 +39,6 @@ pub mod coresdk {
                 jobs: vec![WfActivationJob::from(
                     wf_activation_job::Variant::RemoveFromCache(true),
                 )],
-                from_pending: true,
             }
         }
     }

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -90,10 +90,9 @@ pub(crate) struct NextWfActivation {
 
 impl NextWfActivation {
     /// Attach a task token to the activation so it can be sent out to the lang sdk
-    pub(crate) fn finalize(self, task_token: Vec<u8>, from_pending: bool) -> WfActivation {
+    pub(crate) fn finalize(self, task_token: Vec<u8>) -> WfActivation {
         let mut a = self.activation;
         a.task_token = task_token;
-        a.from_pending = from_pending;
         a
     }
 }

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -951,6 +951,15 @@ async fn fail_wf_task() {
     // The server will want to retry the task. This time we finish the workflow -- but we need
     // to poll a couple of times as there will be more than one required workflow activation.
     let task = core.poll_workflow_task().await.unwrap();
+    // The first poll response will tell us to evict
+    assert_matches!(
+        task.jobs.as_slice(),
+        [WfActivationJob {
+            variant: Some(wf_activation_job::Variant::RemoveFromCache(_)),
+        }]
+    );
+    // So poll again
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
         vec![StartTimer {
             timer_id: "best-timer".to_string(),

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -291,7 +291,7 @@ async fn activity_heartbeat() {
     let task_q_salt: u32 = rng.gen();
     let task_q = &format!("activity_workflow_{}", task_q_salt.to_string());
     let core = get_integ_core(task_q).await;
-    let workflow_id: u32 = dbg!(rng.gen());
+    let workflow_id: u32 = rng.gen();
     create_workflow(&core, task_q, &workflow_id.to_string(), None).await;
     let activity_id: String = rng.gen::<u32>().to_string();
     let task = core.poll_workflow_task().await.unwrap();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Evictions are now sent to lang -- new pending activities that get queued will collapse jobs if there is already a pending activity with the same ID.

## Why?
Need to tell lang about cache evictions

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
