### PR TITLE
Allow directly scraping prometheus metrics

### DIFF
--- a/.buildkite/docker/docker-compose-ci.yaml
+++ b/.buildkite/docker/docker-compose-ci.yaml
@@ -1,0 +1,27 @@
+version: '3.5'
+
+services:
+  unit-test:
+    build:
+      context: ../../
+      dockerfile: .buildkite/docker/Dockerfile
+    security_opt:
+      - seccomp:unconfined
+    command: /bin/sh -c ".buildkite/docker/build.sh"
+    environment:
+      - "USER=unittest"
+    volumes:
+      - "../../:/sdk-core"
+
+  integ-test:
+    build:
+      context: ../../
+      dockerfile: .buildkite/docker/Dockerfile
+    command: /bin/sh -c ".buildkite/docker/build.sh"
+    environment:
+      - "USER=unittest"
+      - "TEMPORAL_SERVICE_ADDRESS=http://temporal:7233"
+    depends_on:
+      - temporal
+    volumes:
+      - "../../:/sdk-core"

--- a/.buildkite/docker/docker-compose-telem.yaml
+++ b/.buildkite/docker/docker-compose-telem.yaml
@@ -1,0 +1,33 @@
+version: '3.5'
+
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - '16686:16686'
+      - '14268'
+      - '14250'
+
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: ['--config=/etc/otel-collector-config.yaml']
+    volumes:
+      - ../../etc/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      #      - "1888:1888"   # pprof extension
+      # It's useful to be able to manually inspect metrics during dev
+      - '8888:8888' # Prometheus metrics exposed by the collector
+      - '8889:8889' # Prometheus exporter metrics
+      #      - "13133:13133" # health_check extension
+      - '4317:4317' # OTLP gRPC receiver
+    #      - "55670:55679" # zpages extension
+    depends_on:
+      - jaeger
+
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    volumes:
+      - ../../etc/prometheus.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - '9090:9090'

--- a/.buildkite/docker/docker-compose.yaml
+++ b/.buildkite/docker/docker-compose.yaml
@@ -5,22 +5,20 @@ services:
     image: cassandra:3.11
     logging:
       driver: none
-    ports:
-      - "9042:9042"
+  #    ports:
+  #      - '9042:9042'
 
   temporal:
     image: temporalio/auto-setup:1.11.0
-    logging:
-      driver: none
     ports:
       - "7233:7233"
       - "7234:7234"
-      - "7235:7235"
-      - "7239:7239"
-      - "6933:6933"
-      - "6934:6934"
-      - "6935:6935"
-      - "6939:6939"
+#      - "7235:7235"
+#      - "7239:7239"
+#      - "6933:6933"
+#      - "6934:6934"
+#      - "6935:6935"
+#      - "6939:6939"
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
@@ -37,28 +35,3 @@ services:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     depends_on:
       - temporal
-
-  unit-test:
-    build:
-      context: ../../
-      dockerfile: .buildkite/docker/Dockerfile
-    security_opt:
-      - seccomp:unconfined
-    command: /bin/sh -c ".buildkite/docker/build.sh"
-    environment:
-      - "USER=unittest"
-    volumes:
-      - "../../:/sdk-core"
-
-  integ-test:
-    build:
-      context: ../../
-      dockerfile: .buildkite/docker/Dockerfile
-    command: /bin/sh -c ".buildkite/docker/build.sh"
-    environment:
-      - "USER=unittest"
-      - "TEMPORAL_SERVICE_ADDRESS=http://temporal:7233"
-    depends_on:
-      - temporal
-    volumes:
-      - "../../:/sdk-core"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,9 @@ steps:
     plugins:
       - docker-compose#v3.0.0:
           run: unit-test
-          config: .buildkite/docker/docker-compose.yaml
+          config:
+            - .buildkite/docker/docker-compose.yaml
+            - .buildkite/docker/docker-compose-ci.yaml
           env:
             - RUSTDOCFLAGS=-Dwarnings
   - label: "lint"
