### PR TITLE
Sticky Queues interface changes

### DIFF
--- a/protos/local/activity_task.proto
+++ b/protos/local/activity_task.proto
@@ -13,13 +13,16 @@ import "google/protobuf/duration.proto";
 message ActivityTask {
     /// A unique identifier for this task
     bytes task_token = 1;
+    // The task queue that this activity task came from. Corresponds to the worker that should be
+    // tasked with handling it.
+    string task_queue = 2;
     /// The activity's ID
-    string activity_id = 2;
+    string activity_id = 3;
     oneof variant {
         /// Start activity execution.
-        Start start = 3;
+        Start start = 4;
         /// Attempt to cancel activity execution.
-        Cancel cancel = 4;
+        Cancel cancel = 5;
     }
 }
 

--- a/protos/local/activity_task.proto
+++ b/protos/local/activity_task.proto
@@ -13,16 +13,13 @@ import "google/protobuf/duration.proto";
 message ActivityTask {
     /// A unique identifier for this task
     bytes task_token = 1;
-    // The task queue that this activity task came from. Corresponds to the worker that should be
-    // tasked with handling it.
-    string task_queue = 2;
     /// The activity's ID
-    string activity_id = 3;
+    string activity_id = 2;
     oneof variant {
         /// Start activity execution.
-        Start start = 4;
+        Start start = 3;
         /// Attempt to cancel activity execution.
-        Cancel cancel = 5;
+        Cancel cancel = 4;
     }
 }
 

