### PR TITLE
Protos moved to own crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["development-tools"]
 # TODO: Feature flag opentelem stuff
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 arc-swap = "1.3"
-base64 = "0.13"
+async-trait = "0.1"
 backoff = "0.3.0"
+base64 = "0.13"
 crossbeam = "0.8"
 dashmap = "4.0"
 derive_builder = "0.10"
@@ -47,6 +47,11 @@ tracing-subscriber = "0.2"
 url = "2.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 
+# 1st party local deps
+[dependencies.temporal-sdk-core-protos]
+path = "sdk-core-protos"
+version = "0.1"
+
 [dependencies.rustfsm]
 path = "fsm"
 version = "0.1"
@@ -62,7 +67,7 @@ test_utils = { path = "test_utils" }
 tonic-build = "0.5"
 
 [workspace]
-members = [".", "fsm", "test_utils"]
+members = [".", "fsm", "test_utils", "sdk-core-protos"]
 
 [[test]]
 name = "integ_tests"

--- a/protos/local/core_interface.proto
+++ b/protos/local/core_interface.proto
@@ -16,7 +16,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 
-// A request as given to [crate::Core::record_activity_heartbeat]
+// A request as given to `record_activity_heartbeat`
 message ActivityHeartbeat {
     bytes task_token = 1;
     // The task queue / worker this activity is associated with
@@ -24,7 +24,7 @@ message ActivityHeartbeat {
     repeated common.Payload details = 3;
 }
 
-// A request as given to [crate::Core::complete_activity_task]
+// A request as given to `complete_activity_task`
 message ActivityTaskCompletion {
     bytes task_token = 1;
     // The task queue / worker this task is associated with

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity="Crate"

--- a/sdk-core-protos/Cargo.toml
+++ b/sdk-core-protos/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "temporal-sdk-core-protos"
+version = "0.1.0"
+edition = "2018"
+authors = ["Spencer Judge <spencer@temporal.io>"]
+license-file = "LICENSE.txt"
+description = "Protobuf definitions for Temporal SDKs Core/Lang interface"
+homepage = "https://temporal.io/"
+repository = "https://github.com/temporalio/sdk-core"
+keywords = ["temporal", "workflow"]
+categories = ["development-tools"]
+
+[dependencies]
+derive_more = "0.99"
+prost = "0.8"
+prost-types = "0.8"
+tonic = "0.5"
+
+[build-dependencies]
+tonic-build = "0.5"

--- a/sdk-core-protos/LICENSE.txt
+++ b/sdk-core-protos/LICENSE.txt
@@ -1,0 +1,23 @@
+Temporal Core SDK
+
+The MIT License
+
+Copyright (c) 2021 Temporal Technologies, Inc. All Rights Reserved
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk-core-protos/build.rs
+++ b/sdk-core-protos/build.rs
@@ -68,10 +68,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("coresdk.Task.variant", "#[derive(::derive_more::From)]")
         .compile(
             &[
-                "protos/local/core_interface.proto",
-                "protos/api_upstream/temporal/api/workflowservice/v1/service.proto",
+                "../protos/local/core_interface.proto",
+                "../protos/api_upstream/temporal/api/workflowservice/v1/service.proto",
             ],
-            &["protos/api_upstream", "protos/local"],
+            &["../protos/api_upstream", "../protos/local"],
         )?;
     Ok(())
 }

--- a/src/core_tests/activity_tasks.rs
+++ b/src/core_tests/activity_tasks.rs
@@ -2,22 +2,6 @@ use crate::{
     errors::PollActivityError,
     job_assert,
     pollers::{MockManualGateway, MockServerGatewayApis},
-    protos::{
-        coresdk::{
-            activity_result::{activity_result, ActivityResult},
-            activity_task::activity_task,
-            workflow_activation::{wf_activation_job, ResolveActivity, WfActivationJob},
-            workflow_commands::{
-                ActivityCancellationType, CompleteWorkflowExecution, RequestCancelActivity,
-                ScheduleActivity, StartTimer,
-            },
-            ActivityTaskCompletion,
-        },
-        temporal::api::workflowservice::v1::{
-            PollActivityTaskQueueResponse, RecordActivityTaskHeartbeatResponse,
-            RespondActivityTaskCompletedResponse,
-        },
-    },
     test_help::{
         build_fake_core, canned_histories, fake_sg_opts, gen_assert_and_reply, mock_core,
         mock_core_with_opts_no_workers, mock_manual_poller, mock_poller, mock_poller_from_resps,
@@ -27,15 +11,32 @@ use crate::{
     ActivityHeartbeat, ActivityTask, Core, CoreInitOptionsBuilder, CoreSDK, WorkerConfigBuilder,
 };
 use futures::FutureExt;
-use std::sync::Arc;
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
+use temporal_sdk_core_protos::{
+    coresdk::{
+        activity_result::{activity_result, ActivityResult},
+        activity_task::activity_task,
+        workflow_activation::{wf_activation_job, ResolveActivity, WfActivationJob},
+        workflow_commands::{
+            ActivityCancellationType, CompleteWorkflowExecution, RequestCancelActivity,
+            ScheduleActivity, StartTimer,
+        },
+        ActivityTaskCompletion,
+    },
+    temporal::api::workflowservice::v1::{
+        PollActivityTaskQueueResponse, RecordActivityTaskHeartbeatResponse,
+        RespondActivityTaskCompletedResponse,
+    },
+};
 use test_utils::fanout_tasks;
-use tokio::sync::Notify;
-use tokio::time::sleep;
+use tokio::{sync::Notify, time::sleep};
 
 #[tokio::test]
 async fn max_activities_respected() {

--- a/src/core_tests/child_workflows.rs
+++ b/src/core_tests/child_workflows.rs
@@ -1,8 +1,10 @@
 use crate::{
-    protos::coresdk::child_workflow::{child_workflow_result, ChildWorkflowCancellationType},
     prototype_rust_sdk::{ChildWorkflowOptions, WfContext, WorkflowFunction, WorkflowResult},
     test_help::canned_histories,
     workflow::managed_wf::ManagedWFFunc,
+};
+use temporal_sdk_core_protos::coresdk::child_workflow::{
+    child_workflow_result, ChildWorkflowCancellationType,
 };
 use tokio::join;
 

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -10,8 +10,6 @@ mod workflow_tasks;
 use crate::{
     errors::{PollActivityError, PollWfError},
     pollers::MockManualGateway,
-    protos::coresdk::workflow_completion::WfActivationCompletion,
-    protos::temporal::api::workflowservice::v1::PollActivityTaskQueueResponse,
     test_help::{
         build_fake_core, canned_histories, fake_sg_opts, hist_to_poll_resp, ResponseType, TEST_Q,
     },
@@ -19,6 +17,10 @@ use crate::{
 };
 use futures::FutureExt;
 use std::time::Duration;
+use temporal_sdk_core_protos::{
+    coresdk::workflow_completion::WfActivationCompletion,
+    temporal::api::workflowservice::v1::PollActivityTaskQueueResponse,
+};
 use tokio::{sync::Barrier, time::sleep};
 
 #[tokio::test]

--- a/src/core_tests/queries.rs
+++ b/src/core_tests/queries.rs
@@ -1,22 +1,23 @@
-use std::collections::{HashMap, VecDeque};
-
 use crate::{
     pollers::MockServerGatewayApis,
-    protos::{
-        coresdk::{
-            workflow_activation::{wf_activation_job, WfActivationJob},
-            workflow_commands::{CompleteWorkflowExecution, QueryResult, QuerySuccess, StartTimer},
-            workflow_completion::WfActivationCompletion,
-        },
-        temporal::api::failure::v1::Failure,
-        temporal::api::history::v1::History,
-        temporal::api::query::v1::WorkflowQuery,
-        temporal::api::workflowservice::v1::{
+    test_help::{canned_histories, hist_to_poll_resp, mock_core, MocksHolder, TEST_Q},
+    Core,
+};
+use std::collections::{HashMap, VecDeque};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        workflow_activation::{wf_activation_job, WfActivationJob},
+        workflow_commands::{CompleteWorkflowExecution, QueryResult, QuerySuccess, StartTimer},
+        workflow_completion::WfActivationCompletion,
+    },
+    temporal::api::{
+        failure::v1::Failure,
+        history::v1::History,
+        query::v1::WorkflowQuery,
+        workflowservice::v1::{
             RespondQueryTaskCompletedResponse, RespondWorkflowTaskCompletedResponse,
         },
     },
-    test_help::{canned_histories, hist_to_poll_resp, mock_core, MocksHolder, TEST_Q},
-    Core,
 };
 
 #[rstest::rstest]

--- a/src/core_tests/replay_flag.rs
+++ b/src/core_tests/replay_flag.rs
@@ -1,11 +1,11 @@
-use crate::workflow::managed_wf::ManagedWFFunc;
 use crate::{
-    protos::temporal::api::enums::v1::CommandType,
     prototype_rust_sdk::{WfContext, WorkflowFunction},
     test_help::canned_histories,
+    workflow::managed_wf::ManagedWFFunc,
 };
 use rstest::{fixture, rstest};
 use std::time::Duration;
+use temporal_sdk_core_protos::temporal::api::enums::v1::CommandType;
 
 fn timers_wf(num_timers: u32) -> WorkflowFunction {
     WorkflowFunction::new(move |mut command_sink: WfContext| async move {

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -1,14 +1,5 @@
 use crate::{
     pollers::{MockManualGateway, MockManualPoller, MockServerGatewayApis},
-    protos::coresdk::{
-        workflow_activation::wf_activation_job,
-        workflow_commands::{
-            workflow_command, ActivityCancellationType, CompleteWorkflowExecution,
-            RequestCancelActivity, ScheduleActivity, StartTimer,
-        },
-        workflow_completion::WfActivationCompletion,
-    },
-    protos::temporal::api::workflowservice::v1::RespondWorkflowTaskCompletedResponse,
     test_help::{
         build_fake_core, build_multihist_mock_sg, canned_histories, hist_to_poll_resp, mock_core,
         mock_core_with_opts_no_workers, register_mock_workers, single_hist_mock_sg,
@@ -19,6 +10,17 @@ use crate::{
 use futures::FutureExt;
 use rstest::{fixture, rstest};
 use std::time::Duration;
+use temporal_sdk_core_protos::{
+    coresdk::{
+        workflow_activation::wf_activation_job,
+        workflow_commands::{
+            workflow_command, ActivityCancellationType, CompleteWorkflowExecution,
+            RequestCancelActivity, ScheduleActivity, StartTimer,
+        },
+        workflow_completion::WfActivationCompletion,
+    },
+    temporal::api::workflowservice::v1::RespondWorkflowTaskCompletedResponse,
+};
 use tokio::sync::watch;
 
 #[tokio::test]

--- a/src/core_tests/workflow_cancels.rs
+++ b/src/core_tests/workflow_cancels.rs
@@ -1,17 +1,17 @@
 use crate::{
     job_assert,
-    protos::coresdk::{
-        workflow_activation::{wf_activation_job, WfActivationJob},
-        workflow_commands::{
-            CancelWorkflowExecution, CompleteWorkflowExecution, FailWorkflowExecution, StartTimer,
-        },
-    },
     test_help::{
         build_fake_core, canned_histories, gen_assert_and_reply, poll_and_reply, ResponseType,
     },
     workflow::WorkflowCachingPolicy::NonSticky,
 };
 use rstest::rstest;
+use temporal_sdk_core_protos::coresdk::{
+    workflow_activation::{wf_activation_job, WfActivationJob},
+    workflow_commands::{
+        CancelWorkflowExecution, CompleteWorkflowExecution, FailWorkflowExecution, StartTimer,
+    },
+};
 
 enum CompletionType {
     Complete,

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -1,32 +1,12 @@
-use crate::test_help::poll_and_reply_clears_outstanding_evicts;
 use crate::{
     errors::PollWfError,
     job_assert,
     pollers::MockServerGatewayApis,
-    protos::{
-        coresdk::{
-            activity_result::{self as ar, activity_result, ActivityResult},
-            workflow_activation::{
-                wf_activation_job, FireTimer, ResolveActivity, StartWorkflow, UpdateRandomSeed,
-                WfActivationJob,
-            },
-            workflow_commands::{
-                ActivityCancellationType, CancelTimer, CompleteWorkflowExecution,
-                FailWorkflowExecution, RequestCancelActivity, ScheduleActivity, StartTimer,
-            },
-        },
-        temporal::api::{
-            enums::v1::EventType,
-            failure::v1::Failure,
-            history::v1::{history_event, TimerFiredEventAttributes},
-            workflowservice::v1::RespondWorkflowTaskCompletedResponse,
-        },
-    },
     test_help::{
         build_fake_core, build_multihist_mock_sg, canned_histories, gen_assert_and_fail,
         gen_assert_and_reply, hist_to_poll_resp, mock_core, mock_core_with_opts_no_workers,
-        poll_and_reply, single_hist_mock_sg, FakeWfResponses, MocksHolder, ResponseType,
-        TestHistoryBuilder, TEST_Q,
+        poll_and_reply, poll_and_reply_clears_outstanding_evicts, single_hist_mock_sg,
+        FakeWfResponses, MocksHolder, ResponseType, TestHistoryBuilder, TEST_Q,
     },
     workflow::WorkflowCachingPolicy::{self, AfterEveryReply, NonSticky},
     Core, CoreInitOptionsBuilder, CoreSDK, WfActivationCompletion, WorkerConfigBuilder,
@@ -36,6 +16,25 @@ use std::{
     collections::VecDeque,
     sync::atomic::{AtomicU64, AtomicUsize, Ordering},
     time::Duration,
+};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        activity_result::{self as ar, activity_result, ActivityResult},
+        workflow_activation::{
+            wf_activation_job, FireTimer, ResolveActivity, StartWorkflow, UpdateRandomSeed,
+            WfActivationJob,
+        },
+        workflow_commands::{
+            ActivityCancellationType, CancelTimer, CompleteWorkflowExecution,
+            FailWorkflowExecution, RequestCancelActivity, ScheduleActivity, StartTimer,
+        },
+    },
+    temporal::api::{
+        enums::v1::EventType,
+        failure::v1::Failure,
+        history::v1::{history_event, TimerFiredEventAttributes},
+        workflowservice::v1::RespondWorkflowTaskCompletedResponse,
+    },
 };
 use test_utils::fanout_tasks;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,9 @@
 //! Error types exposed by public APIs
 
-use crate::{
-    machines::WFMachinesError, protos::coresdk::activity_result::ActivityResult,
-    protos::coresdk::workflow_completion::WfActivationCompletion,
-    protos::temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse, WorkerLookupErr,
+use crate::{machines::WFMachinesError, WorkerLookupErr};
+use temporal_sdk_core_protos::{
+    coresdk::{activity_result::ActivityResult, workflow_completion::WfActivationCompletion},
+    temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse,
 };
 use tonic::codegen::http::uri::InvalidUri;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ pub extern crate assert_matches;
 extern crate tracing;
 
 pub mod errors;
-pub mod protos;
 pub mod prototype_rust_sdk;
 
 pub(crate) mod core_tracing;
@@ -33,7 +32,6 @@ pub use core_tracing::tracing_init;
 pub use pollers::{
     ClientTlsConfig, RetryConfig, ServerGateway, ServerGatewayApis, ServerGatewayOptions, TlsConfig,
 };
-pub use protosext::IntoCompletion;
 pub use url::Url;
 pub use worker::{WorkerConfig, WorkerConfigBuilder};
 
@@ -42,23 +40,24 @@ use crate::{
         ActivityHeartbeatError, CompleteActivityError, CompleteWfError, CoreInitError,
         PollActivityError, PollWfError, WorkerRegistrationError,
     },
-    protos::coresdk::{
-        activity_task::ActivityTask, workflow_activation::WfActivation,
-        workflow_completion::WfActivationCompletion, ActivityHeartbeat, ActivityTaskCompletion,
-    },
+    pollers::GatewayRef,
     task_token::TaskToken,
-    worker::WorkerDispatcher,
+    worker::{Worker, WorkerDispatcher},
 };
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    ops::Deref,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+use temporal_sdk_core_protos::coresdk::{
+    activity_task::ActivityTask, workflow_activation::WfActivation,
+    workflow_completion::WfActivationCompletion, ActivityHeartbeat, ActivityTaskCompletion,
 };
 
-use crate::pollers::GatewayRef;
 #[cfg(test)]
 use crate::test_help::MockWorker;
-use crate::worker::Worker;
-use std::ops::Deref;
 
 lazy_static::lazy_static! {
     /// A process-wide unique string, which will be different on every startup

--- a/src/machines/cancel_external_state_machine.rs
+++ b/src/machines/cancel_external_state_machine.rs
@@ -1,23 +1,21 @@
-use crate::{
-    machines::{
-        workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind,
-        NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
-    },
-    protos::{
-        coresdk::common::NamespacedWorkflowExecution,
-        coresdk::workflow_activation::ResolveRequestCancelExternalWorkflow,
-        temporal::api::command::v1::{
-            command, Command, RequestCancelExternalWorkflowExecutionCommandAttributes,
-        },
-        temporal::api::enums::v1::{
-            CancelExternalWorkflowExecutionFailedCause, CommandType, EventType,
-        },
-        temporal::api::failure::v1::{failure::FailureInfo, ApplicationFailureInfo, Failure},
-        temporal::api::history::v1::{history_event, HistoryEvent},
-    },
+use crate::machines::{
+    workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind, NewMachineWithCommand,
+    OnEventWrapper, WFMachinesAdapter, WFMachinesError,
 };
 use rustfsm::{fsm, TransitionResult};
 use std::convert::TryFrom;
+use temporal_sdk_core_protos::{
+    coresdk::{
+        common::NamespacedWorkflowExecution,
+        workflow_activation::ResolveRequestCancelExternalWorkflow,
+    },
+    temporal::api::{
+        command::v1::{command, Command, RequestCancelExternalWorkflowExecutionCommandAttributes},
+        enums::v1::{CancelExternalWorkflowExecutionFailedCause, CommandType, EventType},
+        failure::v1::{failure::FailureInfo, ApplicationFailureInfo, Failure},
+        history::v1::{history_event, HistoryEvent},
+    },
+};
 
 fsm! {
     pub(super)
@@ -232,9 +230,11 @@ impl Cancellable for CancelExternalMachine {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prototype_rust_sdk::{WfContext, WorkflowFunction, WorkflowResult};
-    use crate::test_help::TestHistoryBuilder;
-    use crate::workflow::managed_wf::ManagedWFFunc;
+    use crate::{
+        prototype_rust_sdk::{WfContext, WorkflowFunction, WorkflowResult},
+        test_help::TestHistoryBuilder,
+        workflow::managed_wf::ManagedWFFunc,
+    };
 
     async fn cancel_sender(mut ctx: WfContext) -> WorkflowResult<()> {
         let res = ctx

--- a/src/machines/cancel_workflow_state_machine.rs
+++ b/src/machines/cancel_workflow_state_machine.rs
@@ -1,16 +1,16 @@
-use crate::{
-    machines::{
-        Cancellable, EventInfo, HistoryEvent, MachineKind, MachineResponse, NewMachineWithCommand,
-        OnEventWrapper, WFMachinesAdapter, WFMachinesError,
-    },
-    protos::{
-        coresdk::workflow_commands::CancelWorkflowExecution,
-        temporal::api::command::v1::Command,
-        temporal::api::enums::v1::{CommandType, EventType},
-    },
+use crate::machines::{
+    Cancellable, EventInfo, HistoryEvent, MachineKind, MachineResponse, NewMachineWithCommand,
+    OnEventWrapper, WFMachinesAdapter, WFMachinesError,
 };
 use rustfsm::{fsm, TransitionResult};
 use std::convert::TryFrom;
+use temporal_sdk_core_protos::{
+    coresdk::workflow_commands::CancelWorkflowExecution,
+    temporal::api::{
+        command::v1::Command,
+        enums::v1::{CommandType, EventType},
+    },
+};
 
 fsm! {
     pub(super)
@@ -121,14 +121,15 @@ impl Cancellable for CancelWorkflowMachine {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prototype_rust_sdk::WfExitValue;
     use crate::{
-        protos::coresdk::workflow_activation::{wf_activation_job, WfActivationJob},
-        prototype_rust_sdk::{WfContext, WorkflowFunction, WorkflowResult},
+        prototype_rust_sdk::{WfContext, WfExitValue, WorkflowFunction, WorkflowResult},
         test_help::canned_histories,
         workflow::managed_wf::ManagedWFFunc,
     };
     use std::time::Duration;
+    use temporal_sdk_core_protos::coresdk::workflow_activation::{
+        wf_activation_job, WfActivationJob,
+    };
 
     async fn wf_with_timer(mut ctx: WfContext) -> WorkflowResult<()> {
         ctx.timer(Duration::from_millis(500)).await;

--- a/src/machines/child_workflow_state_machine.rs
+++ b/src/machines/child_workflow_state_machine.rs
@@ -1,43 +1,39 @@
-use crate::{
-    machines::{
-        workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind,
-        NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
-    },
-    protos::{
-        coresdk::{
-            child_workflow::{
-                self as wfr, child_workflow_result::Status as ChildWorkflowStatus,
-                ChildWorkflowCancellationType, ChildWorkflowResult,
-            },
-            common::Payload,
-            workflow_activation::{
-                resolve_child_workflow_execution_start, ResolveChildWorkflowExecution,
-                ResolveChildWorkflowExecutionStart, ResolveChildWorkflowExecutionStartCancelled,
-                ResolveChildWorkflowExecutionStartFailure,
-                ResolveChildWorkflowExecutionStartSuccess,
-            },
-            workflow_commands::StartChildWorkflowExecution,
-        },
-        temporal::api::{
-            command::v1::Command,
-            common::v1::{Payloads, WorkflowExecution, WorkflowType},
-            enums::v1::{
-                CommandType, EventType, RetryState, StartChildWorkflowExecutionFailedCause,
-                TimeoutType,
-            },
-            failure::v1::{self as failure, failure::FailureInfo, Failure},
-            history::v1::{
-                history_event, ChildWorkflowExecutionCompletedEventAttributes,
-                ChildWorkflowExecutionFailedEventAttributes,
-                ChildWorkflowExecutionStartedEventAttributes,
-                ChildWorkflowExecutionTimedOutEventAttributes, HistoryEvent,
-                StartChildWorkflowExecutionFailedEventAttributes,
-            },
-        },
-    },
+use crate::machines::{
+    workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind, NewMachineWithCommand,
+    OnEventWrapper, WFMachinesAdapter, WFMachinesError,
 };
 use rustfsm::{fsm, MachineError, TransitionResult};
 use std::convert::{TryFrom, TryInto};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        child_workflow::{
+            self as wfr, child_workflow_result::Status as ChildWorkflowStatus,
+            ChildWorkflowCancellationType, ChildWorkflowResult,
+        },
+        common::Payload,
+        workflow_activation::{
+            resolve_child_workflow_execution_start, ResolveChildWorkflowExecution,
+            ResolveChildWorkflowExecutionStart, ResolveChildWorkflowExecutionStartCancelled,
+            ResolveChildWorkflowExecutionStartFailure, ResolveChildWorkflowExecutionStartSuccess,
+        },
+        workflow_commands::StartChildWorkflowExecution,
+    },
+    temporal::api::{
+        command::v1::Command,
+        common::v1::{Payloads, WorkflowExecution, WorkflowType},
+        enums::v1::{
+            CommandType, EventType, RetryState, StartChildWorkflowExecutionFailedCause, TimeoutType,
+        },
+        failure::v1::{self as failure, failure::FailureInfo, Failure},
+        history::v1::{
+            history_event, ChildWorkflowExecutionCompletedEventAttributes,
+            ChildWorkflowExecutionFailedEventAttributes,
+            ChildWorkflowExecutionStartedEventAttributes,
+            ChildWorkflowExecutionTimedOutEventAttributes, HistoryEvent,
+            StartChildWorkflowExecutionFailedEventAttributes,
+        },
+    },
+};
 
 fsm! {
     pub(super) name ChildWorkflowMachine;
@@ -626,10 +622,6 @@ fn convert_payloads(
 mod test {
     use super::*;
     use crate::{
-        protos::coresdk::{
-            child_workflow::child_workflow_result,
-            workflow_activation::resolve_child_workflow_execution_start::Status as StartStatus,
-        },
         prototype_rust_sdk::{
             CancellableFuture, ChildWorkflowOptions, WfContext, WorkflowFunction, WorkflowResult,
         },
@@ -638,6 +630,10 @@ mod test {
     };
     use anyhow::anyhow;
     use rstest::{fixture, rstest};
+    use temporal_sdk_core_protos::coresdk::{
+        child_workflow::child_workflow_result,
+        workflow_activation::resolve_child_workflow_execution_start::Status as StartStatus,
+    };
 
     #[derive(Clone, Copy)]
     enum Expectation {

--- a/src/machines/complete_workflow_state_machine.rs
+++ b/src/machines/complete_workflow_state_machine.rs
@@ -1,20 +1,17 @@
-use crate::machines::{EventInfo, MachineKind};
-use crate::{
-    machines::{
-        workflow_machines::MachineResponse, Cancellable, NewMachineWithCommand, OnEventWrapper,
-        WFMachinesAdapter, WFMachinesError,
-    },
-    protos::{
-        coresdk::workflow_commands::CompleteWorkflowExecution,
-        temporal::api::{
-            command::v1::Command,
-            enums::v1::{CommandType, EventType},
-            history::v1::HistoryEvent,
-        },
-    },
+use crate::machines::{
+    workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind, NewMachineWithCommand,
+    OnEventWrapper, WFMachinesAdapter, WFMachinesError,
 };
 use rustfsm::{fsm, TransitionResult};
 use std::convert::TryFrom;
+use temporal_sdk_core_protos::{
+    coresdk::workflow_commands::CompleteWorkflowExecution,
+    temporal::api::{
+        command::v1::Command,
+        enums::v1::{CommandType, EventType},
+        history::v1::HistoryEvent,
+    },
+};
 
 fsm! {
     pub(super)

--- a/src/machines/continue_as_new_workflow_state_machine.rs
+++ b/src/machines/continue_as_new_workflow_state_machine.rs
@@ -1,15 +1,16 @@
-use crate::machines::{EventInfo, MachineKind};
-use crate::{
-    machines::{
-        Cancellable, HistoryEvent, MachineResponse, NewMachineWithCommand, OnEventWrapper,
-        WFMachinesAdapter, WFMachinesError,
-    },
-    protos::coresdk::workflow_commands::ContinueAsNewWorkflowExecution,
-    protos::temporal::api::command::v1::Command,
-    protos::temporal::api::enums::v1::{CommandType, EventType},
+use crate::machines::{
+    Cancellable, EventInfo, HistoryEvent, MachineKind, MachineResponse, NewMachineWithCommand,
+    OnEventWrapper, WFMachinesAdapter, WFMachinesError,
 };
 use rustfsm::{fsm, TransitionResult};
 use std::convert::TryFrom;
+use temporal_sdk_core_protos::{
+    coresdk::workflow_commands::ContinueAsNewWorkflowExecution,
+    temporal::api::{
+        command::v1::Command,
+        enums::v1::{CommandType, EventType},
+    },
+};
 
 fsm! {
     pub(super)
@@ -119,9 +120,8 @@ impl Cancellable for ContinueAsNewWorkflowMachine {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prototype_rust_sdk::{WfExitValue, WorkflowResult};
     use crate::{
-        prototype_rust_sdk::{WfContext, WorkflowFunction},
+        prototype_rust_sdk::{WfContext, WfExitValue, WorkflowFunction, WorkflowResult},
         test_help::canned_histories,
         workflow::managed_wf::ManagedWFFunc,
     };

--- a/src/machines/fail_workflow_state_machine.rs
+++ b/src/machines/fail_workflow_state_machine.rs
@@ -1,16 +1,16 @@
-use crate::machines::{EventInfo, MachineKind};
-use crate::{
-    machines::{
-        workflow_machines::MachineResponse, Cancellable, NewMachineWithCommand, OnEventWrapper,
-        ProtoCommand, WFMachinesAdapter, WFMachinesError,
-    },
-    protos::coresdk::workflow_commands::FailWorkflowExecution,
-    protos::temporal::api::enums::v1::CommandType,
-    protos::temporal::api::enums::v1::EventType,
-    protos::temporal::api::history::v1::HistoryEvent,
+use crate::machines::{
+    workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind, NewMachineWithCommand,
+    OnEventWrapper, ProtoCommand, WFMachinesAdapter, WFMachinesError,
 };
 use rustfsm::{fsm, TransitionResult};
 use std::convert::TryFrom;
+use temporal_sdk_core_protos::{
+    coresdk::workflow_commands::FailWorkflowExecution,
+    temporal::api::{
+        enums::v1::{CommandType, EventType},
+        history::v1::HistoryEvent,
+    },
+};
 
 fsm! {
     pub(super) name FailWorkflowMachine;

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -27,19 +27,16 @@ mod transition_coverage;
 pub use patch_state_machine::HAS_CHANGE_MARKER_NAME;
 pub(crate) use workflow_machines::{WFMachinesError, WorkflowMachines};
 
-use crate::{
-    core_tracing::VecDisplayer,
-    machines::workflow_machines::MachineResponse,
-    protos::{
-        coresdk::workflow_commands::*,
-        temporal::api::{command::v1::Command, enums::v1::CommandType, history::v1::HistoryEvent},
-    },
-};
+use crate::{core_tracing::VecDisplayer, machines::workflow_machines::MachineResponse};
 use prost::alloc::fmt::Formatter;
 use rustfsm::{MachineError, StateMachine};
 use std::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display},
+};
+use temporal_sdk_core_protos::{
+    coresdk::workflow_commands::*,
+    temporal::api::{command::v1::Command, enums::v1::CommandType, history::v1::HistoryEvent},
 };
 
 #[cfg(test)]

--- a/src/machines/patch_state_machine.rs
+++ b/src/machines/patch_state_machine.rs
@@ -22,17 +22,18 @@ use crate::{
         workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind,
         NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
     },
-    protos::{
-        coresdk::common::build_has_change_marker_details,
-        temporal::api::{
-            command::v1::{Command, RecordMarkerCommandAttributes},
-            enums::v1::CommandType,
-            history::v1::HistoryEvent,
-        },
-    },
+    protosext::HistoryEventExt,
 };
 use rustfsm::{fsm, TransitionResult};
 use std::convert::TryFrom;
+use temporal_sdk_core_protos::{
+    coresdk::common::build_has_change_marker_details,
+    temporal::api::{
+        command::v1::{Command, RecordMarkerCommandAttributes},
+        enums::v1::CommandType,
+        history::v1::HistoryEvent,
+    },
+};
 
 pub const HAS_CHANGE_MARKER_NAME: &str = "core_patch";
 
@@ -222,29 +223,31 @@ impl TryFrom<HistoryEvent> for PatchMachineEvents {
 mod tests {
     use crate::{
         machines::{WFMachinesError, HAS_CHANGE_MARKER_NAME},
-        protos::{
-            coresdk::{
-                common::decode_change_marker_details,
-                workflow_activation::{wf_activation_job, NotifyHasPatch, WfActivationJob},
-            },
-            temporal::api::command::v1::{
-                command::Attributes, RecordMarkerCommandAttributes,
-                ScheduleActivityTaskCommandAttributes,
-            },
-            temporal::api::common::v1::ActivityType,
-            temporal::api::enums::v1::{CommandType, EventType},
-            temporal::api::history::v1::{
-                history_event, ActivityTaskCompletedEventAttributes,
-                ActivityTaskScheduledEventAttributes, ActivityTaskStartedEventAttributes,
-                TimerFiredEventAttributes,
-            },
-        },
         prototype_rust_sdk::{ActivityOptions, WfContext, WorkflowFunction},
         test_help::TestHistoryBuilder,
         workflow::managed_wf::ManagedWFFunc,
     };
     use rstest::rstest;
     use std::time::Duration;
+    use temporal_sdk_core_protos::{
+        coresdk::{
+            common::decode_change_marker_details,
+            workflow_activation::{wf_activation_job, NotifyHasPatch, WfActivationJob},
+        },
+        temporal::api::{
+            command::v1::{
+                command::Attributes, RecordMarkerCommandAttributes,
+                ScheduleActivityTaskCommandAttributes,
+            },
+            common::v1::ActivityType,
+            enums::v1::{CommandType, EventType},
+            history::v1::{
+                history_event, ActivityTaskCompletedEventAttributes,
+                ActivityTaskScheduledEventAttributes, ActivityTaskStartedEventAttributes,
+                TimerFiredEventAttributes,
+            },
+        },
+    };
 
     const MY_PATCH_ID: &str = "test_patch_id";
     #[derive(Eq, PartialEq, Copy, Clone)]

--- a/src/machines/signal_external_state_machine.rs
+++ b/src/machines/signal_external_state_machine.rs
@@ -1,27 +1,23 @@
-use crate::{
-    machines::{
-        workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind,
-        NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
-    },
-    protos::{
-        coresdk::{
-            common::{NamespacedWorkflowExecution, Payload},
-            workflow_activation::ResolveSignalExternalWorkflow,
-            IntoPayloadsExt,
-        },
-        temporal::api::{
-            command::v1::{command, Command, SignalExternalWorkflowExecutionCommandAttributes},
-            common::v1::WorkflowExecution as UpstreamWE,
-            enums::v1::{CommandType, EventType, SignalExternalWorkflowExecutionFailedCause},
-            failure::v1::{
-                failure::FailureInfo, ApplicationFailureInfo, CanceledFailureInfo, Failure,
-            },
-            history::v1::{history_event, HistoryEvent},
-        },
-    },
+use crate::machines::{
+    workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind, NewMachineWithCommand,
+    OnEventWrapper, WFMachinesAdapter, WFMachinesError,
 };
 use rustfsm::{fsm, MachineError, TransitionResult};
 use std::convert::TryFrom;
+use temporal_sdk_core_protos::{
+    coresdk::{
+        common::{NamespacedWorkflowExecution, Payload},
+        workflow_activation::ResolveSignalExternalWorkflow,
+        IntoPayloadsExt,
+    },
+    temporal::api::{
+        command::v1::{command, Command, SignalExternalWorkflowExecutionCommandAttributes},
+        common::v1::WorkflowExecution as UpstreamWE,
+        enums::v1::{CommandType, EventType, SignalExternalWorkflowExecutionFailedCause},
+        failure::v1::{failure::FailureInfo, ApplicationFailureInfo, CanceledFailureInfo, Failure},
+        history::v1::{history_event, HistoryEvent},
+    },
+};
 
 const SIG_CANCEL_MSG: &str = "Signal was cancelled before being sent";
 
@@ -285,10 +281,12 @@ impl Cancellable for SignalExternalMachine {
 mod tests {
     use super::*;
     use crate::{
-        protos::coresdk::workflow_activation::{wf_activation_job, WfActivationJob},
         prototype_rust_sdk::{CancellableFuture, WfContext, WorkflowFunction, WorkflowResult},
         test_help::TestHistoryBuilder,
         workflow::managed_wf::ManagedWFFunc,
+    };
+    use temporal_sdk_core_protos::coresdk::workflow_activation::{
+        wf_activation_job, WfActivationJob,
     };
 
     const SIGNAME: &str = "signame";

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -1,26 +1,23 @@
 #![allow(clippy::large_enum_variant)]
 
-use crate::machines::{EventInfo, MachineKind};
-use crate::{
-    machines::{
-        workflow_machines::{MachineResponse, WFMachinesError},
-        Cancellable, NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter,
-    },
-    protos::{
-        coresdk::{
-            workflow_activation::FireTimer,
-            workflow_commands::{CancelTimer, StartTimer},
-            HistoryEventId,
-        },
-        temporal::api::{
-            command::v1::Command,
-            enums::v1::{CommandType, EventType},
-            history::v1::{history_event, HistoryEvent, TimerFiredEventAttributes},
-        },
-    },
+use crate::machines::{
+    workflow_machines::{MachineResponse, WFMachinesError},
+    Cancellable, EventInfo, MachineKind, NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter,
 };
 use rustfsm::{fsm, MachineError, StateMachine, TransitionResult};
 use std::convert::TryFrom;
+use temporal_sdk_core_protos::{
+    coresdk::{
+        workflow_activation::FireTimer,
+        workflow_commands::{CancelTimer, StartTimer},
+        HistoryEventId,
+    },
+    temporal::api::{
+        command::v1::Command,
+        enums::v1::{CommandType, EventType},
+        history::v1::{history_event, HistoryEvent, TimerFiredEventAttributes},
+    },
+};
 
 fsm! {
     pub(super) name TimerMachine;
@@ -272,12 +269,10 @@ impl Cancellable for TimerMachine {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::prototype_rust_sdk::CancellableFuture;
-    use crate::prototype_rust_sdk::WorkflowFunction;
-    use crate::workflow::managed_wf::ManagedWFFunc;
     use crate::{
-        prototype_rust_sdk::WfContext,
+        prototype_rust_sdk::{CancellableFuture, WfContext, WorkflowFunction},
         test_help::{canned_histories, TestHistoryBuilder},
+        workflow::managed_wf::ManagedWFFunc,
     };
     use rstest::{fixture, rstest};
     use std::time::Duration;

--- a/src/machines/transition_coverage.rs
+++ b/src/machines/transition_coverage.rs
@@ -67,9 +67,9 @@ fn spawn_save_coverage_at_end() -> SyncSender<(String, CoveredTransition)> {
 #[cfg(test)]
 mod machine_coverage_report {
     use super::*;
-    use crate::machines::cancel_external_state_machine::CancelExternalMachine;
     use crate::machines::{
         activity_state_machine::ActivityMachine,
+        cancel_external_state_machine::CancelExternalMachine,
         cancel_workflow_state_machine::CancelWorkflowMachine,
         child_workflow_state_machine::ChildWorkflowMachine,
         complete_workflow_state_machine::CompleteWorkflowMachine,

--- a/src/machines/workflow_task_state_machine.rs
+++ b/src/machines/workflow_task_state_machine.rs
@@ -1,20 +1,17 @@
 #![allow(clippy::enum_variant_names)]
 
-use crate::{
-    machines::{
-        workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind, WFMachinesAdapter,
-        WFMachinesError,
-    },
-    protos::temporal::api::history::v1::history_event::Attributes::WorkflowTaskFailedEventAttributes,
-    protos::temporal::api::{
-        enums::v1::{CommandType, EventType, WorkflowTaskFailedCause},
-        history::v1::HistoryEvent,
-    },
+use crate::machines::{
+    workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind, WFMachinesAdapter,
+    WFMachinesError,
 };
 use rustfsm::{fsm, TransitionResult};
 use std::{
     convert::{TryFrom, TryInto},
     time::SystemTime,
+};
+use temporal_sdk_core_protos::temporal::api::{
+    enums::v1::{CommandType, EventType, WorkflowTaskFailedCause},
+    history::v1::{history_event::Attributes::WorkflowTaskFailedEventAttributes, HistoryEvent},
 };
 
 fsm! {

--- a/src/pending_activations.rs
+++ b/src/pending_activations.rs
@@ -1,10 +1,12 @@
-use crate::protos::coresdk::workflow_activation::{
-    wf_activation_job, WfActivation, WfActivationJob,
-};
 use parking_lot::RwLock;
 use slotmap::SlotMap;
-use std::cmp::Ordering;
-use std::collections::{HashMap, VecDeque};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, VecDeque},
+};
+use temporal_sdk_core_protos::coresdk::workflow_activation::{
+    wf_activation_job, WfActivation, WfActivationJob,
+};
 
 /// Tracks pending activations using an internal queue, while also allowing lookup and removal of
 /// any pending activations by run ID.
@@ -154,7 +156,7 @@ fn evictions_always_last_compare(a: &WfActivationJob, b: &WfActivationJob) -> Or
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protos::coresdk::workflow_activation::create_evict_activation;
+    use temporal_sdk_core_protos::coresdk::workflow_activation::create_evict_activation;
 
     #[test]
     fn merges_same_ids_with_evictions() {

--- a/src/pollers/gateway.rs
+++ b/src/pollers/gateway.rs
@@ -1,16 +1,5 @@
 use crate::{
     pollers::{retry::RetryGateway, Result},
-    protos::{
-        coresdk::{common::Payload, workflow_commands::QueryResult, IntoPayloadsExt},
-        temporal::api::{
-            common::v1::{Payloads, WorkflowExecution, WorkflowType},
-            enums::v1::{TaskQueueKind, WorkflowTaskFailedCause},
-            failure::v1::Failure,
-            query::v1::{WorkflowQuery, WorkflowQueryResult},
-            taskqueue::v1::TaskQueue,
-            workflowservice::v1::{workflow_service_client::WorkflowServiceClient, *},
-        },
-    },
     protosext::WorkflowTaskCompletion,
     task_token::TaskToken,
     CoreInitError,
@@ -21,6 +10,17 @@ use std::{
     ops::Deref,
     sync::Arc,
     time::{Duration, Instant},
+};
+use temporal_sdk_core_protos::{
+    coresdk::{common::Payload, workflow_commands::QueryResult, IntoPayloadsExt},
+    temporal::api::{
+        common::v1::{Payloads, WorkflowExecution, WorkflowType},
+        enums::v1::{TaskQueueKind, WorkflowTaskFailedCause},
+        failure::v1::Failure,
+        query::v1::{WorkflowQuery, WorkflowQueryResult},
+        taskqueue::v1::TaskQueue,
+        workflowservice::v1::{workflow_service_client::WorkflowServiceClient, *},
+    },
 };
 use tonic::{
     codegen::InterceptedService,

--- a/src/pollers/mod.rs
+++ b/src/pollers/mod.rs
@@ -15,7 +15,7 @@ pub use poll_buffer::{
 };
 pub use retry::RetryGateway;
 
-use crate::protos::temporal::api::workflowservice::v1::{
+use temporal_sdk_core_protos::temporal::api::workflowservice::v1::{
     PollActivityTaskQueueResponse, PollWorkflowTaskQueueResponse,
 };
 

--- a/src/pollers/poll_buffer.rs
+++ b/src/pollers/poll_buffer.rs
@@ -1,16 +1,19 @@
 use crate::{
     pollers::{self, Poller},
-    protos::temporal::api::workflowservice::v1::PollActivityTaskQueueResponse,
-    protos::temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse,
     ServerGatewayApis,
 };
 use futures::{prelude::stream::FuturesUnordered, StreamExt};
 use std::{fmt::Debug, future::Future, sync::Arc};
-use tokio::sync::{
-    mpsc::{channel, Receiver},
-    watch, Mutex, Semaphore,
+use temporal_sdk_core_protos::temporal::api::workflowservice::v1::{
+    PollActivityTaskQueueResponse, PollWorkflowTaskQueueResponse,
 };
-use tokio::task::JoinHandle;
+use tokio::{
+    sync::{
+        mpsc::{channel, Receiver},
+        watch, Mutex, Semaphore,
+    },
+    task::JoinHandle,
+};
 
 pub struct LongPollBuffer<T> {
     buffered_polls: Mutex<Receiver<pollers::Result<T>>>,

--- a/src/pollers/retry.rs
+++ b/src/pollers/retry.rs
@@ -1,24 +1,20 @@
-use std::future::Future;
-use std::{fmt::Debug, time::Duration};
-
-use backoff::backoff::Backoff;
-use backoff::ExponentialBackoff;
-use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
-
-use crate::pollers::gateway::{RetryConfig, ServerGatewayApis};
-use crate::pollers::RETRYABLE_ERROR_CODES;
 use crate::{
-    pollers::Result,
-    protos::{
-        coresdk::common::Payload,
-        coresdk::workflow_commands::QueryResult,
-        temporal::api::{
-            common::v1::Payloads, enums::v1::WorkflowTaskFailedCause, failure::v1::Failure,
-            query::v1::WorkflowQuery, workflowservice::v1::*,
-        },
+    pollers::{
+        gateway::{RetryConfig, ServerGatewayApis},
+        Result, RETRYABLE_ERROR_CODES,
     },
     protosext::WorkflowTaskCompletion,
     task_token::TaskToken,
+};
+use backoff::{backoff::Backoff, ExponentialBackoff};
+use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
+use std::{fmt::Debug, future::Future, time::Duration};
+use temporal_sdk_core_protos::{
+    coresdk::{common::Payload, workflow_commands::QueryResult},
+    temporal::api::{
+        common::v1::Payloads, enums::v1::WorkflowTaskFailedCause, failure::v1::Failure,
+        query::v1::WorkflowQuery, workflowservice::v1::*,
+    },
 };
 
 #[derive(Debug)]

--- a/src/prototype_rust_sdk/conversions.rs
+++ b/src/prototype_rust_sdk/conversions.rs
@@ -1,0 +1,8 @@
+use temporal_sdk_core_protos::temporal::api::failure::v1::Failure;
+
+pub(crate) fn anyhow_to_fail(e: anyhow::Error) -> Failure {
+    Failure {
+        message: e.to_string(),
+        ..Default::default()
+    }
+}

--- a/src/prototype_rust_sdk/workflow_context.rs
+++ b/src/prototype_rust_sdk/workflow_context.rs
@@ -1,23 +1,7 @@
-use crate::prototype_rust_sdk::CancelExternalWfResult;
-use crate::{
-    protos::coresdk::{
-        activity_result::ActivityResult,
-        child_workflow::ChildWorkflowCancellationType,
-        child_workflow::ChildWorkflowResult,
-        common::{NamespacedWorkflowExecution, Payload},
-        workflow_activation::resolve_child_workflow_execution_start::Status as ChildWorkflowStartStatus,
-        workflow_commands::{
-            request_cancel_external_workflow_execution as cancel_we,
-            signal_external_workflow_execution as sig_we, workflow_command,
-            ActivityCancellationType, RequestCancelExternalWorkflowExecution, ScheduleActivity,
-            SetPatchMarker, SignalExternalWorkflowExecution, StartChildWorkflowExecution,
-            StartTimer,
-        },
-    },
-    prototype_rust_sdk::{
-        CancellableID, CommandCreateRequest, CommandSubscribeChildWorkflowCompletion, RustWfCmd,
-        SignalExternalWfResult, TimerResult, UnblockEvent, Unblockable,
-    },
+use crate::prototype_rust_sdk::{
+    CancelExternalWfResult, CancellableID, CommandCreateRequest,
+    CommandSubscribeChildWorkflowCompletion, RustWfCmd, SignalExternalWfResult, TimerResult,
+    UnblockEvent, Unblockable,
 };
 use crossbeam::channel::{Receiver, Sender};
 use futures::{task::Context, FutureExt, Stream};
@@ -25,6 +9,18 @@ use parking_lot::RwLock;
 use std::{
     collections::HashMap, future::Future, marker::PhantomData, pin::Pin, sync::Arc, task::Poll,
     time::Duration,
+};
+use temporal_sdk_core_protos::coresdk::{
+    activity_result::ActivityResult,
+    child_workflow::{ChildWorkflowCancellationType, ChildWorkflowResult},
+    common::{NamespacedWorkflowExecution, Payload},
+    workflow_activation::resolve_child_workflow_execution_start::Status as ChildWorkflowStartStatus,
+    workflow_commands::{
+        request_cancel_external_workflow_execution as cancel_we,
+        signal_external_workflow_execution as sig_we, workflow_command, ActivityCancellationType,
+        RequestCancelExternalWorkflowExecution, ScheduleActivity, SetPatchMarker,
+        SignalExternalWorkflowExecution, StartChildWorkflowExecution, StartTimer,
+    },
 };
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/src/test_help/canned_histories.rs
+++ b/src/test_help/canned_histories.rs
@@ -1,12 +1,12 @@
-use crate::{
-    protos::coresdk::common::NamespacedWorkflowExecution,
-    protos::temporal::api::common::v1::{Payload, WorkflowExecution},
-    protos::temporal::api::enums::v1::{
-        EventType, StartChildWorkflowExecutionFailedCause, WorkflowTaskFailedCause,
+use crate::test_help::TestHistoryBuilder;
+use temporal_sdk_core_protos::{
+    coresdk::common::NamespacedWorkflowExecution,
+    temporal::api::{
+        common::v1::{Payload, WorkflowExecution},
+        enums::v1::{EventType, StartChildWorkflowExecutionFailedCause, WorkflowTaskFailedCause},
+        failure::v1::Failure,
+        history::v1::*,
     },
-    protos::temporal::api::failure::v1::Failure,
-    protos::temporal::api::history::v1::*,
-    test_help::TestHistoryBuilder,
 };
 
 ///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED

--- a/src/test_help/history_builder.rs
+++ b/src/test_help/history_builder.rs
@@ -1,14 +1,5 @@
 use crate::{
     machines::HAS_CHANGE_MARKER_NAME,
-    protos::{
-        coresdk::common::{build_has_change_marker_details, NamespacedWorkflowExecution},
-        temporal::api::{
-            common::v1::{Payload, Payloads, WorkflowExecution, WorkflowType},
-            enums::v1::{EventType, WorkflowTaskFailedCause},
-            failure::v1::Failure,
-            history::v1::{history_event::Attributes, *},
-        },
-    },
     test_help::{
         history_info::{HistoryInfo, HistoryInfoError},
         Result,
@@ -17,6 +8,15 @@ use crate::{
 };
 use anyhow::bail;
 use std::time::SystemTime;
+use temporal_sdk_core_protos::{
+    coresdk::common::{build_has_change_marker_details, NamespacedWorkflowExecution},
+    temporal::api::{
+        common::v1::{Payload, Payloads, WorkflowExecution, WorkflowType},
+        enums::v1::{EventType, WorkflowTaskFailedCause},
+        failure::v1::Failure,
+        history::v1::{history_event::Attributes, *},
+    },
+};
 use uuid::Uuid;
 
 #[derive(Default, Clone, Debug)]

--- a/src/test_help/history_info.rs
+++ b/src/test_help/history_info.rs
@@ -1,7 +1,7 @@
-use crate::{
-    protos::temporal::api::enums::v1::EventType,
-    protos::temporal::api::history::v1::{History, HistoryEvent},
-    workflow::HistoryUpdate,
+use crate::workflow::HistoryUpdate;
+use temporal_sdk_core_protos::temporal::api::{
+    enums::v1::EventType,
+    history::v1::{History, HistoryEvent},
 };
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/test_help/mod.rs
+++ b/src/test_help/mod.rs
@@ -3,26 +3,12 @@ pub mod canned_histories;
 mod history_builder;
 mod history_info;
 
+pub(crate) use history_builder::{TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE};
+
 use crate::{
     pollers::{
         BoxedActPoller, BoxedPoller, BoxedWFPoller, MockManualPoller, MockPoller,
         MockServerGatewayApis,
-    },
-    protos::{
-        coresdk::{
-            workflow_activation::WfActivation,
-            workflow_commands::workflow_command,
-            workflow_completion::{self, wf_activation_completion, WfActivationCompletion},
-        },
-        temporal::api::common::v1::{WorkflowExecution, WorkflowType},
-        temporal::api::enums::v1::TaskQueueKind,
-        temporal::api::failure::v1::Failure,
-        temporal::api::history::v1::History,
-        temporal::api::taskqueue::v1::TaskQueue,
-        temporal::api::workflowservice::v1::{
-            PollActivityTaskQueueResponse, PollWorkflowTaskQueueResponse,
-            RespondWorkflowTaskCompletedResponse,
-        },
     },
     task_token::TaskToken,
     workflow::WorkflowCachingPolicy,
@@ -31,8 +17,6 @@ use crate::{
 };
 use bimap::BiMap;
 use futures::FutureExt;
-pub(crate) use history_builder::TestHistoryBuilder;
-pub(crate) use history_builder::DEFAULT_WORKFLOW_TYPE;
 use mockall::TimesRange;
 use parking_lot::RwLock;
 use rand::{thread_rng, Rng};
@@ -41,6 +25,24 @@ use std::{
     ops::RangeFull,
     str::FromStr,
     sync::Arc,
+};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        workflow_activation::WfActivation,
+        workflow_commands::workflow_command,
+        workflow_completion::{self, wf_activation_completion, WfActivationCompletion},
+    },
+    temporal::api::{
+        common::v1::{WorkflowExecution, WorkflowType},
+        enums::v1::TaskQueueKind,
+        failure::v1::Failure,
+        history::v1::History,
+        taskqueue::v1::TaskQueue,
+        workflowservice::v1::{
+            PollActivityTaskQueueResponse, PollWorkflowTaskQueueResponse,
+            RespondWorkflowTaskCompletedResponse,
+        },
+    },
 };
 
 pub type Result<T, E = anyhow::Error> = std::result::Result<T, E>;

--- a/src/worker/activities.rs
+++ b/src/worker/activities.rs
@@ -1,22 +1,23 @@
 mod activity_heartbeat_manager;
 
 use crate::{
-    pollers::BoxedActPoller,
-    protos::{
-        coresdk::{
-            activity_result::{self as ar, activity_result},
-            activity_task::{ActivityCancelReason, ActivityTask},
-            ActivityHeartbeat,
-        },
-        temporal::api::failure::v1::{failure::FailureInfo, CanceledFailureInfo, Failure},
-        temporal::api::workflowservice::v1::PollActivityTaskQueueResponse,
-    },
-    task_token::TaskToken,
-    ActivityHeartbeatError, CompleteActivityError, PollActivityError, ServerGatewayApis,
+    pollers::BoxedActPoller, task_token::TaskToken, ActivityHeartbeatError, CompleteActivityError,
+    PollActivityError, ServerGatewayApis,
 };
 use activity_heartbeat_manager::ActivityHeartbeatManager;
 use dashmap::DashMap;
 use std::{convert::TryInto, ops::Div, sync::Arc, time::Duration};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        activity_result::{self as ar, activity_result},
+        activity_task::{ActivityCancelReason, ActivityTask},
+        ActivityHeartbeat,
+    },
+    temporal::api::{
+        failure::v1::{failure::FailureInfo, CanceledFailureInfo, Failure},
+        workflowservice::v1::PollActivityTaskQueueResponse,
+    },
+};
 use tokio::sync::Semaphore;
 
 #[derive(Debug, derive_more::Constructor)]
@@ -247,7 +248,7 @@ impl WorkerActivityTasks {
                     details.known_not_found = true;
                 }
                 Ok(Some(ActivityTask::cancel_from_ids(
-                    task_token,
+                    task_token.0,
                     details.activity_id.clone(),
                     reason,
                 )))

--- a/src/worker/activities/activity_heartbeat_manager.rs
+++ b/src/worker/activities/activity_heartbeat_manager.rs
@@ -1,13 +1,5 @@
 use crate::{
-    errors::ActivityHeartbeatError,
-    pollers::ServerGatewayApis,
-    protos::{
-        coresdk::{
-            activity_task::ActivityCancelReason, common, ActivityHeartbeat, IntoPayloadsExt,
-        },
-        temporal::api::workflowservice::v1::RecordActivityTaskHeartbeatResponse,
-    },
-    task_token::TaskToken,
+    errors::ActivityHeartbeatError, pollers::ServerGatewayApis, task_token::TaskToken,
     worker::activities::PendingActivityCancel,
 };
 use futures::StreamExt;
@@ -15,6 +7,10 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Arc,
     time::{self, Duration, Instant},
+};
+use temporal_sdk_core_protos::{
+    coresdk::{activity_task::ActivityCancelReason, common, ActivityHeartbeat, IntoPayloadsExt},
+    temporal::api::workflowservice::v1::RecordActivityTaskHeartbeatResponse,
 };
 use tokio::{
     sync::{
@@ -253,15 +249,12 @@ impl ActivityHeartbeatManager {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_help::TEST_Q;
-    use crate::{
-        pollers::MockServerGatewayApis,
-        protos::{
-            coresdk::common::Payload,
-            temporal::api::workflowservice::v1::RecordActivityTaskHeartbeatResponse,
-        },
-    };
+    use crate::{pollers::MockServerGatewayApis, test_help::TEST_Q};
     use std::time::Duration;
+    use temporal_sdk_core_protos::{
+        coresdk::common::Payload,
+        temporal::api::workflowservice::v1::RecordActivityTaskHeartbeatResponse,
+    };
     use tokio::time::sleep;
 
     /// Ensure that heartbeats that are sent with a small delay are aggregated and sent roughly once

--- a/src/workflow/driven_workflow.rs
+++ b/src/workflow/driven_workflow.rs
@@ -1,13 +1,11 @@
-use crate::{
-    machines::WFCommand,
-    protos::{
-        coresdk::workflow_activation::{
-            wf_activation_job, CancelWorkflow, SignalWorkflow, WfActivationJob,
-        },
-        temporal::api::history::v1::WorkflowExecutionStartedEventAttributes,
-    },
-};
+use crate::machines::WFCommand;
 use std::collections::VecDeque;
+use temporal_sdk_core_protos::{
+    coresdk::workflow_activation::{
+        wf_activation_job, CancelWorkflow, SignalWorkflow, WfActivationJob,
+    },
+    temporal::api::history::v1::WorkflowExecutionStartedEventAttributes,
+};
 
 /// Abstracts away the concept of an actual workflow implementation, handling sending it new
 /// jobs and fetching output from it.

--- a/src/workflow/history_update.rs
+++ b/src/workflow/history_update.rs
@@ -1,9 +1,4 @@
-use crate::{
-    protos::temporal::api::enums::v1::EventType,
-    protos::temporal::api::history::v1::{History, HistoryEvent},
-    protos::temporal::api::workflowservice::v1::GetWorkflowExecutionHistoryResponse,
-    ServerGatewayApis,
-};
+use crate::ServerGatewayApis;
 use futures::{future::BoxFuture, stream, stream::BoxStream, FutureExt, Stream, StreamExt};
 use std::{
     collections::VecDeque,
@@ -11,6 +6,11 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+};
+use temporal_sdk_core_protos::temporal::api::{
+    enums::v1::EventType,
+    history::v1::{History, HistoryEvent},
+    workflowservice::v1::GetWorkflowExecutionHistoryResponse,
 };
 
 /// A slimmed down version of a poll workflow task response which includes just the info needed
@@ -230,8 +230,7 @@ impl HistoryUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pollers::MockServerGatewayApis;
-    use crate::test_help::canned_histories;
+    use crate::{pollers::MockServerGatewayApis, test_help::canned_histories};
 
     #[tokio::test]
     async fn consumes_standard_wft_sequence() {

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -7,11 +7,9 @@ pub(crate) use bridge::WorkflowBridge;
 pub(crate) use driven_workflow::{DrivenWorkflow, WorkflowFetcher};
 pub(crate) use history_update::{HistoryPaginator, HistoryUpdate};
 
-use crate::{
-    machines::{ProtoCommand, WFCommand, WFMachinesError, WorkflowMachines},
-    protos::coresdk::workflow_activation::WfActivation,
-};
+use crate::machines::{ProtoCommand, WFCommand, WFMachinesError, WorkflowMachines};
 use std::sync::mpsc::Sender;
+use temporal_sdk_core_protos::coresdk::workflow_activation::WfActivation;
 
 pub(crate) const LEGACY_QUERY_ID: &str = "legacy_query";
 type Result<T, E = WFMachinesError> = std::result::Result<T, E>;
@@ -148,17 +146,16 @@ pub mod managed_wf {
     use super::*;
     use crate::{
         machines::WFCommand,
-        protos::coresdk::{
-            common::Payload,
-            workflow_activation::create_evict_activation,
-            workflow_completion::{wf_activation_completion::Status, WfActivationCompletion},
-        },
         prototype_rust_sdk::{WorkflowFunction, WorkflowResult},
-        test_help::TestHistoryBuilder,
-        test_help::TEST_Q,
+        test_help::{TestHistoryBuilder, TEST_Q},
         workflow::WorkflowFetcher,
     };
     use std::convert::TryInto;
+    use temporal_sdk_core_protos::coresdk::{
+        common::Payload,
+        workflow_activation::create_evict_activation,
+        workflow_completion::{wf_activation_completion::Status, WfActivationCompletion},
+    };
     use tokio::{
         sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
         task::JoinHandle,

--- a/src/workflow/workflow_tasks/concurrency_manager.rs
+++ b/src/workflow/workflow_tasks/concurrency_manager.rs
@@ -1,6 +1,5 @@
 use crate::{
     errors::WorkflowUpdateError,
-    protos::coresdk::workflow_activation::WfActivation,
     protosext::ValidPollWFTQResponse,
     workflow::{
         workflow_tasks::{OutstandingActivation, OutstandingTask},
@@ -14,6 +13,7 @@ use std::{
     fmt::Debug,
     ops::{Deref, DerefMut},
 };
+use temporal_sdk_core_protos::coresdk::workflow_activation::WfActivation;
 
 /// Provides a thread-safe way to access workflow machines for specific workflow runs
 pub(crate) struct WorkflowConcurrencyManager {

--- a/src/workflow/workflow_tasks/mod.rs
+++ b/src/workflow/workflow_tasks/mod.rs
@@ -8,15 +8,7 @@ use crate::{
     machines::{ProtoCommand, WFCommand, WFMachinesError},
     pending_activations::PendingActivations,
     pollers::GatewayRef,
-    protos::coresdk::{
-        workflow_activation::{
-            create_evict_activation, create_query_activation, wf_activation_job, QueryWorkflow,
-            WfActivation,
-        },
-        workflow_commands::QueryResult,
-        FromPayloadsExt,
-    },
-    protosext::ValidPollWFTQResponse,
+    protosext::{ValidPollWFTQResponse, WfActivationExt},
     task_token::TaskToken,
     workflow::{
         workflow_tasks::{
@@ -29,6 +21,14 @@ use crossbeam::queue::SegQueue;
 use futures::FutureExt;
 use parking_lot::Mutex;
 use std::{fmt::Debug, ops::DerefMut};
+use temporal_sdk_core_protos::coresdk::{
+    workflow_activation::{
+        create_evict_activation, create_query_activation, wf_activation_job, QueryWorkflow,
+        WfActivation,
+    },
+    workflow_commands::QueryResult,
+    FromPayloadsExt,
+};
 use tokio::sync::watch;
 
 /// Centralizes concerns related to applying new workflow tasks and reporting the activations they

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -13,3 +13,7 @@ temporal-sdk-core = { path = ".." }
 rand = "0.8"
 url = "2.2"
 base64 = "0.13"
+
+[dependencies.temporal-sdk-core-protos]
+path = "../sdk-core-protos"
+version = "0.1"

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -2,14 +2,15 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use rand::{distributions::Standard, Rng};
 use std::{convert::TryFrom, env, future::Future, sync::Arc, time::Duration};
 use temporal_sdk_core::{
-    protos::coresdk::workflow_commands::{
+    prototype_rust_sdk::TestRustWorker, Core, CoreInitOptions, CoreInitOptionsBuilder,
+    ServerGatewayApis, ServerGatewayOptions, WorkerConfig, WorkerConfigBuilder,
+};
+use temporal_sdk_core_protos::coresdk::{
+    workflow_commands::{
         workflow_command, ActivityCancellationType, CompleteWorkflowExecution, ScheduleActivity,
         StartTimer,
     },
-    protos::coresdk::workflow_completion::WfActivationCompletion,
-    prototype_rust_sdk::TestRustWorker,
-    Core, CoreInitOptions, CoreInitOptionsBuilder, ServerGatewayApis, ServerGatewayOptions,
-    WorkerConfig, WorkerConfigBuilder,
+    workflow_completion::WfActivationCompletion,
 };
 use url::Url;
 

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -1,14 +1,13 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
-use temporal_sdk_core::protos::coresdk::{
+use temporal_sdk_core_protos::coresdk::{
     activity_result::{self, activity_result as act_res, ActivityResult},
     activity_task::activity_task as act_task,
     common::Payload,
     workflow_activation::{wf_activation_job, ResolveActivity, WfActivationJob},
     workflow_commands::ActivityCancellationType,
-    ActivityHeartbeat, ActivityTaskCompletion,
+    ActivityHeartbeat, ActivityTaskCompletion, IntoCompletion,
 };
-use temporal_sdk_core::IntoCompletion;
 use test_utils::{init_core_and_create_wf, schedule_activity_cmd, CoreTestHelpers};
 use tokio::time::sleep;
 

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -3,14 +3,15 @@ use crossbeam::channel::{unbounded, RecvTimeoutError};
 use futures::future::join_all;
 use std::time::Duration;
 use temporal_sdk_core::{
-    protos::coresdk::{
-        activity_task::activity_task as act_task,
-        workflow_activation::{wf_activation_job, FireTimer, WfActivationJob},
-        workflow_commands::{ActivityCancellationType, RequestCancelActivity, StartTimer},
-        workflow_completion::WfActivationCompletion,
-    },
     prototype_rust_sdk::{WfContext, WorkflowResult},
-    Core, CoreInitOptionsBuilder, IntoCompletion,
+    Core, CoreInitOptionsBuilder,
+};
+use temporal_sdk_core_protos::coresdk::{
+    activity_task::activity_task as act_task,
+    workflow_activation::{wf_activation_job, FireTimer, WfActivationJob},
+    workflow_commands::{ActivityCancellationType, RequestCancelActivity, StartTimer},
+    workflow_completion::WfActivationCompletion,
+    IntoCompletion,
 };
 use test_utils::{
     get_integ_server_options, init_core_and_create_wf, schedule_activity_cmd, CoreTestHelpers,

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -1,13 +1,12 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
-use temporal_sdk_core::protos::{
+use temporal_sdk_core_protos::{
     coresdk::{
         workflow_activation::{wf_activation_job, WfActivationJob},
         workflow_commands::{QueryResult, QuerySuccess, StartTimer},
         workflow_completion::WfActivationCompletion,
     },
-    temporal::api::failure::v1::Failure,
-    temporal::api::query::v1::WorkflowQuery,
+    temporal::api::{failure::v1::Failure, query::v1::WorkflowQuery},
 };
 use test_utils::{init_core_and_create_wf, with_gw, CoreTestHelpers, CoreWfStarter, GwApi};
 

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -20,16 +20,18 @@ use std::{
 };
 use temporal_sdk_core::{
     errors::PollWfError,
-    protos::coresdk::{
+    prototype_rust_sdk::{WfContext, WorkflowResult},
+    Core,
+};
+use temporal_sdk_core_protos::{
+    coresdk::{
         activity_result::ActivityResult,
         workflow_activation::{wf_activation_job, WfActivation, WfActivationJob},
         workflow_commands::{ActivityCancellationType, FailWorkflowExecution, StartTimer},
         workflow_completion::WfActivationCompletion,
-        ActivityTaskCompletion,
+        ActivityTaskCompletion, IntoCompletion,
     },
-    protos::temporal::api::failure::v1::Failure,
-    prototype_rust_sdk::{WfContext, WorkflowResult},
-    Core, IntoCompletion,
+    temporal::api::failure::v1::Failure,
 };
 use test_utils::{
     init_core_and_create_wf, schedule_activity_cmd, with_gw, CoreTestHelpers, CoreWfStarter, GwApi,

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -1,19 +1,20 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
-use temporal_sdk_core::{
-    protos::coresdk::{
+use temporal_sdk_core_protos::{
+    coresdk::{
         activity_result::{self, activity_result as act_res, ActivityResult},
         activity_task::activity_task as act_task,
         common::Payload,
         workflow_activation::{wf_activation_job, FireTimer, ResolveActivity, WfActivationJob},
         workflow_commands::{ActivityCancellationType, RequestCancelActivity, StartTimer},
         workflow_completion::WfActivationCompletion,
-        ActivityTaskCompletion,
+        ActivityTaskCompletion, IntoCompletion,
     },
-    protos::temporal::api::common::v1::ActivityType,
-    protos::temporal::api::enums::v1::RetryState,
-    protos::temporal::api::failure::v1::{failure::FailureInfo, ActivityFailureInfo, Failure},
-    IntoCompletion,
+    temporal::api::{
+        common::v1::ActivityType,
+        enums::v1::RetryState,
+        failure::v1::{failure::FailureInfo, ActivityFailureInfo, Failure},
+    },
 };
 use test_utils::{init_core_and_create_wf, schedule_activity_cmd, CoreTestHelpers};
 use tokio::time::sleep;

--- a/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -1,7 +1,5 @@
-use temporal_sdk_core::{
-    protos::coresdk::common::NamespacedWorkflowExecution,
-    prototype_rust_sdk::{WfContext, WorkflowResult},
-};
+use temporal_sdk_core::prototype_rust_sdk::{WfContext, WorkflowResult};
+use temporal_sdk_core_protos::coresdk::common::NamespacedWorkflowExecution;
 use test_utils::CoreWfStarter;
 
 const RECEIVER_WFID: &str = "sends-cancel-receiver";

--- a/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -1,8 +1,6 @@
 use std::time::Duration;
-use temporal_sdk_core::{
-    protos::temporal::api::enums::v1::WorkflowExecutionStatus,
-    prototype_rust_sdk::{WfContext, WfExitValue, WorkflowResult},
-};
+use temporal_sdk_core::prototype_rust_sdk::{WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowExecutionStatus;
 use test_utils::CoreWfStarter;
 
 async fn cancelled_wf(mut ctx: WfContext) -> WorkflowResult<()> {

--- a/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -1,8 +1,6 @@
 use anyhow::anyhow;
-use temporal_sdk_core::{
-    protos::coresdk::child_workflow::{child_workflow_result, Success},
-    prototype_rust_sdk::{ChildWorkflowOptions, WfContext, WorkflowResult},
-};
+use temporal_sdk_core::prototype_rust_sdk::{ChildWorkflowOptions, WfContext, WorkflowResult};
+use temporal_sdk_core_protos::coresdk::child_workflow::{child_workflow_result, Success};
 use test_utils::CoreWfStarter;
 
 static PARENT_WF_TYPE: &str = "parent_wf";

--- a/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -1,8 +1,6 @@
 use std::time::Duration;
-use temporal_sdk_core::{
-    protos::coresdk::workflow_commands::ContinueAsNewWorkflowExecution,
-    prototype_rust_sdk::{WfContext, WfExitValue, WorkflowResult},
-};
+use temporal_sdk_core::prototype_rust_sdk::{WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::coresdk::workflow_commands::ContinueAsNewWorkflowExecution;
 use test_utils::CoreWfStarter;
 
 async fn continue_as_new_wf(mut ctx: WfContext) -> WorkflowResult<()> {

--- a/tests/integ_tests/workflow_tests/patches.rs
+++ b/tests/integ_tests/workflow_tests/patches.rs
@@ -1,5 +1,7 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 use temporal_sdk_core::prototype_rust_sdk::{WfContext, WorkflowResult};
 use test_utils::CoreWfStarter;
 

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
-use temporal_sdk_core::protos::coresdk::{
+use temporal_sdk_core::prototype_rust_sdk::{WfContext, WorkflowResult};
+use temporal_sdk_core_protos::coresdk::{
     workflow_commands::{CancelTimer, CompleteWorkflowExecution, StartTimer},
     workflow_completion::WfActivationCompletion,
 };
-use temporal_sdk_core::prototype_rust_sdk::{WfContext, WorkflowResult};
 use test_utils::{init_core_and_create_wf, CoreTestHelpers, CoreWfStarter};
 
 pub async fn timer_wf(mut command_sink: WfContext) -> WorkflowResult<()> {

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -1,13 +1,10 @@
 use assert_matches::assert_matches;
 use futures::future::join_all;
 use std::time::{Duration, Instant};
-use temporal_sdk_core::prototype_rust_sdk::ActivityOptions;
-use temporal_sdk_core::{
-    protos::coresdk::{
-        activity_result::ActivityResult, activity_task::activity_task as act_task,
-        workflow_commands::ActivityCancellationType, ActivityTaskCompletion,
-    },
-    prototype_rust_sdk::WfContext,
+use temporal_sdk_core::prototype_rust_sdk::{ActivityOptions, WfContext};
+use temporal_sdk_core_protos::coresdk::{
+    activity_result::ActivityResult, activity_task::activity_task as act_task,
+    workflow_commands::ActivityCancellationType, ActivityTaskCompletion,
 };
 use test_utils::CoreWfStarter;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Generated protobuf code (& associated helpers that are reasonable to publicly expose) moved to own crate

## Why?
Better organization, makes it easier to depend on just interface types for other crates.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/185

2. How was this tested:
Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
