### PR TITLE
Use failure for ActivityResult.cancelled, add ChildWorkflowResult.cancelled

### DIFF
--- a/protos/local/activity_result.proto
+++ b/protos/local/activity_result.proto
@@ -5,27 +5,33 @@ package coresdk.activity_result;
 import "common.proto";
 import "temporal/api/failure/v1/message.proto";
 
-/// Used to report activity completion to core and to resolve the activity in a workflow activation
+/**
+ * Used to report activity completion to core and to resolve the activity in a workflow activation
+ */
 message ActivityResult {
     oneof status {
         Success completed = 1;
         Failure failed = 2;
-        Cancelation canceled = 3;
+        Cancellation cancelled = 3;
     }
 }
 
-/// Used in ActivityResult to report cancellation
-message Cancelation {
-    common.Payload details = 1;
-}
-
-/// Used in ActivityResult to report successful completion
+/** Used in ActivityResult to report successful completion */
 message Success {
     common.Payload result = 1;
 }
 
-/// Used in ActivityResult to report failure
+/** Used in ActivityResult to report failure */
 message Failure {
     temporal.api.failure.v1.Failure failure = 1;
 }
 
+/**
+ * Used in ActivityResult to report cancellation from both Core and Lang.
+ * When Lang reports a cancelled ActivityResult, it must put a CancelledFailure in the failure field.
+ * When Core reports a cancelled ActivityResult, it must put an ActivityFailure with CancelledFailure
+ * as the cause in the failure field.
+ */
+message Cancellation {
+    temporal.api.failure.v1.Failure failure = 1;
+}

--- a/protos/local/child_workflow.proto
+++ b/protos/local/child_workflow.proto
@@ -7,14 +7,12 @@ import "temporal/api/failure/v1/message.proto";
 
 /**
  * Used by core to resolve child workflow executions.
- *
- * When a child workflow is cancelled, `status` is failed and
- * failure.cause.info is set to CanceledFailure.
  */
 message ChildWorkflowResult {
     oneof status {
         Success completed = 1;
         Failure failed = 2;
+        Cancellation cancelled = 3;
     }
 }
 
@@ -30,6 +28,14 @@ message Success {
  * application failures, timeouts, terminations, and cancellations.
  */
 message Failure {
+    temporal.api.failure.v1.Failure failure = 1;
+}
+
+/**
+ * Used in ChildWorkflowResult to report cancellation.
+ * Failure should be ChildWorkflowFailure with a CanceledFailure cause.
+ */
+message Cancellation {
     temporal.api.failure.v1.Failure failure = 1;
 }
 

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -442,7 +442,7 @@ async fn activity_timeout_no_double_resolve() {
                 &job_assert!(wf_activation_job::Variant::ResolveActivity(
                     ResolveActivity {
                         result: Some(ActivityResult {
-                            status: Some(activity_result::Status::Canceled(..)),
+                            status: Some(activity_result::Status::Cancelled(..)),
                         }),
                         ..
                     }

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -409,7 +409,7 @@ async fn cancelled_activity_timeout(hist_batches: &'static [usize]) {
                     ResolveActivity {
                         activity_id: _,
                         result: Some(ActivityResult {
-                            status: Some(activity_result::Status::Canceled(..)),
+                            status: Some(activity_result::Status::Cancelled(..)),
                         })
                     }
                 )),
@@ -508,7 +508,7 @@ async fn verify_activity_cancellation(
                     ResolveActivity {
                         activity_id: _,
                         result: Some(ActivityResult {
-                            status: Some(activity_result::Status::Canceled(..)),
+                            status: Some(activity_result::Status::Cancelled(..)),
                         })
                     }
                 )),
@@ -586,7 +586,7 @@ async fn verify_activity_cancellation_wait_for_cancellation(
                     ResolveActivity {
                         activity_id: _,
                         result: Some(ActivityResult {
-                            status: Some(activity_result::Status::Canceled(..)),
+                            status: Some(activity_result::Status::Cancelled(..)),
                         })
                     }
                 )),
@@ -990,7 +990,7 @@ async fn activity_not_canceled_on_replay_repro(hist_batches: &'static [usize]) {
                 &job_assert!(wf_activation_job::Variant::ResolveActivity(
                     ResolveActivity {
                         result: Some(ActivityResult {
-                            status: Some(activity_result::Status::Canceled(..)),
+                            status: Some(activity_result::Status::Cancelled(..)),
                         }),
                         ..
                     }
@@ -1045,7 +1045,7 @@ async fn activity_not_canceled_when_also_completed_repro(hist_batches: &'static 
                 &job_assert!(wf_activation_job::Variant::ResolveActivity(
                     ResolveActivity {
                         result: Some(ActivityResult {
-                            status: Some(activity_result::Status::Canceled(..)),
+                            status: Some(activity_result::Status::Cancelled(..)),
                         }),
                         ..
                     }

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -53,13 +53,25 @@ pub mod coresdk {
     #[allow(clippy::module_inception)]
     pub mod activity_result {
         tonic::include_proto!("coresdk.activity_result");
+        use super::super::temporal::api::failure::v1::{
+            failure, CanceledFailureInfo, Failure as APIFailure,
+        };
         use super::common::Payload;
 
         impl ActivityResult {
             pub fn cancel_from_details(payload: Option<Payload>) -> Self {
                 Self {
-                    status: Some(activity_result::Status::Canceled(Cancelation {
-                        details: payload,
+                    status: Some(activity_result::Status::Cancelled(Cancellation {
+                        failure: Some(APIFailure {
+                            // CanceledFailure
+                            message: "Activity cancelled".to_string(),
+                            failure_info: Some(failure::FailureInfo::CanceledFailureInfo(
+                                CanceledFailureInfo {
+                                    details: payload.map(Into::into),
+                                },
+                            )),
+                            ..Default::default()
+                        }),
                     })),
                 }
             }

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -346,7 +346,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
             variant: Some(wf_activation_job::Variant::ResolveActivity(
                 ResolveActivity {
                     result: Some(ActivityResult {
-                        status: Some(activity_result::activity_result::Status::Canceled(_))
+                        status: Some(activity_result::activity_result::Status::Cancelled(_))
                     }),
                     ..
                 }
@@ -508,11 +508,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
     core.complete_activity_task(ActivityTaskCompletion {
         task_token: activity_task.task_token,
         task_queue: task_q.to_string(),
-        result: Some(ActivityResult {
-            status: Some(activity_result::activity_result::Status::Canceled(
-                activity_result::Cancelation { details: None },
-            )),
-        }),
+        result: Some(ActivityResult::cancel_from_details(None)),
     })
     .await
     .unwrap();


### PR DESCRIPTION
Unifies failure handling all across the API, it's a step toward closing https://github.com/temporalio/sdk-node/issues/178.