### PR TITLE
Add is_replaying attribute to WFActivation

### DIFF
--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -19,8 +19,10 @@ message WFActivation {
     string run_id = 1;
     /// The current time as understood by the workflow, which is set by workflow task started events
     google.protobuf.Timestamp timestamp = 2;
+    /// Whether or not the activation is replaying past events
+    bool is_replaying = 3;
     /// The things to do upon activating the workflow
-    repeated WFActivationJob jobs = 3;
+    repeated WFActivationJob jobs = 4;
 }
 
 message WFActivationJob {

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -409,6 +409,7 @@ impl WorkflowMachines {
         } else {
             Some(WfActivation {
                 timestamp: self.current_wf_time.map(Into::into),
+                is_replaying: self.replaying,
                 run_id: self.run_id.clone(),
                 jobs,
             })

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -62,6 +62,7 @@ pub mod coresdk {
             WfActivation {
                 timestamp: None,
                 run_id,
+                is_replaying: false,
                 jobs: vec![WfActivationJob::from(
                     wf_activation_job::Variant::RemoveFromCache(true),
                 )],


### PR DESCRIPTION
## Why?
This is required in order for lang SDKs to be able to dedupe log messages and metrics.
See https://github.com/temporalio/proposals/blob/master/node/logging-and-metrics-for-user-code.md