### PR TITLE
Automatically fail WFTs when WF code is nondeterministic w/ right cause

### DIFF
--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -992,7 +992,10 @@ pub mod temporal {
         pub mod common {
             pub mod v1 {
                 use crate::coresdk::common;
-                use std::collections::HashMap;
+                use std::{
+                    collections::HashMap,
+                    fmt::{Display, Formatter},
+                };
                 tonic::include_proto!("temporal.api.common.v1");
 
                 impl From<HashMap<String, common::Payload>> for Header {
@@ -1000,6 +1003,24 @@ pub mod temporal {
                         Self {
                             fields: h.into_iter().map(|(k, v)| (k, v.into())).collect(),
                         }
+                    }
+                }
+
+                impl Display for Payload {
+                    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                        // Attempt to render payloads as strings
+                        write!(f, "{}", std::str::from_utf8(&self.data).unwrap_or_default())
+                    }
+                }
+
+                impl Display for Header {
+                    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                        write!(f, "Header(")?;
+                        for kv in &self.fields {
+                            write!(f, "{}: ", kv.0)?;
+                            write!(f, "{}, ", kv.1)?;
+                        }
+                        write!(f, ")")
                     }
                 }
 

--- a/src/core_tests/determinism.rs
+++ b/src/core_tests/determinism.rs
@@ -1,0 +1,94 @@
+use crate::{
+    pollers::MockServerGatewayApis,
+    prototype_rust_sdk::{TestRustWorker, WfContext, WorkflowResult},
+    test_help::{
+        build_mock_pollers, canned_histories, mock_core, MockPollCfg, ResponseType,
+        DEFAULT_WORKFLOW_TYPE, TEST_Q,
+    },
+};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowTaskFailedCause;
+
+static DID_FAIL: AtomicBool = AtomicBool::new(false);
+pub async fn timer_wf_fails_once(mut ctx: WfContext) -> WorkflowResult<()> {
+    ctx.timer(Duration::from_secs(1)).await;
+    if !DID_FAIL.load(Ordering::Relaxed) {
+        DID_FAIL.store(true, Ordering::Relaxed);
+        panic!("Ahh");
+    }
+    Ok(().into())
+}
+
+#[tokio::test]
+async fn test_wf_task_rejected_properly() {
+    let wf_id = "fakeid";
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let t = canned_histories::workflow_fails_with_failure_after_timer("1");
+    let mock = MockServerGatewayApis::new();
+    let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 2], mock);
+    // We should see one wft failure which has unspecified cause, since panics don't have a defined
+    // type.
+    mh.num_expected_fails = Some(1);
+    mh.expect_fail_wft_matcher =
+        Box::new(|_, cause, _| matches!(cause, WorkflowTaskFailedCause::Unspecified));
+    let mock = build_mock_pollers(mh);
+    let core = mock_core(mock);
+    let mut worker = TestRustWorker::new(Arc::new(core), TEST_Q.to_string(), None);
+
+    worker.register_wf(wf_type.to_owned(), timer_wf_fails_once);
+    worker
+        .submit_wf(wf_id.to_owned(), wf_type.to_owned(), vec![])
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+#[rstest::rstest]
+#[case::with_cache(true)]
+#[case::without_cache(false)]
+#[tokio::test]
+async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] use_cache: bool) {
+    let wf_id = "fakeid";
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let t = canned_histories::single_timer_wf_completes("1");
+    let mock = MockServerGatewayApis::new();
+    let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [ResponseType::AllHistory], mock);
+    // We should see one wft failure which has nondeterminism cause
+    mh.num_expected_fails = Some(1);
+    mh.expect_fail_wft_matcher =
+        Box::new(|_, cause, _| matches!(cause, WorkflowTaskFailedCause::NonDeterministicError));
+    let mut mock = build_mock_pollers(mh);
+    if use_cache {
+        mock.worker_cfg(TEST_Q, |cfg| {
+            cfg.max_cached_workflows = 2;
+        });
+    }
+    let core = mock_core(mock);
+    let mut worker = TestRustWorker::new(Arc::new(core), TEST_Q.to_string(), None);
+
+    worker.register_wf(wf_type.to_owned(), |mut ctx: WfContext| {
+        let did_nondeterminism = AtomicBool::new(false);
+        async move {
+            ctx.timer(Duration::from_secs(1)).await;
+            if !did_nondeterminism.load(Ordering::Relaxed) {
+                did_nondeterminism.store(true, Ordering::Relaxed);
+                ctx.timer(Duration::from_secs(1)).await;
+            }
+            Ok(().into())
+        }
+    });
+
+    worker
+        .submit_wf(wf_id.to_owned(), wf_type.to_owned(), vec![])
+        .await
+        .unwrap();
+    // TODO: Shouldn't return error, should just queue eviction per
+    //  https://github.com/temporalio/sdk-core/issues/171
+    assert!(worker.run_until_done().await.is_err());
+}

