### PR TITLE
Ability to export logs to lang

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ futures = "0.3"
 futures-retry = "0.6.0"
 itertools = "0.10"
 lazy_static = "1.4"
+log = "0.4"
 lru = "0.6.5"
 once_cell = "1.5"
 opentelemetry = { version = "0.16", features = ["rt-tokio"] }
@@ -40,10 +41,10 @@ thiserror = "1.0"
 tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs"] }
 tokio-stream = "0.1"
 tonic = { version = "0.5", features = ["tls", "tls-roots"] }
-tracing = { version = "0.1", features = ["log"] }
+tracing = { version = "0.1", features = ["log-always"] }
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.15"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.2", features = ["parking_lot"] }
 url = "2.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ parking_lot = { version = "0.11", features = ["send_guard"] }
 prost = "0.8"
 prost-types = "0.8"
 rand = "0.8.3"
+ringbuf = "0.2"
 slotmap = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs"] }

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -2,7 +2,6 @@ use crate::{
     errors::PollWfError,
     job_assert,
     pollers::MockServerGatewayApis,
-    telemetry::test_telem,
     test_help::{
         build_fake_core, build_multihist_mock_sg, canned_histories, gen_assert_and_fail,
         gen_assert_and_reply, hist_to_poll_resp, mock_core, mock_core_with_opts_no_workers,
@@ -803,7 +802,6 @@ async fn two_signals(hist_batches: &'static [usize]) {
 
 #[tokio::test]
 async fn workflow_failures_only_reported_once() {
-    test_telem();
     let wfid = "fake_wf_id";
     let timer_1 = 1;
     let timer_2 = 2;

--- a/src/core_tests/workflow_tasks.rs
+++ b/src/core_tests/workflow_tasks.rs
@@ -2,6 +2,7 @@ use crate::{
     errors::PollWfError,
     job_assert,
     pollers::MockServerGatewayApis,
+    telemetry::test_telem,
     test_help::{
         build_fake_core, build_multihist_mock_sg, canned_histories, gen_assert_and_fail,
         gen_assert_and_reply, hist_to_poll_resp, mock_core, mock_core_with_opts_no_workers,
@@ -802,6 +803,7 @@ async fn two_signals(hist_batches: &'static [usize]) {
 
 #[tokio::test]
 async fn workflow_failures_only_reported_once() {
+    test_telem();
     let wfid = "fake_wf_id";
     let timer_1 = 1;
     let timer_2 = 2;

--- a/src/log_export.rs
+++ b/src/log_export.rs
@@ -1,0 +1,40 @@
+use log::{Level, Log, Metadata, Record};
+use std::{collections::VecDeque, sync::Mutex, time::Instant};
+
+/// A log line (which ultimately came from a tracing event) exported from Core->Lang
+#[derive(Debug)]
+pub struct CoreLog {
+    message: String,
+    timestamp: Instant,
+    level: Level,
+    // KV pairs aren't meaningfully exposed yet to the log interface by tracing
+}
+
+#[derive(Default)]
+pub(crate) struct CoreExportLogger {
+    records: Mutex<VecDeque<CoreLog>>,
+}
+
+impl Log for CoreExportLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        // TODO: Disable in test only mode where no lang half
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        let clog = CoreLog {
+            message: format!("{}", record.args()),
+            timestamp: Instant::now(),
+            level: record.level(),
+        };
+        dbg!(&clog);
+        self.records
+            .lock()
+            .expect("Logging mutex must be acquired")
+            .push_back(clog)
+    }
+
+    fn flush(&self) {
+        // Does nothing
+    }
+}

--- a/src/log_export.rs
+++ b/src/log_export.rs
@@ -1,40 +1,74 @@
-use log::{Level, Log, Metadata, Record};
-use std::{collections::VecDeque, sync::Mutex, time::Instant};
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use std::{
+    collections::VecDeque,
+    sync::Mutex,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 /// A log line (which ultimately came from a tracing event) exported from Core->Lang
 #[derive(Debug)]
 pub struct CoreLog {
-    message: String,
-    timestamp: Instant,
-    level: Level,
+    /// Log message
+    pub message: String,
+    /// Time log was generated (not when it was exported to lang)
+    pub timestamp: SystemTime,
+    /// Message level
+    pub level: Level,
     // KV pairs aren't meaningfully exposed yet to the log interface by tracing
 }
 
-#[derive(Default)]
+impl CoreLog {
+    /// Return timestamp as ms since epoch
+    pub fn millis_since_epoch(&self) -> u128 {
+        self.timestamp
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_millis()
+    }
+}
+
 pub(crate) struct CoreExportLogger {
     records: Mutex<VecDeque<CoreLog>>,
+    level_filter: LevelFilter,
+}
+
+impl CoreExportLogger {
+    pub(crate) fn new(level: LevelFilter) -> Self {
+        Self {
+            records: Mutex::new(Default::default()),
+            level_filter: level,
+        }
+    }
+
+    pub(crate) fn drain(&self) -> Vec<CoreLog> {
+        self.records
+            .lock()
+            .expect("Logging mutex must be acquired")
+            .drain(..)
+            .collect()
+    }
 }
 
 impl Log for CoreExportLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        // TODO: Disable in test only mode where no lang half
-        true
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        // Never forward logging from other crates
+        if !metadata.target().contains("temporal_sdk_core") {
+            return false;
+        }
+        metadata.level() <= self.level_filter
     }
 
     fn log(&self, record: &Record) {
         let clog = CoreLog {
-            message: format!("{}", record.args()),
-            timestamp: Instant::now(),
+            message: format!("[{}] {}", record.target(), record.args()),
+            timestamp: SystemTime::now(),
             level: record.level(),
         };
-        dbg!(&clog);
         self.records
             .lock()
             .expect("Logging mutex must be acquired")
             .push_back(clog)
     }
 
-    fn flush(&self) {
-        // Does nothing
-    }
+    fn flush(&self) {}
 }

--- a/src/machines/transition_coverage.rs
+++ b/src/machines/transition_coverage.rs
@@ -79,7 +79,7 @@ mod machine_coverage_report {
         workflow_task_state_machine::WorkflowTaskMachine,
     };
     use rustfsm::StateMachine;
-    use std::{fs::File, io::Write};
+    use std::{fs::File, io::Write, ops::Deref};
 
     // This "test" needs to exist so that we have a way to join the spawned thread. Otherwise
     // it'll just get abandoned.
@@ -89,10 +89,7 @@ mod machine_coverage_report {
     #[ignore]
     fn reporter() {
         // Make sure thread handle exists
-        #[allow(clippy::no_effect)] // Haha clippy, you'd be wrong here.
-        {
-            &*COVERAGE_SENDER;
-        }
+        let _ = COVERAGE_SENDER.deref();
         // Join it
         THREAD_HANDLE
             .lock()

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -466,6 +466,9 @@ impl WorkflowMachines {
 
     /// Apply the next entire workflow task from history to these machines.
     pub(crate) async fn apply_next_wft_from_history(&mut self) -> Result<()> {
+        // A much higher-up span (ex: poll) may want this field filled
+        tracing::Span::current().record("run_id", &self.run_id.as_str());
+
         let last_handled_wft_started_id = self.current_started_event_id;
         let events = self
             .last_history_from_server

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod metrics;
 
+use crate::log_export::CoreExportLogger;
 use itertools::Itertools;
+use log::set_boxed_logger;
 use once_cell::sync::OnceCell;
 use opentelemetry::{
     global,
@@ -10,6 +12,7 @@ use opentelemetry::{
 };
 use opentelemetry_otlp::WithExportConfig;
 use std::{collections::VecDeque, time::Duration};
+use tracing::log::LevelFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
 
@@ -53,6 +56,9 @@ struct GlobalTracingDats {
 pub(crate) fn telemetry_init(opts: &TelemetryOptions) -> Result<(), anyhow::Error> {
     TRACING_INIT.get_or_init(|| {
         let mut globaldat = GlobalTracingDats::default();
+
+        log::set_max_level(LevelFilter::Debug);
+        set_boxed_logger(Box::new(CoreExportLogger::default()))?;
 
         let filter_layer = EnvFilter::try_from_env(LOG_FILTER_ENV_VAR)
             .or_else(|_| EnvFilter::try_new(&opts.tracing_filter))?;

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod metrics;
 
-use crate::log_export::CoreExportLogger;
+use crate::{log_export::CoreExportLogger, CoreLog};
 use itertools::Itertools;
-use log::set_boxed_logger;
+use log::LevelFilter;
 use once_cell::sync::OnceCell;
 use opentelemetry::{
     global,
@@ -12,13 +12,13 @@ use opentelemetry::{
 };
 use opentelemetry_otlp::WithExportConfig;
 use std::{collections::VecDeque, time::Duration};
-use tracing::log::LevelFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
 
 const TELEM_SERVICE_NAME: &str = "temporal-core-sdk";
 const LOG_FILTER_ENV_VAR: &str = "TEMPORAL_TRACING_FILTER";
-static TRACING_INIT: OnceCell<Result<GlobalTracingDats, anyhow::Error>> = OnceCell::new();
+static DEFAULT_FILTER: &str = "temporal_sdk_core=INFO";
+static GLOBAL_TELEM_DAT: OnceCell<GlobalTelemDat> = OnceCell::new();
 
 /// Telemetry configuration options
 #[derive(Debug, Clone)]
@@ -31,21 +31,31 @@ pub struct TelemetryOptions {
     /// telemetry or console output. May be overridden by the `TEMPORAL_TRACING_FILTER` env
     /// variable.
     pub tracing_filter: String,
+    /// Core can forward logs to lang for them to be rendered by the user's logging facility.
+    /// The logs are somewhat contextually lacking, but still useful in a local test situation when
+    /// running only one workflow at a time. This sets the level at which they are filtered.
+    /// TRACE level will export span start/stop info as well.
+    ///
+    /// Default is INFO. If set to `Off`, the mechanism is disabled entirely (saves on perf).
+    /// If set to anything besides `Off`, any console output directly from core is disabled.
+    pub log_forwarding_level: LevelFilter,
 }
 
 impl Default for TelemetryOptions {
     fn default() -> Self {
         Self {
             otel_collector_url: None,
-            tracing_filter: "temporal_sdk_core=INFO".to_string(),
+            tracing_filter: DEFAULT_FILTER.to_string(),
+            log_forwarding_level: LevelFilter::Info,
         }
     }
 }
 
 /// Things that need to not be dropped while telemetry is ongoing
 #[derive(Default)]
-struct GlobalTracingDats {
+struct GlobalTelemDat {
     metric_push_controller: Option<PushController>,
+    core_export_logger: Option<CoreExportLogger>,
 }
 
 /// Initialize tracing subscribers and output. Core [crate::init] calls this, but it may be called
@@ -54,14 +64,24 @@ struct GlobalTracingDats {
 ///
 /// See [TelemetryOptions] docs for more on configuration.
 pub(crate) fn telemetry_init(opts: &TelemetryOptions) -> Result<(), anyhow::Error> {
-    TRACING_INIT.get_or_init(|| {
-        let mut globaldat = GlobalTracingDats::default();
+    let res = GLOBAL_TELEM_DAT.get_or_try_init::<_, anyhow::Error>(|| {
+        let mut globaldat = GlobalTelemDat::default();
+        let mut am_forwarding_logs = false;
 
-        log::set_max_level(LevelFilter::Debug);
-        set_boxed_logger(Box::new(CoreExportLogger::default()))?;
+        if opts.log_forwarding_level != LevelFilter::Off {
+            log::set_max_level(opts.log_forwarding_level);
+            globaldat.core_export_logger = Some(CoreExportLogger::new(opts.log_forwarding_level));
+            am_forwarding_logs = true;
+        }
 
-        let filter_layer = EnvFilter::try_from_env(LOG_FILTER_ENV_VAR)
-            .or_else(|_| EnvFilter::try_new(&opts.tracing_filter))?;
+        let filter_layer = EnvFilter::try_from_env(LOG_FILTER_ENV_VAR).or_else(|_| {
+            let filter = if opts.tracing_filter.is_empty() {
+                DEFAULT_FILTER
+            } else {
+                &opts.tracing_filter
+            };
+            EnvFilter::try_new(filter)
+        })?;
 
         if let Some(otel_url) = opts.otel_collector_url.as_ref() {
             let tracer_cfg = Config::default().with_resource(Resource::new(vec![KeyValue::new(
@@ -100,7 +120,7 @@ pub(crate) fn telemetry_init(opts: &TelemetryOptions) -> Result<(), anyhow::Erro
                 .with(opentelemetry)
                 .with(filter_layer)
                 .try_init()?;
-        } else {
+        } else if !am_forwarding_logs {
             let pretty_fmt = tracing_subscriber::fmt::format()
                 .pretty()
                 .with_source_location(false);
@@ -112,9 +132,26 @@ pub(crate) fn telemetry_init(opts: &TelemetryOptions) -> Result<(), anyhow::Erro
             tracing::subscriber::set_global_default(reg)?;
         };
         Ok(globaldat)
-    });
+    })?;
+
+    if let Some(loggr) = &res.core_export_logger {
+        // If telem init is called twice for some reason, this would error, so just ignore that.
+        let _ = log::set_logger(loggr);
+    }
 
     Ok(())
+}
+
+/// Returned buffered logs for export to lang from the global logging instance
+pub(crate) fn fetch_global_buffered_logs() -> Vec<CoreLog> {
+    if let Some(loggr) = GLOBAL_TELEM_DAT
+        .get()
+        .and_then(|gd| gd.core_export_logger.as_ref())
+    {
+        loggr.drain()
+    } else {
+        vec![]
+    }
 }
 
 #[allow(dead_code)] // Not always used, called to enable for debugging when needed
@@ -123,6 +160,7 @@ pub(crate) fn test_telem() {
     telemetry_init(&TelemetryOptions {
         otel_collector_url: None,
         tracing_filter: "temporal_sdk_core=DEBUG".to_string(),
+        log_forwarding_level: LevelFilter::Off,
     })
     .unwrap()
 }

--- a/src/workflow/workflow_tasks/concurrency_manager.rs
+++ b/src/workflow/workflow_tasks/concurrency_manager.rs
@@ -233,7 +233,7 @@ impl WorkflowConcurrencyManager {
             .expect("Machine cannot possibly be accessed simultaneously");
         let res = mutator(&mut wfm).await;
         // Reinsert machine behind lock
-        wfm_mutex.insert(wfm);
+        let _ = wfm_mutex.insert(wfm);
 
         res
     }

--- a/src/workflow/workflow_tasks/mod.rs
+++ b/src/workflow/workflow_tasks/mod.rs
@@ -189,7 +189,7 @@ impl WorkflowTaskManager {
     pub fn request_eviction(&self, run_id: &str) -> Option<u32> {
         if self.workflow_machines.exists(run_id) {
             if !self.activation_has_eviction(run_id) {
-                debug!(%run_id, "Eviction requested for");
+                debug!(%run_id, "Eviction requested");
                 // Queue up an eviction activation
                 self.pending_activations
                     .push(create_evict_activation(run_id.to_string()));


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adds a facility to export logs to lang so that they can show up with the user's configured loggers. Loses some context from tracing but overall still useful.

## Why?
Easy-to-enable debuggability for users

Relates to https://github.com/temporalio/sdk-core/issues/85