### PR TITLE
Stop returning workflow update errors from poll/complete & auto-evict

### DIFF
--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -60,7 +60,7 @@ message WFActivationJob {
         ///
         /// If other job variant are present in the list, this variant will be the last job in the
         /// job list. The string value is a reason for eviction.
-        string remove_from_cache = 50;
+        RemoveFromCache remove_from_cache = 50;
     }
 }
 
@@ -185,4 +185,8 @@ message ResolveRequestCancelExternalWorkflow {
     /// If populated, this signal either failed to be sent or was cancelled depending on failure
     /// type / info.
     temporal.api.failure.v1.Failure failure = 2;
+}
+
+message RemoveFromCache {
+    string reason = 1;
 }

--- a/protos/local/workflow_activation.proto
+++ b/protos/local/workflow_activation.proto
@@ -59,9 +59,8 @@ message WFActivationJob {
         /// after performing the activation.
         ///
         /// If other job variant are present in the list, this variant will be the last job in the
-        /// job list. The boolean value is irrelevant, since the variant type is what matters. It
-        /// will be set to true if this is the variant.
-        bool remove_from_cache = 50;
+        /// job list. The string value is a reason for eviction.
+        string remove_from_cache = 50;
     }
 }
 

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -145,7 +145,7 @@ pub mod coresdk {
                 run_id,
                 is_replaying: false,
                 jobs: vec![WfActivationJob::from(
-                    wf_activation_job::Variant::RemoveFromCache(reason),
+                    wf_activation_job::Variant::RemoveFromCache(RemoveFromCache { reason }),
                 )],
             }
         }

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -139,13 +139,13 @@ pub mod coresdk {
         use std::fmt::{Display, Formatter};
 
         tonic::include_proto!("coresdk.workflow_activation");
-        pub fn create_evict_activation(run_id: String) -> WfActivation {
+        pub fn create_evict_activation(run_id: String, reason: String) -> WfActivation {
             WfActivation {
                 timestamp: None,
                 run_id,
                 is_replaying: false,
                 jobs: vec![WfActivationJob::from(
-                    wf_activation_job::Variant::RemoveFromCache(true),
+                    wf_activation_job::Variant::RemoveFromCache(reason),
                 )],
             }
         }

--- a/src/core_tests/workers.rs
+++ b/src/core_tests/workers.rs
@@ -179,7 +179,7 @@ async fn after_shutdown_of_worker_get_shutdown_err() {
         let res = core.poll_workflow_activation(TEST_Q).await.unwrap();
         assert_matches!(
             res.jobs[0].variant,
-            Some(wf_activation_job::Variant::RemoveFromCache(true))
+            Some(wf_activation_job::Variant::RemoveFromCache(_))
         );
         core.complete_workflow_activation(WfActivationCompletion::empty(TEST_Q, run_id.clone()))
             .await

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,16 @@ pub(crate) struct WorkflowUpdateError {
     pub task_token: Option<TaskToken>,
 }
 
+impl From<WorkflowMissingError> for WorkflowUpdateError {
+    fn from(wme: WorkflowMissingError) -> Self {
+        WorkflowUpdateError {
+            source: WFMachinesError::Fatal("Workflow machines missing".to_string()),
+            run_id: wme.run_id,
+            task_token: None,
+        }
+    }
+}
+
 /// The workflow machines were expected to be in the cache but were not
 #[derive(Debug)]
 pub(crate) struct WorkflowMissingError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -116,15 +116,6 @@ pub enum CompleteWfError {
         /// The completion, which may not be included to avoid unnecessary copies.
         completion: Option<WfActivationCompletion>,
     },
-    /// There was an error specific to a workflow instance. The cached workflow should be deleted
-    /// from lang side.
-    #[error("There was an error with the workflow instance with run id ({run_id}): {source:?}")]
-    WorkflowUpdateError {
-        /// Underlying workflow error
-        source: anyhow::Error,
-        /// The run id of the erring workflow
-        run_id: String,
-    },
     /// There is no worker registered for the queue being polled
     #[error("No worker registered for queue: {0}")]
     NoWorkerForQueue(String),
@@ -132,15 +123,6 @@ pub enum CompleteWfError {
     /// errors, so lang should consider this fatal.
     #[error("Unhandled grpc error when completing workflow task: {0:?}")]
     TonicError(#[from] tonic::Status),
-}
-
-impl From<WorkflowUpdateError> for CompleteWfError {
-    fn from(e: WorkflowUpdateError) -> Self {
-        Self::WorkflowUpdateError {
-            source: e.source.into(),
-            run_id: e.run_id,
-        }
-    }
 }
 
 impl From<WorkerLookupErr> for CompleteWfError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ impl Core for CoreSDK {
 
     fn request_workflow_eviction(&self, task_queue: &str, run_id: &str) {
         if let Ok(w) = self.worker(task_queue) {
-            w.request_wf_eviction(run_id);
+            w.request_wf_eviction(run_id, "Eviction explicitly requested by lang");
         }
     }
 

--- a/src/pending_activations.rs
+++ b/src/pending_activations.rs
@@ -167,8 +167,14 @@ mod tests {
             run_id: rid1.clone(),
             ..Default::default()
         });
-        pas.push(create_evict_activation(rid1.clone()));
-        pas.push(create_evict_activation(rid2.clone()));
+        pas.push(create_evict_activation(
+            rid1.clone(),
+            "whatever".to_string(),
+        ));
+        pas.push(create_evict_activation(
+            rid2.clone(),
+            "whatever".to_string(),
+        ));
         pas.push(WfActivation {
             run_id: rid2.clone(),
             ..Default::default()

--- a/src/prototype_rust_sdk.rs
+++ b/src/prototype_rust_sdk.rs
@@ -383,7 +383,7 @@ pub enum WfExitValue<T: Debug> {
     /// Confirm the workflow was cancelled (can be automatic in a more advanced iteration)
     #[from(ignore)]
     Cancelled,
-    /// TODO: Will go away once we have eviction confirmation
+    /// The run was evicted
     #[from(ignore)]
     Evicted,
     /// Finish with a result

--- a/src/test_help/canned_histories.rs
+++ b/src/test_help/canned_histories.rs
@@ -947,6 +947,7 @@ pub fn two_signals(sig_1_id: &str, sig_2_id: &str) -> TestHistoryBuilder {
 ///  x: EVENT_TYPE_TIMER_FIRED
 ///  x: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
 ///  x: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  x: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
 /// --- End repeat ---
 /// 4 + (num tasks - 1) * 4 + 1: EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
 pub fn long_sequential_timers(num_tasks: usize) -> TestHistoryBuilder {

--- a/src/test_help/mod.rs
+++ b/src/test_help/mod.rs
@@ -47,6 +47,7 @@ use temporal_sdk_core_protos::{
 
 pub type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 pub const TEST_Q: &str = "q";
+pub static NO_MORE_WORK_ERROR_MSG: &str = "No more work to do";
 
 /// When constructing responses for mocks, indicates how a given response should be built
 #[derive(derive_more::From, Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -458,7 +459,7 @@ pub fn build_mock_pollers(mut cfg: MockPollCfg) -> MocksHolder<MockServerGateway
                         }
                     }
                 }
-                Some(Err(tonic::Status::cancelled("No more work to do")))
+                Some(Err(tonic::Status::cancelled(NO_MORE_WORK_ERROR_MSG)))
             });
         let mw = MockWorker::new(&task_q, Box::from(mock_poller));
         mock_pollers.insert(task_q, mw);

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -275,7 +275,7 @@ impl Worker {
             // We must first check if there are pending workflow activations for workflows that are
             // currently replaying or otherwise need immediate jobs, and issue those before
             // bothering the server.
-            if let Some(pa) = self.wft_manager.next_pending_activation()? {
+            if let Some(pa) = self.wft_manager.next_pending_activation() {
                 debug!(activation=%pa, "Sending pending activation to lang");
                 return Ok(pa);
             }
@@ -449,7 +449,7 @@ impl Worker {
         let res = self
             .wft_manager
             .apply_new_poll_resp(work, &self.server_gateway)
-            .await?;
+            .await;
         match &res {
             NewWfTaskOutcome::IssueActivation(a) => {
                 debug!(activation=%a, "Sending activation to lang");
@@ -480,6 +480,10 @@ impl Worker {
                         }),
                     )
                     .await?;
+            }
+            NewWfTaskOutcome::Evict(e) => {
+                warn!(error=?e, run_id=%we.run_id, "Error while applying poll response to workflow");
+                self.request_wf_eviction(&we.run_id);
             }
         };
         Ok(res)

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -284,7 +284,7 @@ impl Worker {
             // activations, since there may be an eviction etc for whatever run is popped here.
             if let Some(buff_wft) = self.wft_manager.next_buffered_poll() {
                 match self.apply_server_work(buff_wft).await? {
-                    NewWfTaskOutcome::IssueActivation(a) => return Ok(a),
+                    Some(a) => return Ok(a),
                     _ => continue,
                 }
             }
@@ -304,14 +304,8 @@ impl Worker {
 
             if let Some(work) = selected_f {
                 self.metrics.wf_tq_poll_ok();
-                match self.apply_server_work(work).await? {
-                    NewWfTaskOutcome::IssueActivation(a) => return Ok(a),
-                    NewWfTaskOutcome::TaskBuffered => {
-                        // If the task was buffered, it's not actually outstanding, so we can
-                        // immediately return a permit.
-                        self.return_workflow_task_permit();
-                    }
-                    _ => {}
+                if let Some(a) = self.apply_server_work(work).await? {
+                    return Ok(a);
                 }
             }
 
@@ -443,18 +437,24 @@ impl Worker {
     async fn apply_server_work(
         &self,
         work: ValidPollWFTQResponse,
-    ) -> Result<NewWfTaskOutcome, PollWfError> {
+    ) -> Result<Option<WfActivation>, PollWfError> {
         let we = work.workflow_execution.clone();
         let tt = work.task_token.clone();
         let res = self
             .wft_manager
             .apply_new_poll_resp(work, &self.server_gateway)
             .await;
-        match &res {
+        Ok(match res {
             NewWfTaskOutcome::IssueActivation(a) => {
                 debug!(activation=%a, "Sending activation to lang");
+                Some(a)
             }
-            NewWfTaskOutcome::TaskBuffered => {}
+            NewWfTaskOutcome::TaskBuffered => {
+                // If the task was buffered, it's not actually outstanding, so we can
+                // immediately return a permit.
+                self.return_workflow_task_permit();
+                None
+            }
             NewWfTaskOutcome::Autocomplete => {
                 debug!(workflow_execution=?we,
                        "No work for lang to perform after polling server. Sending autocomplete.");
@@ -464,6 +464,7 @@ impl Worker {
                     status: Some(workflow_completion::Success::from_variants(vec![]).into()),
                 })
                 .await?;
+                None
             }
             NewWfTaskOutcome::CacheMiss => {
                 debug!(workflow_execution=?we, "Unable to process workflow task with partial \
@@ -480,6 +481,7 @@ impl Worker {
                         }),
                     )
                     .await?;
+                None
             }
             NewWfTaskOutcome::Evict(e) => {
                 warn!(error=?e, run_id=%we.run_id, "Error while applying poll response to workflow");
@@ -487,9 +489,9 @@ impl Worker {
                     &we.run_id,
                     format!("Error while applying poll response to workflow: {:?}", e),
                 );
+                None
             }
-        };
-        Ok(res)
+        })
     }
 
     /// Handle a successful workflow completion
@@ -655,8 +657,7 @@ impl Worker {
             _ => Ok(()),
         };
         if should_evict {
-            self.wft_manager
-                .request_eviction(run_id, "Error reporting WFT to server");
+            self.request_wf_eviction(run_id, "Error reporting WFT to server");
         }
         res.map_err(Into::into)
     }

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -277,6 +277,7 @@ pub mod managed_wf {
             // Send an eviction to ensure wf exits if it has not finished (ex: feeding partial hist)
             let _ = self.activation_tx.send(create_evict_activation(
                 "not actually important".to_string(),
+                "force shutdown".to_string(),
             ));
             self.future_handle.take().unwrap().await.unwrap()
         }

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -3,6 +3,7 @@ mod cancel_external;
 mod cancel_wf;
 mod child_workflows;
 mod continue_as_new;
+mod determinism;
 mod patches;
 mod signals;
 mod stickyness;

--- a/tests/integ_tests/workflow_tests/determinism.rs
+++ b/tests/integ_tests/workflow_tests/determinism.rs
@@ -44,4 +44,6 @@ async fn test_determinism_error_then_recovers() {
         .unwrap();
     worker.run_until_done().await.unwrap();
     starter.shutdown().await;
+    // 4 because we still add on the 3rd and final attempt
+    assert_eq!(RUN_CT.load(Ordering::Relaxed), 4);
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
We no longer return `WorkflowUpdateError` variants from polling/completing workflow tasks. It put an unnecessary burden on lang to deal with those errors, when the only thing that can really ever happen is to evict them. Now this eviction happens automatically.

## Why?
* Remove work from lang
* Correctness. Failing a WFT before this change could put the workflow in a stuck state.

TODO:
- [x] Attach reasons

Closes https://github.com/temporalio/sdk-core/issues/171