--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -1,5 +1,6 @@
 mod activity_tasks;
 mod child_workflows;
+mod determinism;
 mod queries;
 mod replay_flag;
 mod retry;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,17 +1,20 @@
 //! Error types exposed by public APIs
 
-use crate::{machines::WFMachinesError, WorkerLookupErr};
+use crate::{machines::WFMachinesError, task_token::TaskToken, WorkerLookupErr};
 use temporal_sdk_core_protos::{
     coresdk::{activity_result::ActivityResult, workflow_completion::WfActivationCompletion},
     temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse,
 };
 use tonic::codegen::http::uri::InvalidUri;
 
+#[derive(Debug)]
 pub(crate) struct WorkflowUpdateError {
     /// Underlying workflow error
     pub source: WFMachinesError,
     /// The run id of the erring workflow
     pub run_id: String,
+    /// The task token associated with this update, if one existed yet.
+    pub task_token: Option<TaskToken>,
 }
 
 /// Errors thrown during initialization of [crate::Core]

--- a/src/pollers/gateway.rs
+++ b/src/pollers/gateway.rs
@@ -38,8 +38,7 @@ use uuid::Uuid;
 
 #[cfg(test)]
 use futures::Future;
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 use tonic::metadata::{MetadataKey, MetadataValue};
 
 static LONG_POLL_METHOD_NAMES: [&str; 2] = ["PollWorkflowTaskQueue", "PollActivityTaskQueue"];

--- a/src/prototype_rust_sdk.rs
+++ b/src/prototype_rust_sdk.rs
@@ -175,10 +175,7 @@ impl TestRustWorker {
                     debug!("Workflow {} says it's finishing", &completion.run_id);
                     self.incomplete_workflows.fetch_sub(1, Ordering::SeqCst);
                 }
-                self.core
-                    .complete_workflow_activation(completion)
-                    .await
-                    .unwrap();
+                self.core.complete_workflow_activation(completion).await?;
                 if self.incomplete_workflows.load(Ordering::SeqCst) == 0 {
                     break Ok(self);
                 }

--- a/src/workflow/workflow_tasks/concurrency_manager.rs
+++ b/src/workflow/workflow_tasks/concurrency_manager.rs
@@ -100,6 +100,7 @@ impl WorkflowConcurrencyManager {
             Err(WorkflowUpdateError {
                 source: WFMachinesError::Fatal("Workflow machines not found".to_string()),
                 run_id: run_id.to_owned(),
+                task_token: None,
             })
         }
     }
@@ -179,6 +180,7 @@ impl WorkflowConcurrencyManager {
             Err(WorkflowUpdateError {
                 source: WFMachinesError::Fatal("Workflow machines not found".to_string()),
                 run_id: run_id.to_owned(),
+                task_token: None,
             })
         }
     }

