### PR TITLE
Need to interrupt polling when activity cancels come in

### DIFF
--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -263,6 +263,11 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatProcessor<S
                     let _ = self.cancels_tx.send(self.task_token.clone());
                 }
             }
+            // Send cancels for any activity that learns its workflow already finished (which is
+            // one thing not found implies - other reasons would seem equally valid).
+            Err(s) if s.code() == tonic::Code::NotFound => {
+                let _ = self.cancels_tx.send(self.task_token.clone());
+            }
             Err(e) => {
                 warn!("Error when recording heartbeat: {:?}", e)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,9 +378,7 @@ where
         };
         let (res, should_remove) = match maybe_net_err {
             Some(e) if e.code() == tonic::Code::NotFound => {
-                // TODO: Does this make sense? Lang might care if, ex, it's wasting effort somehow
-                //  doing activities that don't exist, though in theory it'd be our fault for
-                //  telling them they do.
+                warn!(task_token = ?tt, details = ?e, "Activity not found on completion");
                 (Ok(()), true)
             }
             Some(err) => (Err(err), false),

--- a/src/pollers/mod.rs
+++ b/src/pollers/mod.rs
@@ -1,6 +1,9 @@
 mod poll_buffer;
 
-pub use poll_buffer::PollWorkflowTaskBuffer;
+pub use poll_buffer::{
+    new_activity_task_buffer, new_workflow_task_buffer, PollActivityTaskBuffer,
+    PollWorkflowTaskBuffer,
+};
 
 use crate::protos::temporal::api::workflowservice::v1::{
     RecordActivityTaskHeartbeatRequest, RecordActivityTaskHeartbeatResponse,

--- a/src/pollers/mod.rs
+++ b/src/pollers/mod.rs
@@ -407,6 +407,9 @@ impl ServerGatewayApis for ServerGateway {
 }
 
 #[cfg(test)]
+pub use manual_mock::MockManualGateway;
+
+#[cfg(test)]
 mod manual_mock {
     use super::*;
     use std::future::Future;

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -9,6 +9,7 @@ pub mod coresdk {
     //! Contains all protobufs relating to communication between core and lang-specific SDKs
 
     tonic::include_proto!("coresdk");
+
     #[allow(clippy::module_inception)]
     pub mod activity_task {
         tonic::include_proto!("coresdk.activity_task");


### PR DESCRIPTION
TODO: Buffer poll, other cleanup

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Make activity cancels take precedence over polling for new ones

## Why?
Otherwise workers can get hung on the poll and not see cancels they should

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
