### PR TITLE
Log grpc call name when printing retry errors

### DIFF
--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.54
+FROM rust:1.56
 
 RUN rustup component add rustfmt && \
 	rustup component add clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "temporal-sdk-core"
 version = "0.1.0-alpha.1"
 authors = ["Spencer Judge <spencer@temporal.io>", "Vitaly Arbuzov <vitaly@temporal.io>"]
-edition = "2018"
+edition = "2021"
 license-file = "LICENSE.txt"
 description = "Library for building new Temporal SDKs"
 homepage = "https://temporal.io/"
@@ -36,15 +36,15 @@ opentelemetry-otlp = { version = "0.9.0", features = ["tokio", "metrics"] }
 opentelemetry-prometheus = "0.9.0"
 parking_lot = { version = "0.11", features = ["send_guard"] }
 prometheus = "0.12"
-prost = "0.8"
-prost-types = "0.8"
+prost = "0.9"
+prost-types = "0.9"
 rand = "0.8.3"
 ringbuf = "0.2"
 slotmap = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs"] }
 tokio-stream = "0.1"
-tonic = { version = "0.5", features = ["tls", "tls-roots"] }
+tonic = { version = "0.6", features = ["tls", "tls-roots"] }
 tower = "0.4"
 tracing = { version = "0.1", features = ["log-always"] }
 tracing-futures = "0.2"
@@ -70,7 +70,7 @@ rstest = "0.10"
 test_utils = { path = "test_utils" }
 
 [build-dependencies]
-tonic-build = "0.5"
+tonic-build = "0.6"
 
 [workspace]
 members = [".", "fsm", "test_utils", "sdk-core-protos"]

--- a/fsm/Cargo.toml
+++ b/fsm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustfsm"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>"]
-edition = "2018"
+edition = "2021"
 license-file = "LICENSE.txt"
 description = "Define state machines that can accept events and produce commands"
 homepage = "https://temporal.io/"

--- a/fsm/rustfsm_procmacro/Cargo.toml
+++ b/fsm/rustfsm_procmacro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustfsm_procmacro"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>"]
-edition = "2018"
+edition = "2021"
 license-file = "LICENSE.txt"
 description = "Procmacro sub-crate of the `rustfsm` crate"
 

--- a/fsm/rustfsm_procmacro/tests/trybuild/no_handle_conversions_require_into_fail.stderr
+++ b/fsm/rustfsm_procmacro/tests/trybuild/no_handle_conversions_require_into_fail.stderr
@@ -1,8 +1,14 @@
 error[E0277]: the trait bound `One: From<Two>` is not satisfied
-  --> $DIR/no_handle_conversions_require_into_fail.rs:11:18
-   |
-11 |     Two --(B)--> One;
-   |                  ^^^ the trait `From<Two>` is not implemented for `One`
-   |
-   = note: required because of the requirements on the impl of `Into<One>` for `Two`
-   = note: required by `TransitionResult::<Sm, Ds>::from`
+   --> tests/trybuild/no_handle_conversions_require_into_fail.rs:11:18
+    |
+11  |     Two --(B)--> One;
+    |                  ^^^ the trait `From<Two>` is not implemented for `One`
+    |
+    = note: required because of the requirements on the impl of `Into<One>` for `Two`
+note: required by `TransitionResult::<Sm, Ds>::from`
+   --> $WORKSPACE/fsm/rustfsm_trait/src/lib.rs
+    |
+    | /     pub fn from<CurrentState>(current_state: CurrentState) -> Self
+    | |     where
+    | |         CurrentState: Into<Ds>,
+    | |_______________________________^

--- a/fsm/rustfsm_trait/Cargo.toml
+++ b/fsm/rustfsm_trait/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustfsm_trait"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>"]
-edition = "2018"
+edition = "2021"
 license-file = "LICENSE.txt"
 description = "Trait sub-crate of the `rustfsm` crate"
 

--- a/sdk-core-protos/Cargo.toml
+++ b/sdk-core-protos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temporal-sdk-core-protos"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Spencer Judge <spencer@temporal.io>"]
 license-file = "LICENSE.txt"
 description = "Protobuf definitions for Temporal SDKs Core/Lang interface"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 
 [dependencies]
 derive_more = "0.99"
-prost = "0.8"
-prost-types = "0.8"
-tonic = "0.5"
+prost = "0.9"
+prost-types = "0.9"
+tonic = "0.6"
 
 [build-dependencies]
 tonic-build = "0.5"

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_utils"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Also cargo updates & 2021 edition setting

This is a slightly annoying way to get this done, but it's straightforward and it works.