### PR TITLE
Fix possible failure to evict when WFT timeout encountered

### DIFF
--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -179,7 +179,7 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatManager<SG>
                 }
             }
         }
-        self.shutdown().await.expect("shutdown should exit cleanly")
+        self.shutdown().await.expect("shutdown should exit cleanly");
     }
 
     /// Records heartbeat, by sending it to the processor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -623,6 +623,8 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> CoreSDK<SG> {
                 }
             }
         }
+
+        self.wft_manager.after_wft_report(run_id);
         Ok(())
     }
 

--- a/src/workflow_tasks.rs
+++ b/src/workflow_tasks.rs
@@ -266,7 +266,6 @@ impl WorkflowTaskManager {
         } else {
             None
         };
-        self.after_wft_report(run_id);
         Ok(ret)
     }
 
@@ -350,8 +349,10 @@ impl WorkflowTaskManager {
     }
 
     /// Called after every WFT completion or failure, updates outstanding task status & issues
-    /// evictions if required
-    fn after_wft_report(&self, run_id: &str) {
+    /// evictions if required. It is important this is called *after* reporting a successful WFT
+    /// to server, as some replies (task not found) may require an eviction, which could be avoided
+    /// if this is called too early.
+    pub(crate) fn after_wft_report(&self, run_id: &str) {
         // Workflows with no more pending activations (IE: They have completed a WFT) must be
         // removed from the outstanding tasks map
         if !self.pending_activations.has_pending(run_id) {

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -472,33 +472,3 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     .await
     .unwrap();
 }
-
-#[tokio::test]
-async fn wft_timeout_on_sticky_switches_to_nonsticky_with_eviction() {
-    let mut wf_starter =
-        CoreWfStarter::new("wft_timeout_on_sticky_switches_to_nonsticky_with_eviction");
-    // Short timeout with cache on
-    wf_starter.wft_timeout(Duration::from_secs(1));
-    let core = wf_starter.get_core().await;
-    let task_q = wf_starter.get_task_queue();
-    let wf_id = &wf_starter.get_wf_id().to_owned();
-
-    wf_starter.start_wf().await;
-
-    // Complete first task to get it onto the sticky queue
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
-    core.complete_workflow_task(WfActivationCompletion::from_cmds(
-        vec![StartTimer {
-            timer_id: "timer".to_string(),
-            start_to_fire_timeout: Some(Duration::from_secs(1).into()),
-        }
-        .into()],
-        task.run_id,
-    ))
-    .await
-    .unwrap();
-
-    // Time out the next task
-    let task = core.poll_workflow_task(&task_q).await.unwrap();
-    sleep(Duration::from_secs(2)).await;
-}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make sure we handle the server telling us a task was stale. Previously, completing the WFT would cause the outstanding task to be removed and therefore eviction would not happen.

## Why?
Fixes a possible bug when dealing with WFT timeouts

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing tests now account for this

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
