### PR TITLE
Fix activity double resolve -- but do we want to?

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "coresdk.workflow_completion.WFActivationCompletion.status",
             "#[derive(::derive_more::From)]",
         )
+        .type_attribute(
+            "coresdk.activity_result.ActivityResult.status",
+            "#[derive(::derive_more::From)]",
+        )
         .type_attribute("coresdk.Task.variant", "#[derive(::derive_more::From)]")
         .compile(
             &[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,6 +560,7 @@ impl<WP: ServerGatewayApis + Send + Sync + 'static> CoreSDK<WP> {
                 completion: None,
             })?;
         let push_result = self.push_lang_commands(run_id, cmds)?;
+        dbg!(&push_result);
         self.enqueue_next_activation_if_needed(run_id, task_token.clone())?;
         // We only actually want to send commands back to the server if there are
         // no more pending activations -- in other words the lang SDK has caught
@@ -1988,4 +1989,9 @@ mod test {
         let r = core.inner.poll_activity_task().await;
         assert_matches!(r.unwrap_err(), PollActivityError::TonicError(_));
     }
+
+    // #[tokio::test]
+    // async fn avoid_double_resolving_activities() {
+    //
+    // }
 }

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -554,7 +554,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     core.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
         vec![StartTimer {
             timer_id: "timer2".to_string(),
-            start_to_fire_timeout: Some(Duration::from_secs(1).into()),
+            start_to_fire_timeout: Some(Duration::from_millis(100).into()),
         }
         .into()],
         task.task_token,
@@ -577,7 +577,8 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     .unwrap();
     dbg!("Completed AT");
     // Ensure we do not get a wakeup with the activity being resolved completed, and instead get
-    // the timer fired event
+    // the timer fired event (also wait for timer to fire)
+    sleep(Duration::from_secs(1)).await;
     let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),

--- a/tests/integ_tests/simple_wf_tests.rs
+++ b/tests/integ_tests/simple_wf_tests.rs
@@ -489,6 +489,111 @@ async fn activity_cancellation_try_cancel() {
 }
 
 #[tokio::test]
+async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
+    let mut rng = rand::thread_rng();
+    let task_q_salt: u32 = rng.gen();
+    let task_q = &format!(
+        "activity_cancellation_plus_complete_doesnt_double_resolve_{}",
+        task_q_salt.to_string()
+    );
+    let core = get_integ_core(task_q).await;
+    let activity_id = "activity_id";
+    create_workflow(&core, task_q, "wfid", None).await;
+    let task = core.poll_workflow_task().await.unwrap();
+    // Complete workflow task and schedule activity and a timer that fires immediately
+    core.complete_workflow_task(schedule_activity_and_timer_cmds(
+        task_q,
+        activity_id,
+        "timer_id",
+        ActivityCancellationType::TryCancel,
+        task,
+        Duration::from_secs(60),
+        Duration::from_millis(50),
+    ))
+    .await
+    .unwrap();
+    let activity_task = core.poll_activity_task().await.unwrap();
+    assert_matches!(activity_task.variant, Some(act_task::Variant::Start(_)));
+    dbg!("Got activity task");
+    let task = core.poll_workflow_task().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        [WfActivationJob {
+            variant: Some(wf_activation_job::Variant::FireTimer(_)),
+        }]
+    );
+    core.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
+        vec![RequestCancelActivity {
+            activity_id: activity_id.to_owned(),
+            ..Default::default()
+        }
+        .into()],
+        task.task_token,
+    ))
+    .await
+    .unwrap();
+    dbg!("Completed w/ cancel");
+    let task = core.poll_workflow_task().await.unwrap();
+    // Should get cancel task
+    assert_matches!(
+        task.jobs.as_slice(),
+        [WfActivationJob {
+            variant: Some(wf_activation_job::Variant::ResolveActivity(
+                ResolveActivity {
+                    result: Some(ActivityResult {
+                        status: Some(activity_result::activity_result::Status::Canceled(_))
+                    }),
+                    ..
+                }
+            )),
+        }]
+    );
+    dbg!("Got cancel task");
+    // We need to complete the wf task to send the activity cancel command to the server, so start
+    // another short timer
+    core.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
+        vec![StartTimer {
+            timer_id: "timer2".to_string(),
+            start_to_fire_timeout: Some(Duration::from_secs(1).into()),
+        }
+        .into()],
+        task.task_token,
+    ))
+    .await
+    .unwrap();
+    // Now say the activity completes anyways
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: activity_task.task_token,
+        result: Some(ActivityResult {
+            status: Some(
+                activity_result::Success {
+                    result: Some(vec![1].into()),
+                }
+                .into(),
+            ),
+        }),
+    })
+    .await
+    .unwrap();
+    dbg!("Completed AT");
+    // Ensure we do not get a wakeup with the activity being resolved completed, and instead get
+    // the timer fired event
+    let task = core.poll_workflow_task().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        [WfActivationJob {
+            variant: Some(wf_activation_job::Variant::FireTimer(_)),
+        }]
+    );
+    core.complete_workflow_task(WfActivationCompletion::ok_from_cmds(
+        vec![CompleteWorkflowExecution { result: None }.into()],
+        task.task_token,
+    ))
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
 async fn started_activity_timeout() {
     let mut rng = rand::thread_rng();
     let task_q_salt: u32 = rng.gen();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Fixes double-resolves by squelching them lang side, but this introduces a problem where we can get a workflow task from the server that we have nothing to about. We could simply respond immediately with an empty command list, but that feels a little weird and introduces completions inside poll which is nonobvious.

We can instead just not do this, and expect lang to ignore (or do whatever else it wants) with the extra completion. It would then also have to return an empty response if there is no further work to be done.

Currently, what will happen if there are no other events in the history is the workflow task will be dropped and eventually time out. Results in a history like this:
```
11
ActivityTaskCancelRequested

12
TimerStarted

13
ActivityTaskStarted

14
ActivityTaskCompleted <-- we don't care about this because we already cancelled it locally

15
WorkflowTaskScheduled

16
WorkflowTaskStarted

17
WorkflowTaskTimedOut
10s (+10s)
```

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 
closes https://github.com/temporalio/sdk-core/issues/110
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
