### PR TITLE
Polling needs to specify queue type

### DIFF
--- a/src/core_tests/mod.rs
+++ b/src/core_tests/mod.rs
@@ -65,7 +65,7 @@ async fn shutdown_interrupts_both_polls() {
     mock_gateway
         .expect_poll_workflow_task()
         .times(1)
-        .returning(move |_| {
+        .returning(move |_, _| {
             async move {
                 BARR.wait().await;
                 sleep(Duration::from_secs(1)).await;

--- a/src/core_tests/retry.rs
+++ b/src/core_tests/retry.rs
@@ -45,14 +45,16 @@ async fn long_poll_non_retryable_errors() {
         let mut mock_gateway = MockServerGatewayApis::new();
         mock_gateway
             .expect_poll_workflow_task()
-            .returning(move |_| Err(Status::new(code, "non-retryable failure")))
+            .returning(move |_, _| Err(Status::new(code, "non-retryable failure")))
             .times(1);
         mock_gateway
             .expect_poll_activity_task()
             .returning(move |_| Err(Status::new(code, "non-retryable failure")))
             .times(1);
         let retry_gateway = RetryGateway::new(mock_gateway, Default::default());
-        let result = retry_gateway.poll_workflow_task("tq".to_string()).await;
+        let result = retry_gateway
+            .poll_workflow_task("tq".to_string(), false)
+            .await;
         assert!(result.is_err());
         let result = retry_gateway.poll_activity_task("tq".to_string()).await;
         assert!(result.is_err());
@@ -86,11 +88,11 @@ async fn long_poll_retries_forever() {
     let mut mock_gateway = MockServerGatewayApis::new();
     mock_gateway
         .expect_poll_workflow_task()
-        .returning(move |_| Err(Status::new(Code::Unknown, "retryable failure")))
+        .returning(move |_, _| Err(Status::new(Code::Unknown, "retryable failure")))
         .times(50);
     mock_gateway
         .expect_poll_workflow_task()
-        .returning(|_| Ok(Default::default()))
+        .returning(|_, _| Ok(Default::default()))
         .times(1);
     mock_gateway
         .expect_poll_activity_task()
@@ -103,7 +105,9 @@ async fn long_poll_retries_forever() {
 
     let retry_gateway = RetryGateway::new(mock_gateway, Default::default());
 
-    let result = retry_gateway.poll_workflow_task("tq".to_string()).await;
+    let result = retry_gateway
+        .poll_workflow_task("tq".to_string(), false)
+        .await;
     assert!(result.is_ok());
     let result = retry_gateway.poll_activity_task("tq".to_string()).await;
     assert!(result.is_ok());
@@ -116,11 +120,11 @@ async fn long_poll_retries_deadline_exceeded() {
         let mut mock_gateway = MockServerGatewayApis::new();
         mock_gateway
             .expect_poll_workflow_task()
-            .returning(move |_| Err(Status::new(code, "retryable failure")))
+            .returning(move |_, _| Err(Status::new(code, "retryable failure")))
             .times(5);
         mock_gateway
             .expect_poll_workflow_task()
-            .returning(|_| Ok(Default::default()))
+            .returning(|_, _| Ok(Default::default()))
             .times(1);
         mock_gateway
             .expect_poll_activity_task()
@@ -133,7 +137,9 @@ async fn long_poll_retries_deadline_exceeded() {
 
         let retry_gateway = RetryGateway::new(mock_gateway, Default::default());
 
-        let result = retry_gateway.poll_workflow_task("tq".to_string()).await;
+        let result = retry_gateway
+            .poll_workflow_task("tq".to_string(), false)
+            .await;
         assert!(result.is_ok());
         let result = retry_gateway.poll_activity_task("tq".to_string()).await;
         assert!(result.is_ok());

--- a/src/pollers/retry.rs
+++ b/src/pollers/retry.rs
@@ -165,12 +165,14 @@ impl<SG: ServerGatewayApis + Send + Sync + 'static> ServerGatewayApis for RetryG
     async fn poll_workflow_task(
         &self,
         task_queue: String,
+        is_sticky: bool,
     ) -> Result<PollWorkflowTaskQueueResponse> {
         retry_call!(
             self,
             CallType::LongPoll,
             poll_workflow_task,
-            task_queue.clone()
+            task_queue.clone(),
+            is_sticky
         )
     }
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -98,6 +98,7 @@ impl Worker {
         let mut wf_task_poll_buffer = new_workflow_task_buffer(
             sg.gw.clone(),
             config.task_queue.clone(),
+            false,
             max_nonsticky_polls,
             max_nonsticky_polls * 2,
         );
@@ -107,6 +108,7 @@ impl Worker {
             let mut sp = new_workflow_task_buffer(
                 sg.gw.clone(),
                 sqn.clone(),
+                true,
                 max_sticky_polls,
                 max_sticky_polls * 2,
             );
@@ -729,7 +731,7 @@ mod tests {
         let mut mock_gateway = MockServerGatewayApis::new();
         mock_gateway
             .expect_poll_workflow_task()
-            .returning(|_| Ok(PollWorkflowTaskQueueResponse::default()));
+            .returning(|_, _| Ok(PollWorkflowTaskQueueResponse::default()));
         let gwref = GatewayRef::new(Arc::new(mock_gateway), fake_sg_opts());
 
         let cfg = WorkerConfigBuilder::default()
@@ -765,7 +767,7 @@ mod tests {
         let mut mock_gateway = MockServerGatewayApis::new();
         mock_gateway
             .expect_poll_workflow_task()
-            .returning(|_| Err(tonic::Status::internal("ahhh")));
+            .returning(|_, _| Err(tonic::Status::internal("ahhh")));
         let gwref = GatewayRef::new(Arc::new(mock_gateway), fake_sg_opts());
 
         let cfg = WorkerConfigBuilder::default()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Apparently polling must specify the queue kind for optimization reasons on server. Fix that.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
