### PR TITLE
Fix activity heartbeat behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ ringbuf = "0.2"
 slotmap = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs"] }
+tokio-util = { version = "0.6.9" }
 tokio-stream = "0.1"
 tonic = { version = "0.6", features = ["tls", "tls-roots"] }
 tower = "0.4"

--- a/src/worker/activities.rs
+++ b/src/worker/activities.rs
@@ -254,10 +254,7 @@ impl WorkerActivityTasks {
             .heartbeat_timeout
             .clone()
             // We treat None as 0 (even though heartbeat_timeout is never set to None by the server)
-            .unwrap_or(prost_types::Duration {
-                nanos: 0,
-                seconds: 0,
-            })
+            .unwrap_or(Default::default())
             .try_into()
             // This technically should never happen since prost duration should be directly mappable
             // to std::time::Duration.

--- a/src/worker/activities.rs
+++ b/src/worker/activities.rs
@@ -254,7 +254,7 @@ impl WorkerActivityTasks {
             .heartbeat_timeout
             .clone()
             // We treat None as 0 (even though heartbeat_timeout is never set to None by the server)
-            .unwrap_or(Default::default())
+            .unwrap_or_default()
             .try_into()
             // This technically should never happen since prost duration should be directly mappable
             // to std::time::Duration.

--- a/src/worker/activities.rs
+++ b/src/worker/activities.rs
@@ -10,7 +10,6 @@ use activity_heartbeat_manager::ActivityHeartbeatManager;
 use dashmap::DashMap;
 use std::{
     convert::TryInto,
-    ops::Div,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -80,6 +79,9 @@ pub(crate) struct WorkerActivityTasks {
     activities_semaphore: Semaphore,
 
     metrics: MetricsContext,
+
+    max_heartbeat_throttle_interval: Duration,
+    default_heartbeat_throttle_interval: Duration,
 }
 
 impl WorkerActivityTasks {
@@ -88,6 +90,8 @@ impl WorkerActivityTasks {
         poller: BoxedActPoller,
         sg: Arc<impl ServerGatewayApis + Send + Sync + 'static + ?Sized>,
         metrics: MetricsContext,
+        max_heartbeat_throttle_interval: Duration,
+        default_heartbeat_throttle_interval: Duration,
     ) -> Self {
         Self {
             heartbeat_manager: ActivityHeartbeatManager::new(sg),
@@ -95,12 +99,13 @@ impl WorkerActivityTasks {
             poller,
             activities_semaphore: Semaphore::new(max_activity_tasks),
             metrics,
+            max_heartbeat_throttle_interval,
+            default_heartbeat_throttle_interval,
         }
     }
 
     pub(crate) fn notify_shutdown(&self) {
         self.poller.notify_shutdown();
-        self.heartbeat_manager.notify_shutdown();
     }
 
     pub(crate) async fn shutdown(self) {
@@ -242,22 +247,33 @@ impl WorkerActivityTasks {
         details: ActivityHeartbeat,
     ) -> Result<(), ActivityHeartbeatError> {
         // TODO: Propagate these back as cancels. Silent fails is too nonobvious
-        let t: Duration = self
+        let heartbeat_timeout: Duration = self
             .outstanding_activity_tasks
             .get(&TaskToken(details.task_token.clone()))
             .ok_or(ActivityHeartbeatError::UnknownActivity)?
             .heartbeat_timeout
             .clone()
-            .ok_or(ActivityHeartbeatError::HeartbeatTimeoutNotSet)?
+            // We treat None as 0 (even though heartbeat_timeout is never set to None by the server)
+            .unwrap_or(prost_types::Duration {
+                nanos: 0,
+                seconds: 0,
+            })
             .try_into()
+            // This technically should never happen since prost duration should be directly mappable
+            // to std::time::Duration.
             .or(Err(ActivityHeartbeatError::InvalidHeartbeatTimeout))?;
+
         // There is a bug in the server that translates non-set heartbeat timeouts into 0 duration.
         // That's why we treat 0 the same way as None, otherwise we wouldn't know which aggregation
         // delay to use, and using 0 is not a good idea as SDK would hammer the server too hard.
-        if t.as_millis() == 0 {
-            return Err(ActivityHeartbeatError::HeartbeatTimeoutNotSet);
-        }
-        self.heartbeat_manager.record(details, t.div(2))
+        let throttle_interval = if heartbeat_timeout.as_millis() == 0 {
+            self.default_heartbeat_throttle_interval
+        } else {
+            heartbeat_timeout.mul_f64(0.8)
+        };
+        let throttle_interval =
+            std::cmp::min(throttle_interval, self.max_heartbeat_throttle_interval);
+        self.heartbeat_manager.record(details, throttle_interval)
     }
 
     async fn next_pending_cancel_task(&self) -> Result<Option<ActivityTask>, PollActivityError> {

--- a/src/worker/activities/activity_heartbeat_manager.rs
+++ b/src/worker/activities/activity_heartbeat_manager.rs
@@ -341,7 +341,7 @@ mod test {
     };
     use tokio::time::sleep;
 
-    /// Ensure that heartbeats that are sent with a small throttleInterval are aggregated and sent roughly once
+    /// Ensure that heartbeats that are sent with a small `throttle_interval` are aggregated and sent roughly once
     /// every 1/2 of the heartbeat timeout.
     #[tokio::test]
     async fn process_heartbeats_and_shutdown() {

--- a/src/worker/activities/activity_heartbeat_manager.rs
+++ b/src/worker/activities/activity_heartbeat_manager.rs
@@ -220,10 +220,12 @@ impl HeartbeatStreamState {
 
     /// Activity should not be tracked anymore, cancel throttle timer if running
     fn evict(&mut self, tt: TaskToken) -> Option<HeartbeatExecutorAction> {
-        if let Some(state) = self.tt_to_state.remove(&tt) {
-            if let Some(tx) = state.throttled_cancellation_token {
-                let _ = tx.cancel();
-            }
+        if let Some(token) = self
+            .tt_to_state
+            .remove(&tt)
+            .and_then(|st| st.throttled_cancellation_token)
+        {
+            let _ = token.cancel();
         };
         None
     }

--- a/src/worker/config.rs
+++ b/src/worker/config.rs
@@ -51,6 +51,17 @@ pub struct WorkerConfig {
     /// and moved to the non-sticky queue where it may be picked up by any worker.
     #[builder(default = "Duration::from_secs(10)")]
     pub sticky_queue_schedule_to_start_timeout: Duration,
+
+    /// Longest interval for throttling activity heartbeats
+    #[builder(default = "Duration::from_secs(60)")]
+    pub max_heartbeat_throttle_interval: Duration,
+
+    /// Default interval for throttling activity heartbeats in case
+    /// `ActivityOptions.heartbeat_timeout` is unset.
+    /// When the timeout *is* set in the `ActivityOptions`, throttling is set to
+    /// `heartbeat_timeout * 0.8`.
+    #[builder(default = "Duration::from_secs(30)")]
+    pub default_heartbeat_throttle_interval: Duration,
 }
 
 impl WorkerConfigBuilder {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -174,6 +174,8 @@ impl Worker {
                     ap,
                     sg.gw.clone(),
                     metrics.clone(),
+                    config.max_heartbeat_throttle_interval,
+                    config.default_heartbeat_throttle_interval,
                 )
             }),
             workflows_semaphore: Semaphore::new(config.max_outstanding_workflow_tasks),


### PR DESCRIPTION
Behavior was incorrect, heartbeats need to be throttled using a timer and not count on Lang to keep sending heartbeats in order to be flushed.

Added 2 new Worker options to control throttling:
* `max_heartbeat_throttle_interval`
* `default_heartbeat_throttle_interval`
