### PR TITLE
Log heartbeat errors instead of returning them back to lang

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,12 +812,7 @@ impl<WP: ServerGatewayApis + Send + Sync + 'static> CoreSDK<WP> {
             _ => Err(err.into()),
         }
     }
-}
 
-impl<WP> CoreSDK<WP>
-where
-    WP: ServerGatewayApis + Send + Sync + 'static,
-{
     fn record_activity_heartbeat_with_errors(
         &self,
         details: ActivityHeartbeat,


### PR DESCRIPTION
## What was changed:
Errors returned by the heartbeat, such as validation failures and heartbeat during shutdown are logged and swallowed instead of being returned to the lang.

## Why?
It has been agreed that this is an optimal behavior for the user to not interrupt activity flow if heartbeat is not working properly.
