### PR TITLE
Add concurrent heartbeat cancellation test

### DIFF
--- a/src/activity/details.rs
+++ b/src/activity/details.rs
@@ -1,7 +1,7 @@
 use prost_types::Duration;
 
 /// Contains minimal set of details that core needs to store, while activity is running.
-#[derive(derive_more::Constructor)]
+#[derive(derive_more::Constructor, Debug)]
 pub(crate) struct InflightActivityDetails {
     pub activity_id: String,
     /// Used to calculate aggregation delay between activity heartbeats.

--- a/src/activity/details.rs
+++ b/src/activity/details.rs
@@ -6,4 +6,6 @@ pub(crate) struct InflightActivityDetails {
     pub activity_id: String,
     /// Used to calculate aggregation delay between activity heartbeats.
     pub heartbeat_timeout: Option<Duration>,
+    /// Set to true if we have already issued a cancellation activation to lang for this activity
+    pub issued_cancel_to_lang: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2171,9 +2171,9 @@ mod test {
                 let calls = match calls_map.entry(tt) {
                     Entry::Occupied(mut e) => {
                         *e.get_mut() += 1;
-                        e.get().clone()
+                        *e.get()
                     }
-                    Entry::Vacant(v) => v.insert(1).clone(),
+                    Entry::Vacant(v) => *v.insert(1),
                 };
                 async move {
                     if calls < 5 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,8 @@ where
                         } else {
                             warn!(task_token = ?task_token,
                                   "Unknown activity task when issuing cancel");
+                            // If we can't find the activity here, it's already been completed,
+                            // in which case issuing a cancel again is pointless.
                             continue;
                         }
                     }

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -27,6 +27,17 @@ pub mod coresdk {
     #[allow(clippy::module_inception)]
     pub mod activity_result {
         tonic::include_proto!("coresdk.activity_result");
+        use super::common::Payload;
+
+        impl ActivityResult {
+            pub fn cancel_from_details(payload: Option<Payload>) -> Self {
+                Self {
+                    status: Some(activity_result::Status::Canceled(Cancelation {
+                        details: payload,
+                    })),
+                }
+            }
+        }
     }
     pub mod common {
         tonic::include_proto!("coresdk.common");

--- a/src/workflow/concurrency_manager.rs
+++ b/src/workflow/concurrency_manager.rs
@@ -45,9 +45,10 @@ impl WorkflowConcurrencyManager {
         let (machine_creator, create_rcv) = unbounded::<MachineCreatorMsg>();
         let (shutdown_chan, shutdown_rx) = bounded(1);
 
-        let wf_thread = thread::spawn(move || {
-            WorkflowConcurrencyManager::workflow_thread(create_rcv, shutdown_rx)
-        });
+        let wf_thread = thread::Builder::new()
+            .name("workflow-manager".to_string())
+            .spawn(move || WorkflowConcurrencyManager::workflow_thread(create_rcv, shutdown_rx))
+            .expect("must be able to spawn workflow manager thread");
 
         Self {
             machines: Default::default(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Added test to verify core isn't getting hung up on many concurrent heartbeat cancels.
Also undo issuing pointless activity task for unknown activities.

## Why?
Better testing around heartbeat concurrency, bench investigation.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