--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -14,17 +14,16 @@ import "google/protobuf/timestamp.proto";
 /// An instruction to the lang sdk to run some workflow code, whether for the first time or from
 /// a cached state.
 message WFActivation {
-    // A unique identifier for this task
-    bytes task_token = 1;
+    /// The id of the currently active run of the workflow. Also used as a cache key. There may
+    /// only ever be one active workflow task (and hence activation) of a run at one time.
+    string run_id = 1;
     // The task queue that this activation's workflow task came from. Corresponds to the worker
     // that should be tasked with handling it.
     string task_queue = 2;
     /// The current time as understood by the workflow, which is set by workflow task started events
     google.protobuf.Timestamp timestamp = 3;
-    /// The id of the currently active run of the workflow
-    string run_id = 4;
     /// The things to do upon activating the workflow
-    repeated WFActivationJob jobs = 5;
+    repeated WFActivationJob jobs = 4;
 }
 
 message WFActivationJob {

--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -17,13 +17,10 @@ message WFActivation {
     /// The id of the currently active run of the workflow. Also used as a cache key. There may
     /// only ever be one active workflow task (and hence activation) of a run at one time.
     string run_id = 1;
-    // The task queue that this activation's workflow task came from. Corresponds to the worker
-    // that should be tasked with handling it.
-    string task_queue = 2;
     /// The current time as understood by the workflow, which is set by workflow task started events
-    google.protobuf.Timestamp timestamp = 3;
+    google.protobuf.Timestamp timestamp = 2;
     /// The things to do upon activating the workflow
-    repeated WFActivationJob jobs = 4;
+    repeated WFActivationJob jobs = 3;
 }
 
 message WFActivationJob {

--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -16,12 +16,15 @@ import "google/protobuf/timestamp.proto";
 message WFActivation {
     // A unique identifier for this task
     bytes task_token = 1;
+    // The task queue that this activation's workflow task came from. Corresponds to the worker
+    // that should be tasked with handling it.
+    string task_queue = 2;
     /// The current time as understood by the workflow, which is set by workflow task started events
-    google.protobuf.Timestamp timestamp = 2;
+    google.protobuf.Timestamp timestamp = 3;
     /// The id of the currently active run of the workflow
-    string run_id = 3;
+    string run_id = 4;
     /// The things to do upon activating the workflow
-    repeated WFActivationJob jobs = 4;
+    repeated WFActivationJob jobs = 5;
 }
 
 message WFActivationJob {

--- a/protos/local/workflow_completion.proto
+++ b/protos/local/workflow_completion.proto
@@ -7,8 +7,8 @@ import "workflow_commands.proto";
 
 /// Result of a single workflow activation, reported from lang to core
 message WFActivationCompletion {
-    // The token from the workflow activation you are completing
-    bytes task_token = 1;
+    // The run id from the workflow activation you are completing
+    string run_id = 1;
     oneof status {
         Success successful = 2;
         Failure failed = 3;

--- a/src/activity/details.rs
+++ b/src/activity/details.rs
@@ -8,4 +8,6 @@ pub(crate) struct InflightActivityDetails {
     pub heartbeat_timeout: Option<Duration>,
     /// Set to true if we have already issued a cancellation activation to lang for this activity
     pub issued_cancel_to_lang: bool,
+    /// The task queue this activity came from
+    pub task_queue: String,
 }

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -1,6 +1,127 @@
 mod activity_heartbeat_manager;
 mod details;
 
-pub(crate) use activity_heartbeat_manager::ActivityHeartbeatManager;
-pub(crate) use activity_heartbeat_manager::ActivityHeartbeatManagerHandle;
+pub(crate) use activity_heartbeat_manager::{
+    ActivityHeartbeatManager, ActivityHeartbeatManagerHandle,
+};
 pub(crate) use details::InflightActivityDetails;
+
+use crate::{
+    protos::coresdk::activity_task::ActivityTask,
+    protos::temporal::api::workflowservice::v1::PollActivityTaskQueueResponse,
+    task_token::TaskToken, worker::Worker, ActivityHeartbeat, ActivityHeartbeatError,
+    CompleteActivityError, PollActivityError, ServerGatewayApis,
+};
+use dashmap::DashMap;
+use std::{convert::TryInto, ops::Div, sync::Arc, time::Duration};
+
+pub(crate) struct ActivityTaskManager {
+    /// Handle to the heartbeat manager
+    activity_heartbeat_manager_handle: ActivityHeartbeatManagerHandle,
+    /// Activities that have been issued to lang but not yet completed, mapped to the worker who
+    /// is processing them.
+    outstanding_activity_tasks: DashMap<TaskToken, InflightActivityDetails>,
+}
+
+impl ActivityTaskManager {
+    pub(crate) fn new<SG: ServerGatewayApis + Send + Sync + 'static>(sg: Arc<SG>) -> Self {
+        Self {
+            activity_heartbeat_manager_handle: ActivityHeartbeatManager::new(sg),
+            outstanding_activity_tasks: Default::default(),
+        }
+    }
+
+    /// Poll for an activity task using the provided worker. Returns `Ok(None)` if no activity is
+    /// ready and the overall polling loop should be retried.
+    pub(crate) async fn poll(
+        &self,
+        worker: &Worker,
+    ) -> Result<Option<ActivityTask>, PollActivityError> {
+        tokio::select! {
+            biased;
+
+            maybe_tt = self.activity_heartbeat_manager_handle.next_pending_cancel() => {
+                // Issue cancellations for anything we noticed was cancelled during heartbeating
+                if let Some(task_token) = maybe_tt {
+                    // It's possible that activity has been completed and we no longer have an
+                    // outstanding activity task. This is fine because it means that we no
+                    // longer need to cancel this activity, so we'll just ignore such orphaned
+                    // cancellations.
+                    if let Some(mut details) =
+                        self.outstanding_activity_tasks.get_mut(&task_token) {
+                            if details.issued_cancel_to_lang {
+                                // Don't double-issue cancellations
+                                return Ok(None)
+                            }
+                            details.issued_cancel_to_lang = true;
+                            return Ok(Some(ActivityTask::cancel_from_ids(
+                                task_token,
+                                details.activity_id.clone(),
+                            )));
+                    } else {
+                        warn!(task_token = ?task_token,
+                              "Unknown activity task when issuing cancel");
+                        // If we can't find the activity here, it's already been completed,
+                        // in which case issuing a cancel again is pointless.
+                        return Ok(None)
+                    }
+                }
+                // The only situation where the next cancel would return none is if the manager
+                // was dropped, which can only happen on shutdown.
+                return Err(PollActivityError::ShutDown);
+            }
+            work = worker.activity_poll() => {
+                match work {
+                    Ok(work) => {
+                        if work == PollActivityTaskQueueResponse::default() {
+                            return Ok(None);
+                        }
+                        self.outstanding_activity_tasks.insert(
+                            work.task_token.clone().into(),
+                            InflightActivityDetails::new(
+                                work.activity_id.clone(),
+                                work.heartbeat_timeout.clone(),
+                                false,
+                                worker.task_queue().to_owned()
+                            ),
+                        );
+                        Ok(Some(ActivityTask::start_from_poll_resp(work)))
+                    }
+                    Err(e) => Err(e)
+                }
+            }
+        }
+    }
+
+    /// Mark the activity associated with the task token as complete, returning the details about it
+    /// if it was present.
+    pub(crate) fn mark_complete(&self, task_token: &TaskToken) -> Option<InflightActivityDetails> {
+        self.outstanding_activity_tasks
+            .remove(&task_token)
+            .map(|x| x.1)
+    }
+
+    /// Attempt to record an activity heartbeat
+    pub(crate) fn record_activity_heartbeat(
+        &self,
+        details: ActivityHeartbeat,
+    ) -> Result<(), ActivityHeartbeatError> {
+        let t: Duration = self
+            .outstanding_activity_tasks
+            .get(&TaskToken(details.task_token.clone()))
+            .ok_or(ActivityHeartbeatError::UnknownActivity)?
+            .heartbeat_timeout
+            .clone()
+            .ok_or(ActivityHeartbeatError::HeartbeatTimeoutNotSet)?
+            .try_into()
+            .or(Err(ActivityHeartbeatError::InvalidHeartbeatTimeout))?;
+        // There is a bug in the server that translates non-set heartbeat timeouts into 0 duration.
+        // That's why we treat 0 the same way as None, otherwise we wouldn't know which aggregation
+        // delay to use, and using 0 is not a good idea as SDK would hammer the server too hard.
+        if t.as_millis() == 0 {
+            return Err(ActivityHeartbeatError::HeartbeatTimeoutNotSet);
+        }
+        self.activity_heartbeat_manager_handle
+            .record(details, t.div(2))
+    }
+}

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -7,10 +7,8 @@ pub(crate) use activity_heartbeat_manager::{
 pub(crate) use details::InflightActivityDetails;
 
 use crate::{
-    protos::coresdk::activity_task::ActivityTask,
-    protos::temporal::api::workflowservice::v1::PollActivityTaskQueueResponse,
-    task_token::TaskToken, worker::Worker, ActivityHeartbeat, ActivityHeartbeatError,
-    PollActivityError, ServerGatewayApis,
+    protos::coresdk::activity_task::ActivityTask, task_token::TaskToken, worker::Worker,
+    ActivityHeartbeat, ActivityHeartbeatError, PollActivityError, ServerGatewayApis,
 };
 use dashmap::DashMap;
 use std::{convert::TryInto, ops::Div, sync::Arc, time::Duration};
@@ -76,10 +74,8 @@ impl ActivityTaskManager {
             }
             work = worker.activity_poll() => {
                 match work {
-                    Ok(work) => {
-                        if work == PollActivityTaskQueueResponse::default() {
-                            return Ok(None);
-                        }
+                    Ok(None) => Ok(None), // Timeout
+                    Ok(Some(work)) => {
                         self.outstanding_activity_tasks.insert(
                             work.task_token.clone().into(),
                             InflightActivityDetails::new(

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     protos::coresdk::activity_task::ActivityTask,
     protos::temporal::api::workflowservice::v1::PollActivityTaskQueueResponse,
     task_token::TaskToken, worker::Worker, ActivityHeartbeat, ActivityHeartbeatError,
-    CompleteActivityError, PollActivityError, ServerGatewayApis,
+    PollActivityError, ServerGatewayApis,
 };
 use dashmap::DashMap;
 use std::{convert::TryInto, ops::Div, sync::Arc, time::Duration};
@@ -29,6 +29,10 @@ impl ActivityTaskManager {
             activity_heartbeat_manager_handle: ActivityHeartbeatManager::new(sg),
             outstanding_activity_tasks: Default::default(),
         }
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.activity_heartbeat_manager_handle.shutdown().await;
     }
 
     /// Poll for an activity task using the provided worker. Returns `Ok(None)` if no activity is

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -59,7 +59,6 @@ impl ActivityTaskManager {
                             return Ok(Some(ActivityTask::cancel_from_ids(
                                 task_token,
                                 details.activity_id.clone(),
-                                details.task_queue.clone()
                             )));
                     } else {
                         warn!(task_token = ?task_token,
@@ -86,8 +85,7 @@ impl ActivityTaskManager {
                                 worker.task_queue().to_owned()
                             ),
                         );
-                        Ok(Some(ActivityTask::start_from_poll_resp(work,
-                                                                   worker.task_queue().to_owned())))
+                        Ok(Some(ActivityTask::start_from_poll_resp(work)))
                     }
                     Err(e) => Err(e)
                 }

--- a/src/activity/mod.rs
+++ b/src/activity/mod.rs
@@ -59,6 +59,7 @@ impl ActivityTaskManager {
                             return Ok(Some(ActivityTask::cancel_from_ids(
                                 task_token,
                                 details.activity_id.clone(),
+                                details.task_queue.clone()
                             )));
                     } else {
                         warn!(task_token = ?task_token,
@@ -85,7 +86,8 @@ impl ActivityTaskManager {
                                 worker.task_queue().to_owned()
                             ),
                         );
-                        Ok(Some(ActivityTask::start_from_poll_resp(work)))
+                        Ok(Some(ActivityTask::start_from_poll_resp(work,
+                                                                   worker.task_queue().to_owned())))
                     }
                     Err(e) => Err(e)
                 }

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -63,7 +63,8 @@ async fn max_activites_respected() {
             .max_outstanding_activities(2usize)
             .build()
             .unwrap(),
-    );
+    )
+    .await;
 
     // We allow two outstanding activities, therefore first two polls should return right away
     let r1 = core.poll_activity_task().await.unwrap();
@@ -301,7 +302,8 @@ async fn many_concurrent_heartbeat_cancels() {
             .max_concurrent_at_polls(1usize)
             .build()
             .unwrap(),
-    );
+    )
+    .await;
 
     // Poll all activities first so they are registered
     for _ in 0..CONCURRENCY_NUM {
@@ -342,7 +344,12 @@ async fn many_concurrent_heartbeat_cancels() {
     .await;
 
     assert_eq!(
-        core.workers.get(TEST_Q).unwrap().outstanding_activities(),
+        core.workers
+            .read()
+            .await
+            .get(TEST_Q)
+            .unwrap()
+            .outstanding_activities(),
         0
     );
     core.shutdown().await;

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -24,6 +24,7 @@ use tokio::time::sleep;
 
 #[tokio::test]
 async fn max_activites_respected() {
+    let task_q = "q";
     let mut tasks = VecDeque::from(vec![
         PollActivityTaskQueueResponse {
             task_token: vec![1],
@@ -45,7 +46,7 @@ async fn max_activites_respected() {
     mock_gateway
         .expect_poll_activity_task()
         .times(3)
-        .returning(move || Ok(tasks.pop_front().unwrap()));
+        .returning(move |_| Ok(tasks.pop_front().unwrap()));
     mock_gateway
         .expect_complete_activity_task()
         .returning(|_, _| Ok(RespondActivityTaskCompletedResponse::default()));
@@ -54,14 +55,15 @@ async fn max_activites_respected() {
         mock_gateway,
         CoreInitOptionsBuilder::default()
             .gateway_opts(fake_sg_opts())
-            .max_outstanding_activities(2usize)
+            // TODO: Set worker options
+            // .max_outstanding_activities(2usize)
             .build()
             .unwrap(),
     );
 
     // We allow two outstanding activities, therefore first two polls should return right away
-    let r1 = core.poll_activity_task().await.unwrap();
-    let _r2 = core.poll_activity_task().await.unwrap();
+    let r1 = core.poll_activity_task(task_q).await.unwrap();
+    let _r2 = core.poll_activity_task(task_q).await.unwrap();
     // Third should block until we complete one of the first two
     let last_finisher = AtomicUsize::new(0);
     tokio::join! {
@@ -73,7 +75,7 @@ async fn max_activites_respected() {
             last_finisher.store(1, Ordering::SeqCst);
         },
         async {
-            core.poll_activity_task().await.unwrap();
+            core.poll_activity_task(task_q).await.unwrap();
             last_finisher.store(2, Ordering::SeqCst);
         }
     };
@@ -105,7 +107,7 @@ async fn heartbeats_report_cancels() {
     mock_gateway
         .expect_poll_activity_task()
         .times(1)
-        .returning(|| {
+        .returning(|_| {
             Ok(PollActivityTaskQueueResponse {
                 task_token: vec![1],
                 activity_id: "act1".to_string(),
@@ -124,14 +126,14 @@ async fn heartbeats_report_cancels() {
 
     let core = mock_core(mock_gateway);
 
-    let act = core.poll_activity_task().await.unwrap();
+    let act = core.poll_activity_task("q").await.unwrap();
     core.record_activity_heartbeat(ActivityHeartbeat {
         task_token: act.task_token,
         details: vec![vec![1u8, 2, 3].into()],
     });
     // We have to wait a beat for the heartbeat to be processed
     sleep(Duration::from_millis(50)).await;
-    let act = core.poll_activity_task().await.unwrap();
+    let act = core.poll_activity_task("q").await.unwrap();
     assert_matches!(
         act,
         ActivityTask {
@@ -163,7 +165,7 @@ async fn activity_cancel_interrupts_poll() {
     mock_gateway
         .expect_poll_activity_task()
         .times(2)
-        .returning(move || poll_resps.pop_front().unwrap());
+        .returning(move |_| poll_resps.pop_front().unwrap());
     mock_gateway
         .expect_record_activity_heartbeat()
         .times(1)
@@ -179,7 +181,7 @@ async fn activity_cancel_interrupts_poll() {
     let core = mock_core(mock_gateway);
     let last_finisher = AtomicUsize::new(0);
     // Perform first poll to get the activity registered
-    let act = core.poll_activity_task().await.unwrap();
+    let act = core.poll_activity_task("q").await.unwrap();
     // Poll should block until heartbeat is sent, issuing the cancel, and interrupting the poll
     tokio::join! {
         async {
@@ -190,7 +192,7 @@ async fn activity_cancel_interrupts_poll() {
             last_finisher.store(1, Ordering::SeqCst);
         },
         async {
-            core.poll_activity_task().await.unwrap();
+            core.poll_activity_task("q").await.unwrap();
             last_finisher.store(2, Ordering::SeqCst);
         }
     };
@@ -205,7 +207,7 @@ async fn activity_poll_timeout_retries() {
     mock_gateway
         .expect_poll_activity_task()
         .times(3)
-        .returning(move || {
+        .returning(move |_| {
             calls += 1;
             if calls <= 2 {
                 Ok(PollActivityTaskQueueResponse::default())
@@ -214,7 +216,7 @@ async fn activity_poll_timeout_retries() {
             }
         });
     let core = mock_core(mock_gateway);
-    let r = core.poll_activity_task().await;
+    let r = core.poll_activity_task("q").await;
     assert_matches!(r.unwrap_err(), PollActivityError::TonicError(_));
 }
 
@@ -223,6 +225,7 @@ async fn many_concurrent_heartbeat_cancels() {
     // Run a whole bunch of activities in parallel, having the server return cancellations for
     // them after a few successful heartbeats
     const CONCURRENCY_NUM: usize = 1000;
+    let task_q = "q";
 
     let mut mock_gateway = MockManualGateway::new();
     let mut poll_resps = VecDeque::from(
@@ -252,7 +255,7 @@ async fn many_concurrent_heartbeat_cancels() {
     let mut calls_map = HashMap::<_, i32>::new();
     mock_gateway
         .expect_poll_activity_task()
-        .returning(move || poll_resps.pop_front().unwrap());
+        .returning(move |_| poll_resps.pop_front().unwrap());
     mock_gateway
         .expect_cancel_activity_task()
         .returning(move |_, _| async move { Ok(Default::default()) }.boxed());
@@ -284,16 +287,17 @@ async fn many_concurrent_heartbeat_cancels() {
         mock_gateway,
         CoreInitOptionsBuilder::default()
             .gateway_opts(fake_sg_opts())
-            .max_outstanding_activities(CONCURRENCY_NUM)
+            // TODO: Set worker options
+            // .max_outstanding_activities(CONCURRENCY_NUM)
             // Only 1 poll at a time to avoid over-polling and running out of responses
-            .max_concurrent_at_polls(1usize)
+            // .max_concurrent_at_polls(1usize)
             .build()
             .unwrap(),
     );
 
     // Poll all activities first so they are registered
     for _ in 0..CONCURRENCY_NUM {
-        core.poll_activity_task().await.unwrap();
+        core.poll_activity_task(task_q).await.unwrap();
     }
 
     // Spawn "activities"
@@ -311,7 +315,7 @@ async fn many_concurrent_heartbeat_cancels() {
 
     // Read all the cancellations and reply to them concurrently
     fanout_tasks(CONCURRENCY_NUM, |_| async move {
-        let r = core.poll_activity_task().await.unwrap();
+        let r = core.poll_activity_task(task_q).await.unwrap();
         assert_matches!(
             r,
             ActivityTask {
@@ -328,6 +332,7 @@ async fn many_concurrent_heartbeat_cancels() {
     })
     .await;
 
-    assert!(core.outstanding_activity_tasks.is_empty());
+    // TODO: Enable again
+    // assert!(core.outstanding_activity_tasks.is_empty());
     core.shutdown().await;
 }

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -341,7 +341,9 @@ async fn many_concurrent_heartbeat_cancels() {
     })
     .await;
 
-    // TODO: Enable again
-    // assert!(core.outstanding_activity_tasks.is_empty());
+    assert_eq!(
+        core.workers.get(TEST_Q).unwrap().outstanding_activities(),
+        0
+    );
     core.shutdown().await;
 }

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -1,7 +1,6 @@
-use crate::machines::test_help::TEST_Q;
 use crate::{
     errors::PollActivityError,
-    machines::test_help::{fake_sg_opts, mock_core},
+    machines::test_help::{fake_sg_opts, mock_core, TEST_Q},
     pollers::{MockManualGateway, MockServerGatewayApis},
     protos::{
         coresdk::{

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -24,6 +24,7 @@ use tokio::time::sleep;
 
 #[tokio::test]
 async fn max_activites_respected() {
+    let task_q = "q";
     let mut tasks = VecDeque::from(vec![
         PollActivityTaskQueueResponse {
             task_token: vec![1],
@@ -67,8 +68,8 @@ async fn max_activites_respected() {
     .await;
 
     // We allow two outstanding activities, therefore first two polls should return right away
-    let r1 = core.poll_activity_task().await.unwrap();
-    let _r2 = core.poll_activity_task().await.unwrap();
+    let r1 = core.poll_activity_task(task_q).await.unwrap();
+    let _r2 = core.poll_activity_task(task_q).await.unwrap();
     // Third should block until we complete one of the first two
     let last_finisher = AtomicUsize::new(0);
     tokio::join! {
@@ -80,7 +81,7 @@ async fn max_activites_respected() {
             last_finisher.store(1, Ordering::SeqCst);
         },
         async {
-            core.poll_activity_task().await.unwrap();
+            core.poll_activity_task(task_q).await.unwrap();
             last_finisher.store(2, Ordering::SeqCst);
         }
     };
@@ -131,14 +132,14 @@ async fn heartbeats_report_cancels() {
 
     let core = mock_core(mock_gateway);
 
-    let act = core.poll_activity_task().await.unwrap();
+    let act = core.poll_activity_task(TEST_Q).await.unwrap();
     core.record_activity_heartbeat(ActivityHeartbeat {
         task_token: act.task_token,
         details: vec![vec![1u8, 2, 3].into()],
     });
     // We have to wait a beat for the heartbeat to be processed
     sleep(Duration::from_millis(50)).await;
-    let act = core.poll_activity_task().await.unwrap();
+    let act = core.poll_activity_task(TEST_Q).await.unwrap();
     assert_matches!(
         act,
         ActivityTask {
@@ -186,7 +187,7 @@ async fn activity_cancel_interrupts_poll() {
     let core = mock_core(mock_gateway);
     let last_finisher = AtomicUsize::new(0);
     // Perform first poll to get the activity registered
-    let act = core.poll_activity_task().await.unwrap();
+    let act = core.poll_activity_task(TEST_Q).await.unwrap();
     // Poll should block until heartbeat is sent, issuing the cancel, and interrupting the poll
     tokio::join! {
         async {
@@ -197,7 +198,7 @@ async fn activity_cancel_interrupts_poll() {
             last_finisher.store(1, Ordering::SeqCst);
         },
         async {
-            core.poll_activity_task().await.unwrap();
+            core.poll_activity_task(TEST_Q).await.unwrap();
             last_finisher.store(2, Ordering::SeqCst);
         }
     };
@@ -221,7 +222,7 @@ async fn activity_poll_timeout_retries() {
             }
         });
     let core = mock_core(mock_gateway);
-    let r = core.poll_activity_task().await;
+    let r = core.poll_activity_task(TEST_Q).await;
     assert_matches!(r.unwrap_err(), PollActivityError::TonicError(_));
 }
 
@@ -307,7 +308,7 @@ async fn many_concurrent_heartbeat_cancels() {
 
     // Poll all activities first so they are registered
     for _ in 0..CONCURRENCY_NUM {
-        core.poll_activity_task().await.unwrap();
+        core.poll_activity_task(TEST_Q).await.unwrap();
     }
 
     // Spawn "activities"
@@ -325,8 +326,7 @@ async fn many_concurrent_heartbeat_cancels() {
 
     // Read all the cancellations and reply to them concurrently
     fanout_tasks(CONCURRENCY_NUM, |_| async move {
-        let r = core.poll_activity_task().await.unwrap();
-        assert_eq!(&r.task_queue, TEST_Q);
+        let r = core.poll_activity_task(TEST_Q).await.unwrap();
         assert_matches!(
             r,
             ActivityTask {

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -325,6 +325,7 @@ async fn many_concurrent_heartbeat_cancels() {
     // Read all the cancellations and reply to them concurrently
     fanout_tasks(CONCURRENCY_NUM, |_| async move {
         let r = core.poll_activity_task(TEST_Q).await.unwrap();
+        assert_eq!(&r.task_queue, TEST_Q);
         assert_matches!(
             r,
             ActivityTask {

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -1,4 +1,5 @@
 mod activity_tasks;
+mod workers;
 mod workflow_tasks;
 
 use crate::{
@@ -52,7 +53,12 @@ async fn shutdown_interrupts_both_polls() {
             async move {
                 let t = canned_histories::single_timer("hi");
                 sleep(Duration::from_secs(1)).await;
-                Ok(hist_to_poll_resp(&t, "wf".to_string(), 100))
+                Ok(hist_to_poll_resp(
+                    &t,
+                    "wf".to_string(),
+                    100,
+                    TEST_Q.to_string(),
+                ))
             }
             .boxed()
         });

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -17,12 +17,12 @@ async fn after_shutdown_server_is_not_polled() {
     let wfid = "fake_wf_id";
     let t = canned_histories::single_timer("fake_timer");
     let core = build_fake_core(wfid, t, &[1]);
-    let res = core.inner.poll_workflow_task().await.unwrap();
+    let res = core.inner.poll_workflow_task("q").await.unwrap();
     assert_eq!(res.jobs.len(), 1);
 
     core.inner.shutdown().await;
     assert_matches!(
-        core.inner.poll_workflow_task().await.unwrap_err(),
+        core.inner.poll_workflow_task("q").await.unwrap_err(),
         PollWfError::ShutDown
     );
 }
@@ -33,7 +33,7 @@ async fn shutdown_interrupts_both_polls() {
     mock_gateway
         .expect_poll_activity_task()
         .times(1)
-        .returning(move || {
+        .returning(move |_| {
             async move {
                 sleep(Duration::from_secs(1)).await;
                 Ok(PollActivityTaskQueueResponse {
@@ -47,7 +47,7 @@ async fn shutdown_interrupts_both_polls() {
     mock_gateway
         .expect_poll_workflow_task()
         .times(1)
-        .returning(move || {
+        .returning(move |_| {
             async move {
                 let t = canned_histories::single_timer("hi");
                 sleep(Duration::from_secs(1)).await;
@@ -60,19 +60,20 @@ async fn shutdown_interrupts_both_polls() {
         mock_gateway,
         CoreInitOptionsBuilder::default()
             .gateway_opts(fake_sg_opts())
+            // TODO: Need to actually set up workers here
             // Need only 1 concurrent pollers for mock expectations to work here
-            .max_concurrent_wft_polls(1usize)
-            .max_concurrent_at_polls(1usize)
+            // .max_concurrent_wft_polls(1usize)
+            // .max_concurrent_at_polls(1usize)
             .build()
             .unwrap(),
     );
     tokio::join! {
         async {
-            assert_matches!(core.poll_activity_task().await.unwrap_err(),
+            assert_matches!(core.poll_activity_task("q").await.unwrap_err(),
                             PollActivityError::ShutDown);
         },
         async {
-            assert_matches!(core.poll_workflow_task().await.unwrap_err(),
+            assert_matches!(core.poll_workflow_task("q").await.unwrap_err(),
                             PollWfError::ShutDown);
         },
         async {

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -78,7 +78,8 @@ async fn shutdown_interrupts_both_polls() {
             .max_concurrent_at_polls(1usize)
             .build()
             .unwrap(),
-    );
+    )
+    .await;
     tokio::join! {
         async {
             assert_matches!(core.poll_activity_task().await.unwrap_err(),

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -19,12 +19,12 @@ async fn after_shutdown_server_is_not_polled() {
     let wfid = "fake_wf_id";
     let t = canned_histories::single_timer("fake_timer");
     let core = build_fake_core(wfid, t, &[1]);
-    let res = core.inner.poll_workflow_task("q").await.unwrap();
+    let res = core.inner.poll_workflow_task().await.unwrap();
     assert_eq!(res.jobs.len(), 1);
 
     core.inner.shutdown().await;
     assert_matches!(
-        core.inner.poll_workflow_task("q").await.unwrap_err(),
+        core.inner.poll_workflow_task().await.unwrap_err(),
         PollWfError::ShutDown
     );
 }
@@ -81,11 +81,11 @@ async fn shutdown_interrupts_both_polls() {
     );
     tokio::join! {
         async {
-            assert_matches!(core.poll_activity_task(TEST_Q).await.unwrap_err(),
+            assert_matches!(core.poll_activity_task().await.unwrap_err(),
                             PollActivityError::ShutDown);
         },
         async {
-            assert_matches!(core.poll_workflow_task(TEST_Q).await.unwrap_err(),
+            assert_matches!(core.poll_workflow_task().await.unwrap_err(),
                             PollWfError::ShutDown);
         },
         async {

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -19,12 +19,12 @@ async fn after_shutdown_server_is_not_polled() {
     let wfid = "fake_wf_id";
     let t = canned_histories::single_timer("fake_timer");
     let core = build_fake_core(wfid, t, &[1]);
-    let res = core.inner.poll_workflow_task().await.unwrap();
+    let res = core.inner.poll_workflow_task("q").await.unwrap();
     assert_eq!(res.jobs.len(), 1);
 
     core.inner.shutdown().await;
     assert_matches!(
-        core.inner.poll_workflow_task().await.unwrap_err(),
+        core.inner.poll_workflow_task("q").await.unwrap_err(),
         PollWfError::ShutDown
     );
 }
@@ -82,11 +82,11 @@ async fn shutdown_interrupts_both_polls() {
     .await;
     tokio::join! {
         async {
-            assert_matches!(core.poll_activity_task().await.unwrap_err(),
+            assert_matches!(core.poll_activity_task(TEST_Q).await.unwrap_err(),
                             PollActivityError::ShutDown);
         },
         async {
-            assert_matches!(core.poll_workflow_task().await.unwrap_err(),
+            assert_matches!(core.poll_workflow_task(TEST_Q).await.unwrap_err(),
                             PollWfError::ShutDown);
         },
         async {

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -1,0 +1,56 @@
+use crate::machines::test_help::build_fake_core;
+use crate::{
+    machines::test_help::{build_multihist_mock_sg, mock_core, FakeWfResponses},
+    protos::coresdk::workflow_activation::wf_activation_job,
+    test_help::canned_histories,
+    Core, PollWfError, WorkerConfigBuilder,
+};
+
+#[tokio::test]
+async fn multi_workers() {
+    // Make histories for 5 different workflows on 5 different task queues
+    let hists = (0..5).into_iter().map(|i| {
+        let wf_id = format!("fake-wf-{}", i);
+        let hist = canned_histories::single_timer("fake_timer");
+        FakeWfResponses {
+            wf_id,
+            hist,
+            response_batches: vec![1, 2],
+            task_q: format!("q-{}", i),
+        }
+    });
+    let mock = build_multihist_mock_sg(hists, false, None);
+
+    // This will register a pointless worker for `TEST_Q` as well, but, nothing will happen with it.
+    let core = &mock_core(mock.sg);
+    for i in 0..5 {
+        core.register_worker(
+            WorkerConfigBuilder::default()
+                .task_queue(format!("q-{}", i))
+                .build()
+                .unwrap(),
+        );
+    }
+
+    for i in 0..5 {
+        let tq = format!("q-{}", i);
+        let res = core.poll_workflow_task(&tq).await.unwrap();
+        assert_eq!(res.task_queue, tq);
+        assert_matches!(
+            res.jobs[0].variant,
+            Some(wf_activation_job::Variant::StartWorkflow(_))
+        );
+    }
+    core.shutdown().await;
+}
+
+#[tokio::test]
+async fn no_worker_for_queue_error_returned_properly() {
+    let wfid = "fake_wf_id";
+    let t = canned_histories::single_timer("fake_timer");
+    let core = build_fake_core(wfid, t, &[2]);
+
+    let fake_q = "not a registered queue";
+    let res = core.inner.poll_workflow_task(&fake_q).await.unwrap_err();
+    assert_matches!(res, PollWfError::NoWorkerForQueue(err_q) => err_q == fake_q);
+}

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -48,9 +48,11 @@ async fn multi_workers() {
 async fn no_worker_for_queue_error_returned_properly() {
     let wfid = "fake_wf_id";
     let t = canned_histories::single_timer("fake_timer");
-    let core = build_fake_core(wfid, t, &[2]);
+    // Empty batches array to specify 0 calls to poll expectation
+    let core = build_fake_core(wfid, t, &[]);
 
     let fake_q = "not a registered queue";
     let res = core.inner.poll_workflow_task(&fake_q).await.unwrap_err();
     assert_matches!(res, PollWfError::NoWorkerForQueue(err_q) => err_q == fake_q);
+    core.inner.shutdown().await;
 }

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -1,58 +1,52 @@
-use crate::machines::test_help::build_fake_core;
 use crate::{
-    machines::test_help::{build_multihist_mock_sg, mock_core, FakeWfResponses},
+    machines::test_help::{build_multihist_mock_sg, fake_sg_opts, FakeWfResponses},
     protos::coresdk::workflow_activation::wf_activation_job,
     test_help::canned_histories,
-    Core, PollWfError, WorkerConfigBuilder,
+    Core, CoreInitOptionsBuilder, CoreSDK, WorkerConfigBuilder,
 };
+use std::collections::HashSet;
 
 #[tokio::test]
 async fn multi_workers() {
+    let mut must_see_queues = HashSet::new();
     // Make histories for 5 different workflows on 5 different task queues
     let hists = (0..5).into_iter().map(|i| {
         let wf_id = format!("fake-wf-{}", i);
         let hist = canned_histories::single_timer("fake_timer");
+        let queue_name = format!("q-{}", i);
+        must_see_queues.insert(queue_name.clone());
         FakeWfResponses {
             wf_id,
             hist,
             response_batches: vec![1, 2],
-            task_q: format!("q-{}", i),
+            task_q: queue_name,
         }
     });
     let mock = build_multihist_mock_sg(hists, false, None);
 
-    // This will register a pointless worker for `TEST_Q` as well, but, nothing will happen with it.
-    let core = &mock_core(mock.sg);
-    for i in 0..5 {
+    let core = CoreSDK::new(
+        mock.sg,
+        CoreInitOptionsBuilder::default()
+            .gateway_opts(fake_sg_opts())
+            .build()
+            .unwrap(),
+    );
+    for queue_name in must_see_queues.iter() {
         core.register_worker(
             WorkerConfigBuilder::default()
-                .task_queue(format!("q-{}", i))
+                .task_queue(queue_name.clone())
                 .build()
                 .unwrap(),
         );
     }
 
-    for i in 0..5 {
-        let tq = format!("q-{}", i);
-        let res = core.poll_workflow_task(&tq).await.unwrap();
-        assert_eq!(res.task_queue, tq);
+    for _ in 0..5 {
+        let res = core.poll_workflow_task().await.unwrap();
+        assert!(must_see_queues.remove(&res.task_queue));
         assert_matches!(
             res.jobs[0].variant,
             Some(wf_activation_job::Variant::StartWorkflow(_))
         );
     }
     core.shutdown().await;
-}
-
-#[tokio::test]
-async fn no_worker_for_queue_error_returned_properly() {
-    let wfid = "fake_wf_id";
-    let t = canned_histories::single_timer("fake_timer");
-    // Empty batches array to specify 0 calls to poll expectation
-    let core = build_fake_core(wfid, t, &[]);
-
-    let fake_q = "not a registered queue";
-    let res = core.inner.poll_workflow_task(&fake_q).await.unwrap_err();
-    assert_matches!(res, PollWfError::NoWorkerForQueue(err_q) => err_q == fake_q);
-    core.inner.shutdown().await;
 }

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -1,6 +1,10 @@
 use crate::{
     machines::test_help::{build_fake_core, build_multihist_mock_sg, mock_core, FakeWfResponses},
     protos::coresdk::workflow_activation::wf_activation_job,
+    protos::coresdk::workflow_commands::{
+        ActivityCancellationType, RequestCancelActivity, ScheduleActivity,
+    },
+    protos::coresdk::workflow_completion::WfActivationCompletion,
     test_help::canned_histories,
     Core, PollWfError, WorkerConfigBuilder,
 };
@@ -54,4 +58,64 @@ async fn no_worker_for_queue_error_returned_properly() {
     let res = core.inner.poll_workflow_task(&fake_q).await.unwrap_err();
     assert_matches!(res, PollWfError::NoWorkerForQueue(err_q) => err_q == fake_q);
     core.inner.shutdown().await;
+}
+
+// Here we're making sure that when a pending activity is generated for a workflow on one task
+// queue that it doesn't "leak" over and get returned when lang polls for a different task queue
+#[tokio::test]
+async fn pending_activities_only_returned_for_their_queue() {
+    let act_id = "act-1";
+    let histmaker = |qname: String| {
+        let hist = canned_histories::cancel_scheduled_activity(act_id, "sig-1");
+        FakeWfResponses {
+            wf_id: "wf1".to_string(),
+            hist,
+            response_batches: vec![1, 2],
+            task_q: qname,
+        }
+    };
+    let hist_q_1 = histmaker("q-1".to_string());
+    let hist_q_2 = histmaker("q-2".to_string());
+    let mock = build_multihist_mock_sg(vec![hist_q_1, hist_q_2], false, None);
+    let core = &mock_core(mock.sg);
+    for i in 1..=2 {
+        core.register_worker(
+            WorkerConfigBuilder::default()
+                .task_queue(format!("q-{}", i))
+                .build()
+                .unwrap(),
+        )
+        .await;
+    }
+
+    // Create a pending activation by cancelling a try-cancel activity
+    let res = core.poll_workflow_task("q-1").await.unwrap();
+    core.complete_workflow_task(WfActivationCompletion::from_cmds(
+        vec![ScheduleActivity {
+            activity_id: act_id.to_string(),
+            cancellation_type: ActivityCancellationType::TryCancel as i32,
+            ..Default::default()
+        }
+        .into()],
+        res.run_id,
+    ))
+    .await
+    .unwrap();
+    let res = core.poll_workflow_task("q-1").await.unwrap();
+    core.complete_workflow_task(WfActivationCompletion::from_cmds(
+        vec![RequestCancelActivity {
+            activity_id: act_id.to_string(),
+            ..Default::default()
+        }
+        .into()],
+        res.run_id,
+    ))
+    .await
+    .unwrap();
+    // Poll on the other task queue, verifying we get start workflow
+    let res = core.poll_workflow_task("q-2").await.unwrap();
+    assert_matches!(
+        res.jobs[0].variant,
+        Some(wf_activation_job::Variant::StartWorkflow(_))
+    );
 }

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -1,53 +1,57 @@
 use crate::{
-    machines::test_help::{build_multihist_mock_sg, fake_sg_opts, FakeWfResponses},
+    machines::test_help::{build_fake_core, build_multihist_mock_sg, mock_core, FakeWfResponses},
     protos::coresdk::workflow_activation::wf_activation_job,
     test_help::canned_histories,
-    Core, CoreInitOptionsBuilder, CoreSDK, WorkerConfigBuilder,
+    Core, PollWfError, WorkerConfigBuilder,
 };
-use std::collections::HashSet;
 
 #[tokio::test]
 async fn multi_workers() {
-    let mut must_see_queues = HashSet::new();
     // Make histories for 5 different workflows on 5 different task queues
     let hists = (0..5).into_iter().map(|i| {
         let wf_id = format!("fake-wf-{}", i);
         let hist = canned_histories::single_timer("fake_timer");
-        let queue_name = format!("q-{}", i);
-        must_see_queues.insert(queue_name.clone());
         FakeWfResponses {
             wf_id,
             hist,
             response_batches: vec![1, 2],
-            task_q: queue_name,
+            task_q: format!("q-{}", i),
         }
     });
     let mock = build_multihist_mock_sg(hists, false, None);
 
-    let core = CoreSDK::new(
-        mock.sg,
-        CoreInitOptionsBuilder::default()
-            .gateway_opts(fake_sg_opts())
-            .build()
-            .unwrap(),
-    );
-    for queue_name in must_see_queues.iter() {
+    // This will register a pointless worker for `TEST_Q` as well, but, nothing will happen with it.
+    let core = &mock_core(mock.sg);
+    for i in 0..5 {
         core.register_worker(
             WorkerConfigBuilder::default()
-                .task_queue(queue_name.clone())
+                .task_queue(format!("q-{}", i))
                 .build()
                 .unwrap(),
         )
         .await;
     }
 
-    for _ in 0..5 {
-        let res = core.poll_workflow_task().await.unwrap();
-        assert!(must_see_queues.remove(&res.task_queue));
+    for i in 0..5 {
+        let tq = format!("q-{}", i);
+        let res = core.poll_workflow_task(&tq).await.unwrap();
         assert_matches!(
             res.jobs[0].variant,
             Some(wf_activation_job::Variant::StartWorkflow(_))
         );
     }
     core.shutdown().await;
+}
+
+#[tokio::test]
+async fn no_worker_for_queue_error_returned_properly() {
+    let wfid = "fake_wf_id";
+    let t = canned_histories::single_timer("fake_timer");
+    // Empty batches array to specify 0 calls to poll expectation
+    let core = build_fake_core(wfid, t, &[]);
+
+    let fake_q = "not a registered queue";
+    let res = core.inner.poll_workflow_task(&fake_q).await.unwrap_err();
+    assert_matches!(res, PollWfError::NoWorkerForQueue(err_q) => err_q == fake_q);
+    core.inner.shutdown().await;
 }

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -37,7 +37,8 @@ async fn multi_workers() {
                 .task_queue(queue_name.clone())
                 .build()
                 .unwrap(),
-        );
+        )
+        .await;
     }
 
     for _ in 0..5 {

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -931,7 +931,7 @@ async fn max_concurrent_wft_respected() {
     let (_, mut r1) = tokio::join! {
         async {
             core.complete_workflow_task(WfActivationCompletion::from_status(
-                r1.task_token,
+                r1.run_id,
                 workflow_completion::Success::from_variants(vec![StartTimer {
                     timer_id: "timer-1".to_string(),
                     ..Default::default()
@@ -952,7 +952,7 @@ async fn max_concurrent_wft_respected() {
     // Since we never did anything with r2, all subsequent activations should be for wf1
     for i in 2..19 {
         core.complete_workflow_task(WfActivationCompletion::from_status(
-            r1.task_token,
+            r1.run_id,
             workflow_completion::Success::from_variants(vec![StartTimer {
                 timer_id: format!("timer-{}", i),
                 ..Default::default()
@@ -1105,7 +1105,7 @@ async fn lots_of_workflows() {
                 _ => CompleteWorkflowExecution { result: None }.into(),
             };
             core.complete_workflow_task(WfActivationCompletion::from_status(
-                wft.task_token,
+                wft.run_id,
                 workflow_completion::Success::from_variants(vec![reply]).into(),
             ))
             .await

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -888,8 +888,8 @@ async fn max_concurrent_wft_respected() {
     );
 
     // Poll twice in a row before completing -- we should be at limit
-    let r1 = core.poll_workflow_task(TEST_Q).await.unwrap();
-    let _r2 = core.poll_workflow_task(TEST_Q).await.unwrap();
+    let r1 = core.poll_workflow_task().await.unwrap();
+    let _r2 = core.poll_workflow_task().await.unwrap();
     // Now we immediately poll for new work, and complete one of the existing activations. The
     // poll must not unblock until the completion goes through.
     let last_finisher = AtomicUsize::new(0);
@@ -906,7 +906,7 @@ async fn max_concurrent_wft_respected() {
             last_finisher.store(1, Ordering::SeqCst);
         },
         async {
-            let r = core.poll_workflow_task(TEST_Q).await.unwrap();
+            let r = core.poll_workflow_task().await.unwrap();
             last_finisher.store(2, Ordering::SeqCst);
             r
         }
@@ -927,7 +927,7 @@ async fn max_concurrent_wft_respected() {
         ))
         .await
         .unwrap();
-        r1 = core.poll_workflow_task(TEST_Q).await.unwrap();
+        r1 = core.poll_workflow_task().await.unwrap();
     }
 }
 
@@ -1057,7 +1057,7 @@ async fn lots_of_workflows() {
     let core = &mock_core(mock.sg);
 
     fanout_tasks(5, |_| async move {
-        while let Ok(wft) = core.poll_workflow_task(TEST_Q).await {
+        while let Ok(wft) = core.poll_workflow_task().await {
             assert_eq!(&wft.task_queue, TEST_Q);
             let job = &wft.jobs[0];
             let reply = match job.variant {
@@ -1136,7 +1136,7 @@ async fn complete_after_eviction() {
     mock.sg.expect_complete_workflow_task().times(0);
     let core = fake_core_from_mock_sg(mock);
 
-    let activation = core.inner.poll_workflow_task(TEST_Q).await.unwrap();
+    let activation = core.inner.poll_workflow_task().await.unwrap();
     // We just got start workflow, immediately evict
     core.inner.request_workflow_eviction(&activation.run_id);
     // Try to complete it. No error should be returned, and nothing happens or is sent to server.

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -885,7 +885,8 @@ async fn max_concurrent_wft_respected() {
             .max_outstanding_workflow_tasks(2usize)
             .build()
             .unwrap(),
-    );
+    )
+    .await;
 
     // Poll twice in a row before completing -- we should be at limit
     let r1 = core.poll_workflow_task().await.unwrap();
@@ -1081,6 +1082,8 @@ async fn lots_of_workflows() {
     assert_eq!(core.wft_manager.outstanding_wft(), 0);
     assert_eq!(
         core.workers
+            .read()
+            .await
             .get(TEST_Q)
             .unwrap()
             .outstanding_workflow_tasks(),

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -1138,7 +1138,7 @@ async fn complete_after_eviction() {
 
     let activation = core.inner.poll_workflow_task(TEST_Q).await.unwrap();
     // We just got start workflow, immediately evict
-    core.inner.request_eviction(&activation.run_id);
+    core.inner.request_workflow_eviction(&activation.run_id);
     // Try to complete it. No error should be returned, and nothing happens or is sent to server.
     core.inner
         .complete_workflow_task(WfActivationCompletion::from_cmd(

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -717,7 +717,6 @@ async fn cancel_timer_before_sent_wf_bridge() {
 #[rstest]
 #[case::no_evict_inc(&[1, 2, 2], NonSticky)]
 #[case::no_evict(&[2, 2], NonSticky)]
-#[case::evict(&[1, 2, 2, 2], AfterEveryReply)]
 #[tokio::test]
 async fn complete_activation_with_failure(
     #[case] batches: &[usize],

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -1093,6 +1093,7 @@ async fn lots_of_workflows() {
 
     fanout_tasks(5, |_| async move {
         while let Ok(wft) = core.poll_workflow_task(TEST_Q).await {
+            assert_eq!(&wft.task_queue, TEST_Q);
             let job = &wft.jobs[0];
             let reply = match job.variant {
                 Some(wf_activation_job::Variant::StartWorkflow(_)) => StartTimer {

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -1113,6 +1113,14 @@ async fn lots_of_workflows() {
     })
     .await;
     assert_eq!(core.wft_manager.outstanding_wft(), 0);
+    assert_eq!(
+        core.workers
+            .get(TEST_Q)
+            .unwrap()
+            .outstanding_workflow_tasks(),
+        0
+    );
+    core.shutdown().await;
 }
 
 #[rstest(hist_batches, case::incremental(&[1, 2]), case::replay(&[2]))]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,6 +55,9 @@ pub enum PollWfError {
     /// even though we already cancelled it)
     #[error("Unhandled error when auto-completing workflow task: {0:?}")]
     AutocompleteError(#[from] CompleteWfError),
+    /// There is no worker registered for the queue being polled
+    #[error("No worker registered for queue: {0}")]
+    NoWorkerForQueue(String),
 }
 
 impl From<WorkflowUpdateError> for PollWfError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,6 +55,9 @@ pub enum PollWfError {
     /// even though we already cancelled it)
     #[error("Unhandled error when auto-completing workflow task: {0:?}")]
     AutocompleteError(#[from] CompleteWfError),
+    /// There is no worker registered for the queue being polled
+    #[error("No worker registered for queue: {0}")]
+    NoWorkerForQueue(String),
 }
 
 impl From<WorkflowUpdateError> for PollWfError {
@@ -83,6 +86,9 @@ pub enum PollActivityError {
     /// errors, so lang should consider this fatal.
     #[error("Unhandled error when calling the temporal server: {0:?}")]
     TonicError(#[from] tonic::Status),
+    /// There is no worker registered for the queue being polled
+    #[error("No worker registered for queue: {0}")]
+    NoWorkerForQueue(String),
 }
 
 impl From<ShutdownErr> for PollActivityError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,9 +55,6 @@ pub enum PollWfError {
     /// even though we already cancelled it)
     #[error("Unhandled error when auto-completing workflow task: {0:?}")]
     AutocompleteError(#[from] CompleteWfError),
-    /// There is no worker registered for the queue being polled
-    #[error("No worker registered for queue: {0}")]
-    NoWorkerForQueue(String),
 }
 
 impl From<WorkflowUpdateError> for PollWfError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,9 +136,9 @@ pub trait Core: Send + Sync {
     fn record_activity_heartbeat(&self, details: ActivityHeartbeat);
 
     /// Request that a workflow be evicted by its run id. This will generate a workflow activation
-    /// with the eviction job inside it to be eventually returned by [poll_workflow_task]. If the
-    /// workflow had any existing outstanding activations, such activations are invalidated and
-    /// TODO: wat
+    /// with the eviction job inside it to be eventually returned by [Core::poll_workflow_task]. If
+    /// the workflow had any existing outstanding activations, such activations are invalidated and
+    /// subsequent completions of them will do nothing and log a warning.
     fn request_eviction(&self, run_id: &str);
 
     /// Returns core's instance of the [ServerGatewayApis] implementor it is using.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,6 @@ where
                 }
             }
 
-            // TODO: Can I eliminate this lock?
             let activation_update_fut = self
                 .workflow_activations_update
                 .lock()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub trait Core: Send + Sync {
     /// with the eviction job inside it to be eventually returned by [Core::poll_workflow_task]. If
     /// the workflow had any existing outstanding activations, such activations are invalidated and
     /// subsequent completions of them will do nothing and log a warning.
-    fn request_eviction(&self, run_id: &str);
+    fn request_workflow_eviction(&self, run_id: &str);
 
     /// Returns core's instance of the [ServerGatewayApis] implementor it is using.
     fn server_gateway(&self) -> Arc<dyn ServerGatewayApis>;
@@ -399,7 +399,7 @@ where
         }
     }
 
-    fn request_eviction(&self, run_id: &str) {
+    fn request_workflow_eviction(&self, run_id: &str) {
         self.wft_manager.evict_run(run_id);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,7 @@ use tokio::sync::{
 #[async_trait::async_trait]
 pub trait Core: Send + Sync {
     /// Register a worker with core. Workers poll on a specific task queue, and when calling core's
-    /// poll functions, you must provide a task queue name. Returned activations will include that
-    /// task queue name as well, so that lang may route them to the appropriate place.
+    /// poll functions, you must provide a task queue name.
     async fn register_worker(&self, config: WorkerConfig);
 
     /// Ask the core for some work, returning a [WfActivation]. It is then the language SDK's

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -183,7 +183,7 @@ pub fn build_multihist_mock_sg(
                 .map::<TimesRange, _>(Into::into)
                 .unwrap_or_else(|| RangeFull.into()),
         )
-        .returning(move || {
+        .returning(move |_| {
             for (wfid, tasks) in ids_to_resps.iter_mut() {
                 if !outstanding.read().contains_left(wfid) {
                     if let Some(t) = tasks.pop_front() {
@@ -247,7 +247,6 @@ pub fn fake_sg_opts() -> ServerGatewayOptions {
     ServerGatewayOptions {
         target_url: Url::from_str("https://fake").unwrap(),
         namespace: "".to_string(),
-        task_queue: "task_queue".to_string(),
         identity: "".to_string(),
         worker_binary_id: "".to_string(),
         long_poll_timeout: Default::default(),
@@ -284,7 +283,8 @@ pub(crate) async fn poll_and_reply<'a>(
                 continue;
             }
 
-            let mut res = core.inner.poll_workflow_task().await.unwrap();
+            // TODO: Plumb the queue through, will probably be needed for something
+            let mut res = core.inner.poll_workflow_task("whatever").await.unwrap();
             let contains_eviction = res.jobs.iter().position(|j| {
                 matches!(
                     j,

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -346,8 +346,7 @@ pub(crate) async fn poll_and_reply<'a>(
                 continue;
             }
 
-            let mut res = core.inner.poll_workflow_task().await.unwrap();
-            assert_eq!(&res.task_queue, TEST_Q);
+            let mut res = core.inner.poll_workflow_task(TEST_Q).await.unwrap();
             let contains_eviction = res.jobs.iter().position(|j| {
                 matches!(
                     j,

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -397,7 +397,7 @@ pub(crate) async fn poll_and_reply<'a>(
                 WorkflowCachingPolicy::NonSticky => (),
                 WorkflowCachingPolicy::AfterEveryReply => {
                     if evictions < expected_evictions {
-                        core.inner.request_eviction(&res.run_id);
+                        core.inner.request_workflow_eviction(&res.run_id);
                         evictions += 1;
                     }
                 }

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -250,6 +250,23 @@ pub fn build_multihist_mock_sg(
     }
 }
 
+/// See [build_multihist_mock_sg] -- one history convenience version
+pub fn single_hist_mock_sg(
+    wf_id: &str,
+    t: TestHistoryBuilder,
+    response_batches: &[usize],
+) -> MockSGAndTasks {
+    build_multihist_mock_sg(
+        vec![FakeWfResponses {
+            wf_id: wf_id.to_owned(),
+            hist: t,
+            response_batches: response_batches.to_vec(),
+        }],
+        true,
+        None,
+    )
+}
+
 pub fn hist_to_poll_resp(
     t: &TestHistoryBuilder,
     wf_id: String,
@@ -364,7 +381,7 @@ pub(crate) async fn poll_and_reply<'a>(
                 WorkflowCachingPolicy::NonSticky => (),
                 WorkflowCachingPolicy::AfterEveryReply => {
                     if evictions < expected_evictions {
-                        core.inner.wft_manager.evict_run(&res.run_id);
+                        core.inner.request_eviction(&res.run_id);
                         evictions += 1;
                     }
                 }

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -81,14 +81,14 @@ pub(crate) fn build_fake_core(
 
 /// See [build_fake_core] -- assemble a mock gateway into the final fake core
 pub(crate) fn fake_core_from_mock_sg(mock_and_tasks: MockSGAndTasks) -> FakeCore {
-    let core = CoreSDK::new(
+    let mut core = CoreSDK::new(
         mock_and_tasks.sg,
         CoreInitOptionsBuilder::default()
             .gateway_opts(fake_sg_opts())
             .build()
             .unwrap(),
     );
-    core.register_worker(
+    core.reg_worker_sync(
         WorkerConfigBuilder::default()
             .task_queue(TEST_Q)
             .build()
@@ -104,14 +104,14 @@ pub(crate) fn mock_core<SG>(sg: SG) -> CoreSDK<impl ServerGatewayApis>
 where
     SG: ServerGatewayApis + Send + Sync + 'static,
 {
-    let core = CoreSDK::new(
+    let mut core = CoreSDK::new(
         sg,
         CoreInitOptionsBuilder::default()
             .gateway_opts(fake_sg_opts())
             .build()
             .unwrap(),
     );
-    core.register_worker(
+    core.reg_worker_sync(
         WorkerConfigBuilder::default()
             .task_queue(TEST_Q)
             .build()

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -173,6 +173,9 @@ pub fn build_multihist_mock_sg(
 
         // Convert history batches into poll responses, while also tracking how many times a given
         // history has been returned so we can increment the associated attempt number on the WFT.
+        // NOTE: This is hard to use properly with the `AfterEveryReply` testing eviction mode.
+        //  Such usages need a history different from other eviction modes which would include
+        //  WFT timeouts or something to simulate the task getting dropped.
         let mut attempts_at_task_num = HashMap::new();
         let responses: Vec<_> = hist
             .response_batches

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -346,7 +346,7 @@ pub(crate) async fn poll_and_reply<'a>(
                 continue;
             }
 
-            let mut res = core.inner.poll_workflow_task(TEST_Q).await.unwrap();
+            let mut res = core.inner.poll_workflow_task().await.unwrap();
             assert_eq!(&res.task_queue, TEST_Q);
             let contains_eviction = res.jobs.iter().position(|j| {
                 matches!(

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -1,4 +1,3 @@
-use crate::workflow::NextWfActivation;
 use crate::{
     core_tracing::VecDisplayer,
     machines::{
@@ -11,7 +10,7 @@ use crate::{
         coresdk::{
             workflow_activation::{
                 wf_activation_job::{self, Variant},
-                StartWorkflow, UpdateRandomSeed,
+                StartWorkflow, UpdateRandomSeed, WfActivation,
             },
             PayloadsExt, PayloadsToPayloadError,
         },
@@ -403,13 +402,13 @@ impl WorkflowMachines {
     ///
     /// Importantly, the returned activation will have an empty task token. A meaningful one is
     /// expected to be attached by something higher in the call stack.
-    pub(crate) fn get_wf_activation(&mut self) -> Option<NextWfActivation> {
+    pub(crate) fn get_wf_activation(&mut self) -> Option<WfActivation> {
         let jobs = self.drive_me.drain_jobs();
         if jobs.is_empty() {
             None
         } else {
-            Some(NextWfActivation {
-                timestamp: self.current_wf_time,
+            Some(WfActivation {
+                timestamp: self.current_wf_time.map(Into::into),
                 run_id: self.run_id.clone(),
                 jobs,
             })

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -1,3 +1,4 @@
+use crate::workflow::NextWfActivation;
 use crate::{
     core_tracing::VecDisplayer,
     machines::{
@@ -10,7 +11,7 @@ use crate::{
         coresdk::{
             workflow_activation::{
                 wf_activation_job::{self, Variant},
-                StartWorkflow, UpdateRandomSeed, WfActivation,
+                StartWorkflow, UpdateRandomSeed,
             },
             PayloadsExt, PayloadsToPayloadError,
         },
@@ -402,16 +403,15 @@ impl WorkflowMachines {
     ///
     /// Importantly, the returned activation will have an empty task token. A meaningful one is
     /// expected to be attached by something higher in the call stack.
-    pub(crate) fn get_wf_activation(&mut self) -> Option<WfActivation> {
+    pub(crate) fn get_wf_activation(&mut self) -> Option<NextWfActivation> {
         let jobs = self.drive_me.drain_jobs();
         if jobs.is_empty() {
             None
         } else {
-            Some(WfActivation {
-                timestamp: self.current_wf_time.map(Into::into),
+            Some(NextWfActivation {
+                timestamp: self.current_wf_time,
                 run_id: self.run_id.clone(),
                 jobs,
-                task_token: vec![],
             })
         }
     }

--- a/src/pending_activations.rs
+++ b/src/pending_activations.rs
@@ -30,10 +30,6 @@ impl PendingActivations {
                 .activations
                 .get_mut(key)
                 .expect("PA run id mapping is always in sync with slot map");
-            assert_eq!(
-                v.task_token, act.task_token,
-                "New PAs that match an existing PA's run id must have the same task token"
-            );
             act.jobs.extend(v.jobs);
         } else {
             let run_id = v.run_id.clone();
@@ -108,24 +104,6 @@ mod tests {
         assert_eq!(&last.run_id, &rid2);
         assert!(!pas.has_pending(&rid2));
         assert!(pas.pop().is_none());
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "New PAs that match an existing PA's run id must have the same task token"
-    )]
-    fn panics_on_same_run_id_different_tokens() {
-        let pas = PendingActivations::default();
-        let rid = "1".to_string();
-        pas.push(WfActivation {
-            run_id: rid.clone(),
-            ..Default::default()
-        });
-        pas.push(WfActivation {
-            run_id: rid,
-            task_token: vec![9],
-            ..Default::default()
-        });
     }
 
     #[test]

--- a/src/pending_activations.rs
+++ b/src/pending_activations.rs
@@ -12,16 +12,16 @@ pub struct PendingActivations {
 
 slotmap::new_key_type! { struct ActivationKey; }
 
-// This could be made more memory efficient with an arena or something if ever needed
 #[derive(Default)]
 struct PaInner {
-    queue: VecDeque<ActivationKey>,
     activations: SlotMap<ActivationKey, WfActivation>,
     by_run_id: HashMap<String, ActivationKey>,
+    // Holds the actual queue of activations per-task-queue
+    by_task_queue: HashMap<String, VecDeque<ActivationKey>>,
 }
 
 impl PendingActivations {
-    pub fn push(&self, v: WfActivation) {
+    pub fn push(&self, v: WfActivation, task_queue: String) {
         let mut inner = self.inner.write();
 
         // Check if an activation with the same ID already exists, and merge joblist if so
@@ -35,20 +35,31 @@ impl PendingActivations {
             let run_id = v.run_id.clone();
             let key = inner.activations.insert(v);
             inner.by_run_id.insert(run_id, key);
-            inner.queue.push_back(key);
+            inner
+                .by_task_queue
+                .entry(task_queue)
+                .or_default()
+                .push_back(key);
         };
     }
 
-    pub fn pop(&self) -> Option<WfActivation> {
+    pub fn pop(&self, task_queue: &str) -> Option<WfActivation> {
         let mut inner = self.inner.write();
-        let rme = inner.queue.pop_front();
-        if let Some(key) = rme {
-            let pa = inner
-                .activations
-                .remove(key)
-                .expect("PAs in queue exist in slot map");
-            inner.by_run_id.remove(&pa.run_id);
-            Some(pa)
+        if let Some(qq) = inner.by_task_queue.get_mut(task_queue) {
+            if let Some(key) = qq.pop_front() {
+                if let Some(pa) = inner.activations.remove(key) {
+                    inner.by_run_id.remove(&pa.run_id);
+                    Some(pa)
+                } else {
+                    // Keys no longer in the slot map are ignored, since they may have been removed
+                    // by run id or anything else. Try to pop the next thing from the queue. Recurse
+                    // to avoid double mutable borrow.
+                    drop(inner); // Will deadlock when we recurse w/o this
+                    self.pop(task_queue)
+                }
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -62,7 +73,6 @@ impl PendingActivations {
         let mut inner = self.inner.write();
 
         if let Some(k) = inner.by_run_id.remove(run_id) {
-            inner.queue.retain(|pa_k| *pa_k != k);
             inner.activations.remove(k);
         }
     }
@@ -74,62 +84,129 @@ mod tests {
 
     #[test]
     fn merges_same_ids() {
+        let tq = "task_q";
         let pas = PendingActivations::default();
         let rid1 = "1".to_string();
         let rid2 = "2".to_string();
-        pas.push(WfActivation {
-            run_id: rid1.clone(),
-            ..Default::default()
-        });
-        pas.push(WfActivation {
-            run_id: rid2.clone(),
-            ..Default::default()
-        });
-        pas.push(WfActivation {
-            run_id: rid2.clone(),
-            ..Default::default()
-        });
-        pas.push(WfActivation {
-            run_id: rid2.clone(),
-            ..Default::default()
-        });
+        pas.push(
+            WfActivation {
+                run_id: rid1.clone(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: rid2.clone(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: rid2.clone(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: rid2.clone(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
         assert!(pas.has_pending(&rid1));
         assert!(pas.has_pending(&rid2));
-        let last = pas.pop().unwrap();
+        let last = pas.pop(tq).unwrap();
         assert_eq!(&last.run_id, &rid1);
         assert!(!pas.has_pending(&rid1));
         assert!(pas.has_pending(&rid2));
         // Should only be one id 2, they are all merged
-        let last = pas.pop().unwrap();
+        let last = pas.pop(tq).unwrap();
         assert_eq!(&last.run_id, &rid2);
         assert!(!pas.has_pending(&rid2));
-        assert!(pas.pop().is_none());
+        assert!(pas.pop(tq).is_none());
     }
 
     #[test]
     fn can_remove_all_with_id() {
+        let tq = "task_q";
         let pas = PendingActivations::default();
         let remove_me = "2".to_string();
-        pas.push(WfActivation {
-            run_id: "1".to_owned(),
-            ..Default::default()
-        });
-        pas.push(WfActivation {
-            run_id: remove_me.clone(),
-            ..Default::default()
-        });
-        pas.push(WfActivation {
-            run_id: remove_me.clone(),
-            ..Default::default()
-        });
-        pas.push(WfActivation {
-            run_id: "3".to_owned(),
-            ..Default::default()
-        });
+        pas.push(
+            WfActivation {
+                run_id: "1".to_owned(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: remove_me.clone(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: remove_me.clone(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: "3".to_owned(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
         pas.remove_all_with_run_id(&remove_me);
         assert!(!pas.has_pending(&remove_me));
-        assert_eq!(&pas.pop().unwrap().run_id, "1");
-        assert_eq!(&pas.pop().unwrap().run_id, "3");
-        assert!(pas.pop().is_none());
+        assert_eq!(&pas.pop(tq).unwrap().run_id, "1");
+        assert_eq!(&pas.pop(tq).unwrap().run_id, "3");
+        assert!(pas.pop(tq).is_none());
+    }
+
+    #[test]
+    fn multiple_task_queues() {
+        let tq = "task_q";
+        let tq2 = "task_q_2";
+        let pas = PendingActivations::default();
+        pas.push(
+            WfActivation {
+                run_id: "1_1".to_owned(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: "2_1".to_owned(),
+                ..Default::default()
+            },
+            tq2.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: "1_2".to_owned(),
+                ..Default::default()
+            },
+            tq.to_owned(),
+        );
+        pas.push(
+            WfActivation {
+                run_id: "2_2".to_owned(),
+                ..Default::default()
+            },
+            tq2.to_owned(),
+        );
+        assert_eq!(&pas.pop(tq).unwrap().run_id, "1_1");
+        assert_eq!(&pas.pop(tq2).unwrap().run_id, "2_1");
+        assert_eq!(&pas.pop(tq).unwrap().run_id, "1_2");
+        assert_eq!(pas.pop(tq), None);
+        assert_eq!(&pas.pop(tq2).unwrap().run_id, "2_2");
+        assert_eq!(pas.pop(tq2), None);
     }
 }

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -17,11 +17,16 @@ pub mod coresdk {
         tonic::include_proto!("coresdk.activity_task");
 
         impl ActivityTask {
-            pub fn cancel_from_ids(task_token: TaskToken, activity_id: String) -> Self {
+            pub fn cancel_from_ids(
+                task_token: TaskToken,
+                activity_id: String,
+                task_queue: String,
+            ) -> Self {
                 ActivityTask {
                     task_token: task_token.0,
                     activity_id,
                     variant: Some(activity_task::Variant::Cancel(Cancel {})),
+                    task_queue,
                 }
             }
         }
@@ -59,7 +64,11 @@ pub mod coresdk {
         use std::fmt::{Display, Formatter};
 
         tonic::include_proto!("coresdk.workflow_activation");
-        pub fn create_evict_activation(task_token: TaskToken, run_id: String) -> WfActivation {
+        pub fn create_evict_activation(
+            task_token: TaskToken,
+            run_id: String,
+            task_queue: String,
+        ) -> WfActivation {
             WfActivation {
                 task_token: task_token.0,
                 timestamp: None,
@@ -67,6 +76,7 @@ pub mod coresdk {
                 jobs: vec![WfActivationJob::from(
                     wf_activation_job::Variant::RemoveFromCache(true),
                 )],
+                task_queue,
             }
         }
 
@@ -295,9 +305,10 @@ pub mod coresdk {
     }
 
     impl ActivityTask {
-        pub fn start_from_poll_resp(r: PollActivityTaskQueueResponse) -> Self {
+        pub fn start_from_poll_resp(r: PollActivityTaskQueueResponse, task_queue: String) -> Self {
             ActivityTask {
                 task_token: r.task_token,
+                task_queue,
                 activity_id: r.activity_id,
                 variant: Some(activity_task::activity_task::Variant::Start(
                     activity_task::Start {

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -17,16 +17,11 @@ pub mod coresdk {
         tonic::include_proto!("coresdk.activity_task");
 
         impl ActivityTask {
-            pub fn cancel_from_ids(
-                task_token: TaskToken,
-                activity_id: String,
-                task_queue: String,
-            ) -> Self {
+            pub fn cancel_from_ids(task_token: TaskToken, activity_id: String) -> Self {
                 ActivityTask {
                     task_token: task_token.0,
                     activity_id,
                     variant: Some(activity_task::Variant::Cancel(Cancel {})),
-                    task_queue,
                 }
             }
         }
@@ -63,14 +58,13 @@ pub mod coresdk {
         use std::fmt::{Display, Formatter};
 
         tonic::include_proto!("coresdk.workflow_activation");
-        pub fn create_evict_activation(run_id: String, task_queue: String) -> WfActivation {
+        pub fn create_evict_activation(run_id: String) -> WfActivation {
             WfActivation {
                 timestamp: None,
                 run_id,
                 jobs: vec![WfActivationJob::from(
                     wf_activation_job::Variant::RemoveFromCache(true),
                 )],
-                task_queue,
             }
         }
 
@@ -296,10 +290,9 @@ pub mod coresdk {
     }
 
     impl ActivityTask {
-        pub fn start_from_poll_resp(r: PollActivityTaskQueueResponse, task_queue: String) -> Self {
+        pub fn start_from_poll_resp(r: PollActivityTaskQueueResponse) -> Self {
             ActivityTask {
                 task_token: r.task_token,
-                task_queue,
                 activity_id: r.activity_id,
                 variant: Some(activity_task::activity_task::Variant::Start(
                     activity_task::Start {

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -149,24 +149,26 @@ pub mod coresdk {
         }
     }
 
-    use crate::protos::{
-        coresdk::{
-            activity_result::ActivityResult,
-            activity_task::ActivityTask,
-            common::{Payload, UserCodeFailure},
-            workflow_activation::SignalWorkflow,
-            workflow_commands::workflow_command::Variant,
-            workflow_completion::Success,
+    use crate::{
+        protos::{
+            coresdk::{
+                activity_result::ActivityResult,
+                activity_task::ActivityTask,
+                common::{Payload, UserCodeFailure},
+                workflow_activation::SignalWorkflow,
+                workflow_commands::workflow_command::Variant,
+                workflow_completion::Success,
+            },
+            temporal::api::{
+                common::v1::{Payloads, WorkflowExecution},
+                failure::v1::ApplicationFailureInfo,
+                failure::v1::{failure::FailureInfo, Failure},
+                history::v1::WorkflowExecutionSignaledEventAttributes,
+                workflowservice::v1::PollActivityTaskQueueResponse,
+            },
         },
-        temporal::api::{
-            common::v1::{Payloads, WorkflowExecution},
-            failure::v1::ApplicationFailureInfo,
-            failure::v1::{failure::FailureInfo, Failure},
-            history::v1::WorkflowExecutionSignaledEventAttributes,
-            workflowservice::v1::PollActivityTaskQueueResponse,
-        },
+        task_token::fmt_tt,
     };
-    use crate::task_token::{fmt_tt, TaskToken};
     use std::convert::TryFrom;
     use std::fmt::{Display, Formatter};
     use workflow_activation::{wf_activation_job, WfActivationJob};

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -293,12 +293,9 @@ pub mod coresdk {
     }
 
     impl ActivityTask {
-        pub fn start_from_poll_resp(
-            r: PollActivityTaskQueueResponse,
-            task_token: TaskToken,
-        ) -> Self {
+        pub fn start_from_poll_resp(r: PollActivityTaskQueueResponse) -> Self {
             ActivityTask {
-                task_token: task_token.0,
+                task_token: r.task_token,
                 activity_id: r.activity_id,
                 variant: Some(activity_task::activity_task::Variant::Start(
                     activity_task::Start {

--- a/src/protosext/mod.rs
+++ b/src/protosext/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 use std::convert::TryFrom;
 
 /// A validated version of a [PollWorkflowTaskQueueResponse]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ValidPollWFTQResponse {
     pub task_token: TaskToken,
     pub task_queue: String,

--- a/src/protosext/mod.rs
+++ b/src/protosext/mod.rs
@@ -62,12 +62,12 @@ impl TryFrom<PollWorkflowTaskQueueResponse> for ValidPollWFTQResponse {
 /// Makes converting outgoing lang commands into [WfActivationCompletion]s easier
 pub trait IntoCompletion {
     /// The conversion function
-    fn into_completion(self, task_token: Vec<u8>) -> WfActivationCompletion;
+    fn into_completion(self, run_id: String) -> WfActivationCompletion;
 }
 
 impl IntoCompletion for workflow_command::Variant {
-    fn into_completion(self, task_token: Vec<u8>) -> WfActivationCompletion {
-        WfActivationCompletion::from_cmd(self, task_token)
+    fn into_completion(self, run_id: String) -> WfActivationCompletion {
+        WfActivationCompletion::from_cmd(self, run_id)
     }
 }
 
@@ -76,10 +76,10 @@ where
     I: IntoIterator<Item = V>,
     V: Into<WorkflowCommand>,
 {
-    fn into_completion(self, task_token: Vec<u8>) -> WfActivationCompletion {
+    fn into_completion(self, run_id: String) -> WfActivationCompletion {
         let success = self.into_iter().map(Into::into).collect::<Vec<_>>().into();
         WfActivationCompletion {
-            task_token,
+            run_id,
             status: Some(wf_activation_completion::Status::Successful(success)),
         }
     }

--- a/src/protosext/mod.rs
+++ b/src/protosext/mod.rs
@@ -17,6 +17,7 @@ use std::convert::TryFrom;
 /// A validated version of a [PollWorkflowTaskQueueResponse]
 pub struct ValidPollWFTQResponse {
     pub task_token: TaskToken,
+    pub task_queue: String,
     pub workflow_execution: WorkflowExecution,
     pub history: History,
     pub next_page_token: Vec<u8>,
@@ -31,6 +32,7 @@ impl TryFrom<PollWorkflowTaskQueueResponse> for ValidPollWFTQResponse {
         match value {
             PollWorkflowTaskQueueResponse {
                 task_token,
+                workflow_execution_task_queue: Some(tq),
                 workflow_execution: Some(workflow_execution),
                 history: Some(history),
                 next_page_token,
@@ -44,6 +46,7 @@ impl TryFrom<PollWorkflowTaskQueueResponse> for ValidPollWFTQResponse {
 
                 Ok(Self {
                     task_token: TaskToken(task_token),
+                    task_queue: tq.name,
                     workflow_execution,
                     history,
                     next_page_token,

--- a/src/test_workflow_driver.rs
+++ b/src/test_workflow_driver.rs
@@ -127,11 +127,10 @@ impl TestRustWorker {
         let mut handles = self.join_handles;
         let core = self.core;
         let workflows = self.workflows;
-        let tq = self.task_queue;
 
         let poller = async {
             loop {
-                let activation = core.poll_workflow_task(&tq).await?;
+                let activation = core.poll_workflow_task().await?;
                 // The activation is expected to apply to some workflow we know about. Use it to
                 // unblock things and advance the workflow.
                 if let Some(tx) = workflows.get_mut(&activation.run_id) {

--- a/src/test_workflow_driver.rs
+++ b/src/test_workflow_driver.rs
@@ -107,7 +107,7 @@ impl TestRustWorker {
                 // to use block_in_place here.
                 let wf_is_done = tokio::task::block_in_place(|| twd.wait_until_wf_iteration_done());
                 let outgoing = twd.drain_pending_commands();
-                core.complete_workflow_task(outgoing.into_completion(activation.task_token))
+                core.complete_workflow_task(outgoing.into_completion(activation.run_id))
                     .await?;
                 if wf_is_done {
                     break;

--- a/src/test_workflow_driver.rs
+++ b/src/test_workflow_driver.rs
@@ -127,10 +127,11 @@ impl TestRustWorker {
         let mut handles = self.join_handles;
         let core = self.core;
         let workflows = self.workflows;
+        let tq = self.task_queue;
 
         let poller = async {
             loop {
-                let activation = core.poll_workflow_task().await?;
+                let activation = core.poll_workflow_task(&tq).await?;
                 // The activation is expected to apply to some workflow we know about. Use it to
                 // unblock things and advance the workflow.
                 if let Some(tx) = workflows.get_mut(&activation.run_id) {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -92,7 +92,9 @@ impl Worker {
     }
     pub(crate) fn shutdown(&self) {
         self.wf_task_poll_buffer.shutdown();
-        self.at_task_poll_buffer.as_ref().map(|b| b.shutdown());
+        if let Some(b) = self.at_task_poll_buffer.as_ref() {
+            b.shutdown();
+        }
     }
 
     pub(crate) fn task_queue(&self) -> &str {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1,0 +1,140 @@
+use crate::{
+    activity::InflightActivityDetails,
+    pollers::{
+        new_activity_task_buffer, new_workflow_task_buffer, PollActivityTaskBuffer,
+        PollWorkflowTaskBuffer,
+    },
+    protos::{
+        coresdk::activity_task::ActivityTask,
+        temporal::api::workflowservice::v1::{
+            PollActivityTaskQueueResponse, PollWorkflowTaskQueueResponse,
+        },
+    },
+    task_token::TaskToken,
+    PollActivityError, PollWfError, ServerGatewayApis,
+};
+use futures::TryFutureExt;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+/// Defines per-worker configuration options
+#[derive(Debug, Clone, derive_builder::Builder)]
+#[builder(setter(into))]
+// TODO: per-second queue limits
+pub struct WorkerConfig {
+    /// What task queue will this worker poll from? This task queue name will be used for both
+    /// workflow and activity polling.
+    pub task_queue: String,
+    /// The maximum allowed number of workflow tasks that will ever be given to this worker at one
+    /// time. Note that one workflow task may require multiple activations - so the WFT counts as
+    /// "outstanding" until all activations it requires have been completed.
+    #[builder(default = "100")]
+    pub max_outstanding_workflow_tasks: usize,
+    /// The maximum allowed number of activity tasks that will ever be given to this worker at one
+    /// time.
+    #[builder(default = "100")]
+    pub max_outstanding_activities: usize,
+    /// Maximum number of concurrent poll workflow task requests we will perform at a time on this
+    /// worker's task queue
+    #[builder(default = "5")]
+    pub max_concurrent_wft_polls: usize,
+    /// Maximum number of concurrent poll activity task requests we will perform at a time on this
+    /// worker's task queue
+    #[builder(default = "5")]
+    pub max_concurrent_at_polls: usize,
+    /// If set to true this worker will only handle workflow tasks and local activities, it will not
+    /// poll for activity tasks. This option exists because
+    #[builder(default = "false")]
+    pub no_remote_activities: bool,
+}
+
+/// A worker polls on a certain task queue
+pub(crate) struct Worker {
+    config: WorkerConfig,
+
+    /// Buffers workflow task polling in the event we need to return a pending activation while
+    /// a poll is ongoing
+    wf_task_poll_buffer: PollWorkflowTaskBuffer,
+    /// Buffers activity task polling in the event we need to return a cancellation while a poll is
+    /// ongoing. May be `None` if this worker does not poll for activities.
+    at_task_poll_buffer: Option<PollActivityTaskBuffer>,
+
+    /// Ensures we stay at or below this worker's maximum concurrent workflow limit
+    workflows_semaphore: Semaphore,
+    /// Ensures we stay at or below this worker's maximum concurrent activity limit
+    activities_semaphore: Semaphore,
+}
+
+impl Worker {
+    pub(crate) fn new<SG: ServerGatewayApis + Send + Sync + 'static>(
+        config: WorkerConfig,
+        sg: Arc<SG>,
+    ) -> Self {
+        let wf_task_poll_buffer = new_workflow_task_buffer(
+            sg.clone(),
+            config.task_queue.clone(),
+            config.max_concurrent_wft_polls,
+            config.max_concurrent_wft_polls * 2,
+        );
+        let at_task_poll_buffer = if config.no_remote_activities {
+            None
+        } else {
+            Some(new_activity_task_buffer(
+                sg,
+                config.task_queue.clone(),
+                config.max_concurrent_at_polls,
+                config.max_concurrent_at_polls * 2,
+            ))
+        };
+        Self {
+            wf_task_poll_buffer,
+            at_task_poll_buffer,
+            workflows_semaphore: Semaphore::new(config.max_outstanding_workflow_tasks),
+            activities_semaphore: Semaphore::new(config.max_outstanding_activities),
+            config,
+        }
+    }
+    pub(crate) fn task_queue(&self) -> &str {
+        &self.config.task_queue
+    }
+
+    /// Wait until not at the outstanding activity limit, and then poll this worker's task queue for
+    /// new activities.
+    pub(crate) async fn activity_poll(
+        &self,
+    ) -> Result<PollActivityTaskQueueResponse, PollActivityError> {
+        // TODO: Explicit error?
+        let poll_buff = self
+            .at_task_poll_buffer
+            .as_ref()
+            .expect("Poll on activity worker means it actually has a poller");
+
+        // Acquire and immediately forget a permit for an outstanding activity. When they are
+        // completed, we must add a new permit to the semaphore, since holding the permit the
+        // entire time lang does work would be a challenge. TODO: Maybe actually a good way, tho?
+        self.activities_semaphore
+            .acquire()
+            .await
+            .expect("outstanding activity semaphore not closed")
+            .forget();
+
+        poll_buff.poll().map_err(Into::into).await
+    }
+
+    /// Wait until not at the outstanding workflow task limit, and then poll this worker's task
+    /// queue for new workflow tasks.
+    pub(crate) async fn workflow_poll(&self) -> Result<PollWorkflowTaskQueueResponse, PollWfError> {
+        self.workflows_semaphore
+            .acquire()
+            .await
+            .expect("outstanding workflow tasks semaphore not dropped")
+            .forget();
+        debug!("Polling server");
+        self.wf_task_poll_buffer.poll().map_err(Into::into).await
+    }
+
+    /// Tell the worker an activity has completed, for tracking max outstanding activities
+    pub(crate) fn activity_done(&self) {
+        self.activities_semaphore.add_permits(1)
+    }
+}

--- a/src/workflow/concurrency_manager.rs
+++ b/src/workflow/concurrency_manager.rs
@@ -2,9 +2,10 @@
 //! doing so is nontrivial
 
 use crate::{
+    protos::coresdk::workflow_activation::WfActivation,
     protos::temporal::api::common::v1::WorkflowExecution,
     protos::temporal::api::history::v1::History,
-    workflow::{NextWfActivation, Result, WorkflowError, WorkflowManager},
+    workflow::{Result, WorkflowError, WorkflowManager},
 };
 use crossbeam::channel::{bounded, unbounded, Receiver, Select, Sender, TryRecvError};
 use dashmap::DashMap;
@@ -38,7 +39,7 @@ struct MachineCreatorMsg {
 }
 /// The response to [MachineCreatorMsg], which includes the wf activation and the channel to
 /// send requests to the newly instantiated workflow manager.
-type MachineCreatorResponseMsg = Result<(NextWfActivation, MachineMutationSender)>;
+type MachineCreatorResponseMsg = Result<(WfActivation, MachineMutationSender)>;
 
 impl WorkflowConcurrencyManager {
     pub fn new() -> Self {
@@ -67,7 +68,7 @@ impl WorkflowConcurrencyManager {
         run_id: &str,
         history: History,
         workflow_execution: WorkflowExecution,
-    ) -> Result<Option<NextWfActivation>> {
+    ) -> Result<Option<WfActivation>> {
         let span = debug_span!("create_or_update machines", %run_id);
 
         if self.exists(run_id) {

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -100,9 +100,8 @@ pub(crate) struct NextWfActivation {
 
 impl NextWfActivation {
     /// Attach a task token & queue to the activation so it can be sent out to the lang sdk
-    pub fn finalize(self, task_token: TaskToken, task_queue: String) -> WfActivation {
+    pub fn finalize(self, task_queue: String) -> WfActivation {
         WfActivation {
-            task_token: task_token.0,
             task_queue,
             timestamp: self.timestamp.map(Into::into),
             run_id: self.run_id,
@@ -117,6 +116,7 @@ impl NextWfActivation {
 
 #[derive(Debug)]
 pub struct OutgoingServerCommands {
+    pub task_token: TaskToken,
     pub commands: Vec<ProtoCommand>,
     pub at_final_workflow_task: bool,
 }
@@ -141,8 +141,10 @@ impl WorkflowManager {
 
     /// Fetch any pending commands that should be sent to the server, as well as if this workflow
     /// is at it's final workflow task in current history.
-    pub fn get_server_commands(&self) -> OutgoingServerCommands {
+    /// TODO: Maybe return a different type here rather than making caller pass in TT
+    pub fn get_server_commands(&self, task_token: TaskToken) -> OutgoingServerCommands {
         OutgoingServerCommands {
+            task_token,
             commands: self.machines.get_commands(),
             at_final_workflow_task: self.at_latest_wf_task(),
         }

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -6,7 +6,6 @@ pub(crate) use bridge::WorkflowBridge;
 pub(crate) use concurrency_manager::WorkflowConcurrencyManager;
 pub(crate) use driven_workflow::{ActivationListener, DrivenWorkflow, WorkflowFetcher};
 
-use crate::task_token::TaskToken;
 use crate::{
     machines::{ProtoCommand, WFCommand, WFMachinesError, WorkflowMachines},
     protos::{
@@ -14,9 +13,12 @@ use crate::{
         temporal::api::{common::v1::WorkflowExecution, history::v1::History},
     },
     protosext::{HistoryInfo, HistoryInfoError},
+    task_token::TaskToken,
 };
-use std::sync::mpsc::{SendError, Sender};
-use std::time::SystemTime;
+use std::{
+    sync::mpsc::{SendError, Sender},
+    time::SystemTime,
+};
 
 type Result<T, E = WorkflowError> = std::result::Result<T, E>;
 

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -178,7 +178,7 @@ impl WorkflowManager {
 
 /// Determines when workflows are kept in the cache or evicted
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum WorkflowCachingPolicy {
+pub(crate) enum WorkflowCachingPolicy {
     /// Workflows are cached until evicted explicitly or the cache size limit is reached, in which
     /// case they are evicted by least-recently-used ordering.
     Sticky {
@@ -193,17 +193,4 @@ pub enum WorkflowCachingPolicy {
     /// even if there are pending activations
     #[cfg(test)]
     AfterEveryReply,
-}
-
-/// The default number of workflows sticky mode will cache at maximum
-pub static STICKY_DEFAULT_MAX_WORKFLOWS: usize = 10_000;
-
-impl WorkflowCachingPolicy {
-    /// Returns a sticky [WorkflowEvictionPolicy] with the cache size set to
-    /// [STICKY_DEFAULT_MAX_WORKFLOWS]
-    pub fn sticky_default() -> Self {
-        WorkflowCachingPolicy::Sticky {
-            max_cached_workflows: STICKY_DEFAULT_MAX_WORKFLOWS,
-        }
-    }
 }

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -175,3 +175,35 @@ impl WorkflowManager {
         Ok(())
     }
 }
+
+/// Determines when workflows are kept in the cache or evicted
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WorkflowCachingPolicy {
+    /// Workflows are cached until evicted explicitly or the cache size limit is reached, in which
+    /// case they are evicted by least-recently-used ordering.
+    Sticky {
+        /// The maximum number of workflows that will be kept in the cache
+        max_cached_workflows: usize,
+    },
+    /// Workflows are evicted after each workflow task completion. Note that this is *not* after
+    /// each workflow activation - there are often multiple activations per workflow task.
+    NonSticky,
+
+    /// Not a real mode, but good for imitating crashes. Evict workflows after *every* reply,
+    /// even if there are pending activations
+    #[cfg(test)]
+    AfterEveryReply,
+}
+
+/// The default number of workflows sticky mode will cache at maximum
+pub static STICKY_DEFAULT_MAX_WORKFLOWS: usize = 10_000;
+
+impl WorkflowCachingPolicy {
+    /// Returns a sticky [WorkflowEvictionPolicy] with the cache size set to
+    /// [STICKY_DEFAULT_MAX_WORKFLOWS]
+    pub fn sticky_default() -> Self {
+        WorkflowCachingPolicy::Sticky {
+            max_cached_workflows: STICKY_DEFAULT_MAX_WORKFLOWS,
+        }
+    }
+}

--- a/src/workflow_tasks.rs
+++ b/src/workflow_tasks.rs
@@ -65,7 +65,7 @@ pub enum NewWfTaskOutcome {
 }
 
 impl WorkflowTaskManager {
-    pub fn new(
+    pub(crate) fn new(
         workflow_task_complete_notify: Arc<Notify>,
         eviction_policy: WorkflowCachingPolicy,
     ) -> Self {

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -119,7 +119,7 @@ impl CoreWfStarter {
         if self.initted_core.is_none() {
             let core = temporal_sdk_core::init(opts).await.unwrap();
             // Register a worker for the task queue
-            core.register_worker(self.worker_config.clone());
+            core.register_worker(self.worker_config.clone()).await;
             self.initted_core = Some(Arc::new(core));
         }
         self.initted_core.as_ref().unwrap().clone()

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -7,7 +7,6 @@ use temporal_sdk_core::{
     },
     test_workflow_driver::TestRustWorker,
     Core, CoreInitOptions, CoreInitOptionsBuilder, ServerGatewayApis, ServerGatewayOptions,
-    WorkflowCachingPolicy,
 };
 use url::Url;
 
@@ -32,7 +31,7 @@ impl CoreWfStarter {
             test_name: test_name.to_owned(),
             core_options: CoreInitOptionsBuilder::default()
                 .gateway_opts(get_integ_server_options(&task_queue))
-                .eviction_policy(WorkflowCachingPolicy::sticky_default())
+                .max_cached_workflows(1000usize)
                 .build()
                 .unwrap(),
             task_queue,
@@ -91,8 +90,8 @@ impl CoreWfStarter {
         &self.test_name
     }
 
-    pub fn eviction_policy(&mut self, policy: WorkflowCachingPolicy) -> &mut Self {
-        self.core_options.eviction_policy = policy;
+    pub fn max_cached_workflows(&mut self, num: usize) -> &mut Self {
+        self.core_options.max_cached_workflows = num;
         self
     }
 
@@ -157,7 +156,7 @@ pub async fn get_integ_core(task_q: &str) -> impl Core {
     temporal_sdk_core::init(
         CoreInitOptionsBuilder::default()
             .gateway_opts(gateway_opts)
-            .eviction_policy(WorkflowCachingPolicy::sticky_default())
+            .max_cached_workflows(1000usize)
             .build()
             .unwrap(),
     )

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -7,6 +7,7 @@ use temporal_sdk_core::{
     },
     test_workflow_driver::TestRustWorker,
     Core, CoreInitOptions, CoreInitOptionsBuilder, ServerGatewayApis, ServerGatewayOptions,
+    WorkflowCachingPolicy,
 };
 use url::Url;
 
@@ -31,7 +32,7 @@ impl CoreWfStarter {
             test_name: test_name.to_owned(),
             core_options: CoreInitOptionsBuilder::default()
                 .gateway_opts(get_integ_server_options(&task_queue))
-                .evict_after_pending_cleared(false)
+                .eviction_policy(WorkflowCachingPolicy::sticky_default())
                 .build()
                 .unwrap(),
             task_queue,
@@ -90,8 +91,8 @@ impl CoreWfStarter {
         &self.test_name
     }
 
-    pub fn evict_after_pending_cleared(&mut self, evict_after_pending_cleared: bool) -> &mut Self {
-        self.core_options.evict_after_pending_cleared = evict_after_pending_cleared;
+    pub fn eviction_policy(&mut self, policy: WorkflowCachingPolicy) -> &mut Self {
+        self.core_options.eviction_policy = policy;
         self
     }
 
@@ -156,7 +157,7 @@ pub async fn get_integ_core(task_q: &str) -> impl Core {
     temporal_sdk_core::init(
         CoreInitOptionsBuilder::default()
             .gateway_opts(gateway_opts)
-            .evict_after_pending_cleared(false)
+            .eviction_policy(WorkflowCachingPolicy::sticky_default())
             .build()
             .unwrap(),
     )

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -17,7 +17,7 @@ use tokio::time::sleep;
 async fn activity_heartbeat() {
     let (core, task_q) = init_core_and_create_wf("activity_heartbeat").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -32,7 +32,7 @@ async fn activity_heartbeat() {
     .await
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
-    let task = core.poll_activity_task(&task_q).await.unwrap();
+    let task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -62,7 +62,7 @@ async fn activity_heartbeat() {
     .await
     .unwrap();
     // Poll workflow task and verify that activity has succeeded.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -17,7 +17,7 @@ use tokio::time::sleep;
 async fn activity_heartbeat() {
     let (core, task_q) = init_core_and_create_wf("activity_heartbeat").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -32,7 +32,7 @@ async fn activity_heartbeat() {
     .await
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
-    let task = core.poll_activity_task().await.unwrap();
+    let task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -62,7 +62,7 @@ async fn activity_heartbeat() {
     .await
     .unwrap();
     // Poll workflow task and verify that activity has succeeded.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -27,7 +27,7 @@ async fn activity_heartbeat() {
             Duration::from_secs(60),
             Duration::from_secs(1),
         )
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -80,7 +80,7 @@ async fn activity_heartbeat() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap()

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -35,7 +35,7 @@ async fn out_of_order_completion_doesnt_hang() {
             }
             .into(),
         ]
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -79,7 +79,7 @@ async fn out_of_order_completion_doesnt_hang() {
         );
         cc.complete_workflow_task(WfActivationCompletion::from_cmds(
             vec![CompleteWorkflowExecution { result: None }.into()],
-            task.task_token,
+            task.run_id,
         ))
         .await
         .unwrap();
@@ -94,7 +94,7 @@ async fn out_of_order_completion_doesnt_hang() {
             ..Default::default()
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -18,7 +18,7 @@ async fn out_of_order_completion_doesnt_hang() {
     let (core, task_q) = init_core_and_create_wf("out_of_order_completion_doesnt_hang").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -41,7 +41,7 @@ async fn out_of_order_completion_doesnt_hang() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is try-cancelled.
-    let activity_task = core.poll_activity_task().await.unwrap();
+    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -49,7 +49,7 @@ async fn out_of_order_completion_doesnt_hang() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -67,7 +67,7 @@ async fn out_of_order_completion_doesnt_hang() {
     let cc = core.clone();
     let jh = tokio::spawn(async move {
         // We want to fail the test if this takes too long -- we should not hit long poll timeout
-        let task = timeout(Duration::from_secs(1), cc.poll_workflow_task())
+        let task = timeout(Duration::from_secs(1), cc.poll_workflow_task(&task_q))
             .await
             .expect("Poll should come back right away")
             .unwrap();
@@ -104,7 +104,7 @@ async fn out_of_order_completion_doesnt_hang() {
 
 #[tokio::test]
 async fn long_poll_timeout_is_retried() {
-    let mut gateway_opts = get_integ_server_options("some_task_q");
+    let mut gateway_opts = get_integ_server_options();
     // Server whines unless long poll > 2 seconds
     gateway_opts.long_poll_timeout = Duration::from_secs(3);
     let core = temporal_sdk_core::init(
@@ -118,7 +118,7 @@ async fn long_poll_timeout_is_retried() {
     // Should block for more than 3 seconds, since we internally retry long poll
     let (tx, rx) = unbounded();
     tokio::spawn(async move {
-        core.poll_workflow_task().await.unwrap();
+        core.poll_workflow_task("doesnt_matter").await.unwrap();
         tx.send(())
     });
     let err = rx.recv_timeout(Duration::from_secs(4)).unwrap_err();

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -18,7 +18,7 @@ async fn out_of_order_completion_doesnt_hang() {
     let (core, task_q) = init_core_and_create_wf("out_of_order_completion_doesnt_hang").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -41,7 +41,7 @@ async fn out_of_order_completion_doesnt_hang() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is try-cancelled.
-    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
+    let activity_task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -49,7 +49,7 @@ async fn out_of_order_completion_doesnt_hang() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -67,7 +67,7 @@ async fn out_of_order_completion_doesnt_hang() {
     let cc = core.clone();
     let jh = tokio::spawn(async move {
         // We want to fail the test if this takes too long -- we should not hit long poll timeout
-        let task = timeout(Duration::from_secs(1), cc.poll_workflow_task(&task_q))
+        let task = timeout(Duration::from_secs(1), cc.poll_workflow_task())
             .await
             .expect("Poll should come back right away")
             .unwrap();
@@ -118,7 +118,7 @@ async fn long_poll_timeout_is_retried() {
     // Should block for more than 3 seconds, since we internally retry long poll
     let (tx, rx) = unbounded();
     tokio::spawn(async move {
-        core.poll_workflow_task("doesnt_matter").await.unwrap();
+        core.poll_workflow_task().await.unwrap();
         tx.send(())
     });
     let err = rx.recv_timeout(Duration::from_secs(4)).unwrap_err();

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -18,7 +18,7 @@ async fn out_of_order_completion_doesnt_hang() {
     let (core, task_q) = init_core_and_create_wf("out_of_order_completion_doesnt_hang").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -41,7 +41,7 @@ async fn out_of_order_completion_doesnt_hang() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is try-cancelled.
-    let activity_task = core.poll_activity_task().await.unwrap();
+    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -49,7 +49,7 @@ async fn out_of_order_completion_doesnt_hang() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -67,7 +67,7 @@ async fn out_of_order_completion_doesnt_hang() {
     let cc = core.clone();
     let jh = tokio::spawn(async move {
         // We want to fail the test if this takes too long -- we should not hit long poll timeout
-        let task = timeout(Duration::from_secs(1), cc.poll_workflow_task())
+        let task = timeout(Duration::from_secs(1), cc.poll_workflow_task(&task_q))
             .await
             .expect("Poll should come back right away")
             .unwrap();
@@ -118,7 +118,7 @@ async fn long_poll_timeout_is_retried() {
     // Should block for more than 3 seconds, since we internally retry long poll
     let (tx, rx) = unbounded();
     tokio::spawn(async move {
-        core.poll_workflow_task().await.unwrap();
+        core.poll_workflow_task("doesnt_matter").await.unwrap();
         tx.send(())
     });
     let err = rx.recv_timeout(Duration::from_secs(4)).unwrap_err();

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -15,7 +15,7 @@ use temporal_sdk_core::{
         workflow_completion::WfActivationCompletion,
         ActivityTaskCompletion,
     },
-    Core, IntoCompletion, PollWfError, WorkflowCachingPolicy,
+    Core, IntoCompletion, PollWfError,
 };
 use test_utils::{
     get_integ_core, init_core_and_create_wf, schedule_activity_cmd, with_gw, CoreWfStarter, GwApi,
@@ -339,7 +339,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     let mut wf_starter = CoreWfStarter::new("wft_timeout_doesnt_create_unsolvable_autocomplete");
     wf_starter
         // Test needs eviction on and a short timeout
-        .eviction_policy(WorkflowCachingPolicy::NonSticky)
+        .max_cached_workflows(0usize)
         .wft_timeout(Duration::from_secs(1));
     let core = wf_starter.get_core().await;
     let task_queue = wf_starter.get_task_queue().to_owned();

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -50,14 +50,14 @@ async fn parallel_workflows_same_queue() {
                 start_to_fire_timeout: Some(Duration::from_secs(1).into()),
             }
             .into()],
-            task.task_token,
+            task.run_id,
         ))
         .await
         .unwrap();
         let task = task_chan.next().await.unwrap();
         core.complete_workflow_task(WfActivationCompletion::from_cmds(
             vec![CompleteWorkflowExecution { result: None }.into()],
-            task.task_token,
+            task.run_id,
         ))
         .await
         .unwrap();
@@ -126,7 +126,7 @@ async fn fail_wf_task() {
             start_to_fire_timeout: Some(Duration::from_millis(200).into()),
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -137,7 +137,7 @@ async fn fail_wf_task() {
     // Then break for whatever reason
     let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::fail(
-        task.task_token,
+        task.run_id,
         UserCodeFailure {
             message: "I did an oopsie".to_string(),
             ..Default::default()
@@ -164,14 +164,14 @@ async fn fail_wf_task() {
             start_to_fire_timeout: Some(Duration::from_millis(200).into()),
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
     let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -188,7 +188,7 @@ async fn fail_workflow_execution() {
             start_to_fire_timeout: Some(Duration::from_secs(1).into()),
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -201,7 +201,7 @@ async fn fail_workflow_execution() {
             }),
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -218,7 +218,7 @@ async fn signal_workflow() {
     // Task is completed with no commands
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![],
-        res.task_token.clone(),
+        res.run_id.clone(),
     ))
     .await
     .unwrap();
@@ -258,7 +258,7 @@ async fn signal_workflow() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        res.task_token,
+        res.run_id,
     ))
     .await
     .unwrap();
@@ -278,7 +278,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
             start_to_fire_timeout: Some(Duration::from_millis(10).into()),
         }
         .into()],
-        res.task_token,
+        res.run_id,
     ))
     .await
     .unwrap();
@@ -292,7 +292,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
         }]
     );
 
-    let task_token = res.task_token.clone();
+    let run_id = res.run_id.clone();
     // Send the signals to the server
     with_gw(core.as_ref(), |gw: GwApi| async move {
         gw.signal_workflow_execution(
@@ -310,7 +310,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     // error will be silenced)
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task_token,
+        run_id,
     ))
     .await
     .unwrap();
@@ -325,7 +325,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        res.task_token,
+        res.run_id,
     ))
     .await
     .unwrap();
@@ -356,7 +356,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
                 Duration::from_secs(60),
                 Duration::from_secs(60),
             )
-            .into_completion(wf_task.task_token.clone()),
+            .into_completion(wf_task.run_id.clone()),
         )
         .await
         .unwrap();
@@ -433,7 +433,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
             // Reply to the first one, finally
             core.complete_workflow_task(WfActivationCompletion::from_cmds(
                 vec![CompleteWorkflowExecution { result: None }.into()],
-                wf_task.task_token,
+                wf_task.run_id,
             ))
             .await
             .unwrap();
@@ -449,7 +449,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     let wf_task = poll_sched_act_poll().await;
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        wf_task.task_token,
+        wf_task.run_id,
     ))
     .await
     .unwrap();

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -15,7 +15,7 @@ use temporal_sdk_core::{
         workflow_completion::WfActivationCompletion,
         ActivityTaskCompletion,
     },
-    Core, IntoCompletion, PollWfError,
+    Core, IntoCompletion, PollWfError, WorkflowCachingPolicy,
 };
 use test_utils::{
     get_integ_core, init_core_and_create_wf, schedule_activity_cmd, with_gw, CoreWfStarter, GwApi,
@@ -339,7 +339,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     let mut wf_starter = CoreWfStarter::new("wft_timeout_doesnt_create_unsolvable_autocomplete");
     wf_starter
         // Test needs eviction on and a short timeout
-        .evict_after_pending_cleared(true)
+        .eviction_policy(WorkflowCachingPolicy::NonSticky)
         .wft_timeout(Duration::from_secs(1));
     let core = wf_starter.get_core().await;
     let task_queue = wf_starter.get_task_queue().to_owned();

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -74,6 +74,7 @@ async fn parallel_workflows_same_queue() {
 
     for _ in 0..num_workflows * 2 {
         let task = core.poll_workflow_task(&task_q).await.unwrap();
+        assert_eq!(&task.task_queue, task_q);
         send_chans
             .get(&task.run_id)
             .unwrap()

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -17,9 +17,7 @@ use temporal_sdk_core::{
     },
     Core, IntoCompletion, PollWfError,
 };
-use test_utils::{
-    get_integ_core, init_core_and_create_wf, schedule_activity_cmd, with_gw, CoreWfStarter, GwApi,
-};
+use test_utils::{init_core_and_create_wf, schedule_activity_cmd, with_gw, CoreWfStarter, GwApi};
 use tokio::time::sleep;
 
 // TODO: We should get expected histories for these tests and confirm that the history at the end
@@ -29,6 +27,7 @@ use tokio::time::sleep;
 async fn parallel_workflows_same_queue() {
     let mut starter = CoreWfStarter::new("parallel_workflows_same_queue");
     let core = starter.get_core().await;
+    let task_q = starter.get_task_queue();
     let num_workflows = 25usize;
 
     let run_ids: Vec<_> = future::join_all(
@@ -74,7 +73,7 @@ async fn parallel_workflows_same_queue() {
         .collect();
 
     for _ in 0..num_workflows * 2 {
-        let task = core.poll_workflow_task().await.unwrap();
+        let task = core.poll_workflow_task(&task_q).await.unwrap();
         send_chans
             .get(&task.run_id)
             .unwrap()
@@ -93,8 +92,9 @@ async fn parallel_workflows_same_queue() {
 // fixed.
 #[tokio::test]
 async fn shutdown_aborts_actively_blocked_poll() {
-    let task_q = "shutdown_aborts_actively_blocked_poll";
-    let core = Arc::new(get_integ_core(task_q).await);
+    let mut starter = CoreWfStarter::new("shutdown_aborts_actively_blocked_poll");
+    let core = starter.get_core().await;
+    let task_q = starter.get_task_queue();
     // Begin the poll, and request shutdown from another thread after a small period of time.
     let tcore = core.clone();
     let handle = tokio::spawn(async move {
@@ -102,24 +102,23 @@ async fn shutdown_aborts_actively_blocked_poll() {
         tcore.shutdown().await;
     });
     assert_matches!(
-        core.poll_workflow_task().await.unwrap_err(),
+        core.poll_workflow_task(&task_q).await.unwrap_err(),
         PollWfError::ShutDown
     );
     handle.await.unwrap();
     // Ensure double-shutdown doesn't explode
     core.shutdown().await;
     assert_matches!(
-        core.poll_workflow_task().await.unwrap_err(),
+        core.poll_workflow_task(&task_q).await.unwrap_err(),
         PollWfError::ShutDown
     );
 }
 
 #[tokio::test]
 async fn fail_wf_task() {
-    let (core, _) = init_core_and_create_wf("fail_wf_task").await;
-
+    let (core, task_q) = init_core_and_create_wf("fail_wf_task").await;
     // Start with a timer
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id: "best-timer".to_string(),
@@ -135,7 +134,7 @@ async fn fail_wf_task() {
     std::thread::sleep(Duration::from_millis(500));
 
     // Then break for whatever reason
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::fail(
         task.task_token,
         UserCodeFailure {
@@ -148,7 +147,7 @@ async fn fail_wf_task() {
 
     // The server will want to retry the task. This time we finish the workflow -- but we need
     // to poll a couple of times as there will be more than one required workflow activation.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // The first poll response will tell us to evict
     assert_matches!(
         task.jobs.as_slice(),
@@ -157,7 +156,7 @@ async fn fail_wf_task() {
         }]
     );
     // So poll again
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id: "best-timer".to_string(),
@@ -168,7 +167,7 @@ async fn fail_wf_task() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.task_token,
@@ -179,9 +178,9 @@ async fn fail_wf_task() {
 
 #[tokio::test]
 async fn fail_workflow_execution() {
-    let (core, _) = init_core_and_create_wf("fail_workflow_execution").await;
+    let (core, task_q) = init_core_and_create_wf("fail_workflow_execution").await;
     let timer_id = "timer-1".to_owned();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id,
@@ -192,7 +191,7 @@ async fn fail_workflow_execution() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![FailWorkflowExecution {
             failure: Some(UserCodeFailure {
@@ -210,11 +209,11 @@ async fn fail_workflow_execution() {
 #[tokio::test]
 async fn signal_workflow() {
     let workflow_id = "signal_workflow";
-    let (core, _) = init_core_and_create_wf(workflow_id).await;
+    let (core, task_q) = init_core_and_create_wf(workflow_id).await;
 
     let signal_id_1 = "signal1";
     let signal_id_2 = "signal2";
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     // Task is completed with no commands
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![],
@@ -244,7 +243,7 @@ async fn signal_workflow() {
     })
     .await;
 
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         res.jobs.as_slice(),
         [
@@ -267,10 +266,10 @@ async fn signal_workflow() {
 #[tokio::test]
 async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     let workflow_id = "signal_workflow_signal_not_handled_on_workflow_completion";
-    let (core, _) = init_core_and_create_wf(workflow_id).await;
+    let (core, task_q) = init_core_and_create_wf(workflow_id).await;
 
     let signal_id_1 = "signal1";
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     // Task is completed with a timer
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
@@ -284,7 +283,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     .unwrap();
 
     // Poll before sending the signal - we should have the timer job
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         res.jobs.as_slice(),
         [WfActivationJob {
@@ -316,7 +315,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     .unwrap();
 
     // We should get a new task with the signal
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         res.jobs.as_slice(),
         [WfActivationJob {
@@ -342,15 +341,15 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
         .max_cached_workflows(0usize)
         .wft_timeout(Duration::from_secs(1));
     let core = wf_starter.get_core().await;
-    let task_queue = wf_starter.get_task_queue().to_owned();
+    let task_q = wf_starter.get_task_queue();
     let wf_id = &wf_starter.get_wf_id().to_owned();
 
     // Set up some helpers for polling and completing
     let poll_sched_act = || async {
-        let wf_task = core.poll_workflow_task().await.unwrap();
+        let wf_task = core.poll_workflow_task(&task_q).await.unwrap();
         core.complete_workflow_task(
             schedule_activity_cmd(
-                &task_queue,
+                &task_q,
                 activity_id,
                 ActivityCancellationType::TryCancel,
                 Duration::from_secs(60),
@@ -364,7 +363,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     };
     let poll_sched_act_poll = || async {
         poll_sched_act().await;
-        let wf_task = core.poll_workflow_task().await.unwrap();
+        let wf_task = core.poll_workflow_task(&task_q).await.unwrap();
         assert_matches!(
             wf_task.jobs.as_slice(),
             [
@@ -388,7 +387,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     let wf_task = poll_sched_act().await;
     // Before polling for a task again, we start and complete the activity and send the
     // corresponding signals.
-    let ac_task = core.poll_activity_task().await.unwrap();
+    let ac_task = core.poll_activity_task(&task_q).await.unwrap();
     let rid = wf_task.run_id.clone();
     // Send the signals to the server & resolve activity -- sometimes this happens too fast
     sleep(Duration::from_millis(200)).await;
@@ -413,7 +412,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     })
     .await;
     // Now poll again, it will be an eviction b/c non-sticky mode.
-    let wf_task = core.poll_workflow_task().await.unwrap();
+    let wf_task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         wf_task.jobs.as_slice(),
         [WfActivationJob {
@@ -426,16 +425,19 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     sleep(Duration::from_secs(2)).await;
     // Poll again, which should not have any work to do and spin, until the complete goes through.
     // Which will be rejected with not found, producing an eviction.
-    let (wf_task, _) = tokio::join!(async { core.poll_workflow_task().await.unwrap() }, async {
-        sleep(Duration::from_millis(500)).await;
-        // Reply to the first one, finally
-        core.complete_workflow_task(WfActivationCompletion::from_cmds(
-            vec![CompleteWorkflowExecution { result: None }.into()],
-            wf_task.task_token,
-        ))
-        .await
-        .unwrap();
-    });
+    let (wf_task, _) = tokio::join!(
+        async { core.poll_workflow_task(&task_q).await.unwrap() },
+        async {
+            sleep(Duration::from_millis(500)).await;
+            // Reply to the first one, finally
+            core.complete_workflow_task(WfActivationCompletion::from_cmds(
+                vec![CompleteWorkflowExecution { result: None }.into()],
+                wf_task.task_token,
+            ))
+            .await
+            .unwrap();
+        }
+    );
     assert_matches!(
         wf_task.jobs.as_slice(),
         [WfActivationJob {

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -73,8 +73,7 @@ async fn parallel_workflows_same_queue() {
         .collect();
 
     for _ in 0..num_workflows * 2 {
-        let task = core.poll_workflow_task().await.unwrap();
-        assert_eq!(&task.task_queue, task_q);
+        let task = core.poll_workflow_task(&task_q).await.unwrap();
         send_chans
             .get(&task.run_id)
             .unwrap()
@@ -95,6 +94,7 @@ async fn parallel_workflows_same_queue() {
 async fn shutdown_aborts_actively_blocked_poll() {
     let mut starter = CoreWfStarter::new("shutdown_aborts_actively_blocked_poll");
     let core = starter.get_core().await;
+    let task_q = starter.get_task_queue();
     // Begin the poll, and request shutdown from another thread after a small period of time.
     let tcore = core.clone();
     let handle = tokio::spawn(async move {
@@ -102,23 +102,23 @@ async fn shutdown_aborts_actively_blocked_poll() {
         tcore.shutdown().await;
     });
     assert_matches!(
-        core.poll_workflow_task().await.unwrap_err(),
+        core.poll_workflow_task(&task_q).await.unwrap_err(),
         PollWfError::ShutDown
     );
     handle.await.unwrap();
     // Ensure double-shutdown doesn't explode
     core.shutdown().await;
     assert_matches!(
-        core.poll_workflow_task().await.unwrap_err(),
+        core.poll_workflow_task(&task_q).await.unwrap_err(),
         PollWfError::ShutDown
     );
 }
 
 #[tokio::test]
 async fn fail_wf_task() {
-    let (core, _) = init_core_and_create_wf("fail_wf_task").await;
+    let (core, task_q) = init_core_and_create_wf("fail_wf_task").await;
     // Start with a timer
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id: "best-timer".to_string(),
@@ -134,7 +134,7 @@ async fn fail_wf_task() {
     std::thread::sleep(Duration::from_millis(500));
 
     // Then break for whatever reason
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::fail(
         task.run_id,
         UserCodeFailure {
@@ -147,7 +147,7 @@ async fn fail_wf_task() {
 
     // The server will want to retry the task. This time we finish the workflow -- but we need
     // to poll a couple of times as there will be more than one required workflow activation.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // The first poll response will tell us to evict
     assert_matches!(
         task.jobs.as_slice(),
@@ -156,7 +156,7 @@ async fn fail_wf_task() {
         }]
     );
     // So poll again
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id: "best-timer".to_string(),
@@ -167,7 +167,7 @@ async fn fail_wf_task() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.run_id,
@@ -178,9 +178,9 @@ async fn fail_wf_task() {
 
 #[tokio::test]
 async fn fail_workflow_execution() {
-    let (core, _) = init_core_and_create_wf("fail_workflow_execution").await;
+    let (core, task_q) = init_core_and_create_wf("fail_workflow_execution").await;
     let timer_id = "timer-1".to_owned();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id,
@@ -191,7 +191,7 @@ async fn fail_workflow_execution() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![FailWorkflowExecution {
             failure: Some(UserCodeFailure {
@@ -209,11 +209,11 @@ async fn fail_workflow_execution() {
 #[tokio::test]
 async fn signal_workflow() {
     let workflow_id = "signal_workflow";
-    let (core, _) = init_core_and_create_wf(workflow_id).await;
+    let (core, task_q) = init_core_and_create_wf(workflow_id).await;
 
     let signal_id_1 = "signal1";
     let signal_id_2 = "signal2";
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     // Task is completed with no commands
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![],
@@ -243,7 +243,7 @@ async fn signal_workflow() {
     })
     .await;
 
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         res.jobs.as_slice(),
         [
@@ -266,10 +266,10 @@ async fn signal_workflow() {
 #[tokio::test]
 async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     let workflow_id = "signal_workflow_signal_not_handled_on_workflow_completion";
-    let (core, _) = init_core_and_create_wf(workflow_id).await;
+    let (core, task_q) = init_core_and_create_wf(workflow_id).await;
 
     let signal_id_1 = "signal1";
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     // Task is completed with a timer
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
@@ -283,7 +283,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     .unwrap();
 
     // Poll before sending the signal - we should have the timer job
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         res.jobs.as_slice(),
         [WfActivationJob {
@@ -315,7 +315,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     .unwrap();
 
     // We should get a new task with the signal
-    let res = core.poll_workflow_task().await.unwrap();
+    let res = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         res.jobs.as_slice(),
         [WfActivationJob {
@@ -346,7 +346,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
 
     // Set up some helpers for polling and completing
     let poll_sched_act = || async {
-        let wf_task = core.poll_workflow_task().await.unwrap();
+        let wf_task = core.poll_workflow_task(&task_q).await.unwrap();
         core.complete_workflow_task(
             schedule_activity_cmd(
                 &task_q,
@@ -363,7 +363,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     };
     let poll_sched_act_poll = || async {
         poll_sched_act().await;
-        let wf_task = core.poll_workflow_task().await.unwrap();
+        let wf_task = core.poll_workflow_task(&task_q).await.unwrap();
         assert_matches!(
             wf_task.jobs.as_slice(),
             [
@@ -387,7 +387,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     let wf_task = poll_sched_act().await;
     // Before polling for a task again, we start and complete the activity and send the
     // corresponding signals.
-    let ac_task = core.poll_activity_task().await.unwrap();
+    let ac_task = core.poll_activity_task(&task_q).await.unwrap();
     let rid = wf_task.run_id.clone();
     // Send the signals to the server & resolve activity -- sometimes this happens too fast
     sleep(Duration::from_millis(200)).await;
@@ -412,7 +412,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     })
     .await;
     // Now poll again, it will be an eviction b/c non-sticky mode.
-    let wf_task = core.poll_workflow_task().await.unwrap();
+    let wf_task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         wf_task.jobs.as_slice(),
         [WfActivationJob {
@@ -425,16 +425,19 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     sleep(Duration::from_secs(2)).await;
     // Poll again, which should not have any work to do and spin, until the complete goes through.
     // Which will be rejected with not found, producing an eviction.
-    let (wf_task, _) = tokio::join!(async { core.poll_workflow_task().await.unwrap() }, async {
-        sleep(Duration::from_millis(500)).await;
-        // Reply to the first one, finally
-        core.complete_workflow_task(WfActivationCompletion::from_cmds(
-            vec![CompleteWorkflowExecution { result: None }.into()],
-            wf_task.run_id,
-        ))
-        .await
-        .unwrap();
-    });
+    let (wf_task, _) = tokio::join!(
+        async { core.poll_workflow_task(&task_q).await.unwrap() },
+        async {
+            sleep(Duration::from_millis(500)).await;
+            // Reply to the first one, finally
+            core.complete_workflow_task(WfActivationCompletion::from_cmds(
+                vec![CompleteWorkflowExecution { result: None }.into()],
+                wf_task.run_id,
+            ))
+            .await
+            .unwrap();
+        }
+    );
     assert_matches!(
         wf_task.jobs.as_slice(),
         [WfActivationJob {

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -37,6 +37,7 @@ async fn activity_workflow() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
     let task = core.poll_activity_task(&task_q).await.unwrap();
+    assert_eq!(&task.task_queue, &task_q);
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -21,7 +21,7 @@ use tokio::time::sleep;
 async fn activity_workflow() {
     let (core, task_q) = init_core_and_create_wf("activity_workflow").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -36,7 +36,7 @@ async fn activity_workflow() {
     .await
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
-    let task = core.poll_activity_task(&task_q).await.unwrap();
+    let task = core.poll_activity_task().await.unwrap();
     assert_eq!(&task.task_queue, &task_q);
     assert_matches!(
         task.variant,
@@ -56,7 +56,7 @@ async fn activity_workflow() {
     .await
     .unwrap();
     // Poll workflow task and verify that activity has succeeded.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -84,7 +84,7 @@ async fn activity_workflow() {
 async fn activity_non_retryable_failure() {
     let (core, task_q) = init_core_and_create_wf("activity_non_retryable_failure").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -99,7 +99,7 @@ async fn activity_non_retryable_failure() {
     .await
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
-    let task = core.poll_activity_task(&task_q).await.unwrap();
+    let task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -125,7 +125,7 @@ async fn activity_non_retryable_failure() {
     .await
     .unwrap();
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -152,7 +152,7 @@ async fn activity_non_retryable_failure() {
 async fn activity_retry() {
     let (core, task_q) = init_core_and_create_wf("activity_retry").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -167,7 +167,7 @@ async fn activity_retry() {
     .await
     .unwrap();
     // Poll activity 1st time
-    let task = core.poll_activity_task(&task_q).await.unwrap();
+    let task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -193,7 +193,7 @@ async fn activity_retry() {
     .await
     .unwrap();
     // Poll 2nd time
-    let task = core.poll_activity_task(&task_q).await.unwrap();
+    let task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -212,7 +212,7 @@ async fn activity_retry() {
     .await
     .unwrap();
     // Poll workflow task and verify activity has succeeded.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -240,7 +240,7 @@ async fn activity_cancellation_try_cancel() {
     let (core, task_q) = init_core_and_create_wf("activity_cancellation_try_cancel").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -263,7 +263,7 @@ async fn activity_cancellation_try_cancel() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is try-cancelled.
-    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
+    let activity_task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -271,7 +271,7 @@ async fn activity_cancellation_try_cancel() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -294,7 +294,7 @@ async fn activity_cancellation_try_cancel() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.run_id,
@@ -308,7 +308,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     let (core, task_q) =
         init_core_and_create_wf("activity_cancellation_plus_complete_doesnt_double_resolve").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -329,9 +329,9 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     )
     .await
     .unwrap();
-    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
+    let activity_task = core.poll_activity_task().await.unwrap();
     assert_matches!(activity_task.variant, Some(act_task::Variant::Start(_)));
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [WfActivationJob {
@@ -348,7 +348,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Should get cancel task
     assert_matches!(
         task.jobs.as_slice(),
@@ -392,7 +392,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     // Ensure we do not get a wakeup with the activity being resolved completed, and instead get
     // the timer fired event (also wait for timer to fire)
     sleep(Duration::from_secs(1)).await;
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [WfActivationJob {
@@ -411,7 +411,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
 async fn started_activity_timeout() {
     let (core, task_q) = init_core_and_create_wf("started_activity_timeout").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity that times out in 1 second.
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -427,14 +427,14 @@ async fn started_activity_timeout() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is timed out after 1 second.
-    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
+    let activity_task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
             assert_eq!(start_activity.activity_type, "test_activity".to_string())
         }
     );
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -463,7 +463,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
         init_core_and_create_wf("activity_cancellation_wait_cancellation_completed").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -486,7 +486,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is wait-cancelled.
-    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
+    let activity_task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -494,7 +494,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -527,7 +527,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
     })
     .await
     .unwrap();
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.run_id,
@@ -541,7 +541,7 @@ async fn activity_cancellation_abandon() {
     let (core, task_q) = init_core_and_create_wf("activity_cancellation_abandon").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -564,7 +564,7 @@ async fn activity_cancellation_abandon() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is abandoned.
-    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
+    let activity_task = core.poll_activity_task().await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -572,7 +572,7 @@ async fn activity_cancellation_abandon() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -597,7 +597,7 @@ async fn activity_cancellation_abandon() {
     .unwrap();
     // Poll workflow task expecting that activation has been created by the state machine
     // immediately after the cancellation request.
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.run_id,

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -21,7 +21,7 @@ use tokio::time::sleep;
 async fn activity_workflow() {
     let (core, task_q) = init_core_and_create_wf("activity_workflow").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -36,7 +36,7 @@ async fn activity_workflow() {
     .await
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
-    let task = core.poll_activity_task().await.unwrap();
+    let task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -55,7 +55,7 @@ async fn activity_workflow() {
     .await
     .unwrap();
     // Poll workflow task and verify that activity has succeeded.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -83,7 +83,7 @@ async fn activity_workflow() {
 async fn activity_non_retryable_failure() {
     let (core, task_q) = init_core_and_create_wf("activity_non_retryable_failure").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -98,7 +98,7 @@ async fn activity_non_retryable_failure() {
     .await
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
-    let task = core.poll_activity_task().await.unwrap();
+    let task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -124,7 +124,7 @@ async fn activity_non_retryable_failure() {
     .await
     .unwrap();
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -151,7 +151,7 @@ async fn activity_non_retryable_failure() {
 async fn activity_retry() {
     let (core, task_q) = init_core_and_create_wf("activity_retry").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -166,7 +166,7 @@ async fn activity_retry() {
     .await
     .unwrap();
     // Poll activity 1st time
-    let task = core.poll_activity_task().await.unwrap();
+    let task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -192,7 +192,7 @@ async fn activity_retry() {
     .await
     .unwrap();
     // Poll 2nd time
-    let task = core.poll_activity_task().await.unwrap();
+    let task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -211,7 +211,7 @@ async fn activity_retry() {
     .await
     .unwrap();
     // Poll workflow task and verify activity has succeeded.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -239,7 +239,7 @@ async fn activity_cancellation_try_cancel() {
     let (core, task_q) = init_core_and_create_wf("activity_cancellation_try_cancel").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -262,7 +262,7 @@ async fn activity_cancellation_try_cancel() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is try-cancelled.
-    let activity_task = core.poll_activity_task().await.unwrap();
+    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -270,7 +270,7 @@ async fn activity_cancellation_try_cancel() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -293,7 +293,7 @@ async fn activity_cancellation_try_cancel() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.task_token,
@@ -307,7 +307,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     let (core, task_q) =
         init_core_and_create_wf("activity_cancellation_plus_complete_doesnt_double_resolve").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -328,9 +328,9 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     )
     .await
     .unwrap();
-    let activity_task = core.poll_activity_task().await.unwrap();
+    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(activity_task.variant, Some(act_task::Variant::Start(_)));
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [WfActivationJob {
@@ -347,7 +347,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Should get cancel task
     assert_matches!(
         task.jobs.as_slice(),
@@ -391,7 +391,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     // Ensure we do not get a wakeup with the activity being resolved completed, and instead get
     // the timer fired event (also wait for timer to fire)
     sleep(Duration::from_secs(1)).await;
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [WfActivationJob {
@@ -410,7 +410,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
 async fn started_activity_timeout() {
     let (core, task_q) = init_core_and_create_wf("started_activity_timeout").await;
     let activity_id = "act-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity that times out in 1 second.
     core.complete_workflow_task(
         schedule_activity_cmd(
@@ -426,14 +426,14 @@ async fn started_activity_timeout() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is timed out after 1 second.
-    let activity_task = core.poll_activity_task().await.unwrap();
+    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
             assert_eq!(start_activity.activity_type, "test_activity".to_string())
         }
     );
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -462,7 +462,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
         init_core_and_create_wf("activity_cancellation_wait_cancellation_completed").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -485,7 +485,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is wait-cancelled.
-    let activity_task = core.poll_activity_task().await.unwrap();
+    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -493,7 +493,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -526,7 +526,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
     })
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.task_token,
@@ -540,7 +540,7 @@ async fn activity_cancellation_abandon() {
     let (core, task_q) = init_core_and_create_wf("activity_cancellation_abandon").await;
     let activity_id = "act-1";
     let timer_id = "timer-1";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     // Complete workflow task and schedule activity and a timer that fires immediately
     core.complete_workflow_task(
         vec![
@@ -563,7 +563,7 @@ async fn activity_cancellation_abandon() {
     .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
     // complete it in this test as activity is abandoned.
-    let activity_task = core.poll_activity_task().await.unwrap();
+    let activity_task = core.poll_activity_task(&task_q).await.unwrap();
     assert_matches!(
         activity_task.variant,
         Some(act_task::Variant::Start(start_activity)) => {
@@ -571,7 +571,7 @@ async fn activity_cancellation_abandon() {
         }
     );
     // Poll workflow task and verify that activity has failed.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [
@@ -596,7 +596,7 @@ async fn activity_cancellation_abandon() {
     .unwrap();
     // Poll workflow task expecting that activation has been created by the state machine
     // immediately after the cancellation request.
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.task_token,

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -31,7 +31,7 @@ async fn activity_workflow() {
             Duration::from_secs(60),
             Duration::from_secs(60),
         )
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -74,7 +74,7 @@ async fn activity_workflow() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap()
@@ -94,7 +94,7 @@ async fn activity_non_retryable_failure() {
             Duration::from_secs(60),
             Duration::from_secs(60),
         )
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -142,7 +142,7 @@ async fn activity_non_retryable_failure() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap()
@@ -162,7 +162,7 @@ async fn activity_retry() {
             Duration::from_secs(60),
             Duration::from_secs(60),
         )
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -229,7 +229,7 @@ async fn activity_retry() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap()
@@ -257,7 +257,7 @@ async fn activity_cancellation_try_cancel() {
             }
             .into(),
         ]
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -290,14 +290,14 @@ async fn activity_cancellation_try_cancel() {
             ..Default::default()
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
     let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -325,7 +325,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
             }
             .into(),
         ]
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -344,7 +344,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
             ..Default::default()
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -371,7 +371,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
             start_to_fire_timeout: Some(Duration::from_millis(100).into()),
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -401,7 +401,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -421,7 +421,7 @@ async fn started_activity_timeout() {
             Duration::from_secs(1),
             Duration::from_secs(60),
         )
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -451,7 +451,7 @@ async fn started_activity_timeout() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -480,7 +480,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
             }
             .into(),
         ]
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -513,7 +513,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
             ..Default::default()
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -530,7 +530,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
     let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -558,7 +558,7 @@ async fn activity_cancellation_abandon() {
             }
             .into(),
         ]
-        .into_completion(task.task_token),
+        .into_completion(task.run_id),
     )
     .await
     .unwrap();
@@ -591,7 +591,7 @@ async fn activity_cancellation_abandon() {
             ..Default::default()
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -600,7 +600,7 @@ async fn activity_cancellation_abandon() {
     let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -31,8 +31,8 @@ async fn timer_workflow_new_way() {
 
 #[tokio::test]
 async fn timer_workflow() {
-    let (core, task_q) = init_core_and_create_wf("timer_workflow").await;
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let (core, _) = init_core_and_create_wf("timer_workflow").await;
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id: "timer-1".to_string(),
@@ -43,7 +43,7 @@ async fn timer_workflow() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.run_id,
@@ -54,10 +54,10 @@ async fn timer_workflow() {
 
 #[tokio::test]
 async fn timer_cancel_workflow() {
-    let (core, task_q) = init_core_and_create_wf("timer_cancel_workflow").await;
+    let (core, _) = init_core_and_create_wf("timer_cancel_workflow").await;
     let timer_id = "wait_timer";
     let cancel_timer_id = "cancel_timer";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -75,7 +75,7 @@ async fn timer_cancel_workflow() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             CancelTimer {
@@ -92,9 +92,9 @@ async fn timer_cancel_workflow() {
 
 #[tokio::test]
 async fn timer_immediate_cancel_workflow() {
-    let (core, task_q) = init_core_and_create_wf("timer_immediate_cancel_workflow").await;
+    let (core, _) = init_core_and_create_wf("timer_immediate_cancel_workflow").await;
     let cancel_timer_id = "cancel_timer";
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -116,10 +116,10 @@ async fn timer_immediate_cancel_workflow() {
 
 #[tokio::test]
 async fn parallel_timer_workflow() {
-    let (core, task_q) = init_core_and_create_wf("parallel_timer_workflow").await;
+    let (core, _) = init_core_and_create_wf("parallel_timer_workflow").await;
     let timer_id = "timer 1".to_string();
     let timer_2_id = "timer 2".to_string();
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -140,7 +140,7 @@ async fn parallel_timer_workflow() {
     // Wait long enough for both timers to complete. Server seems to be a bit weird about actually
     // sending both of these in one go, so we need to wait longer than you would expect.
     std::thread::sleep(Duration::from_millis(1500));
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
+    let task = core.poll_workflow_task().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -31,8 +31,8 @@ async fn timer_workflow_new_way() {
 
 #[tokio::test]
 async fn timer_workflow() {
-    let (core, _) = init_core_and_create_wf("timer_workflow").await;
-    let task = core.poll_workflow_task().await.unwrap();
+    let (core, task_q) = init_core_and_create_wf("timer_workflow").await;
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id: "timer-1".to_string(),
@@ -43,7 +43,7 @@ async fn timer_workflow() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.task_token,
@@ -54,10 +54,10 @@ async fn timer_workflow() {
 
 #[tokio::test]
 async fn timer_cancel_workflow() {
-    let (core, _) = init_core_and_create_wf("timer_cancel_workflow").await;
+    let (core, task_q) = init_core_and_create_wf("timer_cancel_workflow").await;
     let timer_id = "wait_timer";
     let cancel_timer_id = "cancel_timer";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -75,7 +75,7 @@ async fn timer_cancel_workflow() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             CancelTimer {
@@ -92,9 +92,9 @@ async fn timer_cancel_workflow() {
 
 #[tokio::test]
 async fn timer_immediate_cancel_workflow() {
-    let (core, _) = init_core_and_create_wf("timer_immediate_cancel_workflow").await;
+    let (core, task_q) = init_core_and_create_wf("timer_immediate_cancel_workflow").await;
     let cancel_timer_id = "cancel_timer";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -116,10 +116,10 @@ async fn timer_immediate_cancel_workflow() {
 
 #[tokio::test]
 async fn parallel_timer_workflow() {
-    let (core, _) = init_core_and_create_wf("parallel_timer_workflow").await;
+    let (core, task_q) = init_core_and_create_wf("parallel_timer_workflow").await;
     let timer_id = "timer 1".to_string();
     let timer_2_id = "timer 2".to_string();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -140,7 +140,7 @@ async fn parallel_timer_workflow() {
     // Wait long enough for both timers to complete. Server seems to be a bit weird about actually
     // sending both of these in one go, so we need to wait longer than you would expect.
     std::thread::sleep(Duration::from_millis(1500));
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -39,14 +39,14 @@ async fn timer_workflow() {
             start_to_fire_timeout: Some(Duration::from_secs(1).into()),
         }
         .into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
     let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -71,7 +71,7 @@ async fn timer_cancel_workflow() {
             }
             .into(),
         ],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -84,7 +84,7 @@ async fn timer_cancel_workflow() {
             .into(),
             CompleteWorkflowExecution { result: None }.into(),
         ],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -108,7 +108,7 @@ async fn timer_immediate_cancel_workflow() {
             .into(),
             CompleteWorkflowExecution { result: None }.into(),
         ],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -133,7 +133,7 @@ async fn parallel_timer_workflow() {
             }
             .into(),
         ],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();
@@ -161,7 +161,7 @@ async fn parallel_timer_workflow() {
     );
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
-        task.task_token,
+        task.run_id,
     ))
     .await
     .unwrap();

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -31,8 +31,8 @@ async fn timer_workflow_new_way() {
 
 #[tokio::test]
 async fn timer_workflow() {
-    let (core, _) = init_core_and_create_wf("timer_workflow").await;
-    let task = core.poll_workflow_task().await.unwrap();
+    let (core, task_q) = init_core_and_create_wf("timer_workflow").await;
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![StartTimer {
             timer_id: "timer-1".to_string(),
@@ -43,7 +43,7 @@ async fn timer_workflow() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![CompleteWorkflowExecution { result: None }.into()],
         task.run_id,
@@ -54,10 +54,10 @@ async fn timer_workflow() {
 
 #[tokio::test]
 async fn timer_cancel_workflow() {
-    let (core, _) = init_core_and_create_wf("timer_cancel_workflow").await;
+    let (core, task_q) = init_core_and_create_wf("timer_cancel_workflow").await;
     let timer_id = "wait_timer";
     let cancel_timer_id = "cancel_timer";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -75,7 +75,7 @@ async fn timer_cancel_workflow() {
     ))
     .await
     .unwrap();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             CancelTimer {
@@ -92,9 +92,9 @@ async fn timer_cancel_workflow() {
 
 #[tokio::test]
 async fn timer_immediate_cancel_workflow() {
-    let (core, _) = init_core_and_create_wf("timer_immediate_cancel_workflow").await;
+    let (core, task_q) = init_core_and_create_wf("timer_immediate_cancel_workflow").await;
     let cancel_timer_id = "cancel_timer";
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -116,10 +116,10 @@ async fn timer_immediate_cancel_workflow() {
 
 #[tokio::test]
 async fn parallel_timer_workflow() {
-    let (core, _) = init_core_and_create_wf("parallel_timer_workflow").await;
+    let (core, task_q) = init_core_and_create_wf("parallel_timer_workflow").await;
     let timer_id = "timer 1".to_string();
     let timer_2_id = "timer 2".to_string();
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     core.complete_workflow_task(WfActivationCompletion::from_cmds(
         vec![
             StartTimer {
@@ -140,7 +140,7 @@ async fn parallel_timer_workflow() {
     // Wait long enough for both timers to complete. Server seems to be a bit weird about actually
     // sending both of these in one go, so we need to wait longer than you would expect.
     std::thread::sleep(Duration::from_millis(1500));
-    let task = core.poll_workflow_task().await.unwrap();
+    let task = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),
         [

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -86,4 +86,5 @@ async fn activity_load() {
         all_acts
     };
     dbg!(running.elapsed());
+    core.shutdown().await;
 }

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -15,7 +15,6 @@ async fn activity_load() {
     let mut starter = CoreWfStarter::new("activity_load");
     starter.max_wft(1000).max_at(1000);
     let worker = starter.worker().await;
-    let task_q = &starter.get_task_queue().to_owned();
 
     let activity_id = "act-1";
     let activity_timeout = Duration::from_secs(5);
@@ -64,7 +63,7 @@ async fn activity_load() {
     let all_acts = fanout_tasks(1000, |_| {
         let payload_dat = payload_dat.clone();
         async move {
-            let task = core.poll_activity_task(task_q).await.unwrap();
+            let task = core.poll_activity_task().await.unwrap();
             assert_matches!(
                 task.variant,
                 Some(act_task::Variant::Start(start_activity)) => {

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -17,7 +17,7 @@ async fn activity_load() {
     let worker = starter.worker().await;
 
     let activity_id = "act-1";
-    let activity_timeout = Duration::from_secs(5);
+    let activity_timeout = Duration::from_secs(8);
     let payload_dat = b"hello".to_vec();
 
     let starting = Instant::now();

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -15,6 +15,7 @@ async fn activity_load() {
     let mut starter = CoreWfStarter::new("activity_load");
     starter.max_wft(1000).max_at(1000);
     let worker = starter.worker().await;
+    let task_q = &starter.get_task_queue().to_owned();
 
     let activity_id = "act-1";
     let activity_timeout = Duration::from_secs(8);
@@ -63,7 +64,7 @@ async fn activity_load() {
     let all_acts = fanout_tasks(1000, |_| {
         let payload_dat = payload_dat.clone();
         async move {
-            let task = core.poll_activity_task().await.unwrap();
+            let task = core.poll_activity_task(task_q).await.unwrap();
             assert_matches!(
                 task.variant,
                 Some(act_task::Variant::Start(start_activity)) => {

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -15,6 +15,7 @@ async fn activity_load() {
     let mut starter = CoreWfStarter::new("activity_load");
     starter.max_wft(1000).max_at(1000);
     let worker = starter.worker().await;
+    let task_q = &starter.get_task_queue().to_owned();
 
     let activity_id = "act-1";
     let activity_timeout = Duration::from_secs(5);
@@ -63,7 +64,7 @@ async fn activity_load() {
     let all_acts = fanout_tasks(1000, |_| {
         let payload_dat = payload_dat.clone();
         async move {
-            let task = core.poll_activity_task().await.unwrap();
+            let task = core.poll_activity_task(task_q).await.unwrap();
             assert_matches!(
                 task.variant,
                 Some(act_task::Variant::Start(start_activity)) => {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -21,17 +21,18 @@ mod integ_tests {
     #[ignore]
     async fn tls_test() {
         // Load certs/keys
-        let root =
-            tokio::fs::read("/home/sushi/dev/temporal/customization-samples/tls/tls-full/certs/cluster/ca/server-intermediate-ca.pem")
-                .await
-                .unwrap();
+        let root = tokio::fs::read(
+            "/home/sushi/dev/temporal/customization-samples/tls/tls-simple/certs/ca.cert",
+        )
+        .await
+        .unwrap();
         let client_cert = tokio::fs::read(
-            "/home/sushi/dev/temporal/customization-samples/tls/tls-full/certs/client/accounting/client-accounting-namespace-chain.pem",
+            "/home/sushi/dev/temporal/customization-samples/tls/tls-simple/certs/client.pem",
         )
         .await
         .unwrap();
         let client_private_key = tokio::fs::read(
-            "/home/sushi/dev/temporal/customization-samples/tls/tls-full/certs/client/accounting/client-accounting-namespace.key",
+            "/home/sushi/dev/temporal/customization-samples/tls/tls-simple/certs/client.key",
         )
         .await
         .unwrap();
@@ -43,7 +44,7 @@ mod integ_tests {
             long_poll_timeout: Duration::from_secs(60),
             tls_cfg: Some(TlsConfig {
                 server_root_ca_cert: Some(root),
-                domain: Some("accounting.cluster-x.contoso.com".to_string()),
+                domain: Some("tls-sample".to_string()),
                 client_tls_config: Some(ClientTlsConfig {
                     client_cert,
                     client_private_key,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -38,7 +38,6 @@ mod integ_tests {
         let sgo = ServerGatewayOptions {
             target_url: Url::from_str("https://localhost:7233").unwrap(),
             namespace: NAMESPACE.to_string(),
-            task_queue: "whatever".to_string(),
             identity: "ident".to_string(),
             worker_binary_id: "binident".to_string(),
             long_poll_timeout: Duration::from_secs(60),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -21,18 +21,17 @@ mod integ_tests {
     #[ignore]
     async fn tls_test() {
         // Load certs/keys
-        let root = tokio::fs::read(
-            "/home/sushi/dev/temporal/customization-samples/tls/tls-simple/certs/ca.cert",
-        )
-        .await
-        .unwrap();
+        let root =
+            tokio::fs::read("/home/sushi/dev/temporal/customization-samples/tls/tls-full/certs/cluster/ca/server-intermediate-ca.pem")
+                .await
+                .unwrap();
         let client_cert = tokio::fs::read(
-            "/home/sushi/dev/temporal/customization-samples/tls/tls-simple/certs/client.pem",
+            "/home/sushi/dev/temporal/customization-samples/tls/tls-full/certs/client/accounting/client-accounting-namespace-chain.pem",
         )
         .await
         .unwrap();
         let client_private_key = tokio::fs::read(
-            "/home/sushi/dev/temporal/customization-samples/tls/tls-simple/certs/client.key",
+            "/home/sushi/dev/temporal/customization-samples/tls/tls-full/certs/client/accounting/client-accounting-namespace.key",
         )
         .await
         .unwrap();
@@ -45,7 +44,7 @@ mod integ_tests {
             long_poll_timeout: Duration::from_secs(60),
             tls_cfg: Some(TlsConfig {
                 server_root_ca_cert: Some(root),
-                domain: Some("tls-sample".to_string()),
+                domain: Some("accounting.cluster-x.contoso.com".to_string()),
                 client_tls_config: Some(ClientTlsConfig {
                     client_cert,
                     client_private_key,


### PR DESCRIPTION
This PR seeks to iteratively flesh out the design for any interface changes needed to support sticky task queues.

Checklist:
- [x]  Add configuration option to enable or disable sticky mode, with a cache size limit
- [x] Add some way (a new method) to evict specific workflows, or entire cache.
- [x] Decide on if we should change to using run ids rather than task tokens as the primary identifier returned by polls and provided in activations
    - [x] If so, make that change
- [x] Add unit tests for multiple worker scenarios
