### PR TITLE
Sticky queues implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ derive_builder = "0.10"
 derive_more = "0.99"
 futures = "0.3"
 itertools = "0.10"
+lazy_static = "1.4"
 once_cell = "1.5"
 opentelemetry = { version = "0.13", features = ["rt-tokio"] }
 opentelemetry-jaeger = "0.12"
@@ -50,7 +51,6 @@ assert_matches = "1.4"
 bimap = "0.6.1"
 mockall = "0.9"
 rstest = "0.9"
-lazy_static = "1.4"
 test_utils = { path = "test_utils" }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "0.1"
 assert_matches = "1.4"
 bimap = "0.6.1"
 mockall = "0.9"
-rstest = "0.9"
+rstest = "0.10"
 test_utils = { path = "test_utils" }
 
 [build-dependencies]

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -23,7 +23,7 @@ use test_utils::fanout_tasks;
 use tokio::time::sleep;
 
 #[tokio::test]
-async fn max_activites_respected() {
+async fn max_activities_respected() {
     let task_q = "q";
     let mut tasks = VecDeque::from(vec![
         PollActivityTaskQueueResponse {
@@ -204,6 +204,7 @@ async fn activity_cancel_interrupts_poll() {
     };
     // So that we know we blocked
     assert_eq!(last_finisher.load(Ordering::Acquire), 2);
+    core.shutdown().await;
 }
 
 #[tokio::test]

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -288,13 +288,7 @@ async fn many_concurrent_heartbeat_cancels() {
             .boxed()
         });
 
-    let core = &CoreSDK::new(
-        mock_gateway,
-        CoreInitOptionsBuilder::default()
-            .gateway_opts(fake_sg_opts())
-            .build()
-            .unwrap(),
-    );
+    let core = &mock_core(mock_gateway);
     core.register_worker(
         WorkerConfigBuilder::default()
             .task_queue(TEST_Q)

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -1,3 +1,4 @@
+use crate::machines::test_help::mock_core_with_opts_no_workers;
 use crate::{
     errors::PollActivityError,
     machines::test_help::{fake_sg_opts, mock_core, TEST_Q},
@@ -65,7 +66,8 @@ async fn max_activities_respected() {
             .build()
             .unwrap(),
     )
-    .await;
+    .await
+    .unwrap();
 
     // We allow two outstanding activities, therefore first two polls should return right away
     let r1 = core.poll_activity_task(task_q).await.unwrap();
@@ -289,7 +291,7 @@ async fn many_concurrent_heartbeat_cancels() {
             .boxed()
         });
 
-    let core = &mock_core(mock_gateway);
+    let core = &mock_core_with_opts_no_workers(mock_gateway, CoreInitOptionsBuilder::default());
     core.register_worker(
         WorkerConfigBuilder::default()
             .task_queue(TEST_Q)
@@ -299,7 +301,8 @@ async fn many_concurrent_heartbeat_cancels() {
             .build()
             .unwrap(),
     )
-    .await;
+    .await
+    .unwrap();
 
     // Poll all activities first so they are registered
     for _ in 0..CONCURRENCY_NUM {

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -79,7 +79,8 @@ async fn shutdown_interrupts_both_polls() {
             .build()
             .unwrap(),
     )
-    .await;
+    .await
+    .unwrap();
     tokio::join! {
         async {
             assert_matches!(core.poll_activity_task(TEST_Q).await.unwrap_err(),

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -30,6 +30,21 @@ async fn after_shutdown_server_is_not_polled() {
 }
 
 #[tokio::test]
+async fn after_shutdown_of_worker_queue_not_registered() {
+    let wfid = "fake_wf_id";
+    let t = canned_histories::single_timer("fake_timer");
+    let core = build_fake_core(wfid, t, &[1]);
+    let res = core.inner.poll_workflow_task("q").await.unwrap();
+    assert_eq!(res.jobs.len(), 1);
+
+    core.inner.shutdown_worker("q").await;
+    assert_matches!(
+        core.inner.poll_workflow_task("q").await.unwrap_err(),
+        PollWfError::NoWorkerForQueue(_)
+    );
+}
+
+#[tokio::test]
 async fn shutdown_interrupts_both_polls() {
     let mut mock_gateway = MockManualGateway::new();
     mock_gateway

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -34,7 +34,8 @@ async fn multi_workers() {
                 .build()
                 .unwrap(),
         )
-        .await;
+        .await
+        .unwrap();
     }
 
     for i in 0..5 {
@@ -61,11 +62,11 @@ async fn no_worker_for_queue_error_returned_properly() {
 }
 
 #[tokio::test]
-async fn worker_double_register_replaces_old_worker() {
+async fn worker_double_register_is_err() {
     let t = canned_histories::single_timer("fake_timer");
-    let core = build_fake_core("fake_wf_id", t, &[1]);
-    // Replace the existing TEST_Q worker
-    core.inner
+    let core = build_fake_core("fake_wf_id", t, &[]);
+    assert!(core
+        .inner
         .register_worker(
             WorkerConfigBuilder::default()
                 .task_queue(TEST_Q)
@@ -73,11 +74,8 @@ async fn worker_double_register_replaces_old_worker() {
                 .build()
                 .unwrap(),
         )
-        .await;
-
-    // If the old worker wasn't replaced properly this would hang forever
-    core.inner.poll_workflow_task(TEST_Q).await.unwrap();
-    core.inner.shutdown().await;
+        .await
+        .is_err());
 }
 
 // Here we're making sure that when a pending activity is generated for a workflow on one task
@@ -105,7 +103,8 @@ async fn pending_activities_only_returned_for_their_queue() {
                 .build()
                 .unwrap(),
         )
-        .await;
+        .await
+        .unwrap();
     }
 
     // Create a pending activation by cancelling a try-cancel activity

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -1,3 +1,4 @@
+use crate::machines::test_help::TEST_Q;
 use crate::{
     machines::test_help::{build_fake_core, build_multihist_mock_sg, mock_core, FakeWfResponses},
     protos::coresdk::workflow_activation::wf_activation_job,
@@ -49,14 +50,33 @@ async fn multi_workers() {
 
 #[tokio::test]
 async fn no_worker_for_queue_error_returned_properly() {
-    let wfid = "fake_wf_id";
     let t = canned_histories::single_timer("fake_timer");
     // Empty batches array to specify 0 calls to poll expectation
-    let core = build_fake_core(wfid, t, &[]);
+    let core = build_fake_core("fake_wf_id", t, &[]);
 
     let fake_q = "not a registered queue";
     let res = core.inner.poll_workflow_task(&fake_q).await.unwrap_err();
     assert_matches!(res, PollWfError::NoWorkerForQueue(err_q) => err_q == fake_q);
+    core.inner.shutdown().await;
+}
+
+#[tokio::test]
+async fn worker_double_register_replaces_old_worker() {
+    let t = canned_histories::single_timer("fake_timer");
+    let core = build_fake_core("fake_wf_id", t, &[1]);
+    // Replace the existing TEST_Q worker
+    core.inner
+        .register_worker(
+            WorkerConfigBuilder::default()
+                .task_queue(TEST_Q)
+                .max_outstanding_workflow_tasks(2_usize)
+                .build()
+                .unwrap(),
+        )
+        .await;
+
+    // If the old worker wasn't replaced properly this would hang forever
+    core.inner.poll_workflow_task(TEST_Q).await.unwrap();
     core.inner.shutdown().await;
 }
 

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -1,10 +1,9 @@
-use crate::machines::test_help::{fake_sg_opts, mock_core_with_opts};
 use crate::{
     job_assert,
     machines::test_help::{
         build_fake_core, build_multihist_mock_sg, fake_core_from_mock_sg, gen_assert_and_fail,
-        gen_assert_and_reply, hist_to_poll_resp, mock_core, poll_and_reply, single_hist_mock_sg,
-        FakeCore, FakeWfResponses, TestHistoryBuilder, TEST_Q,
+        gen_assert_and_reply, hist_to_poll_resp, mock_core, mock_core_with_opts, poll_and_reply,
+        single_hist_mock_sg, FakeCore, FakeWfResponses, TestHistoryBuilder, TEST_Q,
     },
     pollers::MockServerGatewayApis,
     protos::{
@@ -27,7 +26,7 @@ use crate::{
     },
     test_help::canned_histories,
     workflow::WorkflowCachingPolicy::{self, AfterEveryReply, NonSticky},
-    Core, CoreInitOptionsBuilder, CoreSDK, WfActivationCompletion, WorkerConfigBuilder,
+    Core, CoreInitOptionsBuilder, WfActivationCompletion, WorkerConfigBuilder,
 };
 use rstest::{fixture, rstest};
 use std::{
@@ -873,14 +872,7 @@ async fn max_concurrent_wft_respected() {
         .expect_complete_workflow_task()
         .returning(|_, _, _| Ok(RespondWorkflowTaskCompletedResponse::default()));
 
-    // TODO: Why does extra register (from mock_core) break stuff?
-    let core = CoreSDK::new(
-        mock_gateway,
-        CoreInitOptionsBuilder::default()
-            .gateway_opts(fake_sg_opts())
-            .build()
-            .unwrap(),
-    );
+    let core = mock_core(mock_gateway);
     core.register_worker(
         WorkerConfigBuilder::default()
             .task_queue(TEST_Q)

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -1132,7 +1132,7 @@ async fn complete_after_eviction() {
     let t = canned_histories::single_timer("fake_timer");
     let mut mock = MockServerGatewayApis::new();
     mock.expect_complete_workflow_task().times(0);
-    let mock = single_hist_mock_sg(wfid, t, &[2], mock);
+    let mock = single_hist_mock_sg(wfid, t, &[2], mock, true);
     let core = fake_core_from_mock_sg(mock);
 
     let activation = core.inner.poll_workflow_task(TEST_Q).await.unwrap();
@@ -1159,7 +1159,7 @@ async fn sends_appropriate_sticky_task_queue_responses() {
         .times(1)
         .returning(|_, _, _| Ok(Default::default()));
     mock.expect_complete_workflow_task().times(0);
-    let mock = single_hist_mock_sg(wfid, t, &[1], mock);
+    let mock = single_hist_mock_sg(wfid, t, &[1], mock, false);
     let mut opts = CoreInitOptionsBuilder::default();
     opts.max_cached_workflows(10_usize);
     let core = mock_core_with_opts(mock.sg, opts);

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -884,6 +884,7 @@ async fn max_concurrent_wft_respected() {
 
     // Poll twice in a row before completing -- we should be at limit
     let r1 = core.poll_workflow_task(TEST_Q).await.unwrap();
+    let r1_run_id = r1.run_id.clone();
     let _r2 = core.poll_workflow_task(TEST_Q).await.unwrap();
     // Now we immediately poll for new work, and complete one of the existing activations. The
     // poll must not unblock until the completion goes through.
@@ -923,7 +924,7 @@ async fn max_concurrent_wft_respected() {
         .await
         .unwrap();
         r1 = core.poll_workflow_task(TEST_Q).await.unwrap();
-        // TODO: assert for wf1
+        assert_eq!(r1.run_id, r1_run_id);
     }
     core.shutdown().await;
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -170,3 +170,11 @@ pub enum ActivityHeartbeatError {
     #[error("New heartbeat requests are not accepted while shutting down")]
     ShuttingDown,
 }
+
+/// Errors thrown by [crate::Core::register_worker]
+#[derive(thiserror::Error, Debug)]
+pub enum WorkerRegistrationError {
+    /// A worker has already been registered on this queue
+    #[error("Worker already registered for queue: {0}")]
+    WorkerAlreadyRegisteredForQueue(String),
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -118,6 +118,9 @@ pub enum CompleteWfError {
         /// The run id of the erring workflow
         run_id: String,
     },
+    /// There is no worker registered for the queue being polled
+    #[error("No worker registered for queue: {0}")]
+    NoWorkerForQueue(String),
     /// Unhandled error when calling the temporal server. Core will attempt to retry any non-fatal
     /// errors, so lang should consider this fatal.
     #[error("Unhandled error when calling the temporal server: {0:?}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,8 +338,7 @@ where
         completion: WfActivationCompletion,
     ) -> Result<(), CompleteWfError> {
         let wfstatus = completion.status;
-
-        match wfstatus {
+        let r = match wfstatus {
             Some(wf_activation_completion::Status::Successful(success)) => {
                 self.wf_activation_success(&completion.run_id, success)
                     .await
@@ -351,7 +350,10 @@ where
                 reason: "Workflow completion had empty status field".to_owned(),
                 completion: None,
             }),
-        }
+        };
+
+        self.wft_manager.activation_done(&completion.run_id);
+        r
     }
 
     #[instrument(skip(self))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod test_help;
 
 pub use crate::errors::{
     ActivityHeartbeatError, CompleteActivityError, CompleteWfError, CoreInitError,
-    PollActivityError, PollWfError,
+    PollActivityError, PollWfError, WorkerRegistrationError,
 };
 pub use core_tracing::tracing_init;
 pub use pollers::{
@@ -42,7 +42,6 @@ pub use protosext::IntoCompletion;
 pub use url::Url;
 pub use worker::{WorkerConfig, WorkerConfigBuilder};
 
-use crate::errors::WorkerRegistrationError;
 use crate::{
     activity::ActivityTaskManager,
     errors::ShutdownErr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,8 +540,7 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> CoreSDK<SG> {
                     }
                 }
             } else {
-                // TODO: Worker missing case
-                panic!("Ahh worker expected");
+                return Err(CompleteWfError::NoWorkerForQueue(server_cmds.task_queue));
             }
         }
         Ok(())

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -733,7 +733,7 @@ mod test {
     }
 
     fn activity_workflow_driver(activity_id: &'static str) -> TestWorkflowDriver {
-        TestWorkflowDriver::new(|mut command_sink: CommandSender| async move {
+        TestWorkflowDriver::new(move |mut command_sink: CommandSender| async move {
             let activity = ScheduleActivity {
                 activity_id: activity_id.to_string(),
                 ..Default::default()

--- a/src/machines/test_help/mod.rs
+++ b/src/machines/test_help/mod.rs
@@ -95,11 +95,11 @@ where
     mock_core_with_opts(sg, CoreInitOptionsBuilder::default())
 }
 
-pub(crate) fn mock_core_with_opts<SG>(sg: SG, mut opts: CoreInitOptionsBuilder) -> CoreSDK<SG>
+pub(crate) fn mock_core_with_opts<SG>(sg: SG, opts: CoreInitOptionsBuilder) -> CoreSDK<SG>
 where
     SG: ServerGatewayApis + Send + Sync + 'static,
 {
-    let mut core = CoreSDK::new(sg, opts.gateway_opts(fake_sg_opts()).build().unwrap());
+    let mut core = mock_core_with_opts_no_workers(sg, opts);
     core.reg_worker_sync(
         WorkerConfigBuilder::default()
             .task_queue(TEST_Q)
@@ -107,6 +107,16 @@ where
             .unwrap(),
     );
     core
+}
+
+pub(crate) fn mock_core_with_opts_no_workers<SG>(
+    sg: SG,
+    mut opts: CoreInitOptionsBuilder,
+) -> CoreSDK<SG>
+where
+    SG: ServerGatewayApis + Send + Sync + 'static,
+{
+    CoreSDK::new(sg, opts.gateway_opts(fake_sg_opts()).build().unwrap())
 }
 
 pub struct FakeWfResponses {

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -453,10 +453,8 @@ impl WorkflowMachines {
 
     /// Apply events from history to this machines instance
     pub(crate) fn apply_history_events(&mut self, history_info: &HistoryInfo) -> Result<()> {
-        let (_, events) = history_info
-            .events()
-            .split_at(self.get_last_started_event_id() as usize);
-        let mut history = events.iter().peekable();
+        let events = history_info.events_after(self.get_last_started_event_id());
+        let mut history = events.peekable();
 
         self.set_started_ids(
             history_info.previous_started_event_id,

--- a/src/protosext/history_info.rs
+++ b/src/protosext/history_info.rs
@@ -108,6 +108,12 @@ impl HistoryInfo {
     pub(crate) fn events(&self) -> &[HistoryEvent] {
         &self.events
     }
+
+    pub(crate) fn events_after(&self, event_id: i64) -> impl Iterator<Item = &HistoryEvent> {
+        self.events
+            .iter()
+            .skip_while(move |e| e.event_id <= event_id)
+    }
 }
 
 #[cfg(test)]

--- a/src/protosext/history_info.rs
+++ b/src/protosext/history_info.rs
@@ -105,6 +105,7 @@ impl HistoryInfo {
         Self::new_from_events(&h.events, to_wf_task_num)
     }
 
+    #[cfg(test)]
     pub(crate) fn events(&self) -> &[HistoryEvent] {
         &self.events
     }

--- a/src/test_workflow_driver.rs
+++ b/src/test_workflow_driver.rs
@@ -75,7 +75,7 @@ impl TestRustWorker {
         let (tx, mut rx) = unbounded_channel::<WfActivation>();
         let core = self.core.clone();
         let jh = tokio::spawn(async move {
-            while let Some(activation) = rx.recv().await {
+            'receiver: while let Some(activation) = rx.recv().await {
                 for WfActivationJob { variant } in activation.jobs {
                     if let Some(v) = variant {
                         match v {
@@ -97,6 +97,7 @@ impl TestRustWorker {
                             Variant::RemoveFromCache(_) => {
                                 // Restart the workflow on eviction
                                 twd.init_workflow();
+                                continue 'receiver;
                             }
                         }
                     } else {

--- a/src/test_workflow_driver.rs
+++ b/src/test_workflow_driver.rs
@@ -427,7 +427,7 @@ impl CommandSender {
     }
 
     /// Request to create a timer
-    pub fn timer(&mut self, a: StartTimer) -> impl Future {
+    pub fn timer(&mut self, a: StartTimer) -> impl Future<Output = Option<()>> {
         let id = a.timer_id.clone();
         self.send_blocking_cmd(
             CommandID::Timer(id.clone()),

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -36,7 +36,9 @@ pub struct WorkerConfig {
     #[builder(default = "100")]
     pub max_outstanding_activities: usize,
     /// Maximum number of concurrent poll workflow task requests we will perform at a time on this
-    /// worker's task queue
+    /// worker's task queue and its sticky task queue. Hence note this means the absolute number of
+    /// concurrent polls this worker may theoretically perform is 2x this number if sticky queues
+    /// are being used.
     #[builder(default = "5")]
     pub max_concurrent_wft_polls: usize,
     /// Maximum number of concurrent poll activity task requests we will perform at a time on this
@@ -90,7 +92,6 @@ impl Worker {
             poll_buffer: new_workflow_task_buffer(
                 sg.clone(),
                 sqn.clone(),
-                // TODO: Split this number across normal and sticky poller? Sticky should have more?
                 config.max_concurrent_wft_polls,
                 config.max_concurrent_wft_polls * 2,
             ),

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -200,7 +200,7 @@ impl Worker {
                 biased;
 
                 r = self.wf_task_poll_buffer.poll() => r,
-                r = sq.poll_buffer.poll() => r
+                r = sq.poll_buffer.poll() => r,
             }
         } else {
             self.wf_task_poll_buffer.poll().await

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -137,13 +137,13 @@ impl Worker {
             config,
         }
     }
-    pub(crate) fn shutdown(&self) {
-        self.wf_task_poll_buffer.shutdown();
-        if let Some(sq) = self.sticky_queue.as_ref() {
-            sq.poll_buffer.shutdown();
+    pub(crate) async fn shutdown(self) {
+        self.wf_task_poll_buffer.shutdown().await;
+        if let Some(sq) = self.sticky_queue {
+            sq.poll_buffer.shutdown().await;
         }
-        if let Some(b) = self.at_task_poll_buffer.as_ref() {
-            b.shutdown();
+        if let Some(b) = self.at_task_poll_buffer {
+            b.shutdown().await;
         }
     }
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -20,7 +20,7 @@ use tokio::sync::Semaphore;
 
 /// Defines per-worker configuration options
 #[derive(Debug, Clone, derive_builder::Builder)]
-#[builder(setter(into))]
+#[builder(setter(into), build_fn(validate = "Self::validate"))]
 // TODO: per-second queue limits
 pub struct WorkerConfig {
     /// What task queue will this worker poll from? This task queue name will be used for both
@@ -36,13 +36,14 @@ pub struct WorkerConfig {
     #[builder(default = "100")]
     pub max_outstanding_activities: usize,
     /// Maximum number of concurrent poll workflow task requests we will perform at a time on this
-    /// worker's task queue. See also [nonsticky_to_sticky_poll_ratio]. A zero value will be treated
-    /// as if set to `1`.
+    /// worker's task queue. See also [nonsticky_to_sticky_poll_ratio]. Must be at least 1.
     #[builder(default = "5")]
     pub max_concurrent_wft_polls: usize,
     /// [max_concurrent_wft_polls] * this number = the number of max pollers that will be allowed
     /// for the nonsticky queue when sticky tasks are enabled. If both defaults are used, the sticky
-    /// queue will allow 4 max pollers while the nonsticky queue will allow one.
+    /// queue will allow 4 max pollers while the nonsticky queue will allow one. The minimum for
+    /// either poller is 1, so if `max_concurrent_wft_polls` is 1 and sticky queues are enabled,
+    /// there will be 2 concurrent polls.
     #[builder(default = "0.2")]
     pub nonsticky_to_sticky_poll_ratio: f32,
     /// Maximum number of concurrent poll activity task requests we will perform at a time on this
@@ -53,6 +54,15 @@ pub struct WorkerConfig {
     /// poll for activity tasks. This option exists because
     #[builder(default = "false")]
     pub no_remote_activities: bool,
+}
+
+impl WorkerConfigBuilder {
+    fn validate(&self) -> Result<(), String> {
+        if self.max_concurrent_wft_polls == Some(0) {
+            return Err("`max_concurrent_wft_polls` must be at least 1".to_owned());
+        }
+        Ok(())
+    }
 }
 
 /// A worker polls on a certain task queue
@@ -349,13 +359,11 @@ mod tests {
     }
 
     #[test]
-    fn max_polls_zero() {
-        let cfg = WorkerConfigBuilder::default()
+    fn max_polls_zero_is_err() {
+        assert!(WorkerConfigBuilder::default()
             .task_queue("whatever")
             .max_concurrent_wft_polls(0_usize)
             .build()
-            .unwrap();
-        assert_eq!(cfg.max_nonsticky_polls(), 1);
-        assert_eq!(cfg.max_sticky_polls(), 1);
+            .is_err());
     }
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -117,6 +117,9 @@ impl Worker {
     }
     pub(crate) fn shutdown(&self) {
         self.wf_task_poll_buffer.shutdown();
+        if let Some(sq) = self.sticky_queue.as_ref() {
+            sq.poll_buffer.shutdown();
+        }
         if let Some(b) = self.at_task_poll_buffer.as_ref() {
             b.shutdown();
         }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -36,14 +36,15 @@ pub struct WorkerConfig {
     #[builder(default = "100")]
     pub max_outstanding_activities: usize,
     /// Maximum number of concurrent poll workflow task requests we will perform at a time on this
-    /// worker's task queue. See also [nonsticky_to_sticky_poll_ratio]. Must be at least 1.
+    /// worker's task queue. See also [WorkerConfig::nonsticky_to_sticky_poll_ratio]. Must be at
+    /// least 1.
     #[builder(default = "5")]
     pub max_concurrent_wft_polls: usize,
-    /// [max_concurrent_wft_polls] * this number = the number of max pollers that will be allowed
-    /// for the nonsticky queue when sticky tasks are enabled. If both defaults are used, the sticky
-    /// queue will allow 4 max pollers while the nonsticky queue will allow one. The minimum for
-    /// either poller is 1, so if `max_concurrent_wft_polls` is 1 and sticky queues are enabled,
-    /// there will be 2 concurrent polls.
+    /// [WorkerConfig::max_concurrent_wft_polls] * this number = the number of max pollers that will
+    /// be allowed for the nonsticky queue when sticky tasks are enabled. If both defaults are used,
+    /// the sticky queue will allow 4 max pollers while the nonsticky queue will allow one. The
+    /// minimum for either poller is 1, so if `max_concurrent_wft_polls` is 1 and sticky queues are
+    /// enabled, there will be 2 concurrent polls.
     #[builder(default = "0.2")]
     pub nonsticky_to_sticky_poll_ratio: f32,
     /// Maximum number of concurrent poll activity task requests we will perform at a time on this

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -119,7 +119,9 @@ impl CoreWfStarter {
         if self.initted_core.is_none() {
             let core = temporal_sdk_core::init(opts).await.unwrap();
             // Register a worker for the task queue
-            core.register_worker(self.worker_config.clone()).await;
+            core.register_worker(self.worker_config.clone())
+                .await
+                .unwrap();
             self.initted_core = Some(Arc::new(core));
         }
         self.initted_core.as_ref().unwrap().clone()

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -243,6 +243,9 @@ async fn signal_workflow() {
     })
     .await;
 
+    // Wait a beat, to make sure both signals are in the next task
+    sleep(Duration::from_millis(800)).await;
+
     let res = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         res.jobs.as_slice(),

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -1,4 +1,5 @@
 mod activities;
+mod stickyness;
 mod timers;
 
 use assert_matches::assert_matches;
@@ -15,7 +16,7 @@ use temporal_sdk_core::{
         workflow_completion::WfActivationCompletion,
         ActivityTaskCompletion,
     },
-    tracing_init, Core, IntoCompletion, PollWfError,
+    Core, IntoCompletion, PollWfError,
 };
 use test_utils::{init_core_and_create_wf, schedule_activity_cmd, with_gw, CoreWfStarter, GwApi};
 use tokio::time::sleep;
@@ -129,9 +130,6 @@ async fn fail_wf_task() {
     ))
     .await
     .unwrap();
-
-    // Allow timer to fire
-    std::thread::sleep(Duration::from_millis(500));
 
     // Then break for whatever reason
     let task = core.poll_workflow_task(&task_q).await.unwrap();
@@ -353,7 +351,6 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
 
 #[tokio::test]
 async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
-    tracing_init();
     let activity_id = "act-1";
     let signal_at_start = "at-start";
     let signal_at_complete = "at-complete";

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -243,9 +243,6 @@ async fn signal_workflow() {
     })
     .await;
 
-    // Wait a beat, to make sure both signals are in the next task
-    sleep(Duration::from_millis(800)).await;
-
     let res = core.poll_workflow_task(&task_q).await.unwrap();
     assert_matches!(
         res.jobs.as_slice(),

--- a/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/tests/integ_tests/workflow_tests/stickyness.rs
@@ -1,0 +1,54 @@
+use crate::integ_tests::workflow_tests::timers::timer_wf;
+use std::{sync::Arc, time::Duration};
+use temporal_sdk_core::{
+    protos::coresdk::workflow_commands::StartTimer,
+    test_workflow_driver::{CommandSender, TestRustWorker},
+};
+use test_utils::{CoreWfStarter, NAMESPACE};
+use tokio::time::sleep;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn timer_workflow_not_sticky() {
+    let wf_name = "timer_wf_not_sticky";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.max_cached_workflows(0);
+    let tq = starter.get_task_queue().to_owned();
+    let core = starter.get_core().await;
+
+    let worker = TestRustWorker::new(core.clone(), NAMESPACE.to_owned(), tq.clone());
+    worker
+        .submit_wf(wf_name.to_owned(), Arc::new(timer_wf))
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    core.shutdown().await;
+}
+
+pub async fn timer_timeout_wf(mut command_sink: CommandSender) {
+    let timer = StartTimer {
+        timer_id: "super_timer_id".to_string(),
+        start_to_fire_timeout: Some(Duration::from_secs(1).into()),
+    };
+    let t = command_sink.timer(timer);
+    sleep(Duration::from_secs(3)).await;
+    t.await;
+    command_sink.complete_workflow_execution();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn timer_workflow_timeout_on_sticky() {
+    // This test intentionally times out a workflow task in order to make the next task be scheduled
+    // on a not-sticky queue
+    let wf_name = "timer_workflow_timeout_on_sticky";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.wft_timeout(Duration::from_secs(2));
+    let tq = starter.get_task_queue().to_owned();
+    let core = starter.get_core().await;
+
+    let mut worker = TestRustWorker::new(core.clone(), NAMESPACE.to_owned(), tq.clone());
+    worker.override_deadlock(Duration::from_secs(4));
+    let run_id = starter.start_wf().await;
+    worker.start_wf(Arc::new(timer_timeout_wf), run_id);
+    worker.run_until_done().await.unwrap();
+    core.shutdown().await;
+}

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -11,7 +11,6 @@ use test_utils::{init_core_and_create_wf, CoreWfStarter, NAMESPACE};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn timer_workflow_not_sticky() {
-    tracing_init();
     let wf_name = "timer_wf_not_sticky";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.max_cached_workflows(0);

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -6,7 +6,6 @@ use temporal_sdk_core::protos::coresdk::{
     workflow_completion::WfActivationCompletion,
 };
 use temporal_sdk_core::test_workflow_driver::{CommandSender, TestRustWorker, TestWorkflowDriver};
-use temporal_sdk_core::tracing_init;
 use test_utils::{init_core_and_create_wf, CoreWfStarter, NAMESPACE};
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -1,7 +1,5 @@
-use assert_matches::assert_matches;
 use std::{sync::Arc, time::Duration};
 use temporal_sdk_core::protos::coresdk::{
-    workflow_activation::{wf_activation_job, FireTimer, WfActivationJob},
     workflow_commands::{CancelTimer, CompleteWorkflowExecution, StartTimer},
     workflow_completion::WfActivationCompletion,
 };
@@ -138,55 +136,32 @@ async fn timer_immediate_cancel_workflow() {
     .unwrap();
 }
 
-#[tokio::test]
-async fn parallel_timer_workflow() {
-    let (core, task_q) = init_core_and_create_wf("parallel_timer_workflow").await;
-    let timer_id = "timer 1".to_string();
-    let timer_2_id = "timer 2".to_string();
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
-    core.complete_workflow_task(WfActivationCompletion::from_cmds(
-        vec![
-            StartTimer {
-                timer_id: timer_id.clone(),
-                start_to_fire_timeout: Some(Duration::from_millis(50).into()),
-            }
-            .into(),
-            StartTimer {
-                timer_id: timer_2_id.clone(),
-                start_to_fire_timeout: Some(Duration::from_millis(100).into()),
-            }
-            .into(),
-        ],
-        task.run_id,
-    ))
-    .await
-    .unwrap();
-    // Wait long enough for both timers to complete. Server seems to be a bit weird about actually
-    // sending both of these in one go, so we need to wait longer than you would expect.
-    std::thread::sleep(Duration::from_millis(1500));
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
-    assert_matches!(
-        task.jobs.as_slice(),
-        [
-            WfActivationJob {
-                variant: Some(wf_activation_job::Variant::FireTimer(
-                    FireTimer { timer_id: t1_id }
-                )),
-            },
-            WfActivationJob {
-                variant: Some(wf_activation_job::Variant::FireTimer(
-                    FireTimer { timer_id: t2_id }
-                )),
-            }
-        ] => {
-            assert_eq!(t1_id, &timer_id);
-            assert_eq!(t2_id, &timer_2_id);
-        }
-    );
-    core.complete_workflow_task(WfActivationCompletion::from_cmds(
-        vec![CompleteWorkflowExecution { result: None }.into()],
-        task.run_id,
-    ))
-    .await
-    .unwrap();
+async fn parallel_timer_wf(mut command_sink: CommandSender) {
+    let t1 = command_sink.timer(StartTimer {
+        timer_id: "timer_1".to_string(),
+        start_to_fire_timeout: Some(Duration::from_secs(1).into()),
+    });
+    let t2 = command_sink.timer(StartTimer {
+        timer_id: "timer_2".to_string(),
+        start_to_fire_timeout: Some(Duration::from_secs(1).into()),
+    });
+    let _ = tokio::join!(t1, t2);
+    command_sink.complete_workflow_execution();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_timers() {
+    tracing_init();
+    let wf_name = "parallel_timers";
+    let mut starter = CoreWfStarter::new(wf_name);
+    let tq = starter.get_task_queue().to_owned();
+    let core = starter.get_core().await;
+
+    let worker = TestRustWorker::new(core.clone(), NAMESPACE.to_owned(), tq.clone());
+    worker
+        .submit_wf(wf_name.to_owned(), Arc::new(parallel_timer_wf))
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    core.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -10,11 +10,11 @@ use temporal_sdk_core::tracing_init;
 use test_utils::{init_core_and_create_wf, CoreWfStarter, NAMESPACE};
 
 #[tokio::test(flavor = "multi_thread")]
-async fn timer_workflow_sticky_queue() {
+async fn timer_workflow_not_sticky() {
     tracing_init();
-    let wf_name = "timer_wf_new";
+    let wf_name = "timer_wf_not_sticky";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.max_cached_workflows(10);
+    starter.max_cached_workflows(0);
     let tq = starter.get_task_queue().to_owned();
     let core = starter.get_core().await;
 
@@ -74,6 +74,7 @@ async fn timer_workflow() {
     ))
     .await
     .unwrap();
+    core.shutdown().await;
 }
 
 #[tokio::test]

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -1,5 +1,6 @@
 use assert_matches::assert_matches;
 use futures::future::join_all;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use temporal_sdk_core::protos::coresdk::{
     activity_result::ActivityResult,
@@ -7,53 +8,60 @@ use temporal_sdk_core::protos::coresdk::{
     workflow_commands::{ActivityCancellationType, ScheduleActivity},
     ActivityTaskCompletion,
 };
-use temporal_sdk_core::test_workflow_driver::{CommandSender, TestWorkflowDriver};
+use temporal_sdk_core::test_workflow_driver::CommandSender;
 use test_utils::{fanout_tasks, CoreWfStarter};
+
+const CONCURRENCY: usize = 1000;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn activity_load() {
     let mut starter = CoreWfStarter::new("activity_load");
-    starter.max_wft(1000).max_at(1000);
+    starter
+        .max_wft(CONCURRENCY)
+        .max_cached_workflows(CONCURRENCY)
+        .max_at(CONCURRENCY);
     let worker = starter.worker().await;
     let task_q = &starter.get_task_queue().to_owned();
 
     let activity_id = "act-1";
     let activity_timeout = Duration::from_secs(8);
     let payload_dat = b"hello".to_vec();
+    let task_queue = starter.get_task_queue().to_owned();
+
+    let pd = payload_dat.clone();
+    let wf_fn = Arc::new(move |mut command_sink: CommandSender| {
+        let task_queue = task_queue.clone();
+        let payload_dat = pd.clone();
+
+        async move {
+            let activity = ScheduleActivity {
+                activity_id: activity_id.to_string(),
+                activity_type: "test_activity".to_string(),
+                task_queue,
+                schedule_to_start_timeout: Some(activity_timeout.into()),
+                start_to_close_timeout: Some(activity_timeout.into()),
+                schedule_to_close_timeout: Some(activity_timeout.into()),
+                heartbeat_timeout: Some(activity_timeout.into()),
+                cancellation_type: ActivityCancellationType::TryCancel as i32,
+                ..Default::default()
+            };
+            let res = command_sink
+                .activity(activity)
+                .await
+                .unwrap()
+                .unwrap_ok_payload();
+            assert_eq!(res.data, payload_dat);
+            command_sink.complete_workflow_execution();
+        }
+    });
 
     let starting = Instant::now();
-    join_all((0..1000usize).map(|i| {
-        let task_queue = starter.get_task_queue().to_owned();
-        let payload_dat = payload_dat.clone();
-        let twd = TestWorkflowDriver::new(move |mut command_sink: CommandSender| {
-            let task_queue = task_queue.clone();
-            let payload_dat = payload_dat.clone();
-
-            async move {
-                let activity = ScheduleActivity {
-                    activity_id: activity_id.to_string(),
-                    activity_type: "test_activity".to_string(),
-                    task_queue: task_queue.clone(),
-                    schedule_to_start_timeout: Some(activity_timeout.into()),
-                    start_to_close_timeout: Some(activity_timeout.into()),
-                    schedule_to_close_timeout: Some(activity_timeout.into()),
-                    heartbeat_timeout: Some(activity_timeout.into()),
-                    cancellation_type: ActivityCancellationType::TryCancel as i32,
-                    ..Default::default()
-                };
-                let res = command_sink
-                    .activity(activity)
-                    .await
-                    .unwrap()
-                    .unwrap_ok_payload();
-                assert_eq!(res.data, payload_dat);
-                command_sink.complete_workflow_execution();
-            }
-        });
+    join_all((0..CONCURRENCY).map(|i| {
         let worker = &worker;
+        let wf_fn = wf_fn.clone();
         async move {
             worker
-                .submit_wf(format!("activity_load_{}", i), twd)
+                .submit_wf(format!("activity_load_{}", i), wf_fn)
                 .await
                 .unwrap();
         }
@@ -64,7 +72,7 @@ async fn activity_load() {
     let running = Instant::now();
     let core = &starter.get_core().await;
     // Poll for and complete all activities
-    let all_acts = fanout_tasks(1000, |_| {
+    let all_acts = fanout_tasks(CONCURRENCY, |_| {
         let payload_dat = payload_dat.clone();
         async move {
             let task = core.poll_activity_task(task_q).await.unwrap();

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -23,9 +23,12 @@ async fn activity_load() {
 
     let starting = Instant::now();
     join_all((0..1000usize).map(|i| {
-        let twd = TestWorkflowDriver::new(|mut command_sink: CommandSender| {
-            let task_queue = starter.get_task_queue().to_owned();
+        let task_queue = starter.get_task_queue().to_owned();
+        let payload_dat = payload_dat.clone();
+        let twd = TestWorkflowDriver::new(move |mut command_sink: CommandSender| {
+            let task_queue = task_queue.clone();
             let payload_dat = payload_dat.clone();
+
             async move {
                 let activity = ScheduleActivity {
                     activity_id: activity_id.to_string(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Sticky queues are used now when max cached workflows is nonzero

1. How was this tested:
All integ tests were already using a sort of fake sticky mode. Now they use real sticky mode, and some non-sticky tests are added.
