### PR TITLE
Fix unnecessary activity not found warnings when we already know

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rand = "0.8.3"
 slotmap = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs"] }
+tokio-stream = "0.1"
 tonic = { version = "0.4", features = ["tls", "tls-roots"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -78,6 +78,8 @@ impl ActivityHeartbeatManager {
         Ok(())
     }
 
+    /// Tell the heartbeat manager we are done forever with a certain task, so it may be forgotten.
+    /// Record should *not* be called with the same TaskToken after calling this.
     pub fn evict(&self, task_token: TaskToken) {
         let _ = self.heartbeat_tx.send(HBAction::Evict(task_token));
     }

--- a/src/activity/activity_heartbeat_manager.rs
+++ b/src/activity/activity_heartbeat_manager.rs
@@ -7,78 +7,37 @@ use crate::{
     },
     task_token::TaskToken,
 };
+use futures::StreamExt;
+use std::collections::hash_map::Entry;
 use std::{
     collections::HashMap,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::{self, Duration},
+    sync::Arc,
+    time::{self, Duration, Instant},
 };
 use tokio::{
-    select,
     sync::{
         mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-        watch::{channel, Receiver, Sender},
-        Mutex,
+        watch, Mutex,
     },
-    task::{JoinError, JoinHandle},
-    time::sleep,
+    task::JoinHandle,
 };
-
-pub(crate) struct ActivityHeartbeatManager<SG> {
-    /// Core will aggregate activity heartbeats for each activity and send them to the server
-    /// periodically. This map contains sender channel for each activity, identified by the task
-    /// token, that has an active heartbeat processor.
-    heartbeat_processors: HashMap<TaskToken, ActivityHeartbeatProcessorHandle>,
-    events_tx: UnboundedSender<LifecycleEvent>,
-    events_rx: UnboundedReceiver<LifecycleEvent>,
-    shutdown_tx: Sender<bool>,
-    shutdown_rx: Receiver<bool>,
-    cancels_tx: UnboundedSender<(TaskToken, ActivityCancelReason)>,
-    server_gateway: Arc<SG>,
-}
 
 /// Used to supply new heartbeat events to the activity heartbeat manager, or to send a shutdown
 /// request.
-pub(crate) struct ActivityHeartbeatManagerHandle {
-    shutting_down: AtomicBool,
-    events: UnboundedSender<LifecycleEvent>,
+pub(crate) struct ActivityHeartbeatManager {
+    heartbeat_tx: UnboundedSender<HBAction>,
     /// Cancellations that have been received when heartbeating are queued here and can be consumed
     /// by [fetch_cancellations]
     incoming_cancels: Mutex<UnboundedReceiver<(TaskToken, ActivityCancelReason)>>,
+    shutting_down: watch::Sender<bool>,
     /// Used during `shutdown` to await until all inflight requests are sent.
     join_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
-/// Used to supply heartbeat details to the heartbeat processor, which periodically sends them to
-/// the server.
-struct ActivityHeartbeatProcessorHandle {
-    heartbeat_tx: Sender<Vec<common::Payload>>,
-    join_handle: JoinHandle<()>,
-}
-
-/// Heartbeat processor, that aggregates and periodically sends heartbeat requests for a single
-/// activity to the server.
-struct ActivityHeartbeatProcessor<SG> {
-    task_token: TaskToken,
-    delay: time::Duration,
-    /// Used to receive heartbeat events.
-    heartbeat_rx: Receiver<Vec<common::Payload>>,
-    /// Used to receive shutdown notifications.
-    shutdown_rx: Receiver<bool>,
-    /// Used to send CleanupProcessor event at the end of the processor loop.
-    events_tx: UnboundedSender<LifecycleEvent>,
-    /// Used to send cancellation notices that we learned about when heartbeating back up to core
-    cancels_tx: UnboundedSender<(TaskToken, ActivityCancelReason)>,
-    server_gateway: Arc<SG>,
-}
-
 #[derive(Debug)]
-pub enum LifecycleEvent {
-    Heartbeat(ValidActivityHeartbeat),
-    CleanupProcessor(TaskToken),
-    Shutdown,
+enum HBAction {
+    HB(ValidActivityHeartbeat),
+    Evict(TaskToken),
 }
 
 #[derive(Debug)]
@@ -91,23 +50,25 @@ pub struct ValidActivityHeartbeat {
 /// Handle that is used by the core for all interactions with the manager, allows sending new
 /// heartbeats or requesting and awaiting for the shutdown. When shutdown is requested, signal gets
 /// sent to all processors, which allows them to complete gracefully.
-impl ActivityHeartbeatManagerHandle {
-    /// Records a new heartbeat, note that first call would result in an immediate call to the
-    /// server, while rapid successive calls would accumulate for up to `delay`
-    /// and then latest heartbeat details will be sent to the server. If there is no activity for
-    /// `delay` then heartbeat processor will be reset and process would start
-    /// over again, meaning that next heartbeat will be sent immediately, creating a new processor.
+impl ActivityHeartbeatManager {
+    /// Records a new heartbeat, the first call will result in an immediate call to the server,
+    /// while rapid successive calls would accumulate for up to `delay` and then latest heartbeat
+    /// details will be sent to the server.
+    ///
+    /// It is important that this function is never called with a task token equal to one given
+    /// to [Self::evict] after it has been called, doing so will cause a memory leak, as there is
+    /// no longer an efficient way to forget about that task token.
     pub fn record(
         &self,
         details: ActivityHeartbeat,
         delay: Duration,
     ) -> Result<(), ActivityHeartbeatError> {
-        if self.shutting_down.load(Ordering::Relaxed) {
+        if *self.shutting_down.borrow() {
             return Err(ActivityHeartbeatError::ShuttingDown);
         }
 
-        self.events
-            .send(LifecycleEvent::Heartbeat(ValidActivityHeartbeat {
+        self.heartbeat_tx
+            .send(HBAction::HB(ValidActivityHeartbeat {
                 task_token: TaskToken(details.task_token),
                 details: details.details,
                 delay,
@@ -115,6 +76,10 @@ impl ActivityHeartbeatManagerHandle {
             .expect("Receive half of the heartbeats event channel must not be dropped");
 
         Ok(())
+    }
+
+    pub fn evict(&self, task_token: TaskToken) {
+        let _ = self.heartbeat_tx.send(HBAction::Evict(task_token));
     }
 
     /// Returns a future that resolves any time there is a new activity cancel that must be
@@ -126,15 +91,7 @@ impl ActivityHeartbeatManagerHandle {
     /// Initiates shutdown procedure by stopping lifecycle loop and awaiting for all heartbeat
     /// processors to terminate gracefully.
     pub async fn shutdown(&self) {
-        // If shutdown was called multiple times, shutdown signal has been sent already and consumer
-        // might have been dropped already, meaning that sending to the channel may fail.
-        // All we need to do is to simply await on handle for the completion.
-        if !self.shutting_down.load(Ordering::Relaxed) {
-            self.events
-                .send(LifecycleEvent::Shutdown)
-                .expect("should be able to send shutdown event");
-            self.shutting_down.store(true, Ordering::Relaxed);
-        }
+        let _ = self.shutting_down.send(true);
         let mut handle = self.join_handle.lock().await;
         if let Some(h) = handle.take() {
             h.await.expect("shutdown should exit cleanly");
@@ -142,150 +99,138 @@ impl ActivityHeartbeatManagerHandle {
     }
 }
 
-impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatManager<SG> {
-    #![allow(clippy::new_ret_no_self)]
-    /// Creates a new instance of an activity heartbeat manager and returns a handle to the user,
-    /// which allows to send new heartbeats and initiate the shutdown.
-    pub fn new(sg: Arc<SG>) -> ActivityHeartbeatManagerHandle {
-        let (shutdown_tx, shutdown_rx) = channel(false);
-        let (events_tx, events_rx) = unbounded_channel();
-        let (cancels_tx, cancels_rx) = unbounded_channel();
-        let s = Self {
-            heartbeat_processors: Default::default(),
-            events_tx: events_tx.clone(),
-            events_rx,
-            shutdown_tx,
-            shutdown_rx,
-            cancels_tx,
-            server_gateway: sg,
-        };
-        let join_handle = tokio::spawn(s.lifecycle());
-        ActivityHeartbeatManagerHandle {
-            shutting_down: AtomicBool::new(false),
-            events: events_tx,
-            incoming_cancels: Mutex::new(cancels_rx),
-            join_handle: Mutex::new(Some(join_handle)),
-        }
-    }
+#[derive(Debug)]
+struct HbStreamState {
+    last_sent: HashMap<TaskToken, ActivityHbState>,
+    incoming_hbs: UnboundedReceiver<HBAction>,
+}
 
-    /// Main loop, that handles all heartbeat requests and dispatches them to processors.
-    async fn lifecycle(mut self) {
-        while let Some(event) = self.events_rx.recv().await {
-            match event {
-                LifecycleEvent::Heartbeat(heartbeat) => self.record(heartbeat),
-                LifecycleEvent::Shutdown => break,
-                LifecycleEvent::CleanupProcessor(task_token) => {
-                    self.heartbeat_processors.remove(&task_token);
-                }
-            }
+impl HbStreamState {
+    fn new(incoming_hbs: UnboundedReceiver<HBAction>) -> Self {
+        Self {
+            last_sent: Default::default(),
+            incoming_hbs,
         }
-        self.shutdown().await.expect("shutdown should exit cleanly");
-    }
-
-    /// Records heartbeat, by sending it to the processor.
-    /// New processor is created if one doesn't exist, otherwise new event is dispatched to the
-    /// existing processor's receiver channel.
-    fn record(&mut self, heartbeat: ValidActivityHeartbeat) {
-        match self.heartbeat_processors.get(&heartbeat.task_token) {
-            Some(handle) => {
-                handle
-                    .heartbeat_tx
-                    .send(heartbeat.details)
-                    .expect("heartbeat channel can't be dropped if we are inside this method");
-            }
-            None => {
-                let (heartbeat_tx, heartbeat_rx) = channel(heartbeat.details);
-                let processor = ActivityHeartbeatProcessor {
-                    task_token: heartbeat.task_token.clone(),
-                    delay: heartbeat.delay,
-                    heartbeat_rx,
-                    shutdown_rx: self.shutdown_rx.clone(),
-                    events_tx: self.events_tx.clone(),
-                    cancels_tx: self.cancels_tx.clone(),
-                    server_gateway: self.server_gateway.clone(),
-                };
-                let join_handle = tokio::spawn(processor.run());
-                let handle = ActivityHeartbeatProcessorHandle {
-                    heartbeat_tx,
-                    join_handle,
-                };
-                self.heartbeat_processors
-                    .insert(heartbeat.task_token, handle);
-            }
-        }
-    }
-
-    /// Initiates termination of all heartbeat processors by sending a signal and awaits termination
-    pub async fn shutdown(mut self) -> Result<(), JoinError> {
-        self.shutdown_tx
-            .send(true)
-            .expect("shutdown channel can't be dropped before shutdown is complete");
-        for v in self.heartbeat_processors.drain() {
-            v.1.join_handle.await?;
-        }
-        Ok(())
     }
 }
 
-impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatProcessor<SG> {
-    async fn run(mut self) {
-        // Each processor is initialized with heartbeat payloads, first thing we need to do is send
-        // it out.
-        let not_found = self.record_heartbeat().await;
-        if !not_found {
-            loop {
-                sleep(self.delay).await;
-                select! {
-                    biased;
+#[derive(Debug)]
+struct ActivityHbState {
+    delay: Duration,
+    last_sent: Instant,
+}
 
-                    _ = self.heartbeat_rx.changed() => {
-                        self.record_heartbeat().await;
-                    }
-                    _ = self.shutdown_rx.changed() => {
-                        break;
-                    }
-                    _ = sleep(self.delay) => {
-                        // Timed out while waiting for the next heartbeat. We waited 2 * delay in
-                        // total, where delay is 1/2 of the activity heartbeat timeout. This means
-                        // that activity has either timed out or completed by now.
-                        break;
-                    }
-                };
-            }
-        }
-        self.events_tx
-            .send(LifecycleEvent::CleanupProcessor(self.task_token))
-            .expect("cleanup requests should not be dropped");
-    }
+impl ActivityHeartbeatManager {
+    /// Creates a new instance of an activity heartbeat manager and returns a handle to the user,
+    /// which allows to send new heartbeats and initiate the shutdown.
+    pub fn new<SG: ServerGatewayApis + Send + Sync + 'static>(sg: Arc<SG>) -> Self {
+        let (heartbeat_tx, heartbeat_rx) = unbounded_channel();
+        let (cancels_tx, cancels_rx) = unbounded_channel();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    // Returns true if activity not found
-    async fn record_heartbeat(&mut self) -> bool {
-        let details = self.heartbeat_rx.borrow().clone();
-        match self
-            .server_gateway
-            .record_activity_heartbeat(self.task_token.clone(), details.into_payloads())
-            .await
-        {
-            Ok(RecordActivityTaskHeartbeatResponse { cancel_requested }) => {
-                if cancel_requested {
-                    self.cancels_tx
-                        .send((self.task_token.clone(), ActivityCancelReason::Cancelled))
-                        .expect("Receive half of heartbeat cancels not closed");
+        let join_handle = tokio::spawn(
+            // The stream of incoming heartbeats uses unfold to carry state across each item in the
+            // stream The closure checks if, for any given activity, we should heartbeat or not
+            // depending on its delay and when we last issued a heartbeat for it.
+            futures::stream::unfold(HbStreamState::new(heartbeat_rx), move |mut hb_states| {
+                let mut shutdown = shutdown_rx.clone();
+                async move {
+                    let hb = loop {
+                        tokio::select! {
+                            biased;
+
+                            _ = shutdown.changed() => return None,
+
+                            hb = hb_states.incoming_hbs.recv() => {
+                                if let Some(hb) = hb {
+                                    match hb {
+                                        HBAction::HB(hb) => break hb,
+                                        HBAction::Evict(tt) => {
+                                            hb_states.last_sent.remove(&tt);
+                                            continue
+                                        }
+                                    }
+                                } else {
+                                    return None;
+                                }
+                            }
+                        }
+                    };
+
+                    let do_record = match hb_states.last_sent.entry(hb.task_token.clone()) {
+                        Entry::Vacant(e) => {
+                            e.insert(ActivityHbState {
+                                delay: hb.delay,
+                                last_sent: Instant::now(),
+                            });
+                            true
+                        }
+                        Entry::Occupied(mut o) => {
+                            let o = o.get_mut();
+                            let now = Instant::now();
+                            let elapsed = o.last_sent.elapsed();
+                            let do_rec = elapsed >= o.delay;
+                            if do_rec {
+                                o.last_sent = now;
+                                o.delay = hb.delay;
+                            }
+                            do_rec
+                        }
+                    };
+
+                    if *shutdown.borrow() {
+                        return None;
+                    }
+
+                    let maybe_send_hb = if do_record { Some(hb) } else { None };
+                    Some((maybe_send_hb, hb_states))
                 }
-                false
-            }
-            // Send cancels for any activity that learns its workflow already finished (which is
-            // one thing not found implies - other reasons would seem equally valid).
-            Err(s) if s.code() == tonic::Code::NotFound => {
-                self.cancels_tx
-                    .send((self.task_token.clone(), ActivityCancelReason::NotFound))
-                    .expect("Receive half of heartbeat cancels not closed");
-                true
-            }
-            Err(e) => {
-                warn!("Error when recording heartbeat: {:?}", e);
-                false
-            }
+            })
+            .for_each_concurrent(None, move |hb| {
+                let sg = sg.clone();
+                let cancels_tx = cancels_tx.clone();
+                async move {
+                    let hb = if let Some(hb) = hb {
+                        hb
+                    } else {
+                        return;
+                    };
+
+                    match sg
+                        .record_activity_heartbeat(
+                            hb.task_token.clone(),
+                            hb.details.clone().into_payloads(),
+                        )
+                        .await
+                    {
+                        Ok(RecordActivityTaskHeartbeatResponse { cancel_requested }) => {
+                            if cancel_requested {
+                                cancels_tx
+                                    .send((hb.task_token.clone(), ActivityCancelReason::Cancelled))
+                                    .expect("Receive half of heartbeat cancels not blocked");
+                            }
+                        }
+                        // Send cancels for any activity that learns its workflow already finished
+                        // (which is one thing not found implies - other reasons would seem equally
+                        // valid).
+                        Err(s) if s.code() == tonic::Code::NotFound => {
+                            cancels_tx
+                                .send((hb.task_token.clone(), ActivityCancelReason::NotFound))
+                                .expect("Receive half of heartbeat cancels not blocked");
+                        }
+                        Err(e) => {
+                            warn!("Error when recording heartbeat: {:?}", e)
+                        }
+                    }
+                }
+            }),
+        );
+
+        Self {
+            heartbeat_tx,
+            incoming_cancels: Mutex::new(cancels_rx),
+            shutting_down: shutdown_tx,
+            join_handle: Mutex::new(Some(join_handle)),
         }
     }
 }
@@ -293,12 +238,17 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ActivityHeartbeatProcessor<S
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::pollers::MockServerGatewayApis;
-    use crate::protos::coresdk::common::Payload;
-    use crate::protos::temporal::api::workflowservice::v1::RecordActivityTaskHeartbeatResponse;
+    use crate::{
+        pollers::MockServerGatewayApis,
+        protos::{
+            coresdk::common::Payload,
+            temporal::api::workflowservice::v1::RecordActivityTaskHeartbeatResponse,
+        },
+    };
     use std::time::Duration;
+    use tokio::time::sleep;
 
-    /// Ensure that hearbeats that are sent with a small delay are aggregated and sent roughly once
+    /// Ensure that heartbeats that are sent with a small delay are aggregated and sent roughly once
     /// every 1/2 of the heartbeat timeout.
     #[tokio::test]
     async fn process_heartbeats_and_shutdown() {
@@ -309,11 +259,12 @@ mod test {
             .times(2);
         let hm = ActivityHeartbeatManager::new(Arc::new(mock_gateway));
         let fake_task_token = vec![1, 2, 3];
-        // Sending heartbeat requests for 400ms, this should send first hearbeat right away, and all other
-        // requests should be aggregated and last one should be sent to the server in 500ms (1/2 of heartbeat timeout).
-        for i in 0u8..40 {
-            sleep(Duration::from_millis(10)).await;
+        // Sending heartbeat requests for 600ms, this should send first heartbeat right away, and
+        // all other requests should be aggregated and last one should be sent to the server in
+        // 500ms (1/2 of heartbeat timeout).
+        for i in 0u8..60 {
             record_heartbeat(&hm, fake_task_token.clone(), i, Duration::from_millis(1000));
+            sleep(Duration::from_millis(10)).await;
         }
         hm.shutdown().await;
     }
@@ -326,19 +277,19 @@ mod test {
         mock_gateway
             .expect_record_activity_heartbeat()
             .returning(|_, _| Ok(RecordActivityTaskHeartbeatResponse::default()))
-            .times(2);
+            .times(1);
         let hm = ActivityHeartbeatManager::new(Arc::new(mock_gateway));
         let fake_task_token = vec![1, 2, 3];
-        // Sending heartbeat requests for 400ms, this should send first hearbeat right away, and all other
-        // requests should be aggregated and last one should be sent to the server in 500ms (1/2 of heartbeat timeout).
+        // Send a whole bunch of heartbeats very fast. We should still only send one total.
         for i in 0u8..u8::MAX {
             record_heartbeat(&hm, fake_task_token.clone(), i, Duration::from_millis(1000));
         }
+        // Let it propagate
+        sleep(Duration::from_millis(50)).await;
         hm.shutdown().await;
     }
 
-    /// This test reports one heartbeat and waits until processor times out and exits then sends another one.
-    /// Expectation is that new processor should be spawned and heartbeat shouldn't get lost.
+    /// This test reports one heartbeat and waits for the delay to elapse before sending another
     #[tokio::test]
     async fn report_heartbeat_after_timeout() {
         let mut mock_gateway = MockServerGatewayApis::new();
@@ -350,7 +301,27 @@ mod test {
         let fake_task_token = vec![1, 2, 3];
         record_heartbeat(&hm, fake_task_token.clone(), 0, Duration::from_millis(100));
         sleep(Duration::from_millis(500)).await;
-        record_heartbeat(&hm, fake_task_token.clone(), 1, Duration::from_millis(100));
+        record_heartbeat(&hm, fake_task_token, 1, Duration::from_millis(100));
+        // Let it propagate
+        sleep(Duration::from_millis(50)).await;
+        hm.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn evict_works() {
+        let mut mock_gateway = MockServerGatewayApis::new();
+        mock_gateway
+            .expect_record_activity_heartbeat()
+            .returning(|_, _| Ok(RecordActivityTaskHeartbeatResponse::default()))
+            .times(2);
+        let hm = ActivityHeartbeatManager::new(Arc::new(mock_gateway));
+        let fake_task_token = vec![1, 2, 3];
+        record_heartbeat(&hm, fake_task_token.clone(), 0, Duration::from_millis(100));
+        hm.evict(fake_task_token.clone().into());
+        record_heartbeat(&hm, fake_task_token, 0, Duration::from_millis(100));
+        // Let it propagate
+        sleep(Duration::from_millis(100)).await;
+        // We know it works b/c otherwise we would have only called record 1 time w/o sleep
         hm.shutdown().await;
     }
 
@@ -384,9 +355,9 @@ mod test {
     }
 
     fn record_heartbeat(
-        hm: &ActivityHeartbeatManagerHandle,
+        hm: &ActivityHeartbeatManager,
         task_token: Vec<u8>,
-        i: u8,
+        payload_data: u8,
         delay: Duration,
     ) {
         hm.record(
@@ -394,10 +365,11 @@ mod test {
                 task_token,
                 details: vec![Payload {
                     metadata: Default::default(),
-                    data: vec![i],
+                    data: vec![payload_data],
                 }],
             },
-            delay,
+            // Mimic the same delay we would apply in activity task manager
+            delay / 2,
         )
         .expect("hearbeat recording should not fail");
     }

--- a/src/activity/details.rs
+++ b/src/activity/details.rs
@@ -8,6 +8,10 @@ pub(crate) struct InflightActivityDetails {
     pub heartbeat_timeout: Option<Duration>,
     /// Set to true if we have already issued a cancellation activation to lang for this activity
     pub issued_cancel_to_lang: bool,
+    /// Set to true if we have already learned from the server this activity doesn't exist. EX:
+    /// we have learned from heartbeating and issued a cancel task, in which case we may simply
+    /// discard the reply.
+    pub known_not_found: bool,
     /// The task queue this activity came from
     pub task_queue: String,
 }

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -303,7 +303,7 @@ async fn many_concurrent_heartbeat_cancels() {
                 async move {
                     Ok(PollActivityTaskQueueResponse {
                         task_token: i.to_be_bytes().to_vec(),
-                        heartbeat_timeout: Some(Duration::from_millis(500).into()),
+                        heartbeat_timeout: Some(Duration::from_millis(200).into()),
                         ..Default::default()
                     })
                 }
@@ -373,12 +373,12 @@ async fn many_concurrent_heartbeat_cancels() {
     // Spawn "activities"
     fanout_tasks(CONCURRENCY_NUM, |i| async move {
         let task_token = i.to_be_bytes().to_vec();
-        for _ in 0..10 {
+        for _ in 0..12 {
             core.record_activity_heartbeat(ActivityHeartbeat {
                 task_token: task_token.clone(),
                 details: vec![],
             });
-            sleep(Duration::from_millis(100)).await;
+            sleep(Duration::from_millis(50)).await;
         }
     })
     .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,9 @@ pub trait Core: Send + Sync {
     /// The returned activation is guaranteed to be for the same task queue / worker which was
     /// provided as the `task_queue` argument.
     ///
+    /// It is rarely a good idea to call poll concurrently. It handles polling the server
+    /// concurrently internally.
+    ///
     /// TODO: Examples
     async fn poll_workflow_task(&self, task_queue: &str) -> Result<WfActivation, PollWfError>;
 
@@ -118,17 +121,20 @@ pub trait Core: Send + Sync {
     /// The returned activation is guaranteed to be for the same task queue / worker which was
     /// provided as the `task_queue` argument.
     ///
+    /// It is rarely a good idea to call poll concurrently. It handles polling the server
+    /// concurrently internally.
+    ///
     /// TODO: Examples
     async fn poll_activity_task(&self, task_queue: &str)
         -> Result<ActivityTask, PollActivityError>;
 
-    /// Tell the core that a workflow activation has completed
+    /// Tell the core that a workflow activation has completed. May be freely called concurrently.
     async fn complete_workflow_task(
         &self,
         completion: WfActivationCompletion,
     ) -> Result<(), CompleteWfError>;
 
-    /// Tell the core that an activity has finished executing
+    /// Tell the core that an activity has finished executing. May be freely called concurrently.
     async fn complete_activity_task(
         &self,
         completion: ActivityTaskCompletion,

--- a/src/pollers/poll_buffer.rs
+++ b/src/pollers/poll_buffer.rs
@@ -87,6 +87,7 @@ where
     /// then polling will happen concurrently.
     ///
     /// Returns `None` if the poll buffer has been shut down
+    #[instrument(name = "long_poll", level = "trace", skip(self))]
     async fn poll(&self) -> Option<pollers::Result<T>> {
         self.polls_requested.add_permits(1);
         let mut locked = self.buffered_polls.lock().await;

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -107,6 +107,11 @@ impl CoreWfStarter {
         self
     }
 
+    pub fn max_at_polls(&mut self, max: usize) -> &mut Self {
+        self.worker_config.max_concurrent_at_polls = max;
+        self
+    }
+
     pub fn wft_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.wft_timeout = Some(timeout);
         self

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -1,15 +1,17 @@
 use assert_matches::assert_matches;
 use futures::future::join_all;
 use std::time::{Duration, Instant};
-use temporal_sdk_core::protos::coresdk::{
-    activity_result::ActivityResult,
-    activity_task::activity_task as act_task,
-    workflow_commands::{ActivityCancellationType, ScheduleActivity},
-    ActivityTaskCompletion,
+use temporal_sdk_core::{
+    protos::coresdk::{
+        activity_result::ActivityResult,
+        activity_task::activity_task as act_task,
+        workflow_commands::{ActivityCancellationType, ScheduleActivity},
+        ActivityTaskCompletion,
+    },
+    test_workflow_driver::WfContext,
+    tracing_init,
 };
-use temporal_sdk_core::test_workflow_driver::WfContext;
-use temporal_sdk_core::tracing_init;
-use test_utils::{fanout_tasks, CoreWfStarter};
+use test_utils::CoreWfStarter;
 
 const CONCURRENCY: usize = 1000;
 

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -8,16 +8,20 @@ use temporal_sdk_core::protos::coresdk::{
     ActivityTaskCompletion,
 };
 use temporal_sdk_core::test_workflow_driver::WfContext;
+use temporal_sdk_core::tracing_init;
 use test_utils::{fanout_tasks, CoreWfStarter};
 
 const CONCURRENCY: usize = 1000;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn activity_load() {
+    tracing_init();
+
     let mut starter = CoreWfStarter::new("activity_load");
     starter
         .max_wft(CONCURRENCY)
         .max_cached_workflows(CONCURRENCY)
+        .max_at_polls(10)
         .max_at(CONCURRENCY);
     let worker = starter.worker().await;
     let task_q = &starter.get_task_queue().to_owned();
@@ -69,26 +73,36 @@ async fn activity_load() {
     dbg!(starting.elapsed());
 
     let running = Instant::now();
-    let core = &starter.get_core().await;
+    let core = starter.get_core().await;
+
     // Poll for and complete all activities
-    let all_acts = fanout_tasks(CONCURRENCY, |_| {
-        let payload_dat = payload_dat.clone();
-        async move {
-            let task = core.poll_activity_task(task_q).await.unwrap();
+    let c2 = core.clone();
+    let all_acts = async move {
+        let mut act_complete_futs = vec![];
+        for _ in 0..CONCURRENCY {
+            let task = c2.poll_activity_task(task_q).await.unwrap();
             assert_matches!(
                 task.variant,
-                Some(act_task::Variant::Start(start_activity)) => {
-                    assert_eq!(start_activity.activity_type, "test_activity".to_string())
+                Some(act_task::Variant::Start(ref start_activity)) => {
+                    assert_eq!(start_activity.activity_type, "test_activity")
                 }
             );
-            core.complete_activity_task(ActivityTaskCompletion {
-                task_token: task.task_token,
-                result: Some(ActivityResult::ok(payload_dat.into())),
-            })
-            .await
-            .unwrap();
+            let pd = payload_dat.clone();
+            let core = c2.clone();
+            act_complete_futs.push(tokio::spawn(async move {
+                core.complete_activity_task(ActivityTaskCompletion {
+                    task_token: task.task_token,
+                    result: Some(ActivityResult::ok(pd.into())),
+                })
+                .await
+                .unwrap()
+            }));
         }
-    });
+        join_all(act_complete_futs)
+            .await
+            .into_iter()
+            .for_each(|h| h.unwrap());
+    };
     tokio::join! {
         async {
             worker.run_until_done().await.unwrap();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
No longer warn if we have prior knowledge an activity already doesn't exist according to server.

## Why?
No spurious warnings

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Against node js bench

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
