### PR TITLE
Avoid pointless extra calls to the poll buffer

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "coresdk.activity_result.ActivityResult.status",
             "#[derive(::derive_more::From)]",
         )
+        .type_attribute(
+            "coresdk.activity_task.ActivityCancelReason",
+            "#[derive(::derive_more::Display)]",
+        )
         .type_attribute("coresdk.Task.variant", "#[derive(::derive_more::From)]")
         .compile(
             &[

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -287,6 +287,7 @@ async fn worker_shutdown_during_multiple_poll_doesnt_deadlock(
     let poll2fut = core.poll_workflow_task("q2");
     let shutdownfut = async {
         core.shutdown_worker("q1").await;
+        // Will allow both workers to proceed
         let _ = tx.send(true);
     };
     let (pollres, poll2res, _) = tokio::join!(pollfut, poll2fut, shutdownfut);

--- a/src/pollers/poll_buffer.rs
+++ b/src/pollers/poll_buffer.rs
@@ -121,7 +121,6 @@ impl Poller<PollWorkflowTaskQueueResponse> for WorkflowTaskPoller {
     async fn poll(&self) -> Option<pollers::Result<PollWorkflowTaskQueueResponse>> {
         if let Some(sq) = self.sticky_poller.as_ref() {
             tokio::select! {
-                biased; // TODO: Remove once mocking happens above this level
                 r = self.normal_poller.poll() => r,
                 r = sq.poll() => r,
             }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Previously we always began a poll even if there might be pending notification of a task update. Avoid that.

## Why?
Optimize. Avoid pointless server calls.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
