### PR TITLE
Make unhandled command WFT completions trigger an eviction

### DIFF
--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -631,6 +631,7 @@ impl Worker {
                     // them besides poll again, which it will do anyway.
                     tonic::Code::InvalidArgument if err.message() == "UnhandledCommand" => {
                         warn!("Unhandled command response when completing: {}", err);
+                        should_evict = true;
                         Ok(())
                     }
                     tonic::Code::NotFound => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Previously when completing a workflow task returned "unhandled command" we did not evict. This could lead to potential confusion about workflow state. Now we evict.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/211

2. How was this tested:
Upgraded existing test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
