### PR TITLE
Remove unreachable assertion if reached unexpected workflow execution event

### DIFF
--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -489,12 +489,6 @@ impl WorkflowMachines {
             }
 
             self.handle_event(event, next_event.is_some())?;
-
-            if next_event.is_none() {
-                if event.is_final_wf_execution_event() {
-                    return Ok(());
-                }
-            }
         }
 
         Ok(())

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -494,7 +494,6 @@ impl WorkflowMachines {
                 if event.is_final_wf_execution_event() {
                     return Ok(());
                 }
-                unreachable!()
             }
         }
 


### PR DESCRIPTION
Fixes panic when receiving a query for a workflow which was started on a different worker.