### PR TITLE
Handling server errors during heartbeat

### DIFF
--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -290,16 +290,16 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatProcessor<S
                 Err(e) => {
                     warn!("Error when recording heartbeat: {:?}", e);
                     match e.code() {
-                        Code::InvalidArgument => {
+                        Code::NotFound => {
                             self.errors_tx
                                 .send((
                                     self.task_token.clone(),
-                                    ActivityHeartbeatError::NonRetryableServerError(e),
+                                    ActivityHeartbeatError::UnknownActivity,
                                 ))
                                 .expect("errors should not be dropped");
                             break;
                         }
-                        Code::NotFound => {
+                        Code::InvalidArgument => {
                             self.errors_tx
                                 .send((
                                     self.task_token.clone(),

--- a/src/activity/details.rs
+++ b/src/activity/details.rs
@@ -1,3 +1,4 @@
+use crate::errors::ActivityHeartbeatError;
 use prost_types::Duration;
 
 /// Contains minimal set of details that core needs to store, while activity is running.
@@ -6,4 +7,6 @@ pub(crate) struct InflightActivityDetails {
     pub activity_id: String,
     /// Used to calculate aggregation delay between activity heartbeats.
     pub heartbeat_timeout: Option<Duration>,
+    /// Last heartbeat error.
+    pub last_heartbeat_error: Option<ActivityHeartbeatError>,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use crate::{
     workflow::WorkflowError,
 };
 use tonic::codegen::http::uri::InvalidUri;
+use tonic::Status;
 
 pub(crate) struct ShutdownErr;
 pub(crate) struct WorkflowUpdateError {
@@ -145,7 +146,7 @@ pub enum CompleteActivityError {
 }
 
 /// Errors thrown by [crate::Core::record_activity_heartbeat] and [crate::Core::get_last_activity_heartbeat]
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum ActivityHeartbeatError {
     #[error("Heartbeat has been sent for activity that either completed or never started on this worker.")]
     UnknownActivity,
@@ -157,4 +158,6 @@ pub enum ActivityHeartbeatError {
     ShuttingDown,
     #[error("Unable to dispatch heartbeat.")]
     SendError,
+    #[error("Attempt to send heartbeat has been made but server has returned an error.")]
+    NonRetryableServerError(Status),
 }


### PR DESCRIPTION
This PR adds handling for server errors during activity heartbeat.
Some errors will be retried, while others will be propagated back to the user.
Error dispatch is similar to cancellation dispatch that comes as part of the heartbeat.
I copied current behavior [from java](https://github.com/temporalio/sdk-java/blob/86189b209f18f3d906de8bbd7f7ce2aaadec6414/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityExecutionContextImpl.java#L221), but I think there is some room for improvement in terms of retry strategy.