### PR TITLE
Fix possible re-application of final WFT when querying

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub trait Core: Send + Sync {
     fn request_workflow_eviction(&self, task_queue: &str, run_id: &str);
 
     /// Returns core's instance of the [ServerGatewayApis] implementor it is using.
-    fn server_gateway(&self) -> Arc<dyn ServerGatewayApis>;
+    fn server_gateway(&self) -> Arc<dyn ServerGatewayApis + Send + Sync>;
 
     /// Initiates async shutdown procedure, eventually ceases all polling of the server and shuts
     /// down all registered workers. [Core::poll_workflow_activation] should be called until it
@@ -311,7 +311,7 @@ impl Core for CoreSDK {
         }
     }
 
-    fn server_gateway(&self) -> Arc<dyn ServerGatewayApis> {
+    fn server_gateway(&self) -> Arc<dyn ServerGatewayApis + Send + Sync> {
         self.server_gateway.gw.clone()
     }
 

--- a/src/test_help/canned_histories.rs
+++ b/src/test_help/canned_histories.rs
@@ -33,6 +33,13 @@ pub fn single_timer(timer_id: &str) -> TestHistoryBuilder {
     t
 }
 
+pub fn single_timer_wf_completes(timer_id: &str) -> TestHistoryBuilder {
+    let mut t = single_timer(timer_id);
+    t.add_workflow_task_completed();
+    t.add_workflow_execution_completed();
+    t
+}
+
 ///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
 ///  2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
 ///  3: EVENT_TYPE_WORKFLOW_TASK_STARTED

--- a/src/workflow/workflow_tasks/mod.rs
+++ b/src/workflow/workflow_tasks/mod.rs
@@ -251,7 +251,7 @@ impl WorkflowTaskManager {
         debug!(
             task_token = %&work.task_token,
             history_length = %work.history.events.len(),
-            "Applying new workflow task from server"
+            "Applying new workflow task from server {:?}", work
         );
         let task_start_time = Instant::now();
 
@@ -277,6 +277,7 @@ impl WorkflowTaskManager {
         // Immediately dispatch query activation if no other jobs
         let legacy_query = if next_activation.jobs.is_empty() {
             if let Some(lq) = legacy_query {
+                debug!("Dispatching legacy query {:?}", &lq);
                 next_activation
                     .jobs
                     .push(wf_activation_job::Variant::QueryWorkflow(lq).into());

--- a/src/workflow/workflow_tasks/mod.rs
+++ b/src/workflow/workflow_tasks/mod.rs
@@ -251,7 +251,7 @@ impl WorkflowTaskManager {
         debug!(
             task_token = %&work.task_token,
             history_length = %work.history.events.len(),
-            "Applying new workflow task from server {:?}", work
+            "Applying new workflow task from server"
         );
         let task_start_time = Instant::now();
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,8 +1,7 @@
 use futures::{stream::FuturesUnordered, StreamExt};
 use log::LevelFilter;
 use rand::{distributions::Standard, Rng};
-use std::net::SocketAddr;
-use std::{convert::TryFrom, env, future::Future, sync::Arc, time::Duration};
+use std::{convert::TryFrom, env, future::Future, net::SocketAddr, sync::Arc, time::Duration};
 use temporal_sdk_core::{
     prototype_rust_sdk::TestRustWorker, Core, CoreInitOptions, CoreInitOptionsBuilder,
     ServerGatewayApis, ServerGatewayOptions, TelemetryOptions, WorkerConfig, WorkerConfigBuilder,

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -1,4 +1,6 @@
 use assert_matches::assert_matches;
+use futures::prelude::stream::FuturesUnordered;
+use futures::{FutureExt, StreamExt};
 use std::time::Duration;
 use temporal_sdk_core_protos::{
     coresdk::{
@@ -108,11 +110,38 @@ async fn simple_query_legacy() {
 async fn query_after_execution_complete(#[case] do_evict: bool) {
     let workflow_id = &format!("after_done_query_evict-{}", do_evict);
     let query_resp = b"response";
-    let (core, task_q) = init_core_and_create_wf(workflow_id).await;
+    let (ref core, ref task_q) = init_core_and_create_wf(workflow_id).await;
 
-    let do_workflow = || async {
+    let do_workflow = |go_until_query: bool| async move {
         loop {
-            let task = core.poll_workflow_activation(&task_q).await.unwrap();
+            let task = core.poll_workflow_activation(task_q).await.unwrap();
+
+            // When we see the query, handle it.
+            if go_until_query {
+                if let [WfActivationJob {
+                    variant: Some(wf_activation_job::Variant::QueryWorkflow(query)),
+                }] = task.jobs.as_slice()
+                {
+                    core.complete_workflow_activation(WfActivationCompletion::from_cmd(
+                        task_q,
+                        task.run_id,
+                        QueryResult {
+                            query_id: query.query_id.clone(),
+                            variant: Some(
+                                QuerySuccess {
+                                    response: Some(query_resp.into()),
+                                }
+                                .into(),
+                            ),
+                        }
+                        .into(),
+                    ))
+                    .await
+                    .unwrap();
+                    break "".to_string();
+                }
+            }
+
             if matches!(
                 task.jobs.as_slice(),
                 [WfActivationJob {
@@ -120,7 +149,7 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
                 }]
             ) {
                 core.complete_workflow_activation(WfActivationCompletion::empty(
-                    &task_q,
+                    task_q,
                     task.run_id,
                 ))
                 .await
@@ -134,68 +163,47 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
                 }]
             );
             let run_id = task.run_id.clone();
-            core.complete_timer(&task_q, &task.run_id, 1, Duration::from_millis(500))
+            core.complete_timer(task_q, &task.run_id, 1, Duration::from_millis(500))
                 .await;
-            let task = core.poll_workflow_activation(&task_q).await.unwrap();
-            core.complete_execution(&task_q, &task.run_id).await;
-            break run_id;
+            let task = core.poll_workflow_activation(task_q).await.unwrap();
+            core.complete_execution(task_q, &task.run_id).await;
+            if !go_until_query {
+                break run_id;
+            }
         }
     };
 
-    let run_id = do_workflow().await;
+    let run_id = &do_workflow(false).await;
+    assert!(!run_id.is_empty());
 
     if do_evict {
-        core.request_workflow_eviction(&task_q, &run_id);
+        core.request_workflow_eviction(task_q, run_id);
     }
+    // Spam some queries (sending multiple queries after WF closed covers a possible path where
+    // we could screw-up re-applying the final WFT)
+    let mut query_futs = FuturesUnordered::new();
+    for _ in 0..3 {
+        let gw = core.server_gateway().clone();
+        let query_fut = async move {
+            let q_resp = gw
+                .query_workflow_execution(
+                    workflow_id.to_string(),
+                    run_id.to_string(),
+                    WorkflowQuery {
+                        query_type: "myquery".to_string(),
+                        query_args: Some(b"hi".into()),
+                    },
+                )
+                .await
+                .unwrap();
+            // Ensure query response is as expected
+            assert_eq!(q_resp.unwrap()[0].data, query_resp);
+        };
 
-    let query_fut = with_gw(core.as_ref(), |gw: GwApi| async move {
-        gw.query_workflow_execution(
-            workflow_id.to_string(),
-            run_id,
-            WorkflowQuery {
-                query_type: "myquery".to_string(),
-                query_args: Some(b"hi".into()),
-            },
-        )
-        .await
-        .unwrap()
-    });
-
-    let query_handling_fut = async {
-        // If we evicted, we should need to replay the whole workflow before we execute the query
-        if do_evict {
-            do_workflow().await;
-        }
-
-        let task = core.poll_workflow_activation(&task_q).await.unwrap();
-
-        let query = assert_matches!(
-            task.jobs.as_slice(),
-            [WfActivationJob {
-                variant: Some(wf_activation_job::Variant::QueryWorkflow(q)),
-            }] => q
-        );
-        // Complete the query
-        core.complete_workflow_activation(WfActivationCompletion::from_cmd(
-            &task_q,
-            task.run_id,
-            QueryResult {
-                query_id: query.query_id.clone(),
-                variant: Some(
-                    QuerySuccess {
-                        response: Some(query_resp.into()),
-                    }
-                    .into(),
-                ),
-            }
-            .into(),
-        ))
-        .await
-        .unwrap();
-    };
-    let (q_resp, _) = tokio::join!(query_fut, query_handling_fut);
-    // Ensure query response is as expected
-    assert_eq!(&q_resp.unwrap()[0].data, query_resp);
+        query_futs.push(query_fut.boxed());
+        query_futs.push(do_workflow(true).map(|_| ()).boxed());
+    }
+    while query_futs.next().await.is_some() {}
 }
 
 #[ignore]

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -1,6 +1,5 @@
 use assert_matches::assert_matches;
-use futures::prelude::stream::FuturesUnordered;
-use futures::{FutureExt, StreamExt};
+use futures::{prelude::stream::FuturesUnordered, FutureExt, StreamExt};
 use std::time::Duration;
 use temporal_sdk_core_protos::{
     coresdk::{


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix bug where we could re-apply the final WFT when handling queries after WF is closed

## Why?
Bugs bad yo

## Checklist
<!--- add/delete as needed --->

1. Closes #198 

2. How was this tested:
Query test upgraded to verify this

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
