### PR TITLE
Smattering of bugfixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,15 @@ impl CoreSDK {
         self.workers.set_worker_for_task_queue(tq, worker).unwrap();
     }
 
+    #[cfg(test)]
+    pub(crate) fn outstanding_wfts(&self, tq: &str) -> usize {
+        self.worker(tq).unwrap().outstanding_workflow_tasks()
+    }
+    #[cfg(test)]
+    pub(crate) fn available_wft_permits(&self, tq: &str) -> usize {
+        self.worker(tq).unwrap().available_wft_permits()
+    }
+
     fn get_sticky_q_name_for_worker(&self, config: &WorkerConfig) -> Option<String> {
         if config.max_cached_workflows > 0 {
             Some(format!(

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -248,7 +248,8 @@ where
         let res = self.cancel();
         res.map_err(|e| match e {
             MachineError::InvalidTransition => WFMachinesError::Fatal(format!(
-                "Invalid transition while attempting to cancel in {}",
+                "Invalid transition while attempting to cancel {} in {}",
+                self.name(),
                 self.state(),
             )),
             MachineError::Underlying(e) => e.into(),

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -39,6 +39,10 @@ fsm! {
         --(CommandCancelTimer, on_command_cancel_timer) --> CancelTimerCommandSent;
 
     CancelTimerCommandSent --(TimerCanceled) --> Canceled;
+
+    // Ignore any spurious cancellations after resolution
+    Canceled --(Cancel) --> Canceled;
+    Fired --(Cancel) --> Fired;
 }
 
 #[derive(Debug, derive_more::Display)]
@@ -275,6 +279,7 @@ mod test {
         workflow::managed_wf::ManagedWFFunc,
     };
     use rstest::{fixture, rstest};
+    use std::mem::discriminant;
     use std::time::Duration;
 
     #[fixture]
@@ -419,5 +424,18 @@ mod test {
         let commands = wfm.get_server_commands().await.commands;
         assert_eq!(commands.len(), 0);
         wfm.shutdown().await.unwrap();
+    }
+
+    #[test]
+    fn cancels_ignored_terminal() {
+        for state in [TimerMachineState::Canceled(Canceled {}), Fired {}.into()] {
+            let mut s = TimerMachine {
+                state: state.clone(),
+                shared_state: Default::default(),
+            };
+            let cmds = s.cancel().unwrap();
+            assert_eq!(cmds.len(), 0);
+            assert_eq!(discriminant(&state), discriminant(&s.state))
+        }
     }
 }

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -626,15 +626,15 @@ impl WorkflowMachines {
                     .machine_mut(c.machine)
                     .handle_command(c.command.command_type())?;
                 self.process_machine_responses(c.machine, machine_responses)?;
+                self.commands.push_back(c);
             }
-            self.commands.push_back(c);
         }
         debug!(commands = %self.commands.display(), "prepared commands");
         Ok(())
     }
 
     /// After a machine handles either an event or a command, it produces [MachineResponses] which
-    /// this function uses to drive sending jobs to lang, trigging new workflow tasks, etc.
+    /// this function uses to drive sending jobs to lang, triggering new workflow tasks, etc.
     fn process_machine_responses(
         &mut self,
         sm: MachineKey,

--- a/src/test_help/canned_histories.rs
+++ b/src/test_help/canned_histories.rs
@@ -228,39 +228,9 @@ pub fn single_activity(activity_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
-    let started_event_id = t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
-    t.add(
-        EventType::ActivityTaskCompleted,
-        history_event::Attributes::ActivityTaskCompletedEventAttributes(
-            ActivityTaskCompletedEventAttributes {
-                scheduled_event_id,
-                started_event_id,
-                // todo add the result payload
-                ..Default::default()
-            },
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
+    let started_event_id = t.add_activity_task_started(scheduled_event_id);
+    t.add_activity_task_completed(scheduled_event_id, started_event_id, Default::default());
     t.add_workflow_task_scheduled_and_started();
     t
 }
@@ -278,28 +248,8 @@ pub fn single_failed_activity(activity_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
-    let started_event_id = t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
+    let started_event_id = t.add_activity_task_started(scheduled_event_id);
     t.add(
         EventType::ActivityTaskFailed,
         history_event::Attributes::ActivityTaskFailedEventAttributes(
@@ -329,17 +279,7 @@ pub fn cancel_scheduled_activity(activity_id: &str, signal_id: &str) -> TestHist
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add_we_signaled(
         signal_id,
         vec![Payload {
@@ -375,17 +315,7 @@ pub fn scheduled_activity_timeout(activity_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add(
         EventType::ActivityTaskTimedOut,
         history_event::Attributes::ActivityTaskTimedOutEventAttributes(
@@ -422,17 +352,7 @@ pub fn scheduled_cancelled_activity_timeout(
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add_we_signaled(
         signal_id,
         vec![Payload {

--- a/src/test_help/history_builder.rs
+++ b/src/test_help/history_builder.rs
@@ -9,7 +9,10 @@ use crate::{
 use anyhow::bail;
 use std::time::SystemTime;
 use temporal_sdk_core_protos::{
-    coresdk::common::{build_has_change_marker_details, NamespacedWorkflowExecution},
+    coresdk::common::{
+        build_has_change_marker_details, NamespacedWorkflowExecution, Payload as CorePayload,
+    },
+    coresdk::IntoPayloadsExt,
     temporal::api::{
         common::v1::{Payload, Payloads, WorkflowExecution, WorkflowType},
         enums::v1::{EventType, WorkflowTaskFailedCause},
@@ -134,6 +137,52 @@ impl TestHistoryBuilder {
     pub fn add_cancelled(&mut self) {
         let attrs = WorkflowExecutionCanceledEventAttributes::default();
         self.build_and_push_event(EventType::WorkflowExecutionCanceled, attrs.into());
+    }
+
+    pub fn add_activity_task_scheduled(&mut self, activity_id: impl Into<String>) -> i64 {
+        self.add_get_event_id(
+            EventType::ActivityTaskScheduled,
+            Some(
+                history_event::Attributes::ActivityTaskScheduledEventAttributes(
+                    ActivityTaskScheduledEventAttributes {
+                        activity_id: activity_id.into(),
+                        ..Default::default()
+                    },
+                ),
+            ),
+        )
+    }
+    pub fn add_activity_task_started(&mut self, scheduled_event_id: i64) -> i64 {
+        self.add_get_event_id(
+            EventType::ActivityTaskStarted,
+            Some(
+                history_event::Attributes::ActivityTaskStartedEventAttributes(
+                    ActivityTaskStartedEventAttributes {
+                        scheduled_event_id,
+                        ..Default::default()
+                    },
+                ),
+            ),
+        )
+    }
+
+    pub fn add_activity_task_completed(
+        &mut self,
+        scheduled_event_id: i64,
+        started_event_id: i64,
+        payload: CorePayload,
+    ) {
+        self.add(
+            EventType::ActivityTaskCompleted,
+            history_event::Attributes::ActivityTaskCompletedEventAttributes(
+                ActivityTaskCompletedEventAttributes {
+                    scheduled_event_id,
+                    started_event_id,
+                    result: vec![payload].into_payloads(),
+                    ..Default::default()
+                },
+            ),
+        )
     }
 
     pub fn add_activity_task_cancel_requested(&mut self, scheduled_event_id: i64) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* Fix a situation where we could get stuck polling if WFTs were repeatedly being failed
* Allow lang to send us cancels for already-completed things. This is unavoidable in some situations and we shouldn't blow up. Now they are simply dropped
* Fix for us accidentally still sending commands sometimes for things that were cancelled immediately

## Why?
Bugs!

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
