### PR TITLE
Allow long polling to retry indefinitely and under more circumstances

### DIFF
--- a/src/core_tests/retry.rs
+++ b/src/core_tests/retry.rs
@@ -12,6 +12,7 @@ async fn non_retryable_errors() {
         Code::AlreadyExists,
         Code::PermissionDenied,
         Code::FailedPrecondition,
+        Code::Cancelled,
         Code::DeadlineExceeded,
         Code::Unauthenticated,
         Code::Unimplemented,
@@ -31,13 +32,41 @@ async fn non_retryable_errors() {
 }
 
 #[tokio::test]
+async fn long_poll_non_retryable_errors() {
+    for code in [
+        Code::InvalidArgument,
+        Code::NotFound,
+        Code::AlreadyExists,
+        Code::PermissionDenied,
+        Code::FailedPrecondition,
+        Code::Unauthenticated,
+        Code::Unimplemented,
+    ] {
+        let mut mock_gateway = MockServerGatewayApis::new();
+        mock_gateway
+            .expect_poll_workflow_task()
+            .returning(move |_| Err(Status::new(code, "non-retryable failure")))
+            .times(1);
+        mock_gateway
+            .expect_poll_activity_task()
+            .returning(move |_| Err(Status::new(code, "non-retryable failure")))
+            .times(1);
+        let retry_gateway = RetryGateway::new(mock_gateway, Default::default());
+        let result = retry_gateway.poll_workflow_task("tq".to_string()).await;
+        assert!(result.is_err());
+        let result = retry_gateway.poll_activity_task("tq".to_string()).await;
+        assert!(result.is_err());
+    }
+}
+
+#[tokio::test]
 async fn retryable_errors() {
     for code in RETRYABLE_ERROR_CODES {
         let mut mock_gateway = MockServerGatewayApis::new();
         mock_gateway
             .expect_cancel_activity_task()
             .returning(move |_, _| Err(Status::new(code, "retryable failure")))
-            .times(1);
+            .times(3);
         mock_gateway
             .expect_cancel_activity_task()
             .returning(|_, _| Ok(Default::default()))
@@ -47,7 +76,66 @@ async fn retryable_errors() {
         let result = retry_gateway
             .cancel_activity_task(vec![1].into(), None)
             .await;
-        // Expecting successful response after one retry.
+        // Expecting successful response after retries
+        assert!(result.is_ok());
+    }
+}
+
+#[tokio::test]
+async fn long_poll_retries_forever() {
+    let mut mock_gateway = MockServerGatewayApis::new();
+    mock_gateway
+        .expect_poll_workflow_task()
+        .returning(move |_| Err(Status::new(Code::Unknown, "retryable failure")))
+        .times(50);
+    mock_gateway
+        .expect_poll_workflow_task()
+        .returning(|_| Ok(Default::default()))
+        .times(1);
+    mock_gateway
+        .expect_poll_activity_task()
+        .returning(move |_| Err(Status::new(Code::Unknown, "retryable failure")))
+        .times(50);
+    mock_gateway
+        .expect_poll_activity_task()
+        .returning(|_| Ok(Default::default()))
+        .times(1);
+
+    let retry_gateway = RetryGateway::new(mock_gateway, Default::default());
+
+    let result = retry_gateway.poll_workflow_task("tq".to_string()).await;
+    assert!(result.is_ok());
+    let result = retry_gateway.poll_activity_task("tq".to_string()).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn long_poll_retries_deadline_exceeded() {
+    // For some reason we will get cancelled in these situations occasionally (always?) too
+    for code in [Code::Cancelled, Code::DeadlineExceeded] {
+        let mut mock_gateway = MockServerGatewayApis::new();
+        mock_gateway
+            .expect_poll_workflow_task()
+            .returning(move |_| Err(Status::new(code, "retryable failure")))
+            .times(5);
+        mock_gateway
+            .expect_poll_workflow_task()
+            .returning(|_| Ok(Default::default()))
+            .times(1);
+        mock_gateway
+            .expect_poll_activity_task()
+            .returning(move |_| Err(Status::new(code, "retryable failure")))
+            .times(5);
+        mock_gateway
+            .expect_poll_activity_task()
+            .returning(|_| Ok(Default::default()))
+            .times(1);
+
+        let retry_gateway = RetryGateway::new(mock_gateway, Default::default());
+
+        let result = retry_gateway.poll_workflow_task("tq".to_string()).await;
+        assert!(result.is_ok());
+        let result = retry_gateway.poll_activity_task("tq".to_string()).await;
         assert!(result.is_ok());
     }
 }

--- a/src/pollers/gateway.rs
+++ b/src/pollers/gateway.rs
@@ -43,7 +43,7 @@ use tonic::metadata::{MetadataKey, MetadataValue};
 
 static LONG_POLL_METHOD_NAMES: [&str; 2] = ["PollWorkflowTaskQueue", "PollActivityTaskQueue"];
 /// The server times out polls after 60 seconds. Set our timeout to be slightly beyond that.
-const LONG_POLL_TIMEOUT: Duration = Duration::from_secs(62);
+const LONG_POLL_TIMEOUT: Duration = Duration::from_secs(70);
 const OTHER_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct GatewayRef {
@@ -160,6 +160,19 @@ impl Default for RetryConfig {
             max_interval: Duration::from_secs(5), // until it reaches 5 seconds.
             max_elapsed_time: Some(Duration::from_secs(10)), // 10 seconds total allocated time for all retries.
             max_retries: 10,
+        }
+    }
+}
+
+impl RetryConfig {
+    pub(crate) fn poll_retry_policy() -> Self {
+        Self {
+            initial_interval: Duration::from_millis(200),
+            randomization_factor: 0.2,
+            multiplier: 2.0,
+            max_interval: Duration::from_secs(10),
+            max_elapsed_time: None,
+            max_retries: 0,
         }
     }
 }

--- a/src/pollers/retry.rs
+++ b/src/pollers/retry.rs
@@ -89,7 +89,7 @@ impl TonicErrorHandler {
             return true;
         }
         // Warn if the attempts are more than 50% of max retries
-        if cur_attempt * 2 >= self.max_retries {
+        if self.max_retries > 0 && cur_attempt * 2 >= self.max_retries {
             return true;
         }
         false

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -581,7 +581,7 @@ async fn activity_cancellation_abandon() {
 
 #[tokio::test]
 async fn async_activity_completion_workflow() {
-    let (core, task_q) = init_core_and_create_wf("activity_workflow").await;
+    let (core, task_q) = init_core_and_create_wf("async_activity_workflow").await;
     let activity_id = "act-1";
     let task = core.poll_workflow_activation(&task_q).await.unwrap();
     // Complete workflow task and schedule activity


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Polling now will retry indefinitely, and ignores cancel/deadline exceeded problems

## Why?
No reason not to. Polling should retry all transient conditions

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Upgraded / added UTs

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
