### PR TITLE
Pass history event header fields to StartWorkflow activation job

### DIFF
--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -63,6 +63,8 @@ message StartWorkflow {
     /// The seed must be used to initialize the random generator used by SDK.
     /// RandomSeedUpdatedAttributes are used to deliver seed updates.
     uint64 randomness_seed = 4;
+    /// Used to add metadata e.g. for tracing and auth, meant to be read and written to by interceptors.
+    map<string, common.Payload> headers = 5;
 
     // TODO: Do we need namespace here, or should that just be fetchable easily?
     //   will be others - workflow exe started attrs, etc

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     protos::{
         coresdk::{
+            common::Payload,
             workflow_activation::{
                 wf_activation_job::{self, Variant},
                 StartWorkflow, UpdateRandomSeed, WfActivation,
@@ -15,6 +16,7 @@ use crate::{
             PayloadsExt, PayloadsToPayloadError,
         },
         temporal::api::{
+            common::v1::Header,
             enums::v1::{CommandType, EventType},
             history::v1::{history_event, HistoryEvent},
         },
@@ -339,6 +341,13 @@ impl WorkflowMachines {
                             randomness_seed: str_to_randomness_seed(
                                 &attrs.original_execution_run_id,
                             ),
+                            headers: match &attrs.header {
+                                None => HashMap::new(),
+                                Some(Header { fields }) => fields
+                                    .iter()
+                                    .map(|(k, v)| (k.clone(), Payload::from(v.clone())))
+                                    .collect(),
+                            },
                         }
                         .into(),
                     );


### PR DESCRIPTION
## Why?
Used by interceptors to pass metadata from the client

## Checklist

2. How was this tested:
Tested with the Node SDK

