### PR TITLE
Pass required client name/version headers on rpc calls

### DIFF
--- a/.buildkite/docker/docker-compose.yaml
+++ b/.buildkite/docker/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
   #      - '9042:9042'
 
   temporal:
-    image: temporalio/auto-setup:1.11.0
+    image: temporalio/auto-setup:1.12.1
     ports:
       - "7233:7233"
       - "7234:7234"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,9 @@ mod test_help;
 pub use log_export::CoreLog;
 pub use pollers::{
     ClientTlsConfig, RetryConfig, RetryGateway, ServerGateway, ServerGatewayApis,
-    ServerGatewayOptions, TlsConfig,
+    ServerGatewayOptions, ServerGatewayOptionsBuilder, TlsConfig,
 };
-pub use telemetry::TelemetryOptions;
+pub use telemetry::{TelemetryOptions, TelemetryOptionsBuilder};
 pub use url::Url;
 pub use worker::{WorkerConfig, WorkerConfigBuilder};
 
@@ -191,6 +191,7 @@ pub trait Core: Send + Sync {
 /// Holds various configuration information required to call [init]
 #[derive(Debug, Clone, derive_builder::Builder)]
 #[builder(setter(into))]
+#[non_exhaustive]
 pub struct CoreInitOptions {
     /// Options for the connection to the temporal server
     pub gateway_opts: ServerGatewayOptions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,14 +379,14 @@ impl CoreSDK {
 
     fn worker(&self, tq: &str) -> Result<impl Deref<Target = Worker>, WorkerLookupErr> {
         let worker = self.workers.get(tq);
-        if worker.is_none() && self.shutdown_requested.load(Ordering::Relaxed) {
+        if worker.is_err() && self.shutdown_requested.load(Ordering::Relaxed) {
             return Err(WorkerLookupErr::Shutdown(tq.to_owned()));
         }
-        let worker = worker.ok_or_else(|| WorkerLookupErr::NoWorker(tq.to_owned()))?;
-        Ok(worker)
+        worker
     }
 }
 
+#[derive(Debug)]
 enum WorkerLookupErr {
     Shutdown(String),
     NoWorker(String),

--- a/src/pollers/gateway.rs
+++ b/src/pollers/gateway.rs
@@ -43,7 +43,8 @@ use std::str::FromStr;
 use tonic::metadata::{MetadataKey, MetadataValue};
 
 static LONG_POLL_METHOD_NAMES: [&str; 2] = ["PollWorkflowTaskQueue", "PollActivityTaskQueue"];
-const LONG_POLL_TIMEOUT: Duration = Duration::from_secs(60);
+/// The server times out polls after 60 seconds. Set our timeout to be slightly beyond that.
+const LONG_POLL_TIMEOUT: Duration = Duration::from_secs(62);
 const OTHER_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct GatewayRef {

--- a/src/pollers/mod.rs
+++ b/src/pollers/mod.rs
@@ -7,7 +7,7 @@ pub use gateway::{MockManualGateway, MockServerGatewayApis};
 
 pub use gateway::{
     ClientTlsConfig, GatewayRef, RetryConfig, ServerGateway, ServerGatewayApis,
-    ServerGatewayOptions, TlsConfig,
+    ServerGatewayOptions, ServerGatewayOptionsBuilder, TlsConfig,
 };
 pub use poll_buffer::{
     new_activity_task_buffer, new_workflow_task_buffer, PollActivityTaskBuffer,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -27,16 +27,19 @@ static DEFAULT_FILTER: &str = "temporal_sdk_core=INFO";
 static GLOBAL_TELEM_DAT: OnceCell<GlobalTelemDat> = OnceCell::new();
 static TELETM_MUTEX: Mutex<()> = const_mutex(());
 
-/// Telemetry configuration options
-#[derive(Debug, Clone)]
+/// Telemetry configuration options. Construct with [TelemetryOptionsBuilder]
+#[derive(Debug, Clone, derive_builder::Builder)]
+#[non_exhaustive]
 pub struct TelemetryOptions {
     /// The url of the OTel collector to export telemetry and metrics to. Lang SDK should also
     /// export to this same collector. If unset, telemetry is not exported and tracing data goes
     /// to the console instead.
+    #[builder(setter(into, strip_option), default)]
     pub otel_collector_url: Option<Url>,
     /// A string in the [EnvFilter] format which specifies what tracing data is included in
     /// telemetry, log forwarded to lang, or console output. May be overridden by the
     /// `TEMPORAL_TRACING_FILTER` env variable.
+    #[builder(default = "DEFAULT_FILTER.to_string()")]
     pub tracing_filter: String,
     /// Core can forward logs to lang for them to be rendered by the user's logging facility.
     /// The logs are somewhat contextually lacking, but still useful in a local test situation when
@@ -45,22 +48,19 @@ pub struct TelemetryOptions {
     ///
     /// Default is INFO. If set to `Off`, the mechanism is disabled entirely (saves on perf).
     /// If set to anything besides `Off`, any console output directly from core is disabled.
+    #[builder(setter(into), default = "LevelFilter::Info")]
     pub log_forwarding_level: LevelFilter,
     /// If set, prometheus metrics will be exposed directly via an embedded http server bound to
     /// the provided address. Useful if users would like to collect metrics with prometheus but
     /// do not want to run an OTel collector. **Note**: If this is set metrics will *not* be sent
     /// to the OTel collector if it is also set, only traces will be.
+    #[builder(setter(into, strip_option), default)]
     pub prometheus_export_bind_address: Option<SocketAddr>,
 }
 
 impl Default for TelemetryOptions {
     fn default() -> Self {
-        Self {
-            otel_collector_url: None,
-            tracing_filter: DEFAULT_FILTER.to_string(),
-            log_forwarding_level: LevelFilter::Info,
-            prometheus_export_bind_address: None,
-        }
+        TelemetryOptionsBuilder::default().build().unwrap()
     }
 }
 

--- a/src/test_help/mod.rs
+++ b/src/test_help/mod.rs
@@ -491,9 +491,11 @@ pub fn fake_sg_opts() -> ServerGatewayOptions {
     ServerGatewayOptions {
         target_url: Url::from_str("https://fake").unwrap(),
         namespace: "".to_string(),
+        client_name: "".to_string(),
+        client_version: "".to_string(),
+        static_headers: Default::default(),
         identity: "".to_string(),
         worker_binary_id: "".to_string(),
-        long_poll_timeout: Default::default(),
         tls_cfg: None,
         retry_config: Default::default(),
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -2,8 +2,10 @@
 
 #[cfg(test)]
 mod integ_tests {
-    use std::{str::FromStr, time::Duration};
-    use temporal_sdk_core::{ClientTlsConfig, ServerGatewayApis, ServerGatewayOptions, TlsConfig};
+    use std::str::FromStr;
+    use temporal_sdk_core::{
+        ClientTlsConfig, ServerGatewayApis, ServerGatewayOptionsBuilder, TlsConfig,
+    };
     use test_utils::NAMESPACE;
     use url::Url;
 
@@ -35,22 +37,20 @@ mod integ_tests {
         )
         .await
         .unwrap();
-        let sgo = ServerGatewayOptions {
-            target_url: Url::from_str("https://localhost:7233").unwrap(),
-            namespace: NAMESPACE.to_string(),
-            identity: "ident".to_string(),
-            worker_binary_id: "binident".to_string(),
-            long_poll_timeout: Duration::from_secs(60),
-            tls_cfg: Some(TlsConfig {
+        let sgo = ServerGatewayOptionsBuilder::default()
+            .target_url(Url::from_str("https://localhost:7233").unwrap())
+            .namespace(NAMESPACE.to_string())
+            .worker_binary_id("binident".to_string())
+            .tls_cfg(TlsConfig {
                 server_root_ca_cert: Some(root),
                 domain: Some("tls-sample".to_string()),
                 client_tls_config: Some(ClientTlsConfig {
                     client_cert,
                     client_private_key,
                 }),
-            }),
-            retry_config: Default::default(),
-        };
+            })
+            .build()
+            .unwrap();
         let con = sgo.connect().await.unwrap();
         con.list_namespaces().await.unwrap();
     }


### PR DESCRIPTION
* Also use builder pattern for big options structs

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Pass needed headers, getting client name/version from lang

## Why?
So server can yell at us when we're too old.

## Checklist

- [x] When https://github.com/temporalio/temporal/pull/1949 is merged do the right thing for that too

1. Closes #76 

2. How was this tested:
Integ tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
