### PR TITLE
Fix issue with receiving child wf result before we awaited for it

### DIFF
--- a/src/core_tests/child_workflows.rs
+++ b/src/core_tests/child_workflows.rs
@@ -44,13 +44,13 @@ async fn signal_child_workflow(#[case] serial: bool) {
             .into_started()
             .expect("Child should get started");
         let (sigres, res) = if serial {
-            let sigfut = start_res.signal(&mut ctx, SIGNAME, b"Hi!");
-            let resfut = start_res.result();
-            join!(sigfut, resfut)
-        } else {
             let sigres = start_res.signal(&mut ctx, SIGNAME, b"Hi!").await;
             let res = start_res.result().await;
             (sigres, res)
+        } else {
+            let sigfut = start_res.signal(&mut ctx, SIGNAME, b"Hi!");
+            let resfut = start_res.result();
+            join!(sigfut, resfut)
         };
         sigres.expect("signal result is ok");
         res.status.expect("child wf result is ok");

--- a/src/core_tests/child_workflows.rs
+++ b/src/core_tests/child_workflows.rs
@@ -1,8 +1,15 @@
 use crate::{
-    prototype_rust_sdk::{ChildWorkflowOptions, WfContext, WorkflowFunction, WorkflowResult},
-    test_help::canned_histories,
+    pollers::MockServerGatewayApis,
+    prototype_rust_sdk::{
+        ChildWorkflowOptions, TestRustWorker, WfContext, WorkflowFunction, WorkflowResult,
+    },
+    test_help::{
+        build_mock_pollers, canned_histories, mock_core, MockPollCfg, ResponseType,
+        DEFAULT_WORKFLOW_TYPE, TEST_Q,
+    },
     workflow::managed_wf::ManagedWFFunc,
 };
+use std::sync::Arc;
 use temporal_sdk_core_protos::coresdk::child_workflow::{
     child_workflow_result, ChildWorkflowCancellationType,
 };
@@ -10,33 +17,52 @@ use tokio::join;
 
 const SIGNAME: &str = "SIGNAME";
 
-async fn parent_wf(mut ctx: WfContext) -> WorkflowResult<()> {
-    let child = ctx.child_workflow(ChildWorkflowOptions {
-        workflow_id: "child-id-1".to_string(),
-        workflow_type: "child".to_string(),
-        ..Default::default()
-    });
-
-    let start_res = child
-        .start(&mut ctx)
-        .await
-        .as_started()
-        .expect("Child should get started");
-    let sigfut = start_res.signal(&mut ctx, SIGNAME, b"Hi!");
-    let resfut = start_res.result(&mut ctx);
-    let (sigres, res) = join!(sigfut, resfut);
-    sigres.expect("signal result is ok");
-    res.status.expect("child wf result is ok");
-    Ok(().into())
-}
-
+#[rstest::rstest]
+#[case::signal_then_result(true)]
+#[case::signal_and_result_concurrent(false)]
 #[tokio::test]
-async fn signal_child_workflow() {
-    let func = WorkflowFunction::new(parent_wf);
+async fn signal_child_workflow(#[case] serial: bool) {
+    let wf_id = "fakeid";
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
     let t = canned_histories::single_child_workflow_signaled("child-id-1", SIGNAME);
-    let mut wfm = ManagedWFFunc::new(t, func, vec![]);
-    wfm.process_all_activations().await.unwrap();
-    wfm.shutdown().await.unwrap();
+    let mock = MockServerGatewayApis::new();
+    let mh = MockPollCfg::from_resp_batches(wf_id, t, [ResponseType::AllHistory], mock);
+    let mock = build_mock_pollers(mh);
+    let core = mock_core(mock);
+    let mut worker = TestRustWorker::new(Arc::new(core), TEST_Q.to_string(), None);
+
+    let wf = move |mut ctx: WfContext| async move {
+        let child = ctx.child_workflow(ChildWorkflowOptions {
+            workflow_id: "child-id-1".to_string(),
+            workflow_type: "child".to_string(),
+            ..Default::default()
+        });
+
+        let start_res = child
+            .start(&mut ctx)
+            .await
+            .into_started()
+            .expect("Child should get started");
+        let (sigres, res) = if serial {
+            let sigfut = start_res.signal(&mut ctx, SIGNAME, b"Hi!");
+            let resfut = start_res.result();
+            join!(sigfut, resfut)
+        } else {
+            let sigres = start_res.signal(&mut ctx, SIGNAME, b"Hi!").await;
+            let res = start_res.result().await;
+            (sigres, res)
+        };
+        sigres.expect("signal result is ok");
+        res.status.expect("child wf result is ok");
+        Ok(().into())
+    };
+
+    worker.register_wf(wf_type.to_owned(), wf);
+    worker
+        .submit_wf(wf_id.to_owned(), wf_type.to_owned(), vec![])
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
 }
 
 async fn parent_cancels_child_wf(mut ctx: WfContext) -> WorkflowResult<()> {
@@ -50,10 +76,10 @@ async fn parent_cancels_child_wf(mut ctx: WfContext) -> WorkflowResult<()> {
     let start_res = child
         .start(&mut ctx)
         .await
-        .as_started()
+        .into_started()
         .expect("Child should get started");
     let cancel_fut = start_res.cancel(&mut ctx);
-    let resfut = start_res.result(&mut ctx);
+    let resfut = start_res.result();
     let (cancel_res, res) = join!(cancel_fut, resfut);
     cancel_res.expect("cancel result is ok");
     let stat = res.status.expect("child wf result is ok");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,8 @@ impl Core for CoreSDK {
         }
     }
 
-    #[instrument(level = "debug", skip(self, completion), fields(completion=%&completion))]
+    #[instrument(level = "debug", skip(self, completion), 
+      fields(completion=%&completion, run_id=%completion.run_id))]
     async fn complete_workflow_activation(
         &self,
         completion: WfActivationCompletion,

--- a/src/machines/child_workflow_state_machine.rs
+++ b/src/machines/child_workflow_state_machine.rs
@@ -693,12 +693,7 @@ mod test {
         };
         match (
             expectation,
-            start_res
-                .as_started()
-                .unwrap()
-                .result(&mut ctx)
-                .await
-                .status,
+            start_res.into_started().unwrap().result().await.status,
         ) {
             (Expectation::Success, Some(child_workflow_result::Status::Completed(_))) => {
                 Ok(().into())

--- a/src/prototype_rust_sdk.rs
+++ b/src/prototype_rust_sdk.rs
@@ -12,7 +12,10 @@ pub use workflow_context::{
     ActivityOptions, CancellableFuture, ChildWorkflow, ChildWorkflowOptions, WfContext,
 };
 
-use crate::{prototype_rust_sdk::workflow_context::PendingChildWorkflow, Core};
+use crate::{
+    prototype_rust_sdk::workflow_context::{ChildWfCommon, PendingChildWorkflow},
+    Core,
+};
 use anyhow::{anyhow, bail};
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use std::{
@@ -219,12 +222,12 @@ pub type CancelExternalWfResult = Result<CancelExternalOk, Failure>;
 trait Unblockable {
     type OtherDat;
 
-    fn unblock(ue: UnblockEvent, od: &Self::OtherDat) -> Self;
+    fn unblock(ue: UnblockEvent, od: Self::OtherDat) -> Self;
 }
 
 impl Unblockable for TimerResult {
     type OtherDat = ();
-    fn unblock(ue: UnblockEvent, _: &Self::OtherDat) -> Self {
+    fn unblock(ue: UnblockEvent, _: Self::OtherDat) -> Self {
         match ue {
             UnblockEvent::Timer(_) => TimerResult,
             _ => panic!("Invalid unblock event for timer"),
@@ -234,7 +237,7 @@ impl Unblockable for TimerResult {
 
 impl Unblockable for ActivityResult {
     type OtherDat = ();
-    fn unblock(ue: UnblockEvent, _: &Self::OtherDat) -> Self {
+    fn unblock(ue: UnblockEvent, _: Self::OtherDat) -> Self {
         match ue {
             UnblockEvent::Activity(_, result) => *result,
             _ => panic!("Invalid unblock event for activity"),
@@ -244,13 +247,12 @@ impl Unblockable for ActivityResult {
 
 impl Unblockable for PendingChildWorkflow {
     // Other data here is workflow id
-    type OtherDat = String;
-    fn unblock(ue: UnblockEvent, od: &Self::OtherDat) -> Self {
+    type OtherDat = ChildWfCommon;
+    fn unblock(ue: UnblockEvent, od: Self::OtherDat) -> Self {
         match ue {
-            UnblockEvent::WorkflowStart(seq, result) => PendingChildWorkflow {
-                child_wf_cmd_seq_num: seq,
+            UnblockEvent::WorkflowStart(_, result) => PendingChildWorkflow {
                 status: *result,
-                wfid: od.clone(),
+                common: od,
             },
             _ => panic!("Invalid unblock event for child workflow start"),
         }
@@ -259,7 +261,7 @@ impl Unblockable for PendingChildWorkflow {
 
 impl Unblockable for ChildWorkflowResult {
     type OtherDat = ();
-    fn unblock(ue: UnblockEvent, _: &Self::OtherDat) -> Self {
+    fn unblock(ue: UnblockEvent, _: Self::OtherDat) -> Self {
         match ue {
             UnblockEvent::WorkflowComplete(_, result) => *result,
             _ => panic!("Invalid unblock event for child workflow complete"),
@@ -269,7 +271,7 @@ impl Unblockable for ChildWorkflowResult {
 
 impl Unblockable for SignalExternalWfResult {
     type OtherDat = ();
-    fn unblock(ue: UnblockEvent, _: &Self::OtherDat) -> Self {
+    fn unblock(ue: UnblockEvent, _: Self::OtherDat) -> Self {
         match ue {
             UnblockEvent::SignalExternal(_, maybefail) => {
                 if let Some(f) = maybefail {
@@ -285,7 +287,7 @@ impl Unblockable for SignalExternalWfResult {
 
 impl Unblockable for CancelExternalWfResult {
     type OtherDat = ();
-    fn unblock(ue: UnblockEvent, _: &Self::OtherDat) -> Self {
+    fn unblock(ue: UnblockEvent, _: Self::OtherDat) -> Self {
         match ue {
             UnblockEvent::CancelExternal(_, maybefail) => {
                 if let Some(f) = maybefail {

--- a/src/prototype_rust_sdk/workflow_context.rs
+++ b/src/prototype_rust_sdk/workflow_context.rs
@@ -280,7 +280,7 @@ pub trait CancellableFuture<T>: Future<Output = T> {
 struct WFCommandFut<T, D> {
     _unused: PhantomData<T>,
     result_rx: oneshot::Receiver<UnblockEvent>,
-    other_dat: D,
+    other_dat: Option<D>,
 }
 impl<T> WFCommandFut<T, ()> {
     fn new() -> (Self, oneshot::Sender<UnblockEvent>) {
@@ -295,7 +295,7 @@ impl<T, D> WFCommandFut<T, D> {
             Self {
                 _unused: PhantomData,
                 result_rx: rx,
-                other_dat,
+                other_dat: Some(other_dat),
             },
             tx,
         )
@@ -310,9 +310,15 @@ where
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.result_rx
-            .poll_unpin(cx)
-            .map(|x| Unblockable::unblock(x.unwrap(), &self.other_dat))
+        self.result_rx.poll_unpin(cx).map(|x| {
+            // SAFETY: Because we can only enter this section once the future has resolved, we
+            // know it will never be polled again, therefore consuming the option is OK.
+            let od = self
+                .other_dat
+                .take()
+                .expect("Other data must exist when resolving command future");
+            Unblockable::unblock(x.unwrap(), od)
+        })
     }
 }
 
@@ -348,10 +354,7 @@ where
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.cmd_fut
-            .result_rx
-            .poll_unpin(cx)
-            .map(|x| Unblockable::unblock(x.unwrap(), &self.cmd_fut.other_dat))
+        self.cmd_fut.poll_unpin(cx)
     }
 }
 
@@ -460,21 +463,24 @@ pub struct ChildWorkflow {
     opts: ChildWorkflowOptions,
 }
 
+pub struct ChildWfCommon {
+    workflow_id: String,
+    result_future: CancellableWFCommandFut<ChildWorkflowResult, ()>,
+}
+
 pub struct PendingChildWorkflow {
-    pub(crate) child_wf_cmd_seq_num: u32,
     pub status: ChildWorkflowStartStatus,
-    pub wfid: String,
+    pub common: ChildWfCommon,
 }
 
 impl PendingChildWorkflow {
     /// Returns `None` if the child did not start successfully. The returned [StartedChildWorkflow]
     /// can be used to wait on, signal, or cancel the child workflow.
-    pub fn as_started(&self) -> Option<StartedChildWorkflow> {
-        match &self.status {
+    pub fn into_started(self) -> Option<StartedChildWorkflow> {
+        match self.status {
             ChildWorkflowStartStatus::Succeeded(s) => Some(StartedChildWorkflow {
-                child_wf_cmd_seq_num: self.child_wf_cmd_seq_num,
-                run_id: s.run_id.clone(),
-                workflow_id: self.wfid.clone(),
+                run_id: s.run_id,
+                common: self.common,
             }),
             _ => None,
         }
@@ -482,9 +488,8 @@ impl PendingChildWorkflow {
 }
 
 pub struct StartedChildWorkflow {
-    pub(crate) child_wf_cmd_seq_num: u32,
     pub run_id: String,
-    pub workflow_id: String,
+    common: ChildWfCommon,
 }
 
 impl ChildWorkflow {
@@ -492,10 +497,35 @@ impl ChildWorkflow {
     pub fn start(self, cx: &mut WfContext) -> impl CancellableFuture<PendingChildWorkflow> {
         let child_seq = cx.next_child_workflow_sequence_number;
         cx.next_child_workflow_sequence_number += 1;
-        let (cmd, unblocker) = CancellableWFCommandFut::new_with_dat(
-            CancellableID::ChildWorkflow(child_seq),
-            self.opts.workflow_id.clone(),
+        // Immediately create the command/future for the result, otherwise if the user does
+        // not await the result until *after* we receive an activation for it, there will be nothing
+        // to match when unblocking.
+        let cancel_seq = cx.next_cancel_external_wf_sequence_number;
+        cx.next_cancel_external_wf_sequence_number += 1;
+        let (result_cmd, unblocker) =
+            CancellableWFCommandFut::new(CancellableID::ExternalWorkflow {
+                seqnum: cancel_seq,
+                execution: NamespacedWorkflowExecution {
+                    workflow_id: self.opts.workflow_id.clone(),
+                    ..Default::default()
+                },
+                only_child: true,
+            });
+        cx.send(
+            CommandSubscribeChildWorkflowCompletion {
+                seq: child_seq,
+                unblocker,
+            }
+            .into(),
         );
+
+        let common = ChildWfCommon {
+            workflow_id: self.opts.workflow_id.clone(),
+            result_future: result_cmd,
+        };
+
+        let (cmd, unblocker) =
+            CancellableWFCommandFut::new_with_dat(CancellableID::ChildWorkflow(child_seq), common);
         cx.send(
             CommandCreateRequest {
                 cmd: self.opts.into_command(child_seq).into(),
@@ -503,38 +533,23 @@ impl ChildWorkflow {
             }
             .into(),
         );
+
         cmd
     }
 }
 
 impl StartedChildWorkflow {
-    /// Create a future that will wait until completion of this child workflow execution
-    pub fn result(&self, cx: &mut WfContext) -> impl CancellableFuture<ChildWorkflowResult> {
-        let cancel_seq = cx.next_cancel_external_wf_sequence_number;
-        cx.next_cancel_external_wf_sequence_number += 1;
-        let (cmd, unblocker) = CancellableWFCommandFut::new(CancellableID::ExternalWorkflow {
-            seqnum: cancel_seq,
-            execution: NamespacedWorkflowExecution {
-                workflow_id: self.workflow_id.clone(),
-                ..Default::default()
-            },
-            only_child: true,
-        });
-        cx.send(
-            CommandSubscribeChildWorkflowCompletion {
-                seq: self.child_wf_cmd_seq_num,
-                unblocker,
-            }
-            .into(),
-        );
-        cmd
+    /// Consumes self and returns a future that will wait until completion of this child workflow
+    /// execution
+    pub fn result(self) -> impl CancellableFuture<ChildWorkflowResult> {
+        self.common.result_future
     }
 
     /// Cancel the child workflow
     pub fn cancel(&self, cx: &mut WfContext) -> impl Future<Output = CancelExternalWfResult> {
         let target = NamespacedWorkflowExecution {
             namespace: cx.namespace().to_string(),
-            workflow_id: self.workflow_id.clone(),
+            workflow_id: self.common.workflow_id.clone(),
             ..Default::default()
         };
         cx.cancel_external(target)
@@ -547,7 +562,7 @@ impl StartedChildWorkflow {
         signal_name: impl Into<String>,
         payload: impl Into<Payload>,
     ) -> impl CancellableFuture<SignalExternalWfResult> {
-        let target = sig_we::Target::ChildWorkflowId(self.workflow_id.clone());
+        let target = sig_we::Target::ChildWorkflowId(self.common.workflow_id.clone());
         cx.send_signal_wf(signal_name, payload, target)
     }
 }

--- a/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -20,9 +20,9 @@ async fn parent_wf(mut ctx: WfContext) -> WorkflowResult<()> {
     let started = child
         .start(&mut ctx)
         .await
-        .as_started()
+        .into_started()
         .expect("Child chould start OK");
-    match started.result(&mut ctx).await.status {
+    match started.result().await.status {
         Some(child_workflow_result::Status::Completed(Success { .. })) => Ok(().into()),
         _ => Err(anyhow!("Unexpected child WF status")),
     }

--- a/tests/integ_tests/workflow_tests/signals.rs
+++ b/tests/integ_tests/workflow_tests/signals.rs
@@ -78,13 +78,13 @@ async fn signals_child(mut ctx: WfContext) -> WorkflowResult<()> {
         })
         .start(&mut ctx)
         .await
-        .as_started()
+        .into_started()
         .expect("Must start ok");
     started_child
         .signal(&mut ctx, SIGNAME, b"hiya!")
         .await
         .unwrap();
-    started_child.result(&mut ctx).await.status.unwrap();
+    started_child.result().await.status.unwrap();
     Ok(().into())
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Before this fix if the test SDK received an activation resolving a child workflow before the workflow code awaited on the result, it would blow up because there was nothing to "resolve" yet.

This problem is now fixed by creating the future for resolution at the same time we start the child wf. 

## Why?
Bug