--- a/src/workflow/workflow_tasks/mod.rs
+++ b/src/workflow/workflow_tasks/mod.rs
@@ -133,7 +133,7 @@ pub enum ActivationAction {
 }
 
 macro_rules! machine_mut {
-    ($myself:ident, $run_id:ident, $clos:expr) => {{
+    ($myself:ident, $run_id:ident, $task_token:ident, $clos:expr) => {{
         $myself
             .workflow_machines
             .access($run_id, $clos)
@@ -141,6 +141,7 @@ macro_rules! machine_mut {
             .map_err(|source| WorkflowUpdateError {
                 source,
                 run_id: $run_id.to_owned(),
+                task_token: Some($task_token.clone()),
             })
     }};
 }
@@ -355,6 +356,7 @@ impl WorkflowTaskManager {
                             return Err(WorkflowUpdateError {
                                 source: WFMachinesError::Fatal("Legacy query activation response included other commands, this is not allowed and constitutes an error in the lang SDK".to_string()),
                                 run_id: run_id.to_string(),
+                                task_token: Some(task_token)
                             });
                         }
                         query_responses.push(qr);
@@ -365,15 +367,27 @@ impl WorkflowTaskManager {
             }
 
             // Send commands from lang into the machines
-            machine_mut!(self, run_id, |wfm: &mut WorkflowManager| {
+            machine_mut!(self, run_id, task_token, |wfm: &mut WorkflowManager| {
                 wfm.push_commands(commands).boxed()
             })?;
-            self.enqueue_next_activation_if_needed(run_id).await?;
+            // Check if the workflow run needs another activation and queue it up if there is one
+            // by pushing it into the pending activations list
+            let next_activation = machine_mut!(
+                self,
+                run_id,
+                task_token,
+                move |mgr: &mut WorkflowManager| mgr.get_next_activation().boxed()
+            )?;
+            if !next_activation.jobs.is_empty() {
+                self.pending_activations.push(next_activation);
+                let _ = self.pending_activations_notifier.send(true);
+            }
             // We want to fetch the outgoing commands only after any new activation has been queued,
             // as doing so may have altered the outgoing commands.
-            let server_cmds = machine_mut!(self, run_id, |wfm: &mut WorkflowManager| {
-                async move { Ok(wfm.get_server_commands()) }.boxed()
-            })?;
+            let server_cmds =
+                machine_mut!(self, run_id, task_token, |wfm: &mut WorkflowManager| {
+                    async move { Ok(wfm.get_server_commands()) }.boxed()
+                })?;
             // We only actually want to send commands back to the server if there are no more
             // pending activations and we are caught up on replay.
             if !self.pending_activations.has_pending(run_id) && !server_cmds.replaying {
@@ -488,24 +502,12 @@ impl WorkflowTaskManager {
 
                 Ok((wft_info, activation))
             }
-            Err(source) => Err(WorkflowUpdateError { source, run_id }),
+            Err(source) => Err(WorkflowUpdateError {
+                source,
+                run_id,
+                task_token: Some(wft_info.task_token),
+            }),
         }
-    }
-
-    /// Check if thew workflow run needs another activation and queue it up if there is one by
-    /// pushing it into the pending activations list
-    async fn enqueue_next_activation_if_needed(
-        &self,
-        run_id: &str,
-    ) -> Result<(), WorkflowUpdateError> {
-        let next_activation = machine_mut!(self, run_id, move |mgr: &mut WorkflowManager| mgr
-            .get_next_activation()
-            .boxed())?;
-        if !next_activation.jobs.is_empty() {
-            self.pending_activations.push(next_activation);
-            let _ = self.pending_activations_notifier.send(true);
-        }
-        Ok(())
     }
 
     /// Called after every WFT completion or failure, updates outstanding task status & issues


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Now errors on workflow completion result in auto-failure of the workflow task. In principle this should only ever be nondeterministic failures, or other edge-case panic type things.

This code can be cleaned up a bit once we do https://github.com/temporalio/sdk-core/issues/171 which I may just do next for exactly that reason, but it will require a bit more work to verify (and should result in Node changes where some code can be removed too)

## Why?
Seemingly before this change we'd just let WFT time out which I'm slightly surprised by. Now we fail properly, and include the right error code.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/170
2. How was this tested:
Existing and new tests and node integ tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
