### PR TITLE
Remove heartbeat timeout from core heartbeat API

### DIFF
--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -20,7 +20,6 @@ import "google/protobuf/empty.proto";
 message ActivityHeartbeat {
     bytes task_token = 1;
     repeated common.Payload details = 2;
-    google.protobuf.Duration heartbeat_timeout = 3;
 }
 
 // A request as given to [crate::Core::complete_activity_task]

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -7,10 +7,9 @@ use crate::{
     ServerGatewayApis,
 };
 use crossbeam::channel as cb_channel;
+use std::time::Duration;
 use std::{
     collections::HashMap,
-    convert::TryInto,
-    ops::Div,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -99,18 +98,16 @@ impl ActivityHeartbeatManagerHandle {
     /// and then latest heartbeat details will be sent to the server. If there is no activity for
     /// 1/2 of the heartbeat timeout then heartbeat processor will be reset and process would start
     /// over again, meaning that next heartbeat will be sent immediately.
-    pub fn record(&self, details: ActivityHeartbeat) -> Result<(), ActivityHeartbeatError> {
-        let heartbeat_timeout: time::Duration = details
-            .heartbeat_timeout
-            .ok_or(ActivityHeartbeatError::HeartbeatTimeoutNotSet)?
-            .try_into()
-            .or(Err(ActivityHeartbeatError::InvalidHeartbeatTimeout))?;
-
+    pub fn record(
+        &self,
+        details: ActivityHeartbeat,
+        delay: Duration,
+    ) -> Result<(), ActivityHeartbeatError> {
         self.events
             .send(LifecycleEvent::Heartbeat(ValidActivityHeartbeat {
                 task_token: details.task_token,
                 details: details.details,
-                delay: heartbeat_timeout.div(2),
+                delay,
             }))
             .map_err(|_| ActivityHeartbeatError::SendError)?;
 
@@ -349,14 +346,16 @@ mod test {
             .times(0);
         let hm = ActivityHeartbeatManager::new(Arc::new(mock_gateway));
         hm.shutdown().await;
-        match hm.record(ActivityHeartbeat {
-            task_token: vec![1, 2, 3],
-            details: vec![Payload {
-                // payload doesn't matter in this case, as it shouldn't get sent anyways.
-                ..Default::default()
-            }],
-            heartbeat_timeout: Some(Duration::from_millis(1000).into()),
-        }) {
+        match hm.record(
+            ActivityHeartbeat {
+                task_token: vec![1, 2, 3],
+                details: vec![Payload {
+                    // payload doesn't matter in this case, as it shouldn't get sent anyways.
+                    ..Default::default()
+                }],
+            },
+            Duration::from_millis(1000),
+        ) {
             Ok(_) => {
                 unreachable!("heartbeat should not be recorded after the shutdown")
             }
@@ -366,48 +365,22 @@ mod test {
         }
     }
 
-    /// Ensure that error is returned if heartbeat timeout is not set. Heartbeat timeout is required
-    /// because it's used to derive aggregation delay.
-    #[tokio::test]
-    async fn record_without_heartbeat_timeout() {
-        let mut mock_gateway = MockServerGatewayApis::new();
-        mock_gateway
-            .expect_record_activity_heartbeat()
-            .returning(|_, _| Ok(RecordActivityTaskHeartbeatResponse::default()))
-            .times(0);
-        let hm = ActivityHeartbeatManager::new(Arc::new(mock_gateway));
-        match hm.record(ActivityHeartbeat {
-            task_token: vec![1, 2, 3],
-            details: vec![Payload {
-                // payload doesn't matter in this case, as it shouldn't get sent anyways.
-                ..Default::default()
-            }],
-            heartbeat_timeout: None,
-        }) {
-            Ok(_) => {
-                unreachable!("heartbeat should not be recorded without timeout")
-            }
-            Err(e) => {
-                matches!(e, ActivityHeartbeatError::HeartbeatTimeoutNotSet);
-            }
-        }
-        hm.shutdown().await;
-    }
-
     fn record_heartbeat(
         hm: &ActivityHeartbeatManagerHandle,
         task_token: Vec<u8>,
         i: u8,
         delay: Duration,
     ) {
-        hm.record(ActivityHeartbeat {
-            task_token,
-            details: vec![Payload {
-                metadata: Default::default(),
-                data: vec![i],
-            }],
-            heartbeat_timeout: Some(delay.into()),
-        })
+        hm.record(
+            ActivityHeartbeat {
+                task_token,
+                details: vec![Payload {
+                    metadata: Default::default(),
+                    data: vec![i],
+                }],
+            },
+            delay,
+        )
         .expect("hearbeat recording should not fail");
     }
 }

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -94,10 +94,10 @@ pub struct ValidActivityHeartbeat {
 /// sent to all processors, which allows them to complete gracefully.
 impl ActivityHeartbeatManagerHandle {
     /// Records a new heartbeat, note that first call would result in an immediate call to the
-    /// server, while rapid successive calls would accumulate for up to 1/2 of the heartbeat timeout
+    /// server, while rapid successive calls would accumulate for up to `delay`
     /// and then latest heartbeat details will be sent to the server. If there is no activity for
-    /// 1/2 of the heartbeat timeout then heartbeat processor will be reset and process would start
-    /// over again, meaning that next heartbeat will be sent immediately.
+    /// `delay` then heartbeat processor will be reset and process would start
+    /// over again, meaning that next heartbeat will be sent immediately, creating a new processor.
     pub fn record(
         &self,
         details: ActivityHeartbeat,

--- a/src/activity/details.rs
+++ b/src/activity/details.rs
@@ -1,13 +1,8 @@
 use prost_types::Duration;
 
 /// Contains minimal set of details that core needs to store, while activity is running.
+#[derive(derive_more::Constructor)]
 pub(crate) struct InflightActivityDetails {
     /// Used to calculate aggregation delay between activity heartbeats.
     pub heartbeat_timeout: Option<Duration>,
-}
-
-impl InflightActivityDetails {
-    pub fn new(heartbeat_timeout: Option<Duration>) -> Self {
-        Self { heartbeat_timeout }
-    }
 }

--- a/src/activity/details.rs
+++ b/src/activity/details.rs
@@ -1,0 +1,13 @@
+use prost_types::Duration;
+
+/// Contains minimal set of details that core needs to store, while activity is running.
+pub(crate) struct InflightActivityDetails {
+    /// Used to calculate aggregation delay between activity heartbeats.
+    pub heartbeat_timeout: Option<Duration>,
+}
+
+impl InflightActivityDetails {
+    pub fn new(heartbeat_timeout: Option<Duration>) -> Self {
+        Self { heartbeat_timeout }
+    }
+}

--- a/src/activity/details.rs
+++ b/src/activity/details.rs
@@ -3,6 +3,7 @@ use prost_types::Duration;
 /// Contains minimal set of details that core needs to store, while activity is running.
 #[derive(derive_more::Constructor)]
 pub(crate) struct InflightActivityDetails {
+    pub activity_id: String,
     /// Used to calculate aggregation delay between activity heartbeats.
     pub heartbeat_timeout: Option<Duration>,
 }

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -1,4 +1,6 @@
 mod activity_heartbeat_manager;
+mod details;
 
 pub(crate) use activity_heartbeat_manager::ActivityHeartbeatManager;
 pub(crate) use activity_heartbeat_manager::ActivityHeartbeatManagerHandle;
+pub(crate) use details::InflightActivityDetails;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -149,9 +149,9 @@ pub enum CompleteActivityError {
 pub enum ActivityHeartbeatError {
     #[error("Heartbeat has been sent for activity that either completed or never started on this worker.")]
     UnknownActivity,
-    #[error("Heartbeat request must contain heartbeat timeout.")]
+    #[error("Heartbeat is only allowed on activities with heartbeat timeout.")]
     HeartbeatTimeoutNotSet,
-    #[error("Heartbeat request must contain valid heartbeat timeout.")]
+    #[error("Unable to parse activity heartbeat timeout.")]
     InvalidHeartbeatTimeout,
     #[error("New heartbeat requests are not accepted while shutting down")]
     ShuttingDown,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -147,6 +147,8 @@ pub enum CompleteActivityError {
 /// Errors thrown by [crate::Core::record_activity_heartbeat] and [crate::Core::get_last_activity_heartbeat]
 #[derive(thiserror::Error, Debug)]
 pub enum ActivityHeartbeatError {
+    #[error("Heartbeat has been sent for activity that either completed or never started on this worker.")]
+    UnknownActivity,
     #[error("Heartbeat request must contain heartbeat timeout.")]
     HeartbeatTimeoutNotSet,
     #[error("Heartbeat request must contain valid heartbeat timeout.")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1726,6 +1726,7 @@ mod test {
                 Ok(PollActivityTaskQueueResponse {
                     task_token: vec![1],
                     activity_id: "act1".to_string(),
+                    heartbeat_timeout: Some(Duration::from_secs(1).into()),
                     ..Default::default()
                 })
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1752,7 +1752,6 @@ mod test {
         core.record_activity_heartbeat(ActivityHeartbeat {
             task_token: act.task_token,
             details: vec![vec![1u8, 2, 3].into()],
-            heartbeat_timeout: Some(Duration::from_secs(1).into()),
         })
         .await
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@ where
         // That's why we treat 0 the same way as None, otherwise we wouldn't know which aggregation
         // delay to use, and using 0 is not a good idea as SDK would hammer the server too hard.
         if t.as_millis() == 0 {
-            Err(ActivityHeartbeatError::HeartbeatTimeoutNotSet)?;
+            return Err(ActivityHeartbeatError::HeartbeatTimeoutNotSet);
         }
         self.activity_heartbeat_manager_handle
             .record(details, t.div(2))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,13 +107,15 @@ pub trait Core: Send + Sync {
     /// `activity_heartbeat_timeout` to finish must call this function in order to report progress,
     /// otherwise activity will timeout and new attempt will be scheduled.
     /// `result` contains latest known activity cancelation status.
-    /// Note that heartbeat requests are getting batched and are sent to the server periodically,
-    /// this function is going to return immediately and request will be queued in the core.
+    /// First heartbeat request will be sent immediately, sub-sequent rapid calls to this
+    /// function would result in heartbeat requests being aggregated and the last one received during
+    /// the aggregation period will be sent to the server.
     /// Unlike java/go SDKs we are not going to return cancellation status as part of heartbeat response
     /// and instead will send it as a separate activity task to the lang, decoupling heartbeat and
     /// cancellation processing.
     /// For now activity still needs to heartbeat if it wants to receive cancellation requests.
     /// In the future we are going to change this and will dispatch cancellations more proactively.
+    /// Note that this function is not blocking on the server call and will return immediately.
     async fn record_activity_heartbeat(
         &self,
         details: ActivityHeartbeat,

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -14,10 +14,10 @@ pub mod coresdk {
         tonic::include_proto!("coresdk.activity_task");
 
         impl ActivityTask {
-            pub fn from_task_token(task_token: Vec<u8>) -> Self {
+            pub fn from_ids(task_token: Vec<u8>, activity_id: String) -> Self {
                 ActivityTask {
                     task_token,
-                    activity_id: "".to_string(),
+                    activity_id,
                     variant: Some(activity_task::Variant::Cancel(Cancel {})),
                 }
             }

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -322,7 +322,6 @@ async fn activity_heartbeat() {
         core.record_activity_heartbeat(ActivityHeartbeat {
             task_token: task.task_token.clone(),
             details: vec![],
-            heartbeat_timeout: Some(Duration::from_secs(1).into()),
         })
         .await
         .unwrap();


### PR DESCRIPTION
This change makes core memorize heartbeat timeout from the poll activity task response, rather than require it from the lang side.