### PR TITLE
Implement child workflow state machine

### DIFF
--- a/protos/local/child_workflow.proto
+++ b/protos/local/child_workflow.proto
@@ -38,6 +38,7 @@ message Failure {
  * in case its parent is closed.
  */
 enum ParentClosePolicy {
+    /** Let's the server set the default. */
     PARENT_CLOSE_POLICY_UNSPECIFIED = 0;
     /** Terminate means terminating the child workflow. */
     PARENT_CLOSE_POLICY_TERMINATE = 1;
@@ -57,13 +58,13 @@ enum StartChildWorkflowExecutionFailedCause {
  * Controls at which point to report back to lang when it cancels a child workflow
  */
 enum ChildWorkflowCancellationType {
-    /// Do not request cancellation of the child workflow
+    /** Do not request cancellation of the child workflow if already scheduled */
     ABANDON = 0;
-    /// Initiate a cancellation request and immediately report cancellation to the parent.
+    /** Initiate a cancellation request and immediately report cancellation to the parent. */
     TRY_CANCEL = 1;
-    /// Wait for child cancellation completion.
+    /** Wait for child cancellation completion. */
     WAIT_CANCELLATION_COMPLETED = 2;
-    /// Request cancellation of the child and wait for confirmation that the request was received.
+    /** Request cancellation of the child and wait for confirmation that the request was received. */
     WAIT_CANCELLATION_REQUESTED = 3;
 }
 

--- a/protos/local/child_workflow.proto
+++ b/protos/local/child_workflow.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package coresdk.child_workflow;
+
+import "common.proto";
+import "temporal/api/failure/v1/message.proto";
+
+/**
+ * Used by core to resolve child workflow executions.
+ *
+ * When a child workflow is cancelled, `status` is failed and
+ * failure.cause.info is set to CanceledFailure.
+ */
+message ChildWorkflowResult {
+    oneof status {
+        Success completed = 1;
+        Failure failed = 2;
+    }
+}
+
+/**
+ * Used in ChildWorkflowResult to report successful completion.
+ */
+message Success {
+    common.Payload result = 1;
+}
+
+/**
+ * Used in ChildWorkflowResult to report non successful outcomes such as
+ * application failures, timeouts, terminations, and cancellations.
+ */
+message Failure {
+    temporal.api.failure.v1.Failure failure = 1;
+}
+
+/**
+ * Used by the service to determine the fate of a child workflow
+ * in case its parent is closed.
+ */
+enum ParentClosePolicy {
+    PARENT_CLOSE_POLICY_UNSPECIFIED = 0;
+    /** Terminate means terminating the child workflow. */
+    PARENT_CLOSE_POLICY_TERMINATE = 1;
+    /** Abandon means not doing anything on the child workflow. */
+    PARENT_CLOSE_POLICY_ABANDON = 2;
+    /** Cancel means requesting cancellation on the child workflow. */
+    PARENT_CLOSE_POLICY_REQUEST_CANCEL = 3;
+}
+
+/** Possible causes of failure to start a child workflow */
+enum StartChildWorkflowExecutionFailedCause {
+    START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED = 0;
+    START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_EXISTS = 1;
+}
+
+/**
+ * Controls at which point to report back to lang when it cancels a child workflow
+ */
+enum ChildWorkflowCancellationType {
+    /// Do not request cancellation of the child workflow
+    ABANDON = 0;
+    /// Initiate a cancellation request and immediately report cancellation to the parent.
+    TRY_CANCEL = 1;
+    /// Wait for child cancellation completion.
+    WAIT_CANCELLATION_COMPLETED = 2;
+    /// Request cancellation of the child and wait for confirmation that the request was received.
+    WAIT_CANCELLATION_REQUESTED = 3;
+}
+

--- a/protos/local/common.proto
+++ b/protos/local/common.proto
@@ -38,3 +38,26 @@ message RetryPolicy {
     // If a stringified error matches something in this list, retries will cease.
     repeated string non_retryable_error_types = 5;
 }
+
+enum WorkflowIdReusePolicy {
+    WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED = 0;
+    // Allow start a workflow execution using the same workflow Id, when workflow not running.
+    WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE = 1;
+    // Allow start a workflow execution using the same workflow Id, when workflow not running, and the last execution close state is in
+    // [terminated, cancelled, timed out, failed].
+    WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY = 2;
+    // Do not allow start a workflow execution using the same workflow Id at all.
+    WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE = 3;
+}
+
+/** Possible causes of failure to cancel an external workflow */
+enum CancelExternalWorkflowExecutionFailedCause {
+    CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED = 0;
+    CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND = 1;
+}
+
+/** Possible causes of failure to signal an external workflow */
+enum SignalExternalWorkflowExecutionFailedCause {
+    SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED = 0;
+    SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND = 1;
+}

--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -8,7 +8,9 @@ package coresdk.workflow_activation;
 
 import "common.proto";
 import "activity_result.proto";
+import "child_workflow.proto";
 
+import "temporal/api/failure/v1/message.proto";
 import "google/protobuf/timestamp.proto";
 
 /// An instruction to the lang sdk to run some workflow code, whether for the first time or from
@@ -39,13 +41,16 @@ message WFActivationJob {
         CancelWorkflow cancel_workflow = 6;
         /// A request to signal the workflow was received.
         SignalWorkflow signal_workflow = 7;
-        /// An activity was resolved with, result could be completed, failed or cancelled
+        /// An activity was resolved, result could be completed, failed or cancelled
         ResolveActivity resolve_activity = 8;
         /// A change marker has been detected and lang is being told that change exists. This
         /// job is strange in that it is sent pre-emptively to lang without any corresponding
         /// command being sent first.
         NotifyHasChange notify_has_change = 9;
-
+        /// A child workflow execution has started or failed to start
+        ResolveChildWorkflowExecutionStart resolve_child_workflow_execution_start = 10;
+        /// A child workflow was resolved, result could be completed or failed
+        ResolveChildWorkflowExecution resolve_child_workflow_execution = 11;
         /// Remove the workflow identified by the [WFActivation] containing this job from the cache
         /// after performing the activation.
         ///
@@ -83,6 +88,41 @@ message FireTimer {
 message ResolveActivity {
     string activity_id = 1;
     activity_result.ActivityResult result = 2;
+}
+
+/// Notify a workflow that a start child workflow execution request has succeeded, failed or was cancelled.
+message ResolveChildWorkflowExecutionStart {
+    string workflow_id = 1;
+    oneof status {
+        ResolveChildWorkflowExecutionStartSuccess succeeded = 2;
+        ResolveChildWorkflowExecutionStartFailure failed = 3;
+        ResolveChildWorkflowExecutionStartCancelled cancelled = 4;
+    }
+}
+
+/// Simply pass the run_id to lang
+message ResolveChildWorkflowExecutionStartSuccess {
+    string run_id = 1;
+}
+
+/// Provide lang the cause of failure
+message ResolveChildWorkflowExecutionStartFailure {
+    /// Lang should have this information but it's more convenient to pass it back
+    /// for error construction on the lang side.
+    string workflow_type = 1;
+    child_workflow.StartChildWorkflowExecutionFailedCause cause = 2;
+}
+
+/// `failure` should be ChildWorkflowFailure with cause set to CancelledFailure.
+/// The failure is constructed in core for lang's convenience.
+message ResolveChildWorkflowExecutionStartCancelled {
+  temporal.api.failure.v1.Failure failure = 1;
+}
+
+/// Notify a workflow that a child workflow execution has been resolved
+message ResolveChildWorkflowExecution {
+    string workflow_id = 1;
+    child_workflow.ChildWorkflowResult result = 2;
 }
 
 /// Update the workflow's random seed

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -8,6 +8,7 @@ syntax = "proto3";
 package coresdk.workflow_commands;
 
 import "common.proto";
+import "child_workflow.proto";
 import "google/protobuf/duration.proto";
 import "temporal/api/failure/v1/message.proto";
 
@@ -23,14 +24,11 @@ message WorkflowCommand {
         ContinueAsNewWorkflowExecution continue_as_new_workflow_execution = 8;
         CancelWorkflowExecution cancel_workflow_execution = 9;
         SetChangeMarker set_change_marker = 10;
+        StartChildWorkflowExecution start_child_workflow_execution = 11;
+        RequestCancelExternalWorkflowExecution request_cancel_external_workflow_execution = 12;
+        SignalExternalWorkflowExecution signal_external_workflow_execution = 13;
 
         // To be added as/if needed:
-        //  RequestCancelActivityTask request_cancel_activity_task_command_attributes = 6;
-        //  RequestCancelExternalWorkflowExecution request_cancel_external_workflow_execution_command_attributes = 9;
-        //  RecordMarker record_marker_command_attributes = 10;
-        //  ContinueAsNewWorkflowExecution continue_as_new_workflow_execution_command_attributes = 11;
-        //  StartChildWorkflowExecution start_child_workflow_execution_command_attributes = 12;
-        //  SignalExternalWorkflowExecution signal_external_workflow_execution_command_attributes = 13;
         //  UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 14;
     }
 }
@@ -149,4 +147,54 @@ message SetChangeMarker {
     // Can be set to true to indicate that branches using this change are being removed, and all
     // future worker deployments will only have the "with change" code in them.
     bool deprecated = 2;
+}
+
+/// Start a child workflow execution
+message StartChildWorkflowExecution {
+    string namespace = 1;
+    string workflow_id = 2;
+    string workflow_type = 3;
+    string task_queue = 4;
+    repeated common.Payload input = 5;
+    /// Total workflow execution timeout including retries and continue as new.
+    google.protobuf.Duration workflow_execution_timeout = 6;
+    /// Timeout of a single workflow run.
+    google.protobuf.Duration workflow_run_timeout = 7;
+    /// Timeout of a single workflow task.
+    google.protobuf.Duration workflow_task_timeout = 8;
+    /// Default: PARENT_CLOSE_POLICY_TERMINATE.
+    child_workflow.ParentClosePolicy parent_close_policy = 9;
+    // string control = 10; (unused from StartChildWorkflowExecutionCommandAttributes)
+    // Default: WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE.
+    common.WorkflowIdReusePolicy workflow_id_reuse_policy = 11;
+    common.RetryPolicy retry_policy = 12;
+    string cron_schedule = 13;
+    /// Header fields
+    map<string, common.Payload> header = 14;
+    /// Memo fields
+    map<string, common.Payload> memo = 15;
+    /// Search attributes
+    map<string, common.Payload> search_attributes = 16;
+    /// Defines behaviour of the underlying workflow when child workflow cancellation has been requested.
+    child_workflow.ChildWorkflowCancellationType cancellation_type = 17;
+}
+
+/// Request cancellation of an external workflow execution, can be used for child workflows
+message RequestCancelExternalWorkflowExecution {
+    string namespace = 1;
+    /// Required workflow_id of the Workflow to cancel
+    string workflow_id = 2;
+    /// Optional run_id of the Workflow to cancel
+    string run_id = 3;
+}
+
+/// Send a signal to an external workflow, can be used for child workflows
+message SignalExternalWorkflowExecution {
+    string namespace = 1;
+    /// workflow_id and optional run_id
+    common.WorkflowExecution workflow_execution = 2;
+    /// Name of the signal handler
+    string signal_name = 3;
+    /// Arguments for the handler
+    repeated common.Payload args = 4;
 }

--- a/src/machines/child_workflow_state_machine.rs
+++ b/src/machines/child_workflow_state_machine.rs
@@ -1,31 +1,85 @@
-use rustfsm::{fsm, TransitionResult};
+use crate::machines::activity_state_machine::ActivityMachineCommand::Fail;
+use crate::{
+    machines::{
+        workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind,
+        NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
+    },
+    protos::{
+        coresdk::{
+            child_workflow::{
+                self as wfr, child_workflow_result::Status as ChildWorkflowStatus,
+                ChildWorkflowCancellationType, ChildWorkflowResult,
+            },
+            common::Payload,
+            workflow_activation::{
+                resolve_child_workflow_execution_start, ResolveChildWorkflowExecution,
+                ResolveChildWorkflowExecutionStart, ResolveChildWorkflowExecutionStartCancelled,
+                ResolveChildWorkflowExecutionStartFailure,
+                ResolveChildWorkflowExecutionStartSuccess,
+            },
+            workflow_commands::StartChildWorkflowExecution,
+        },
+        temporal::api::{
+            command::v1::{command, Command},
+            common::v1::{Payloads, WorkflowExecution, WorkflowType},
+            enums::v1::{
+                CommandType, EventType, RetryState, StartChildWorkflowExecutionFailedCause,
+                TimeoutType,
+            },
+            failure::v1::{self as failure, failure::FailureInfo, ActivityFailureInfo, Failure},
+            history::v1::{
+                history_event, ChildWorkflowExecutionCanceledEventAttributes,
+                ChildWorkflowExecutionCompletedEventAttributes,
+                ChildWorkflowExecutionFailedEventAttributes,
+                ChildWorkflowExecutionStartedEventAttributes,
+                ChildWorkflowExecutionTerminatedEventAttributes,
+                ChildWorkflowExecutionTimedOutEventAttributes, HistoryEvent,
+                StartChildWorkflowExecutionFailedEventAttributes,
+            },
+        },
+    },
+};
+use rustfsm::{fsm, MachineError, TransitionResult};
+use std::convert::{TryFrom, TryInto};
+use tonic::Status;
 
 fsm! {
-    pub(super) name ChildWorkflowMachine; command ChildWorkflowCommand; error ChildWorkflowMachineError;
+    pub(super) name ChildWorkflowMachine;
+    command ChildWorkflowCommand;
+    error WFMachinesError;
+    shared_state SharedState;
 
     Created --(Schedule, on_schedule) --> StartCommandCreated;
-
-    Started --(ChildWorkflowExecutionCompleted, on_child_workflow_execution_completed) --> Completed;
-    Started --(ChildWorkflowExecutionFailed, on_child_workflow_execution_failed) --> Failed;
-    Started --(ChildWorkflowExecutionTimedOut, on_child_workflow_execution_timed_out) --> TimedOut;
-    Started --(ChildWorkflowExecutionCanceled, on_child_workflow_execution_canceled) --> Canceled;
-    Started --(ChildWorkflowExecutionTerminated, on_child_workflow_execution_terminated) --> Terminated;
-
     StartCommandCreated --(CommandStartChildWorkflowExecution) --> StartCommandCreated;
-    StartCommandCreated --(StartChildWorkflowExecutionInitiated, on_start_child_workflow_execution_initiated) --> StartEventRecorded;
-    StartCommandCreated --(Cancel, on_cancel) --> Canceled;
+    StartCommandCreated --(StartChildWorkflowExecutionInitiated(i64), shared on_start_child_workflow_execution_initiated) --> StartEventRecorded;
+    StartCommandCreated --(Cancel, shared on_cancelled) --> Cancelled;
 
-    StartEventRecorded --(ChildWorkflowExecutionStarted, on_child_workflow_execution_started) --> Started;
-    StartEventRecorded --(StartChildWorkflowExecutionFailed, on_start_child_workflow_execution_failed) --> StartFailed;
+    StartEventRecorded --(ChildWorkflowExecutionStarted(ChildWorkflowExecutionStartedEventAttributes), on_child_workflow_execution_started) --> Started;
+    StartEventRecorded --(StartChildWorkflowExecutionFailed(StartChildWorkflowExecutionFailedEventAttributes), on_start_child_workflow_execution_failed) --> StartFailed;
+
+    Started --(ChildWorkflowExecutionCompleted(ChildWorkflowExecutionCompletedEventAttributes), on_child_workflow_execution_completed) --> Completed;
+    Started --(ChildWorkflowExecutionFailed(ChildWorkflowExecutionFailedEventAttributes), shared on_child_workflow_execution_failed) --> Failed;
+    Started --(ChildWorkflowExecutionTimedOut(ChildWorkflowExecutionTimedOutEventAttributes), shared on_child_workflow_execution_timed_out) --> TimedOut;
+    Started --(ChildWorkflowExecutionCancelled(ChildWorkflowExecutionCanceledEventAttributes), shared on_child_workflow_execution_cancelled) --> Cancelled;
+    Started --(ChildWorkflowExecutionTerminated(ChildWorkflowExecutionTerminatedEventAttributes), shared on_child_workflow_execution_terminated) --> Terminated;
 }
 
-#[derive(thiserror::Error, Debug)]
-pub(super) enum ChildWorkflowMachineError {}
-
-pub(super) enum ChildWorkflowCommand {}
+#[derive(Debug, derive_more::Display)]
+pub(super) enum ChildWorkflowCommand {
+    #[display(fmt = "Start")]
+    Start(WorkflowExecution),
+    #[display(fmt = "Complete")]
+    Complete(Option<Payloads>),
+    #[display(fmt = "Fail")]
+    Fail(Failure),
+    #[display(fmt = "StartFail")]
+    StartFail(StartChildWorkflowExecutionFailedCause),
+    #[display(fmt = "StartCancel")]
+    StartCancel(Failure),
+}
 
 #[derive(Default, Clone)]
-pub(super) struct Canceled {}
+pub(super) struct Cancelled {}
 
 #[derive(Default, Clone)]
 pub(super) struct Completed {}
@@ -35,7 +89,7 @@ pub(super) struct Created {}
 
 impl Created {
     pub(super) fn on_schedule(self) -> ChildWorkflowMachineTransition<StartCommandCreated> {
-        unimplemented!()
+        TransitionResult::default()
     }
 }
 
@@ -48,11 +102,58 @@ pub(super) struct StartCommandCreated {}
 impl StartCommandCreated {
     pub(super) fn on_start_child_workflow_execution_initiated(
         self,
+        dat: SharedState,
+        scheduled_event_id: i64,
     ) -> ChildWorkflowMachineTransition<StartEventRecorded> {
-        unimplemented!()
+        ChildWorkflowMachineTransition::ok_shared(
+            vec![],
+            StartEventRecorded::default(),
+            SharedState {
+                scheduled_event_id,
+                ..dat
+            },
+        )
     }
-    pub(super) fn on_cancel(self) -> ChildWorkflowMachineTransition<Canceled> {
-        unimplemented!()
+
+    pub(super) fn on_cancelled(
+        self,
+        dat: SharedState,
+    ) -> ChildWorkflowMachineTransition<Cancelled> {
+        let state = SharedState {
+            cancelled_before_sent: true,
+            ..dat
+        };
+        ChildWorkflowMachineTransition::ok_shared(
+            vec![ChildWorkflowCommand::StartCancel(Failure {
+                message: "Child Workflow execution cancelled before scheduled".to_owned(),
+                cause: Some(Box::new(Failure {
+                    failure_info: Some(FailureInfo::CanceledFailureInfo(
+                        failure::CanceledFailureInfo {
+                            ..Default::default()
+                        },
+                    )),
+                    ..Default::default()
+                })),
+                failure_info: Some(FailureInfo::ChildWorkflowExecutionFailureInfo(
+                    failure::ChildWorkflowExecutionFailureInfo {
+                        namespace: state.attrs.namespace.clone(),
+                        workflow_type: Some(WorkflowType {
+                            name: state.attrs.workflow_type.clone(),
+                        }),
+                        initiated_event_id: 0,
+                        started_event_id: 0,
+                        retry_state: RetryState::NonRetryableFailure as i32,
+                        workflow_execution: Some(WorkflowExecution {
+                            workflow_id: state.attrs.workflow_id.clone(),
+                            ..Default::default()
+                        }),
+                    },
+                )),
+                ..Default::default()
+            })],
+            Cancelled::default(),
+            state,
+        )
     }
 }
 
@@ -62,13 +163,23 @@ pub(super) struct StartEventRecorded {}
 impl StartEventRecorded {
     pub(super) fn on_child_workflow_execution_started(
         self,
+        attrs: ChildWorkflowExecutionStartedEventAttributes,
     ) -> ChildWorkflowMachineTransition<Started> {
-        unimplemented!()
+        ChildWorkflowMachineTransition::ok(vec![
+            ChildWorkflowCommand::Start(attrs.workflow_execution.expect("ChildWorkflowExecutionStartedEventAttributes.workflow_execution should not be empty"))
+        ], Started::default())
     }
     pub(super) fn on_start_child_workflow_execution_failed(
         self,
+        attrs: StartChildWorkflowExecutionFailedEventAttributes,
     ) -> ChildWorkflowMachineTransition<StartFailed> {
-        unimplemented!()
+        ChildWorkflowMachineTransition::ok(
+            vec![ChildWorkflowCommand::StartFail(
+                StartChildWorkflowExecutionFailedCause::from_i32(attrs.cause)
+                    .expect("Invalid StartChildWorkflowExecutionFailedCause"),
+            )],
+            StartFailed::default(),
+        )
     }
 }
 
@@ -81,28 +192,146 @@ pub(super) struct Started {}
 impl Started {
     pub(super) fn on_child_workflow_execution_completed(
         self,
+        attrs: ChildWorkflowExecutionCompletedEventAttributes,
     ) -> ChildWorkflowMachineTransition<Completed> {
-        unimplemented!()
+        ChildWorkflowMachineTransition::ok(
+            vec![ChildWorkflowCommand::Complete(attrs.result)],
+            Completed::default(),
+        )
     }
     pub(super) fn on_child_workflow_execution_failed(
         self,
+        dat: SharedState,
+        attrs: ChildWorkflowExecutionFailedEventAttributes,
     ) -> ChildWorkflowMachineTransition<Failed> {
-        unimplemented!()
+        ChildWorkflowMachineTransition::ok(
+            vec![ChildWorkflowCommand::Fail(Failure {
+                message: "Child Workflow execution failed".to_owned(),
+                cause: attrs.failure.map(Box::new),
+                failure_info: Some(FailureInfo::ChildWorkflowExecutionFailureInfo(
+                    failure::ChildWorkflowExecutionFailureInfo {
+                        namespace: attrs.namespace,
+                        workflow_type: Some(WorkflowType {
+                            name: dat.attrs.workflow_type,
+                        }),
+                        initiated_event_id: attrs.initiated_event_id,
+                        started_event_id: attrs.started_event_id,
+                        retry_state: attrs.retry_state,
+                        workflow_execution: attrs.workflow_execution,
+                    },
+                )),
+                ..Default::default()
+            })],
+            Failed::default(),
+        )
     }
     pub(super) fn on_child_workflow_execution_timed_out(
         self,
+        dat: SharedState,
+        attrs: ChildWorkflowExecutionTimedOutEventAttributes,
     ) -> ChildWorkflowMachineTransition<TimedOut> {
-        unimplemented!()
+        ChildWorkflowMachineTransition::ok(
+            vec![ChildWorkflowCommand::Fail(Failure {
+                message: "Child Workflow execution timed out".to_owned(),
+                cause: Some(Box::new(Failure {
+                    message: "Timed out".to_owned(),
+                    failure_info: Some(FailureInfo::TimeoutFailureInfo(
+                        failure::TimeoutFailureInfo {
+                            last_heartbeat_details: None,
+                            timeout_type: TimeoutType::StartToClose as i32,
+                        },
+                    )),
+                    ..Default::default()
+                })),
+                failure_info: Some(FailureInfo::ChildWorkflowExecutionFailureInfo(
+                    failure::ChildWorkflowExecutionFailureInfo {
+                        namespace: attrs.namespace,
+                        workflow_type: Some(WorkflowType {
+                            name: dat.attrs.workflow_type,
+                        }),
+                        initiated_event_id: attrs.initiated_event_id,
+                        started_event_id: attrs.started_event_id,
+                        retry_state: attrs.retry_state,
+                        workflow_execution: attrs.workflow_execution,
+                    },
+                )),
+                ..Default::default()
+            })],
+            TimedOut::default(),
+        )
     }
-    pub(super) fn on_child_workflow_execution_canceled(
+    pub(super) fn on_child_workflow_execution_cancelled(
         self,
-    ) -> ChildWorkflowMachineTransition<Canceled> {
-        unimplemented!()
+        dat: SharedState,
+        attrs: ChildWorkflowExecutionCanceledEventAttributes,
+    ) -> ChildWorkflowMachineTransition<Cancelled> {
+        match dat.cancellation_type {
+            ChildWorkflowCancellationType::Abandon => {
+                ChildWorkflowMachineTransition::ok(vec![], Cancelled::default())
+            }
+            _ => ChildWorkflowMachineTransition::ok(
+                vec![ChildWorkflowCommand::Fail(Failure {
+                    message: "Child Workflow execution cancelled before scheduled".to_owned(),
+                    cause: Some(Box::new(Failure {
+                        failure_info: Some(FailureInfo::CanceledFailureInfo(
+                            failure::CanceledFailureInfo {
+                                ..Default::default()
+                            },
+                        )),
+                        ..Default::default()
+                    })),
+                    failure_info: Some(FailureInfo::ChildWorkflowExecutionFailureInfo(
+                        failure::ChildWorkflowExecutionFailureInfo {
+                            namespace: dat.attrs.namespace.clone(),
+                            workflow_type: Some(WorkflowType {
+                                name: dat.attrs.workflow_type.clone(),
+                            }),
+                            initiated_event_id: attrs.initiated_event_id,
+                            started_event_id: attrs.started_event_id,
+                            retry_state: RetryState::NonRetryableFailure as i32,
+                            workflow_execution: Some(WorkflowExecution {
+                                workflow_id: dat.attrs.workflow_id,
+                                ..Default::default()
+                            }),
+                        },
+                    )),
+                    ..Default::default()
+                })],
+                Cancelled::default(),
+            ),
+        }
     }
     pub(super) fn on_child_workflow_execution_terminated(
         self,
+        dat: SharedState,
+        attrs: ChildWorkflowExecutionTerminatedEventAttributes,
     ) -> ChildWorkflowMachineTransition<Terminated> {
-        unimplemented!()
+        ChildWorkflowMachineTransition::ok(
+            vec![ChildWorkflowCommand::Fail(Failure {
+                message: "Child Workflow execution terminated".to_owned(),
+                cause: Some(Box::new(Failure {
+                    message: "Terminated".to_owned(),
+                    failure_info: Some(FailureInfo::TerminatedFailureInfo(
+                        failure::TerminatedFailureInfo {},
+                    )),
+                    ..Default::default()
+                })),
+                failure_info: Some(FailureInfo::ChildWorkflowExecutionFailureInfo(
+                    failure::ChildWorkflowExecutionFailureInfo {
+                        namespace: attrs.namespace,
+                        workflow_type: Some(WorkflowType {
+                            name: dat.attrs.workflow_type,
+                        }),
+                        initiated_event_id: attrs.initiated_event_id,
+                        started_event_id: attrs.started_event_id,
+                        retry_state: RetryState::NonRetryableFailure as i32,
+                        workflow_execution: attrs.workflow_execution,
+                    },
+                )),
+                ..Default::default()
+            })],
+            Terminated::default(),
+        )
     }
 }
 
@@ -111,3 +340,487 @@ pub(super) struct Terminated {}
 
 #[derive(Default, Clone)]
 pub(super) struct TimedOut {}
+
+#[derive(Default, Clone)]
+pub(super) struct SharedState {
+    scheduled_event_id: i64,
+    //     started_event_id: i64,
+    attrs: StartChildWorkflowExecution,
+    cancellation_type: ChildWorkflowCancellationType,
+    cancelled_before_sent: bool,
+}
+
+/// Creates a new child workflow state machine and a command to start it on the server.
+pub(super) fn new_child_workflow(
+    attribs: StartChildWorkflowExecution,
+) -> NewMachineWithCommand<ChildWorkflowMachine> {
+    let (wf, add_cmd) = ChildWorkflowMachine::new_scheduled(attribs);
+    NewMachineWithCommand {
+        command: add_cmd,
+        machine: wf,
+    }
+}
+
+impl ChildWorkflowMachine {
+    /// Create a new child workflow and immediately schedule it.
+    pub(crate) fn new_scheduled(attribs: StartChildWorkflowExecution) -> (Self, Command) {
+        let mut s = Self {
+            state: Created {}.into(),
+            shared_state: SharedState {
+                cancellation_type: ChildWorkflowCancellationType::from_i32(
+                    attribs.cancellation_type,
+                )
+                .unwrap(),
+                attrs: attribs.clone(),
+                ..Default::default()
+            },
+        };
+        OnEventWrapper::on_event_mut(&mut s, ChildWorkflowMachineEvents::Schedule)
+            .expect("Scheduling child workflows doesn't fail");
+        let cmd = Command {
+            command_type: CommandType::StartChildWorkflowExecution as i32,
+            attributes: Some(attribs.into()),
+        };
+        (s, cmd)
+    }
+}
+
+impl TryFrom<HistoryEvent> for ChildWorkflowMachineEvents {
+    type Error = WFMachinesError;
+
+    fn try_from(e: HistoryEvent) -> Result<Self, Self::Error> {
+        Ok(match EventType::from_i32(e.event_type) {
+            Some(EventType::StartChildWorkflowExecutionInitiated) => {
+                Self::StartChildWorkflowExecutionInitiated(e.event_id)
+            }
+            Some(EventType::StartChildWorkflowExecutionFailed) => {
+                if let Some(
+                    history_event::Attributes::StartChildWorkflowExecutionFailedEventAttributes(
+                        attrs,
+                    ),
+                ) = e.attributes
+                {
+                    Self::StartChildWorkflowExecutionFailed(attrs)
+                } else {
+                    return Err(WFMachinesError::Fatal(
+                        "StartChildWorkflowExecutionFailed attributes were unset".to_string(),
+                    ));
+                }
+            }
+            Some(EventType::ChildWorkflowExecutionStarted) => {
+                if let Some(
+                    history_event::Attributes::ChildWorkflowExecutionStartedEventAttributes(attrs),
+                ) = e.attributes
+                {
+                    Self::ChildWorkflowExecutionStarted(attrs)
+                } else {
+                    return Err(WFMachinesError::Fatal(
+                        "ChildWorkflowExecutionStarted attributes were unset".to_string(),
+                    ));
+                }
+            }
+            Some(EventType::ChildWorkflowExecutionCompleted) => {
+                if let Some(
+                    history_event::Attributes::ChildWorkflowExecutionCompletedEventAttributes(
+                        attrs,
+                    ),
+                ) = e.attributes
+                {
+                    Self::ChildWorkflowExecutionCompleted(attrs)
+                } else {
+                    return Err(WFMachinesError::Fatal(
+                        "ChildWorkflowExecutionCompleted attributes were unset".to_string(),
+                    ));
+                }
+            }
+            Some(EventType::ChildWorkflowExecutionFailed) => {
+                if let Some(
+                    history_event::Attributes::ChildWorkflowExecutionFailedEventAttributes(attrs),
+                ) = e.attributes
+                {
+                    Self::ChildWorkflowExecutionFailed(attrs)
+                } else {
+                    return Err(WFMachinesError::Fatal(
+                        "ChildWorkflowExecutionFailed attributes were unset".to_string(),
+                    ));
+                }
+            }
+            Some(EventType::ChildWorkflowExecutionTerminated) => {
+                if let Some(
+                    history_event::Attributes::ChildWorkflowExecutionTerminatedEventAttributes(
+                        attrs,
+                    ),
+                ) = e.attributes
+                {
+                    Self::ChildWorkflowExecutionTerminated(attrs)
+                } else {
+                    return Err(WFMachinesError::Fatal(
+                        "ChildWorkflowExecutionTerminated attributes were unset".to_string(),
+                    ));
+                }
+            }
+            Some(EventType::ChildWorkflowExecutionTimedOut) => {
+                if let Some(
+                    history_event::Attributes::ChildWorkflowExecutionTimedOutEventAttributes(attrs),
+                ) = e.attributes
+                {
+                    Self::ChildWorkflowExecutionTimedOut(attrs)
+                } else {
+                    return Err(WFMachinesError::Fatal(
+                        "ChildWorkflowExecutionTimedOut attributes were unset".to_string(),
+                    ));
+                }
+            }
+            Some(EventType::ChildWorkflowExecutionCanceled) => {
+                if let Some(
+                    history_event::Attributes::ChildWorkflowExecutionCanceledEventAttributes(attrs),
+                ) = e.attributes
+                {
+                    Self::ChildWorkflowExecutionCancelled(attrs)
+                } else {
+                    return Err(WFMachinesError::Fatal(
+                        "ChildWorkflowExecutionCanceled attributes were unset".to_string(),
+                    ));
+                }
+            }
+            _ => {
+                return Err(WFMachinesError::Fatal(
+                    "Child workflow machine does not handle this event".to_string(),
+                ))
+            }
+        })
+    }
+}
+
+impl WFMachinesAdapter for ChildWorkflowMachine {
+    fn adapt_response(
+        &self,
+        my_command: Self::Command,
+        event_info: Option<EventInfo>,
+    ) -> Result<Vec<MachineResponse>, WFMachinesError> {
+        Ok(match my_command {
+            ChildWorkflowCommand::Start(we) => {
+                vec![ResolveChildWorkflowExecutionStart {
+                    workflow_id: we.workflow_id.clone(),
+                    status: Some(resolve_child_workflow_execution_start::Status::Succeeded(
+                        ResolveChildWorkflowExecutionStartSuccess { run_id: we.run_id },
+                    )),
+                }
+                .into()]
+            }
+            ChildWorkflowCommand::StartFail(cause) => {
+                vec![ResolveChildWorkflowExecutionStart {
+                    workflow_id: self.shared_state.attrs.workflow_id.clone(),
+                    status: Some(resolve_child_workflow_execution_start::Status::Failed(
+                        ResolveChildWorkflowExecutionStartFailure {
+                            workflow_type: self.shared_state.attrs.workflow_type.clone(),
+                            cause: cause as i32,
+                        },
+                    )),
+                }
+                .into()]
+            }
+            ChildWorkflowCommand::StartCancel(failure) => {
+                vec![ResolveChildWorkflowExecutionStart {
+                    workflow_id: self.shared_state.attrs.workflow_id.clone(),
+                    status: Some(resolve_child_workflow_execution_start::Status::Cancelled(
+                        ResolveChildWorkflowExecutionStartCancelled {
+                            failure: Some(failure),
+                        },
+                    )),
+                }
+                .into()]
+            }
+            ChildWorkflowCommand::Complete(result) => {
+                vec![ResolveChildWorkflowExecution {
+                    workflow_id: self.shared_state.attrs.workflow_id.clone(),
+                    result: Some(ChildWorkflowResult {
+                        status: Some(ChildWorkflowStatus::Completed(wfr::Success {
+                            result: convert_payloads(event_info, result)?,
+                        })),
+                    }),
+                }
+                .into()]
+            }
+            ChildWorkflowCommand::Fail(failure) => {
+                vec![ResolveChildWorkflowExecution {
+                    workflow_id: self.shared_state.attrs.workflow_id.clone(),
+                    result: Some(ChildWorkflowResult {
+                        status: Some(ChildWorkflowStatus::Failed(wfr::Failure {
+                            failure: Some(failure),
+                        })),
+                    }),
+                }
+                .into()]
+            }
+        })
+    }
+
+    fn matches_event(&self, event: &HistoryEvent) -> bool {
+        matches!(
+            event.event_type(),
+            EventType::StartChildWorkflowExecutionInitiated
+                | EventType::StartChildWorkflowExecutionFailed
+                | EventType::ChildWorkflowExecutionStarted
+                | EventType::ChildWorkflowExecutionCompleted
+                | EventType::ChildWorkflowExecutionFailed
+                | EventType::ChildWorkflowExecutionTimedOut
+                | EventType::ChildWorkflowExecutionTerminated
+                | EventType::ChildWorkflowExecutionCanceled
+        )
+    }
+
+    fn kind(&self) -> MachineKind {
+        MachineKind::ChildWorkflow
+    }
+}
+
+impl TryFrom<CommandType> for ChildWorkflowMachineEvents {
+    type Error = ();
+
+    fn try_from(c: CommandType) -> Result<Self, Self::Error> {
+        Ok(match c {
+            CommandType::StartChildWorkflowExecution => Self::CommandStartChildWorkflowExecution,
+            _ => return Err(()),
+        })
+    }
+}
+
+/// Cancellation through this machine is valid only when start child workflow command is not sent
+/// yet. Cancellation of an initiated child workflow is done through CancelExternal.
+/// All of the types besides ABANDON are treated differently.
+impl Cancellable for ChildWorkflowMachine {
+    fn cancel(&mut self) -> Result<Vec<MachineResponse>, MachineError<Self::Error>> {
+        let event = ChildWorkflowMachineEvents::Cancel;
+        let vec = OnEventWrapper::on_event_mut(self, event)?;
+        let res = vec
+            .into_iter()
+            .flat_map(|mc| match mc {
+                ChildWorkflowCommand::StartCancel(failure) => {
+                    vec![ResolveChildWorkflowExecutionStart {
+                        workflow_id: self.shared_state.attrs.workflow_id.to_owned(),
+                        status: Some(resolve_child_workflow_execution_start::Status::Cancelled(
+                            ResolveChildWorkflowExecutionStartCancelled {
+                                failure: Some(failure),
+                            },
+                        )),
+                    }
+                    .into()]
+                }
+                ChildWorkflowCommand::Fail(failure) => {
+                    vec![ResolveChildWorkflowExecution {
+                        workflow_id: self.shared_state.attrs.workflow_id.to_owned(),
+                        result: Some(ChildWorkflowResult {
+                            status: Some(ChildWorkflowStatus::Failed(wfr::Failure {
+                                failure: Some(failure),
+                            })),
+                        }),
+                    }
+                    .into()]
+                }
+                x => panic!("Invalid cancel event response {:?}", x),
+            })
+            .collect();
+        Ok(res)
+    }
+
+    fn was_cancelled_before_sent_to_server(&self) -> bool {
+        self.shared_state.cancelled_before_sent
+    }
+}
+
+fn convert_payloads(
+    event_info: Option<EventInfo>,
+    result: Option<Payloads>,
+) -> Result<Option<Payload>, WFMachinesError> {
+    result.map(TryInto::try_into).transpose().map_err(|pe| {
+        WFMachinesError::Fatal(format!(
+            "Not exactly one payload in child workflow result ({}) for event: {}",
+            pe,
+            event_info.map(|e| e.event.clone()).unwrap_or_default()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod test {
+    extern crate derive_more;
+
+    use super::*;
+    use crate::machines::cancel_external_state_machine::RequestCancelExternalCommandCreated;
+    use crate::{
+        protos::coresdk::child_workflow::{child_workflow_result, Success},
+        protos::coresdk::workflow_activation::resolve_child_workflow_execution_start::Status as StartStatus,
+        protos::coresdk::workflow_activation::{
+            wf_activation_job, ResolveChildWorkflowExecutionStartSuccess, WfActivationJob,
+        },
+        prototype_rust_sdk::{WfContext, WorkflowFunction, WorkflowResult},
+        test_help::{canned_histories, TestHistoryBuilder},
+        workflow::managed_wf::ManagedWFFunc,
+    };
+    use anyhow::anyhow;
+    use rstest::{fixture, rstest};
+    use std::time::Duration;
+
+    #[derive(Clone)]
+    enum Expectation {
+        Success = 0,
+        Failure = 1,
+        StartFailure = 2,
+    }
+
+    impl Expectation {
+        fn try_from_u8(x: u8) -> Option<Self> {
+            Some(match x {
+                0 => Expectation::Success,
+                1 => Expectation::Failure,
+                2 => Expectation::StartFailure,
+                _ => return None,
+            })
+        }
+    }
+
+    #[fixture]
+    fn child_workflow_happy_hist() -> ManagedWFFunc {
+        let func = WorkflowFunction::new(parent_wf);
+        let t = canned_histories::single_child_workflow("child-id-1");
+        assert_eq!(3, t.get_full_history_info().unwrap().wf_task_count());
+        ManagedWFFunc::new(t, func, vec![[Expectation::Success as u8].into()])
+    }
+
+    #[fixture]
+    fn child_workflow_fail_hist() -> ManagedWFFunc {
+        let func = WorkflowFunction::new(parent_wf);
+        let t = canned_histories::single_child_workflow_fail("child-id-1");
+        assert_eq!(3, t.get_full_history_info().unwrap().wf_task_count());
+        ManagedWFFunc::new(t, func, vec![[Expectation::Failure as u8].into()])
+    }
+
+    #[fixture]
+    fn child_workflow_start_fail_hist() -> ManagedWFFunc {
+        let func = WorkflowFunction::new(parent_wf);
+        let t = canned_histories::single_child_workflow_start_fail("child-id-1");
+        assert_eq!(2, t.get_full_history_info().unwrap().wf_task_count());
+        ManagedWFFunc::new(t, func, vec![[Expectation::StartFailure as u8].into()])
+    }
+
+    async fn parent_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+        let expectation = Expectation::try_from_u8(ctx.get_args()[0].data[0]).unwrap();
+        let req = StartChildWorkflowExecution {
+            workflow_id: "child-id-1".to_string(),
+            workflow_type: "child".to_string(),
+            input: vec![],
+            ..Default::default()
+        };
+        match (expectation.clone(), ctx.start_child_workflow(req).await) {
+            (Expectation::Success | Expectation::Failure, StartStatus::Succeeded(_)) => {}
+            (Expectation::StartFailure, StartStatus::Failed(_)) => return Ok(().into()),
+            _ => return Err(anyhow!("Unexpected start status")),
+        };
+        match (
+            expectation,
+            ctx.child_workflow_result("child-id-1".to_string())
+                .await
+                .status,
+        ) {
+            (Expectation::Success, Some(child_workflow_result::Status::Completed(_))) => {
+                Ok(().into())
+            }
+            (Expectation::Failure, _) => Ok(().into()),
+            _ => Err(anyhow!("Unexpected child WF status")),
+        }
+    }
+
+    #[rstest(
+        wfm,
+        case::success(child_workflow_happy_hist()),
+        case::failure(child_workflow_fail_hist())
+    )]
+    #[tokio::test]
+    async fn single_child_workflow_until_completion(mut wfm: ManagedWFFunc) {
+        wfm.get_next_activation().await.unwrap();
+        let commands = wfm.get_server_commands().await.commands;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command_type,
+            CommandType::StartChildWorkflowExecution as i32
+        );
+
+        wfm.get_next_activation().await.unwrap();
+        let commands = wfm.get_server_commands().await.commands;
+        assert_eq!(commands.len(), 0);
+
+        wfm.get_next_activation().await.unwrap();
+        let commands = wfm.get_server_commands().await.commands;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command_type,
+            CommandType::CompleteWorkflowExecution as i32
+        );
+        wfm.shutdown().await.unwrap();
+    }
+
+    #[rstest(wfm, case::start_failure(child_workflow_start_fail_hist()))]
+    #[tokio::test]
+    async fn single_child_workflow_start_fail(mut wfm: ManagedWFFunc) {
+        wfm.get_next_activation().await.unwrap();
+        let commands = wfm.get_server_commands().await.commands;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command_type,
+            CommandType::StartChildWorkflowExecution as i32
+        );
+
+        wfm.get_next_activation().await.unwrap();
+        let commands = wfm.get_server_commands().await.commands;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command_type,
+            CommandType::CompleteWorkflowExecution as i32
+        );
+        wfm.shutdown().await.unwrap();
+    }
+
+    async fn cancel_before_send_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+        let workflow_id = "child-id-1";
+        let start = ctx.start_child_workflow(StartChildWorkflowExecution {
+            workflow_id: workflow_id.to_string(),
+            workflow_type: "child".to_string(),
+            input: vec![],
+            ..Default::default()
+        });
+        ctx.cancel_child_workflow(workflow_id);
+        match start.await {
+            StartStatus::Cancelled(_) => Ok(().into()),
+            _ => Err(anyhow!("Unexpected start status")),
+        }
+    }
+
+    #[fixture]
+    fn child_workflow_cancel_before_sent() -> ManagedWFFunc {
+        let func = WorkflowFunction::new(cancel_before_send_wf);
+        let mut t = TestHistoryBuilder::default();
+        t.add_by_type(EventType::WorkflowExecutionStarted);
+        t.add_full_wf_task();
+        t.add_workflow_task_scheduled_and_started();
+        assert_eq!(2, t.get_full_history_info().unwrap().wf_task_count());
+        ManagedWFFunc::new(t, func, vec![])
+    }
+
+    #[rstest(wfm, case::default(child_workflow_cancel_before_sent()))]
+    #[tokio::test]
+    async fn single_child_workflow_cancel_before_sent(mut wfm: ManagedWFFunc) {
+        wfm.get_next_activation().await.unwrap();
+        let commands = wfm.get_server_commands().await.commands;
+        assert_eq!(commands.len(), 0);
+
+        wfm.get_next_activation().await.unwrap();
+        let commands = wfm.get_server_commands().await.commands;
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command_type,
+            CommandType::CompleteWorkflowExecution as i32
+        );
+        wfm.shutdown().await.unwrap();
+    }
+}

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -5,7 +5,6 @@ mod activity_state_machine;
 #[allow(unused)]
 mod cancel_external_state_machine;
 mod cancel_workflow_state_machine;
-#[allow(unused)]
 mod child_workflow_state_machine;
 mod complete_workflow_state_machine;
 mod continue_as_new_workflow_state_machine;

--- a/src/machines/transition_coverage.rs
+++ b/src/machines/transition_coverage.rs
@@ -70,6 +70,7 @@ mod machine_coverage_report {
     use crate::machines::{
         activity_state_machine::ActivityMachine,
         cancel_workflow_state_machine::CancelWorkflowMachine,
+        child_workflow_state_machine::ChildWorkflowMachine,
         complete_workflow_state_machine::CompleteWorkflowMachine,
         continue_as_new_workflow_state_machine::ContinueAsNewWorkflowMachine,
         fail_workflow_state_machine::FailWorkflowMachine, timer_state_machine::TimerMachine,
@@ -102,6 +103,7 @@ mod machine_coverage_report {
         // Gather visualizations for all machines
         let mut activity = ActivityMachine::visualizer().to_owned();
         let mut timer = TimerMachine::visualizer().to_owned();
+        let mut child_wf = ChildWorkflowMachine::visualizer().to_owned();
         let mut complete_wf = CompleteWorkflowMachine::visualizer().to_owned();
         let mut wf_task = WorkflowTaskMachine::visualizer().to_owned();
         let mut fail_wf = FailWorkflowMachine::visualizer().to_owned();
@@ -116,6 +118,7 @@ mod machine_coverage_report {
             match machine.as_ref() {
                 m @ "ActivityMachine" => cover_transitions(m, &mut activity, coverage),
                 m @ "TimerMachine" => cover_transitions(m, &mut timer, coverage),
+                m @ "ChildWorkflowMachine" => cover_transitions(m, &mut child_wf, coverage),
                 m @ "CompleteWorkflowMachine" => cover_transitions(m, &mut complete_wf, coverage),
                 m @ "WorkflowTaskMachine" => cover_transitions(m, &mut wf_task, coverage),
                 m @ "FailWorkflowMachine" => cover_transitions(m, &mut fail_wf, coverage),

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -208,6 +208,12 @@ pub mod coresdk {
                         wf_activation_job::Variant::NotifyHasChange(_) => {
                             write!(f, "NotifyHasChange")
                         }
+                        wf_activation_job::Variant::ResolveChildWorkflowExecutionStart(_) => {
+                            write!(f, "ResolveChildWorkflowExecutionStart")
+                        }
+                        wf_activation_job::Variant::ResolveChildWorkflowExecution(_) => {
+                            write!(f, "ResolveChildWorkflowExecution")
+                        }
                         wf_activation_job::Variant::RemoveFromCache(_) => {
                             write!(f, "RemoveFromCache")
                         }
@@ -246,6 +252,10 @@ pub mod coresdk {
             }
         }
     }
+    pub mod child_workflow {
+        tonic::include_proto!("coresdk.child_workflow");
+    }
+
     pub mod workflow_commands {
         tonic::include_proto!("coresdk.workflow_commands");
 
@@ -283,6 +293,15 @@ pub mod coresdk {
                         }
                         workflow_command::Variant::SetChangeMarker(_) => {
                             write!(f, "SetChangeMarker")
+                        }
+                        workflow_command::Variant::StartChildWorkflowExecution(_) => {
+                            write!(f, "StartChildWorkflowExecution")
+                        }
+                        workflow_command::Variant::RequestCancelExternalWorkflowExecution(_) => {
+                            write!(f, "RequestCancelExternalWorkflowExecution")
+                        }
+                        workflow_command::Variant::SignalExternalWorkflowExecution(_) => {
+                            write!(f, "SignalExternalWorkflowExecution")
                         }
                     },
                 }
@@ -731,7 +750,7 @@ pub mod temporal {
 
                 use crate::protos::{
                     coresdk::{workflow_commands, PayloadsExt},
-                    temporal::api::common::v1::ActivityType,
+                    temporal::api::common::v1::{ActivityType, WorkflowType},
                     temporal::api::enums::v1::CommandType,
                 };
                 use command::Attributes;
@@ -822,6 +841,33 @@ pub mod temporal {
                                 start_to_close_timeout: s.start_to_close_timeout,
                                 heartbeat_timeout: s.heartbeat_timeout,
                                 retry_policy: s.retry_policy.map(Into::into),
+                            },
+                        )
+                    }
+                }
+
+                impl From<workflow_commands::StartChildWorkflowExecution> for command::Attributes {
+                    fn from(s: workflow_commands::StartChildWorkflowExecution) -> Self {
+                        Self::StartChildWorkflowExecutionCommandAttributes(
+                            StartChildWorkflowExecutionCommandAttributes {
+                                workflow_id: s.workflow_id,
+                                workflow_type: Some(WorkflowType {
+                                    name: s.workflow_type,
+                                }),
+                                control: "".into(),
+                                namespace: s.namespace,
+                                task_queue: Some(s.task_queue.into()),
+                                header: Some(s.header.into()),
+                                memo: Some(s.memo.into()),
+                                search_attributes: Some(s.search_attributes.into()),
+                                input: s.input.into_payloads(),
+                                workflow_id_reuse_policy: s.workflow_id_reuse_policy,
+                                workflow_execution_timeout: s.workflow_execution_timeout,
+                                workflow_run_timeout: s.workflow_run_timeout,
+                                workflow_task_timeout: s.workflow_task_timeout,
+                                retry_policy: s.retry_policy.map(Into::into),
+                                cron_schedule: s.cron_schedule.clone(),
+                                parent_close_policy: s.parent_close_policy,
                             },
                         )
                     }

--- a/src/prototype_rust_sdk.rs
+++ b/src/prototype_rust_sdk.rs
@@ -12,8 +12,12 @@ pub use workflow_context::WfContext;
 use crate::{
     protos::coresdk::{
         activity_result::ActivityResult,
+        child_workflow::ChildWorkflowResult,
         common::Payload,
-        workflow_activation::{wf_activation_job::Variant, WfActivation, WfActivationJob},
+        workflow_activation::{
+            resolve_child_workflow_execution_start::Status as ChildWorkflowStartStatus,
+            wf_activation_job::Variant, WfActivation, WfActivationJob,
+        },
         workflow_commands::{workflow_command, ContinueAsNewWorkflowExecution},
     },
     Core,
@@ -72,26 +76,38 @@ impl TestRustWorker {
 
     /// Create a workflow, asking the server to start it with the provided workflow ID and using the
     /// provided workflow function.
-    pub async fn submit_wf<F: Into<WorkflowFunction>>(
+    /// Increments the expected Workflow run count.
+    pub async fn submit_wf(
         &self,
-        input: Vec<Payload>,
         workflow_id: String,
-        wf_function: F,
+        workflow_type: String,
+        input: Vec<Payload>,
     ) -> Result<(), tonic::Status> {
         self.core
             .server_gateway()
             .start_workflow(
                 input,
                 self.task_queue.clone(),
-                workflow_id.clone(),
-                workflow_id.clone(),
+                workflow_id,
+                workflow_type,
                 self.task_timeout,
             )
             .await?;
 
-        self.workflow_fns.insert(workflow_id, wf_function.into());
-        self.incomplete_workflows.fetch_add(1, Ordering::SeqCst);
+        self.incr_expected_run_count(1);
         Ok(())
+    }
+
+    /// Register a Workflow function to invoke when Worker is requested to run `workflow_type`
+    pub fn register_wf<F: Into<WorkflowFunction>>(&self, workflow_type: String, wf_function: F) {
+        self.workflow_fns.insert(workflow_type, wf_function.into());
+    }
+
+    /// Increment the expected Workflow run count on this Worker. The Worker tracks the run count
+    /// and will resolve `run_until_done` when it goes down to 0.
+    /// You do not have to increment if scheduled a Workflow with `submit_wf`.
+    pub fn incr_expected_run_count(&self, count: usize) {
+        self.incomplete_workflows.fetch_add(count, Ordering::SeqCst);
     }
 
     /// Drives all workflows until they have all finished, repeatedly polls server to fetch work
@@ -111,8 +127,8 @@ impl TestRustWorker {
                 {
                     let wf_function = self
                         .workflow_fns
-                        .get(&sw.workflow_id)
-                        .ok_or_else(|| anyhow!("Workflow id not found"))?;
+                        .get(&sw.workflow_type)
+                        .ok_or_else(|| anyhow!("Workflow type not found"))?;
 
                     // NOTE: Don't clone args if this gets ported to be a non-test rust worker
                     let (wff, activations) =
@@ -163,6 +179,8 @@ impl TestRustWorker {
 enum UnblockEvent {
     Timer(String),
     Activity(String, Box<ActivityResult>),
+    WorkflowStart(String, Box<ChildWorkflowStartStatus>),
+    WorkflowComplete(String, Box<ChildWorkflowResult>),
 }
 
 #[derive(derive_more::From)]
@@ -172,13 +190,21 @@ enum RustWfCmd {
     CancelTimer(String),
     #[from(ignore)]
     CancelActivity(String),
+    #[from(ignore)]
+    CancelChildWorkflow(String),
     ForceWFTFailure(anyhow::Error),
     NewCmd(CommandCreateRequest),
     NewNonblockingCmd(workflow_command::Variant),
+    SubscribeChildWorkflowCompletion(CommandSubscribeChildWorkflowCompletion),
 }
 
 struct CommandCreateRequest {
     cmd: workflow_command::Variant,
+    unblocker: oneshot::Sender<UnblockEvent>,
+}
+
+struct CommandSubscribeChildWorkflowCompletion {
+    workflow_id: String,
     unblocker: oneshot::Sender<UnblockEvent>,
 }
 
@@ -234,7 +260,7 @@ mod tests {
     use super::*;
     use crate::{
         protos::coresdk::workflow_commands::StartTimer,
-        test_help::{build_fake_core, canned_histories, TEST_Q},
+        test_help::{build_fake_core, canned_histories, DEFAULT_WORKFLOW_TYPE, TEST_Q},
     };
 
     pub async fn timer_wf(mut ctx: WfContext) -> WorkflowResult<()> {
@@ -249,12 +275,14 @@ mod tests {
     #[tokio::test]
     async fn new_test_wf_core() {
         let wf_id = "fakeid";
+        let wf_type = DEFAULT_WORKFLOW_TYPE;
         let t = canned_histories::single_timer("fake_timer");
         let core = build_fake_core(wf_id, t, [2]);
         let worker = TestRustWorker::new(Arc::new(core), TEST_Q.to_string(), None);
 
+        worker.register_wf(wf_type.to_owned(), timer_wf);
         worker
-            .submit_wf(vec![], wf_id.to_string(), WorkflowFunction::new(timer_wf))
+            .submit_wf(wf_id.to_owned(), wf_type.to_owned(), vec![])
             .await
             .unwrap();
         worker.run_until_done().await.unwrap();

--- a/src/prototype_rust_sdk/workflow_future.rs
+++ b/src/prototype_rust_sdk/workflow_future.rs
@@ -296,6 +296,12 @@ impl Future for WorkflowFuture {
                 }
             }
 
+            // TODO: deadlock detector
+            // Check if there's nothing to unblock and workflow has not completed.
+            // This is different from the assertion that was here before that checked that WF did
+            // not produce any commands which is completely viable in the case WF is waiting on
+            // multiple completions.
+
             self.outgoing_completions
                 .send(WfActivationCompletion::from_cmds(activation_cmds, run_id))
                 .expect("Completion channel intact");

--- a/src/test_help/canned_histories.rs
+++ b/src/test_help/canned_histories.rs
@@ -1381,6 +1381,8 @@ pub fn activity_double_resolve_repro() -> TestHistoryBuilder {
 /// 10: EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED
 /// 11: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
 /// 12: EVENT_TYPE_WORKFLOW_TASK_STARTED
+/// 13: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+/// 14: EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
 pub fn single_child_workflow(child_wf_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
@@ -1423,7 +1425,8 @@ pub fn single_child_workflow(child_wf_id: &str) -> TestHistoryBuilder {
             },
         ),
     );
-    t.add_workflow_task_scheduled_and_started();
+    t.add_full_wf_task();
+    t.add_workflow_execution_completed();
     t
 }
 
@@ -1439,6 +1442,8 @@ pub fn single_child_workflow(child_wf_id: &str) -> TestHistoryBuilder {
 /// 10: EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED
 /// 11: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
 /// 12: EVENT_TYPE_WORKFLOW_TASK_STARTED
+/// 13: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+/// 14: EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
 pub fn single_child_workflow_fail(child_wf_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
@@ -1480,7 +1485,8 @@ pub fn single_child_workflow_fail(child_wf_id: &str) -> TestHistoryBuilder {
             },
         ),
     );
-    t.add_workflow_task_scheduled_and_started();
+    t.add_full_wf_task();
+    t.add_workflow_execution_completed();
     t
 }
 
@@ -1492,6 +1498,8 @@ pub fn single_child_workflow_fail(child_wf_id: &str) -> TestHistoryBuilder {
 ///  5: EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED
 ///  6: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
 ///  7: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  8: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+///  9: EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
 pub fn single_child_workflow_start_fail(child_wf_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
@@ -1520,6 +1528,7 @@ pub fn single_child_workflow_start_fail(child_wf_id: &str) -> TestHistoryBuilder
             ),
         ),
     );
-    t.add_workflow_task_scheduled_and_started();
+    t.add_full_wf_task();
+    t.add_workflow_execution_completed();
     t
 }

--- a/src/test_help/canned_histories.rs
+++ b/src/test_help/canned_histories.rs
@@ -1,13 +1,19 @@
 use crate::{
-    protos::temporal::api::common::v1::Payload,
-    protos::temporal::api::enums::v1::{EventType, WorkflowTaskFailedCause},
+    protos::temporal::api::common::v1::{Payload, WorkflowExecution},
+    protos::temporal::api::enums::v1::{
+        EventType, StartChildWorkflowExecutionFailedCause, WorkflowTaskFailedCause,
+    },
     protos::temporal::api::failure::v1::Failure,
     protos::temporal::api::history::v1::{
         history_event, ActivityTaskCancelRequestedEventAttributes,
         ActivityTaskCanceledEventAttributes, ActivityTaskCompletedEventAttributes,
         ActivityTaskFailedEventAttributes, ActivityTaskScheduledEventAttributes,
         ActivityTaskStartedEventAttributes, ActivityTaskTimedOutEventAttributes,
-        TimerCanceledEventAttributes, TimerFiredEventAttributes,
+        ChildWorkflowExecutionCompletedEventAttributes,
+        ChildWorkflowExecutionFailedEventAttributes, ChildWorkflowExecutionStartedEventAttributes,
+        StartChildWorkflowExecutionFailedEventAttributes,
+        StartChildWorkflowExecutionInitiatedEventAttributes, TimerCanceledEventAttributes,
+        TimerFiredEventAttributes,
     },
     test_help::TestHistoryBuilder,
 };
@@ -1360,5 +1366,160 @@ pub fn activity_double_resolve_repro() -> TestHistoryBuilder {
     t.add_full_wf_task();
     t.add_workflow_execution_completed();
 
+    t
+}
+
+///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+///  2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  3: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  4: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+///  5: EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED
+///  6: EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED
+///  7: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  8: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  9: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+/// 10: EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED
+/// 11: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+/// 12: EVENT_TYPE_WORKFLOW_TASK_STARTED
+pub fn single_child_workflow(child_wf_id: &str) -> TestHistoryBuilder {
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    let initiated_event_id = t.add_get_event_id(
+        EventType::StartChildWorkflowExecutionInitiated,
+        Some(
+            history_event::Attributes::StartChildWorkflowExecutionInitiatedEventAttributes(
+                StartChildWorkflowExecutionInitiatedEventAttributes {
+                    workflow_id: child_wf_id.to_owned(),
+                    ..Default::default()
+                },
+            ),
+        ),
+    );
+    let started_event_id = t.add_get_event_id(
+        EventType::ChildWorkflowExecutionStarted,
+        Some(
+            history_event::Attributes::ChildWorkflowExecutionStartedEventAttributes(
+                ChildWorkflowExecutionStartedEventAttributes {
+                    initiated_event_id,
+                    workflow_execution: Some(WorkflowExecution {
+                        workflow_id: child_wf_id.to_owned(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ),
+        ),
+    );
+    t.add_full_wf_task();
+    t.add(
+        EventType::ChildWorkflowExecutionCompleted,
+        history_event::Attributes::ChildWorkflowExecutionCompletedEventAttributes(
+            ChildWorkflowExecutionCompletedEventAttributes {
+                initiated_event_id,
+                started_event_id,
+                // todo add the result payload
+                ..Default::default()
+            },
+        ),
+    );
+    t.add_workflow_task_scheduled_and_started();
+    t
+}
+
+///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+///  2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  3: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  4: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+///  5: EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED
+///  6: EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED
+///  7: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  8: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  9: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+/// 10: EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED
+/// 11: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+/// 12: EVENT_TYPE_WORKFLOW_TASK_STARTED
+pub fn single_child_workflow_fail(child_wf_id: &str) -> TestHistoryBuilder {
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    let initiated_event_id = t.add_get_event_id(
+        EventType::StartChildWorkflowExecutionInitiated,
+        Some(
+            history_event::Attributes::StartChildWorkflowExecutionInitiatedEventAttributes(
+                StartChildWorkflowExecutionInitiatedEventAttributes {
+                    workflow_id: child_wf_id.to_owned(),
+                    ..Default::default()
+                },
+            ),
+        ),
+    );
+    let started_event_id = t.add_get_event_id(
+        EventType::ChildWorkflowExecutionStarted,
+        Some(
+            history_event::Attributes::ChildWorkflowExecutionStartedEventAttributes(
+                ChildWorkflowExecutionStartedEventAttributes {
+                    initiated_event_id,
+                    workflow_execution: Some(WorkflowExecution {
+                        workflow_id: child_wf_id.to_owned(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ),
+        ),
+    );
+    t.add_full_wf_task();
+    t.add(
+        EventType::ChildWorkflowExecutionFailed,
+        history_event::Attributes::ChildWorkflowExecutionFailedEventAttributes(
+            ChildWorkflowExecutionFailedEventAttributes {
+                initiated_event_id,
+                started_event_id,
+                ..Default::default()
+            },
+        ),
+    );
+    t.add_workflow_task_scheduled_and_started();
+    t
+}
+
+///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+///  2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  3: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  4: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+///  5: EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED
+///  5: EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED
+///  6: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  7: EVENT_TYPE_WORKFLOW_TASK_STARTED
+pub fn single_child_workflow_start_fail(child_wf_id: &str) -> TestHistoryBuilder {
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    let initiated_event_id = t.add_get_event_id(
+        EventType::StartChildWorkflowExecutionInitiated,
+        Some(
+            history_event::Attributes::StartChildWorkflowExecutionInitiatedEventAttributes(
+                StartChildWorkflowExecutionInitiatedEventAttributes {
+                    workflow_id: child_wf_id.to_owned(),
+                    ..Default::default()
+                },
+            ),
+        ),
+    );
+    t.add_get_event_id(
+        EventType::StartChildWorkflowExecutionFailed,
+        Some(
+            history_event::Attributes::StartChildWorkflowExecutionFailedEventAttributes(
+                StartChildWorkflowExecutionFailedEventAttributes {
+                    workflow_id: child_wf_id.to_owned(),
+                    initiated_event_id,
+                    cause: StartChildWorkflowExecutionFailedCause::WorkflowAlreadyExists as i32,
+                    ..Default::default()
+                },
+            ),
+        ),
+    );
+    t.add_workflow_task_scheduled_and_started();
     t
 }

--- a/src/test_help/history_builder.rs
+++ b/src/test_help/history_builder.rs
@@ -1,7 +1,7 @@
 use crate::machines::HAS_CHANGE_MARKER_NAME;
 use crate::protos::coresdk::common::build_has_change_marker_details;
 use crate::{
-    protos::temporal::api::common::v1::{Payload, Payloads},
+    protos::temporal::api::common::v1::{Payload, Payloads, WorkflowType},
     protos::temporal::api::failure::v1::Failure,
     protos::temporal::api::history::v1::WorkflowExecutionSignaledEventAttributes,
     protos::temporal::api::{
@@ -235,10 +235,15 @@ impl TestHistoryBuilder {
     }
 }
 
+pub static DEFAULT_WORKFLOW_TYPE: &str = "not_specified";
+
 fn default_attribs(et: EventType) -> Result<Attributes> {
     Ok(match et {
         EventType::WorkflowExecutionStarted => WorkflowExecutionStartedEventAttributes {
             original_execution_run_id: Uuid::new_v4().to_string(),
+            workflow_type: Some(WorkflowType {
+                name: DEFAULT_WORKFLOW_TYPE.to_owned(),
+            }),
             ..Default::default()
         }
         .into(),

--- a/src/test_help/mod.rs
+++ b/src/test_help/mod.rs
@@ -3,8 +3,6 @@ pub mod canned_histories;
 mod history_builder;
 mod history_info;
 
-pub(crate) use history_builder::TestHistoryBuilder;
-
 use crate::{
     pollers::{
         BoxedActPoller, BoxedPoller, BoxedWFPoller, MockManualPoller, MockPoller,
@@ -16,7 +14,7 @@ use crate::{
             workflow_commands::workflow_command,
             workflow_completion::{self, wf_activation_completion, WfActivationCompletion},
         },
-        temporal::api::common::v1::WorkflowExecution,
+        temporal::api::common::v1::{WorkflowExecution, WorkflowType},
         temporal::api::enums::v1::TaskQueueKind,
         temporal::api::failure::v1::Failure,
         temporal::api::history::v1::History,
@@ -33,6 +31,8 @@ use crate::{
 };
 use bimap::BiMap;
 use futures::FutureExt;
+pub(crate) use history_builder::TestHistoryBuilder;
+pub(crate) use history_builder::DEFAULT_WORKFLOW_TYPE;
 use mockall::TimesRange;
 use parking_lot::RwLock;
 use rand::{thread_rng, Rng};
@@ -451,6 +451,9 @@ pub fn hist_to_poll_resp(
         history: Some(History { events: batch }),
         workflow_execution: Some(wf),
         task_token: task_token.to_vec(),
+        workflow_type: Some(WorkflowType {
+            name: DEFAULT_WORKFLOW_TYPE.to_owned(),
+        }),
         workflow_execution_task_queue: Some(TaskQueue {
             name: task_queue,
             kind: TaskQueueKind::Normal as i32,

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -22,6 +22,8 @@ type Result<T, E = WFMachinesError> = std::result::Result<T, E>;
 pub(crate) enum CommandID {
     Timer(String),
     Activity(String),
+    ChildWorkflowStart(String),
+    ChildWorkflowComplete(String),
 }
 
 /// Manages an instance of a [WorkflowMachines], which is not thread-safe, as well as other data

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -150,8 +150,9 @@ async fn can_paginate_long_history() {
     starter.max_cached_workflows(0);
 
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), many_parallel_timers_longhist);
     worker
-        .submit_wf(vec![], wf_name.to_owned(), many_parallel_timers_longhist)
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -1,6 +1,7 @@
 mod activities;
 mod cancel_wf;
 mod changes;
+mod child_workflows;
 mod continue_as_new;
 mod stickyness;
 mod timers;
@@ -101,18 +102,19 @@ pub async fn cache_evictions_wf(mut command_sink: WfContext) -> WorkflowResult<(
 
 #[tokio::test]
 async fn workflow_lru_cache_evictions() {
-    let wf_name = "workflow_lru_cache_evictions";
-    let mut starter = CoreWfStarter::new(wf_name);
+    let wf_type = "workflow_lru_cache_evictions";
+    let mut starter = CoreWfStarter::new(wf_type);
     starter.max_cached_workflows(1);
     let worker = starter.worker().await;
+    worker.register_wf(wf_type.to_string(), cache_evictions_wf);
 
     let n_workflows = 3;
     for _ in 0..n_workflows {
         worker
             .submit_wf(
-                vec![],
                 format!("wce-{}", Uuid::new_v4()),
-                cache_evictions_wf,
+                wf_type.to_string(),
+                vec![],
             )
             .await
             .unwrap();

--- a/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -30,9 +30,10 @@ async fn cancel_during_timer() {
     let mut starter = CoreWfStarter::new(wf_name);
     let core = starter.get_core().await;
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_string(), cancelled_wf);
 
     worker
-        .submit_wf(vec![], wf_name.to_owned(), cancelled_wf)
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
         .await
         .unwrap();
 

--- a/tests/integ_tests/workflow_tests/changes.rs
+++ b/tests/integ_tests/workflow_tests/changes.rs
@@ -46,9 +46,10 @@ async fn writes_change_markers() {
     let wf_name = "writes_change_markers";
     let mut starter = CoreWfStarter::new(wf_name);
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), changes_wf);
 
     worker
-        .submit_wf(vec![], wf_name.to_owned(), changes_wf)
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
@@ -93,9 +94,10 @@ async fn can_add_change_markers() {
     let wf_name = "can_add_change_markers";
     let mut starter = CoreWfStarter::new(wf_name);
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), no_change_then_change_wf);
 
     worker
-        .submit_wf(vec![], wf_name.to_owned(), no_change_then_change_wf)
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();

--- a/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -1,0 +1,53 @@
+use anyhow::anyhow;
+use temporal_sdk_core::{
+    protos::coresdk::child_workflow::{child_workflow_result, Success},
+    protos::coresdk::workflow_activation,
+    protos::coresdk::workflow_activation::resolve_child_workflow_execution_start::Status as StartStatus,
+    protos::coresdk::workflow_commands::StartChildWorkflowExecution,
+    prototype_rust_sdk::{WfContext, WorkflowResult},
+};
+use test_utils::CoreWfStarter;
+
+static PARENT_WF_TYPE: &str = "parent_wf";
+static CHILD_WF_TYPE: &str = "child_wf";
+
+async fn child_wf(_ctx: WfContext) -> WorkflowResult<()> {
+    Ok(().into())
+}
+
+async fn parent_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+    let req = StartChildWorkflowExecution {
+        workflow_id: "id1".to_string(),
+        workflow_type: CHILD_WF_TYPE.to_string(),
+        input: vec![],
+        ..Default::default()
+    };
+    let _run_id = match ctx.start_child_workflow(req).await {
+        StartStatus::Succeeded(
+            workflow_activation::ResolveChildWorkflowExecutionStartSuccess { run_id },
+        ) => run_id,
+        _ => return Err(anyhow!("Unexpected start status")),
+    };
+    match ctx.child_workflow_result("id1".to_string()).await.status {
+        Some(child_workflow_result::Status::Completed(Success { .. })) => Ok(().into()),
+        _ => Err(anyhow!("Unexpected child WF status")),
+    }
+}
+
+#[tokio::test]
+async fn child_workflow_happy_path() {
+    let mut starter = CoreWfStarter::new("child-workflows");
+    let worker = starter.worker().await;
+
+    worker.register_wf(PARENT_WF_TYPE.to_string(), parent_wf);
+    worker.register_wf(CHILD_WF_TYPE.to_string(), child_wf);
+    worker.incr_expected_run_count(1); // Expect another WF to be run as child
+
+    worker
+        .submit_wf("parent".to_string(), PARENT_WF_TYPE.to_owned(), vec![])
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+
+    starter.shutdown().await;
+}

--- a/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -27,9 +27,10 @@ async fn continue_as_new_happy_path() {
     let wf_name = "continue_as_new_happy_path";
     let mut starter = CoreWfStarter::new(wf_name);
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_string(), continue_as_new_wf);
 
     worker
-        .submit_wf(vec![[1].into()], wf_name.to_owned(), continue_as_new_wf)
+        .submit_wf(wf_name.to_string(), wf_name.to_string(), vec![[1].into()])
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();

--- a/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/tests/integ_tests/workflow_tests/stickyness.rs
@@ -15,9 +15,10 @@ async fn timer_workflow_not_sticky() {
     let mut starter = CoreWfStarter::new(wf_name);
     starter.max_cached_workflows(0);
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), timer_wf);
 
     worker
-        .submit_wf(vec![], wf_name.to_owned(), timer_wf)
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
@@ -49,9 +50,10 @@ async fn timer_workflow_timeout_on_sticky() {
     let mut starter = CoreWfStarter::new(wf_name);
     starter.wft_timeout(Duration::from_secs(2));
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), timer_timeout_wf);
 
     worker
-        .submit_wf(vec![], wf_name.to_owned(), timer_timeout_wf)
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -20,9 +20,10 @@ async fn timer_workflow_workflow_driver() {
     let wf_name = "timer_wf_new";
     let mut starter = CoreWfStarter::new(wf_name);
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), timer_wf);
 
     worker
-        .submit_wf(vec![], wf_name.to_owned(), timer_wf)
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
@@ -128,9 +129,10 @@ async fn parallel_timers() {
     let wf_name = "parallel_timers";
     let mut starter = CoreWfStarter::new(wf_name);
     let worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), parallel_timer_wf);
 
     worker
-        .submit_wf(vec![], wf_name.to_owned(), parallel_timer_wf)
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -54,12 +54,14 @@ async fn activity_load() {
     };
 
     let starting = Instant::now();
+    let wf_type = "activity_load";
+    worker.register_wf(wf_type.to_owned(), wf_fn);
     join_all((0..CONCURRENCY).map(|i| {
         let worker = &worker;
-        let wf_fn = wf_fn.clone();
+        let wf_id = format!("activity_load_{}", i);
         async move {
             worker
-                .submit_wf(vec![], format!("activity_load_{}", i), wf_fn)
+                .submit_wf(wf_id, wf_type.to_owned(), vec![])
                 .await
                 .unwrap();
         }


### PR DESCRIPTION
Implemented the ChildWorkflowMachine, currently we index child WF machines by their workflow ID which is a bug, @Sushisource let's discuss how we'd change this, we'll need to change it for activities as well.
I suggest we make the correlation ID change later and merge this as is.
For complete child workflow functionality we should implement the external WF machines for cancel and signal.