@@ -20,7 +22,9 @@ steps:
     plugins:
       - docker-compose#v3.0.0:
           run: unit-test
-          config: .buildkite/docker/docker-compose.yaml
+          config:
+            - .buildkite/docker/docker-compose.yaml
+            - .buildkite/docker/docker-compose-ci.yaml
   - label: "test"
     agents:
       queue: "default"
@@ -33,7 +37,9 @@ steps:
     plugins:
       - docker-compose#v3.0.0:
           run: unit-test
-          config: .buildkite/docker/docker-compose.yaml
+          config:
+            - .buildkite/docker/docker-compose.yaml
+            - .buildkite/docker/docker-compose-ci.yaml
   - label: "integ-test"
     agents:
       queue: "default"
@@ -43,5 +49,7 @@ steps:
     plugins:
       - docker-compose#v3.0.0:
           run: integ-test
-          config: .buildkite/docker/docker-compose.yaml
+          config:
+            - .buildkite/docker/docker-compose.yaml
+            - .buildkite/docker/docker-compose-ci.yaml
   - wait

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+integ-test = ["test", "--test", "integ_tests"]

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ src/protos/*.rs
 !src/protos/mod.rs
 /tarpaulin-report.html
 /machine_coverage/
-/.cargo/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["development-tools"]
 
 [lib]
 
-# TODO: Feature flag opentelem stuff
 [dependencies]
 anyhow = "1.0"
 arc-swap = "1.3"
@@ -26,6 +25,7 @@ derive_more = "0.99"
 futures = "0.3"
 futures-retry = "0.6.0"
 http = "0.2"
+hyper = "0.14"
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Core SDK that can be used as a base for all other Temporal SDKs.
 
 See the [Architecture](ARCHITECTURE.md) doc for some high-level information.
 
-This repo uses a submodule for upstream protobuf files. The path `protos/api_upstream` is a 
-submodule -- when checking out the repo for the first time make sure you've run 
-`git submodule update --init --recursive`. TODO: Makefile.
+This repo uses a subtree for upstream protobuf files. The path `protos/api_upstream` is a 
+subtree. To update it, use:
+`git subtree pull --prefix protos/api_upstream/ git://github.com/temporalio/api.git master --squash`
 
 ## Dependencies
 * Protobuf compiler
@@ -23,6 +23,9 @@ You can buld and test the project using cargo:
 `cargo build`
 `cargo test`
 
+Run integ tests with `cargo integ-test`. You will need to already be running the server:
+`docker-compose -f .buildkite/docker/docker-compose.yaml up`
+
 ## Formatting
 To format all code run:
 `cargo fmt --all`
@@ -35,23 +38,20 @@ You can run it using:
 ## Debugging
 The crate uses [tracing](https://github.com/tokio-rs/tracing) to help with debugging. To enable
 it for a test, insert the below snippet at the start of the test. By default, tracing data is output
-to stdout in a (reasonably) pretty manner, and to a Jaeger instance if one exists.
+to stdout in a (reasonably) pretty manner.
 
 ```rust
-core_tracing::tracing_init();
+crate::telemetry::telemetry_init(Default::default());
 let s = info_span!("Test start");
 let _enter = s.enter();
 ```
 
-To run the Jaeger instance:
-`docker run --rm -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest`
-Jaeger collection is off by default, you must set `TEMPORAL_ENABLE_OPENTELEMENTRY=true` in the
-environment to enable it.
+The passed in options to initialization can be customized to export to an OTel collector, etc.
 
-To show logs in the console, set the `RUST_LOG` environment variable to `temporal_sdk_core=DEBUG`
-or whatever level you desire. The env var is parsed according to tracing's 
-[EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html)
-rules.
+To run integ tests with OTel collection on, you can use `integ-with-otel.sh`. You will want to make
+sure you are running the collector via docker, which can be done like so:
+`docker-compose -f .buildkite/docker/docker-compose.yaml -f .buildkite/docker/docker-compose-telem.yaml up`
+
 
 If you are working on a language SDK, you are expected to initialize tracing early in your `main`
 equivalent.

--- a/etc/otel-collector-config.yaml
+++ b/etc/otel-collector-config.yaml
@@ -1,0 +1,36 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  prometheus:
+    endpoint: '0.0.0.0:8889'
+    namespace: temporal_sdk
+  logging:
+
+  jaeger:
+    endpoint: jaeger:14250
+    insecure: true
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, prometheus]

--- a/etc/prometheus.yaml
+++ b/etc/prometheus.yaml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: 'otel-collector'
+    scrape_interval: 3s
+    static_configs:
+      - targets: ['otel-collector:8889']
+      - targets: ['otel-collector:8888']

--- a/integ-with-otel.sh
+++ b/integ-with-otel.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Run integ tests with OTel collector export enabled
+export TEMPORAL_INTEG_OTEL_URL="grpc://localhost:4317"
+export TEMPORAL_TRACING_FILTER="temporal_sdk_core=DEBUG"
+
+cargo integ-test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ mod test_help;
 
 pub use log_export::CoreLog;
 pub use pollers::{
-    ClientTlsConfig, RetryConfig, ServerGateway, ServerGatewayApis, ServerGatewayOptions, TlsConfig,
+    ClientTlsConfig, RetryConfig, RetryGateway, ServerGateway, ServerGatewayApis,
+    ServerGatewayOptions, TlsConfig,
 };
 pub use telemetry::TelemetryOptions;
 pub use url::Url;

--- a/src/pollers/retry.rs
+++ b/src/pollers/retry.rs
@@ -18,12 +18,14 @@ use temporal_sdk_core_protos::{
 };
 
 #[derive(Debug)]
+/// A wrapper for a [ServerGatewayApis] implementor which performs auto-retries
 pub struct RetryGateway<SG> {
     gateway: SG,
     retry_config: RetryConfig,
 }
 
 impl<SG> RetryGateway<SG> {
+    /// Use the provided retry config with the provided gateway
     pub fn new(gateway: SG, retry_config: RetryConfig) -> Self {
         Self {
             gateway,

--- a/src/telemetry/metrics.rs
+++ b/src/telemetry/metrics.rs
@@ -179,7 +179,13 @@ impl MetricsContext {
 }
 
 lazy_static::lazy_static! {
-    static ref METRIC_METER: Meter = global::meter(TELEM_SERVICE_NAME);
+    static ref METRIC_METER: Meter = {
+        #[cfg(not(test))]
+        if crate::telemetry::GLOBAL_TELEM_DAT.get().is_none() {
+            panic!("Tried to use a metric but telemetry has not been initialized")
+        }
+        global::meter(TELEM_SERVICE_NAME)
+    };
 }
 
 /// Define a temporal metric. All metrics are kept private to this file, and should be accessed
@@ -338,7 +344,7 @@ static TASK_SCHED_TO_START_MS_BUCKETS: &[f64] = &[100., 500., 1000., 5000., 10_0
 
 /// Default buckets. Should never really be used as they will be meaningless for many things, but
 /// broadly it's trying to represent latencies in millis.
-static DEFAULT_MS_BUCKETS: &[f64] = &[50., 100., 500., 1000., 2500., 10_000.];
+pub(super) static DEFAULT_MS_BUCKETS: &[f64] = &[50., 100., 500., 1000., 2500., 10_000.];
 
 /// Chooses appropriate aggregators for our metrics
 #[derive(Debug)]

--- a/src/telemetry/prometheus_server.rs
+++ b/src/telemetry/prometheus_server.rs
@@ -1,0 +1,94 @@
+use crate::telemetry::metrics::{SDKAggSelector, DEFAULT_MS_BUCKETS};
+use hyper::{
+    header::CONTENT_TYPE,
+    service::{make_service_fn, service_fn},
+    Body, Method, Request, Response, Server,
+};
+use opentelemetry::{
+    global,
+    metrics::MetricsError,
+    sdk::{export::metrics::ExportKindSelector, metrics::controllers},
+};
+use opentelemetry_prometheus::PrometheusExporter;
+use prometheus::{Encoder, TextEncoder};
+use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
+
+/// Exposes prometheus metrics for scraping
+pub(super) struct PromServer {
+    addr: SocketAddr,
+    pub exporter: Arc<PrometheusExporter>,
+}
+
+impl PromServer {
+    pub fn new(addr: SocketAddr) -> Result<Self, MetricsError> {
+        let exporter = create_exporter()?;
+        Ok(Self {
+            exporter: Arc::new(exporter),
+            addr,
+        })
+    }
+
+    pub async fn run(&self) -> hyper::Result<()> {
+        // Spin up hyper server to serve metrics for scraping. We use hyper since we already depend
+        // on it via Tonic.
+        let expclone = self.exporter.clone();
+        let svc = make_service_fn(move |_conn| {
+            let expclone = expclone.clone();
+            async move { Ok::<_, Infallible>(service_fn(move |req| metrics_req(req, expclone.clone()))) }
+        });
+        let server = Server::bind(&self.addr).serve(svc);
+        server.await
+    }
+}
+
+/// Serves prometheus metrics in the expected format for scraping
+async fn metrics_req(
+    req: Request<Body>,
+    exporter: Arc<PrometheusExporter>,
+) -> Result<Response<Body>, hyper::Error> {
+    let response = match (req.method(), req.uri().path()) {
+        (&Method::GET, "/metrics") => {
+            let mut buffer = vec![];
+            let encoder = TextEncoder::new();
+            let metric_families = exporter.registry().gather();
+            encoder.encode(&metric_families, &mut buffer).unwrap();
+
+            Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, encoder.format_type())
+                .body(Body::from(buffer))
+                .unwrap()
+        }
+        _ => Response::builder()
+            .status(404)
+            .body(Body::empty())
+            .expect("Can't fail to construct empty resp"),
+    };
+    Ok(response)
+}
+
+/// There is no easy way to customize the aggregation selector for the prom exporter so this
+/// code is some dupe of the exporter's try_init code.
+pub fn create_exporter() -> Result<PrometheusExporter, MetricsError> {
+    let controller_builder = controllers::pull(
+        Box::new(SDKAggSelector),
+        Box::new(ExportKindSelector::Cumulative),
+    )
+    .with_cache_period(Duration::from_secs(0))
+    .with_memory(true);
+    let controller = controller_builder.build();
+
+    global::set_meter_provider(controller.provider());
+
+    // No choice bro https://github.com/open-telemetry/opentelemetry-rust/issues/633
+    #[allow(deprecated)]
+    PrometheusExporter::new(
+        prometheus::Registry::new(),
+        controller,
+        DEFAULT_MS_BUCKETS.to_vec(),
+        DEFAULT_MS_BUCKETS.to_vec(),
+        // Host and port aren't actually used for anything
+        "".to_string(),
+        0,
+    )
+}

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -149,6 +149,7 @@ pub async fn init_core_and_create_wf(test_name: &str) -> (Arc<dyn Core>, String)
     (core, starter.get_task_queue().to_string())
 }
 
+// TODO: This should get removed. Pretty pointless now that gateway is exported
 pub async fn with_gw<F: FnOnce(GwApi) -> Fout, Fout: Future>(
     core: &dyn Core,
     fun: F,
@@ -177,9 +178,11 @@ pub fn get_integ_server_options() -> ServerGatewayOptions {
 pub fn get_integ_telem_options() -> TelemetryOptions {
     // TODO: Customize w/ env var
     TelemetryOptions {
-        otel_collector_url: Some("grpc://localhost:4317".parse().unwrap()),
-        tracing_filter: "temporal_sdk_core=DEBUG".to_string(),
+        // otel_collector_url: Some("grpc://localhost:4317".parse().unwrap()),
+        otel_collector_url: None,
+        tracing_filter: "temporal_sdk_core=INFO".to_string(),
         log_forwarding_level: LevelFilter::Off,
+        prometheus_export_bind_address: Some(([127, 0, 0, 1], 3000).into()),
     }
 }
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,6 +1,7 @@
 use futures::{stream::FuturesUnordered, StreamExt};
 use log::LevelFilter;
 use rand::{distributions::Standard, Rng};
+use std::net::SocketAddr;
 use std::{convert::TryFrom, env, future::Future, sync::Arc, time::Duration};
 use temporal_sdk_core::{
     prototype_rust_sdk::TestRustWorker, Core, CoreInitOptions, CoreInitOptionsBuilder,
@@ -17,6 +18,10 @@ use url::Url;
 
 pub const NAMESPACE: &str = "default";
 pub type GwApi = Arc<dyn ServerGatewayApis>;
+/// If set, turn export traces and metrics to the OTel collector at the given URL
+const OTEL_URL_ENV_VAR: &str = "TEMPORAL_INTEG_OTEL_URL";
+/// If set, enable direct scraping of prom metrics on the specified port
+const PROM_ENABLE_ENV_VAR: &str = "TEMPORAL_INTEG_PROM_PORT";
 
 /// Implements a builder pattern to help integ tests initialize core and create workflows
 pub struct CoreWfStarter {
@@ -176,13 +181,16 @@ pub fn get_integ_server_options() -> ServerGatewayOptions {
 }
 
 pub fn get_integ_telem_options() -> TelemetryOptions {
-    // TODO: Customize w/ env var
+    let otel_collector_url = env::var(OTEL_URL_ENV_VAR).ok().map(|x| x.parse().unwrap());
+    let prometheus_export_bind_address = env::var(PROM_ENABLE_ENV_VAR)
+        .ok()
+        .map(|x| SocketAddr::new([127, 0, 0, 1].into(), x.parse().unwrap()));
+
     TelemetryOptions {
-        // otel_collector_url: Some("grpc://localhost:4317".parse().unwrap()),
-        otel_collector_url: None,
+        otel_collector_url,
         tracing_filter: "temporal_sdk_core=INFO".to_string(),
         log_forwarding_level: LevelFilter::Off,
-        prometheus_export_bind_address: Some(([127, 0, 0, 1], 3000).into()),
+        prometheus_export_bind_address,
     }
 }
 

--- a/tests/integ_tests/client_tests.rs
+++ b/tests/integ_tests/client_tests.rs
@@ -1,12 +1,11 @@
 use std::time::Duration;
-use temporal_sdk_core::ServerGatewayApis;
-use test_utils::get_integ_server_options;
+use test_utils::CoreWfStarter;
 
 #[tokio::test]
 async fn can_use_retry_gateway() {
     // Not terribly interesting by itself but can be useful for manually inspecting metrics etc
-    let sgopts = get_integ_server_options();
-    let retry_client = sgopts.connect().await.unwrap();
+    let mut core = CoreWfStarter::new("retry_gateway");
+    let retry_client = core.get_core().await.server_gateway();
     for _ in 0..10 {
         retry_client.list_namespaces().await.unwrap();
         tokio::time::sleep(Duration::from_millis(10)).await;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose an option to enable direct scraping of prometheus metrics.

## Why?
Many users may not care about exporting metrics to the OTel collector, and only use prometheus for metrics. This way they don't have to run the OTel collector if they don't care about traces.

## Checklist
<!--- add/delete as needed --->

1. Relates to https://github.com/temporalio/sdk-core/issues/85 

2. How was this tested:
Verified metrics are properly exposed on specified endpoint

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
