### PR TITLE
Local activity timer-based backoff

### DIFF
--- a/protos/local/activity_result.proto
+++ b/protos/local/activity_result.proto
@@ -66,6 +66,8 @@ message WillCompleteAsync {
  * from lang. So expecting lang to start the timer / next pass of the activity fits more smoothly.
  */
 message DoBackoff {
+    // The attempt number that lang should provide when scheduling the retry. If the LA failed
+    // on attempt 4 and we told lang to back off with a timer, this number will be 5.
     uint32 attempt = 1;
     google.protobuf.Duration backoff_duration = 2;
 }

--- a/protos/local/external_data.proto
+++ b/protos/local/external_data.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package coresdk.external_data;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 
 // This file defines data that Core might write externally. The first motivating case being
 // storing data in markers in event history. Defining such data as protos provides an easy way
@@ -10,10 +11,17 @@ import "google/protobuf/timestamp.proto";
 
 message LocalActivityMarkerData {
   uint32 seq = 1;
-  string activity_id = 2;
-  string activity_type = 3;
+  // The number of attempts at execution before we recorded this result. Typically starts at 1,
+  // but it is possible to start at a higher number when backing off using a timer.
+  uint32 attempt = 2;
+  string activity_id = 3;
+  string activity_type = 4;
   // You can think of this as "perceived completion time". It is the time the local activity thought
   // it was when it completed. Which could be different from wall-clock time because of workflow
   // replay. It's the WFT start time + the LA's runtime
-  google.protobuf.Timestamp complete_time = 4;
+  google.protobuf.Timestamp complete_time = 5;
+  // If set, this local activity conceptually is retrying after the specified backoff.
+  // Implementation wise, they are really two different LA machines, but with the same type & input.
+  // The retry starts with an attempt number > 1.
+  google.protobuf.Duration backoff = 6;
 }

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -109,6 +109,10 @@ message ScheduleLocalActivity {
     /// Specify a retry policy for the local activity. By default local activities will be retried
     /// indefinitely.
     common.RetryPolicy retry_policy = 10;
+    /// If the activity is retrying and backoff would exceed this value, lang will be told to
+    /// schedule a timer and retry the activity after. Otherwise, backoff will happen internally in
+    /// core.
+    google.protobuf.Duration local_retry_threshold = 11;
 }
 
 enum ActivityCancellationType {

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -87,24 +87,28 @@ message ScheduleLocalActivity {
     uint32 seq = 1;
     string activity_id = 2;
     string activity_type = 3;
-    map<string, common.Payload> header_fields = 4;
+    /// Local activities can start with a non-1 attempt, if lang has been told to backoff using
+    /// a timer before retrying. It should pass the attempt number from a `DoBackoff` activity
+    /// resolution.
+    uint32 attempt = 4;
+    map<string, common.Payload> header_fields = 5;
     /// Arguments/input to the activity.
-    repeated common.Payload arguments = 7;
+    repeated common.Payload arguments = 6;
     /// Indicates how long the caller is willing to wait for local activity completion. Limits how
     /// long retries will be attempted. Either this or start_to_close_timeout_seconds must be
     /// specified. When not specified defaults to the workflow execution timeout.
-    google.protobuf.Duration schedule_to_close_timeout = 8;
+    google.protobuf.Duration schedule_to_close_timeout = 7;
     /// Limits time the local activity can idle internally before being executed. That can happen if
     /// the worker is currently at max concurrent local activity executions. This timeout is always
     /// non retryable as all a retry would achieve is to put it back into the same queue. Defaults
     /// to schedule_to_close_timeout or workflow execution timeout if not specified.
-    google.protobuf.Duration schedule_to_start_timeout = 9;
+    google.protobuf.Duration schedule_to_start_timeout = 8;
     /// Maximum time the local activity is allowed to execute after the task is dispatched. This
     /// timeout is always retryable. Either this or schedule_to_close_timeout must be specified.
-    google.protobuf.Duration start_to_close_timeout = 10;
+    google.protobuf.Duration start_to_close_timeout = 9;
     /// Specify a retry policy for the local activity. By default local activities will be retried
     /// indefinitely.
-    common.RetryPolicy retry_policy = 12;
+    common.RetryPolicy retry_policy = 10;
 }
 
 enum ActivityCancellationType {

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -29,6 +29,7 @@ message WorkflowCommand {
         RequestCancelExternalWorkflowExecution request_cancel_external_workflow_execution = 13;
         SignalExternalWorkflowExecution signal_external_workflow_execution = 14;
         CancelSignalWorkflow cancel_signal_workflow = 15;
+        ScheduleLocalActivity schedule_local_activity = 16;
 
         // To be added as/if needed:
         //  UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 14;
@@ -72,13 +73,38 @@ message ScheduleActivity {
     google.protobuf.Duration heartbeat_timeout = 11;
     /// Activities are provided by a default retry policy controlled through the service dynamic
     /// configuration. Retries are happening up to schedule_to_close_timeout. To disable retries set
-    /// retry_policy.maximum_attempts to 2.
+    /// retry_policy.maximum_attempts to 1.
     common.RetryPolicy retry_policy = 12;
     /// Defines behaviour of the underlying workflow when activity cancellation has been requested.
     ActivityCancellationType cancellation_type = 13;
     // If set true, this activity will be local. Only this worker will execute it and heartbeating
     // will not apply.
     bool local = 14;
+}
+
+message ScheduleLocalActivity {
+    /// Lang's incremental sequence number, used as the operation identifier
+    uint32 seq = 1;
+    string activity_id = 2;
+    string activity_type = 3;
+    map<string, common.Payload> header_fields = 4;
+    /// Arguments/input to the activity.
+    repeated common.Payload arguments = 7;
+    /// Indicates how long the caller is willing to wait for local activity completion. Limits how
+    /// long retries will be attempted. Either this or start_to_close_timeout_seconds must be
+    /// specified. When not specified defaults to the workflow execution timeout.
+    google.protobuf.Duration schedule_to_close_timeout = 8;
+    /// Limits time the local activity can idle internally before being executed. That can happen if
+    /// the worker is currently at max concurrent local activity executions. This timeout is always
+    /// non retryable as all a retry would achieve is to put it back into the same queue. Defaults
+    /// to schedule_to_close_timeout or workflow execution timeout if not specified.
+    google.protobuf.Duration schedule_to_start_timeout = 9;
+    /// Maximum time the local activity is allowed to execute after the task is dispatched. This
+    /// timeout is always retryable. Either this or schedule_to_close_timeout must be specified.
+    google.protobuf.Duration start_to_close_timeout = 10;
+    /// Specify a retry policy for the local activity. By default local activities will be retried
+    /// indefinitely.
+    common.RetryPolicy retry_policy = 12;
 }
 
 enum ActivityCancellationType {

--- a/sdk-core-protos/build.rs
+++ b/sdk-core-protos/build.rs
@@ -79,6 +79,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "coresdk.external_data.LocalActivityMarkerData.complete_time",
             "#[serde(with = \"opt_timestamp\")]",
         )
+        .field_attribute(
+            "coresdk.external_data.LocalActivityMarkerData.backoff",
+            "#[serde(with = \"opt_duration\")]",
+        )
         .compile(
             &[
                 "../protos/local/core_interface.proto",

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -494,6 +494,16 @@ pub mod coresdk {
             }
         }
 
+        impl Display for ScheduleLocalActivity {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(
+                    f,
+                    "ScheduleLocalActivity({}, {})",
+                    self.seq, self.activity_type
+                )
+            }
+        }
+
         impl Display for QueryResult {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 write!(f, "RespondToQuery({})", self.query_id)

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -220,9 +220,12 @@ pub mod coresdk {
     }
 
     pub mod external_data {
-        use prost_types::Timestamp;
+        use prost_types::{Duration, Timestamp};
         use serde::{Deserialize, Deserializer, Serialize, Serializer};
         tonic::include_proto!("coresdk.external_data");
+
+        // Buncha hullaballoo because prost types aren't serde compat.
+        // See https://github.com/tokio-rs/prost/issues/75 which hilariously Chad opened ages ago
 
         #[derive(Serialize, Deserialize)]
         #[serde(remote = "Timestamp")]
@@ -230,9 +233,6 @@ pub mod coresdk {
             pub seconds: i64,
             pub nanos: i32,
         }
-
-        // Buncha hullaballoo because prost types aren't serde compat.
-        // See https://github.com/tokio-rs/prost/issues/75 which hilariously Chad opened ages ago
         mod opt_timestamp {
             use super::*;
 
@@ -252,6 +252,38 @@ pub mod coresdk {
             {
                 #[derive(Deserialize)]
                 struct Helper(#[serde(with = "TimestampDef")] Timestamp);
+
+                let helper = Option::deserialize(deserializer)?;
+                Ok(helper.map(|Helper(external)| external))
+            }
+        }
+
+        // Luckily Duration is also stored the exact same way
+        #[derive(Serialize, Deserialize)]
+        #[serde(remote = "Duration")]
+        struct DurationDef {
+            pub seconds: i64,
+            pub nanos: i32,
+        }
+        mod opt_duration {
+            use super::*;
+
+            pub fn serialize<S>(value: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                #[derive(Serialize)]
+                struct Helper<'a>(#[serde(with = "DurationDef")] &'a Duration);
+
+                value.as_ref().map(Helper).serialize(serializer)
+            }
+
+            pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper(#[serde(with = "DurationDef")] Duration);
 
                 let helper = Option::deserialize(deserializer)?;
                 Ok(helper.map(|Helper(external)| external))

--- a/src/core_tests/determinism.rs
+++ b/src/core_tests/determinism.rs
@@ -16,7 +16,7 @@ use std::{
 use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowTaskFailedCause;
 
 static DID_FAIL: AtomicBool = AtomicBool::new(false);
-pub async fn timer_wf_fails_once(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn timer_wf_fails_once(ctx: WfContext) -> WorkflowResult<()> {
     ctx.timer(Duration::from_secs(1)).await;
     if DID_FAIL
         .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
@@ -85,7 +85,7 @@ async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] use_cache:
     let mut worker = TestRustWorker::new(Arc::new(core), TEST_Q.to_string(), None);
 
     let started_count: &'static _ = Box::leak(Box::new(AtomicUsize::new(0)));
-    worker.register_wf(wf_type.to_owned(), move |mut ctx: WfContext| async move {
+    worker.register_wf(wf_type.to_owned(), move |ctx: WfContext| async move {
         // The workflow is replaying all of history, so the when it schedules an extra timer it
         // should not have, it causes a nondeterminism error.
         if started_count.fetch_add(1, Ordering::Relaxed) == 0 {

--- a/src/core_tests/local_activities.rs
+++ b/src/core_tests/local_activities.rs
@@ -17,8 +17,8 @@ use std::{
     time::Duration,
 };
 use temporal_sdk_core_protos::{
-    coresdk::{common::RetryPolicy, AsJsonPayloadExt},
-    temporal::api::enums::v1::EventType,
+    coresdk::{activity_result::activity_resolution, common::RetryPolicy, AsJsonPayloadExt},
+    temporal::api::{enums::v1::EventType, failure::v1::Failure},
 };
 use tokio::sync::Barrier;
 
@@ -244,7 +244,7 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
     let attempts: &'static _ = Box::leak(Box::new(AtomicUsize::new(0)));
     worker.register_activity("echo", move |_: String| async move {
         // Succeed on 3rd attempt
-        if 2 == attempts.fetch_add(1, Ordering::Relaxed) && eventually_pass {
+        if 3 == attempts.fetch_add(1, Ordering::Relaxed) && eventually_pass {
             Ok(())
         } else {
             Err(anyhow!("Oh no I failed!"))
@@ -257,4 +257,77 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
     worker.run_until_done().await.unwrap();
     let expected_attempts = if eventually_pass { 3 } else { 4 };
     assert_eq!(expected_attempts, attempts.load(Ordering::Relaxed));
+}
+
+#[tokio::test]
+async fn local_act_retry_long_backoff_uses_timer() {
+    let mut t = TestHistoryBuilder::default();
+    let mut wes_short_wft_timeout = default_wes_attribs();
+    wes_short_wft_timeout.workflow_task_timeout = Some(Duration::from_millis(500).into());
+    t.add(
+        EventType::WorkflowExecutionStarted,
+        wes_short_wft_timeout.into(),
+    );
+    t.add_full_wf_task();
+    t.add_local_activity_fail_marker(
+        1,
+        "1",
+        Failure::application_failure("la failed".to_string(), false),
+    );
+    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    t.add_timer_fired(timer_started_event_id, "1".to_string());
+    t.add_full_wf_task();
+    // t.add_local_activity_result_marker(1, "1", b"echo".into());
+    t.add_workflow_execution_completed();
+
+    let wf_id = "fakeid";
+    let mock = MockServerGatewayApis::new();
+    let mh = MockPollCfg::from_resp_batches(wf_id, t, [1.into(), ResponseType::AllHistory], mock);
+    let mut mock = build_mock_pollers(mh);
+    // TODO: Probably test w/o cache too -
+    mock.worker_cfg(TEST_Q, |w| w.max_cached_workflows = 1);
+    let core = mock_core(mock);
+    let mut worker = TestRustWorker::new(Arc::new(core), TEST_Q.to_string(), None);
+
+    worker.register_wf(
+        DEFAULT_WORKFLOW_TYPE.to_owned(),
+        |mut ctx: WfContext| async move {
+            let la_res = ctx
+                .local_activity(LocalActivityOptions {
+                    activity_type: "echo".to_string(),
+                    input: "hi".as_json_payload().expect("serializes fine"),
+                    retry_policy: RetryPolicy {
+                        initial_interval: Some(Duration::from_millis(65).into()),
+                        // This will make the second backoff 65 seconds, plenty to use timer
+                        backoff_coefficient: 1_000.,
+                        maximum_interval: Some(Duration::from_secs(600).into()),
+                        maximum_attempts: 3,
+                        non_retryable_error_types: vec![],
+                    },
+                    ..Default::default()
+                })
+                .await;
+            if let Some(activity_resolution::Status::Backoff(b)) = la_res.status {
+                ctx.timer(
+                    b.backoff_duration
+                        .expect("Duration is set")
+                        .try_into()
+                        .expect("duration converts ok"),
+                )
+                .await;
+            } else {
+                panic!("LA must resolve with backoff result");
+            }
+            Ok(().into())
+        },
+    );
+    worker.register_activity("echo", move |_: String| async move {
+        // Activity just always fails since our workflow doesn't *actually* retry it after timer
+        Result::<(), _>::Err(anyhow!("Oh no I failed!"))
+    });
+    worker
+        .submit_wf(wf_id.to_owned(), DEFAULT_WORKFLOW_TYPE.to_owned(), vec![])
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
 }

--- a/src/core_tests/local_activities.rs
+++ b/src/core_tests/local_activities.rs
@@ -17,11 +17,7 @@ use std::{
     time::Duration,
 };
 use temporal_sdk_core_protos::{
-    coresdk::{
-        activity_result::{activity_resolution, ActivityResolution},
-        common::RetryPolicy,
-        AsJsonPayloadExt,
-    },
+    coresdk::{common::RetryPolicy, AsJsonPayloadExt},
     temporal::api::{enums::v1::EventType, failure::v1::Failure},
 };
 use tokio::sync::Barrier;
@@ -303,39 +299,22 @@ async fn local_act_retry_long_backoff_uses_timer() {
     worker.register_wf(
         DEFAULT_WORKFLOW_TYPE.to_owned(),
         |ctx: WfContext| async move {
-            let mut la_opts = LocalActivityOptions {
-                activity_type: "echo".to_string(),
-                input: "hi".as_json_payload().expect("serializes fine"),
-                retry_policy: RetryPolicy {
-                    initial_interval: Some(Duration::from_millis(65).into()),
-                    // This will make the second backoff 65 seconds, plenty to use timer
-                    backoff_coefficient: 1_000.,
-                    maximum_interval: Some(Duration::from_secs(600).into()),
-                    maximum_attempts: 4,
-                    non_retryable_error_types: vec![],
-                },
-                ..Default::default()
-            };
-
-            let la_res = ctx.local_activity_no_timer_retry(la_opts.clone()).await;
-            if let Some(activity_resolution::Status::Backoff(b)) = la_res.status {
-                ctx.timer(
-                    b.backoff_duration
-                        .expect("Duration is set")
-                        .try_into()
-                        .expect("duration converts ok"),
-                )
+            let la_res = ctx
+                .local_activity(LocalActivityOptions {
+                    activity_type: "echo".to_string(),
+                    input: "hi".as_json_payload().expect("serializes fine"),
+                    retry_policy: RetryPolicy {
+                        initial_interval: Some(Duration::from_millis(65).into()),
+                        // This will make the second backoff 65 seconds, plenty to use timer
+                        backoff_coefficient: 1_000.,
+                        maximum_interval: Some(Duration::from_secs(600).into()),
+                        maximum_attempts: 3,
+                        non_retryable_error_types: vec![],
+                    },
+                    ..Default::default()
+                })
                 .await;
-                // Attempt # is 3 because we wanted to use timer backoff after failing the 2nd time
-                assert_eq!(b.attempt, 3);
-                // Explicitly schedule the next attempt
-                la_opts.attempt = Some(b.attempt);
-                let la_res = ctx.local_activity_no_timer_retry(la_opts).await;
-                assert_matches!(la_res, ActivityResolution {
-                    status: Some(activity_resolution::Status::Backoff(b))} if b.attempt == 4);
-            } else {
-                panic!("LA must resolve with backoff result");
-            }
+            assert!(la_res.failed());
             // Extra timer just to have an extra workflow task which we can return full history for
             ctx.timer(Duration::from_secs(1)).await;
             Ok(().into())

--- a/src/core_tests/local_activities.rs
+++ b/src/core_tests/local_activities.rs
@@ -263,12 +263,7 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
 #[tokio::test]
 async fn local_act_retry_long_backoff_uses_timer() {
     let mut t = TestHistoryBuilder::default();
-    let mut wes_short_wft_timeout = default_wes_attribs();
-    wes_short_wft_timeout.workflow_task_timeout = Some(Duration::from_millis(500).into());
-    t.add(
-        EventType::WorkflowExecutionStarted,
-        wes_short_wft_timeout.into(),
-    );
+    t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     t.add_local_activity_fail_marker(
         1,

--- a/src/core_tests/replay_flag.rs
+++ b/src/core_tests/replay_flag.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use temporal_sdk_core_protos::temporal::api::enums::v1::CommandType;
 
 fn timers_wf(num_timers: u32) -> WorkflowFunction {
-    WorkflowFunction::new(move |mut command_sink: WfContext| async move {
+    WorkflowFunction::new(move |command_sink: WfContext| async move {
         for _ in 1..=num_timers {
             command_sink.timer(Duration::from_secs(1)).await;
         }

--- a/src/machines/activity_state_machine.rs
+++ b/src/machines/activity_state_machine.rs
@@ -776,7 +776,7 @@ mod test {
         ManagedWFFunc::new(t, func, vec![])
     }
 
-    async fn activity_wf(mut command_sink: WfContext) -> WorkflowResult<()> {
+    async fn activity_wf(command_sink: WfContext) -> WorkflowResult<()> {
         command_sink.activity(ActivityOptions::default()).await;
         Ok(().into())
     }
@@ -825,10 +825,10 @@ mod test {
 
     #[tokio::test]
     async fn immediate_activity_cancelation() {
-        let func = WorkflowFunction::new(|mut ctx: WfContext| async move {
+        let func = WorkflowFunction::new(|ctx: WfContext| async move {
             let cancel_activity_future = ctx.activity(ActivityOptions::default());
             // Immediately cancel the activity
-            cancel_activity_future.cancel(&mut ctx);
+            cancel_activity_future.cancel(&ctx);
             cancel_activity_future.await;
             Ok(().into())
         });

--- a/src/machines/cancel_external_state_machine.rs
+++ b/src/machines/cancel_external_state_machine.rs
@@ -236,7 +236,7 @@ mod tests {
         workflow::managed_wf::ManagedWFFunc,
     };
 
-    async fn cancel_sender(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn cancel_sender(ctx: WfContext) -> WorkflowResult<()> {
         let res = ctx
             .cancel_external(NamespacedWorkflowExecution {
                 namespace: "some_namespace".to_string(),

--- a/src/machines/cancel_workflow_state_machine.rs
+++ b/src/machines/cancel_workflow_state_machine.rs
@@ -132,7 +132,7 @@ mod tests {
         wf_activation_job, WfActivationJob,
     };
 
-    async fn wf_with_timer(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn wf_with_timer(ctx: WfContext) -> WorkflowResult<()> {
         ctx.timer(Duration::from_millis(500)).await;
         Ok(WfExitValue::Cancelled)
     }

--- a/src/machines/child_workflow_state_machine.rs
+++ b/src/machines/child_workflow_state_machine.rs
@@ -673,7 +673,7 @@ mod test {
         ManagedWFFunc::new(t, func, vec![[Expectation::StartFailure as u8].into()])
     }
 
-    async fn parent_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn parent_wf(ctx: WfContext) -> WorkflowResult<()> {
         let expectation = Expectation::try_from_u8(ctx.get_args()[0].data[0]).unwrap();
         let child = ctx.child_workflow(ChildWorkflowOptions {
             workflow_id: "child-id-1".to_string(),
@@ -681,7 +681,7 @@ mod test {
             ..Default::default()
         });
 
-        let start_res = child.start(&mut ctx).await;
+        let start_res = child.start(&ctx).await;
         match (expectation, &start_res.status) {
             (Expectation::Success | Expectation::Failure, StartStatus::Succeeded(_)) => {}
             (Expectation::StartFailure, StartStatus::Failed(_)) => return Ok(().into()),
@@ -751,15 +751,15 @@ mod test {
         wfm.shutdown().await.unwrap();
     }
 
-    async fn cancel_before_send_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn cancel_before_send_wf(ctx: WfContext) -> WorkflowResult<()> {
         let workflow_id = "child-id-1";
         let child = ctx.child_workflow(ChildWorkflowOptions {
             workflow_id: workflow_id.to_string(),
             workflow_type: "child".to_string(),
             ..Default::default()
         });
-        let start = child.start(&mut ctx);
-        start.cancel(&mut ctx);
+        let start = child.start(&ctx);
+        start.cancel(&ctx);
         match start.await.status {
             StartStatus::Cancelled(_) => Ok(().into()),
             _ => Err(anyhow!("Unexpected start status")),

--- a/src/machines/continue_as_new_workflow_state_machine.rs
+++ b/src/machines/continue_as_new_workflow_state_machine.rs
@@ -128,7 +128,7 @@ mod tests {
     };
     use std::time::Duration;
 
-    async fn wf_with_timer(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn wf_with_timer(ctx: WfContext) -> WorkflowResult<()> {
         ctx.timer(Duration::from_millis(500)).await;
         Ok(WfExitValue::continue_as_new(
             ContinueAsNewWorkflowExecution {

--- a/src/machines/local_activity_state_machine.rs
+++ b/src/machines/local_activity_state_machine.rs
@@ -446,7 +446,7 @@ impl WFMachinesAdapter for LocalActivityMachine {
                     ActivityResolution {
                         status: Some(
                             DoBackoff {
-                                attempt,
+                                attempt: attempt + 1,
                                 backoff_duration: Some(b.clone()),
                             }
                             .into(),

--- a/src/machines/local_activity_state_machine.rs
+++ b/src/machines/local_activity_state_machine.rs
@@ -1,10 +1,9 @@
-use crate::protosext::TryIntoOrNone;
 use crate::{
     machines::{
         workflow_machines::MachineResponse, Cancellable, EventInfo, MachineKind, OnEventWrapper,
         WFMachinesAdapter, WFMachinesError,
     },
-    protosext::{CompleteLocalActivityData, HistoryEventExt},
+    protosext::{CompleteLocalActivityData, HistoryEventExt, TryIntoOrNone},
 };
 use rustfsm::{fsm, MachineError, StateMachine, TransitionResult};
 use std::{
@@ -17,7 +16,7 @@ use temporal_sdk_core_protos::{
         common::build_local_activity_marker_details,
         external_data::LocalActivityMarkerData,
         workflow_activation::ResolveActivity,
-        workflow_commands::ScheduleActivity,
+        workflow_commands::ScheduleLocalActivity,
     },
     temporal::api::{
         command::v1::{Command, RecordMarkerCommandAttributes},
@@ -105,7 +104,7 @@ impl From<CompleteLocalActivityData> for ResolveDat {
 /// must resolve before we send a record marker command. A [MachineResponse] may be produced,
 /// to queue the LA for execution if it needs to be.
 pub(super) fn new_local_activity(
-    attrs: ScheduleActivity,
+    attrs: ScheduleLocalActivity,
     replaying_when_invoked: bool,
     maybe_pre_resolved: Option<ResolveDat>,
     wf_time: Option<SystemTime>,
@@ -232,14 +231,14 @@ impl LocalActivityMachine {
 
 #[derive(Clone)]
 pub(super) struct SharedState {
-    attrs: ScheduleActivity,
+    attrs: ScheduleLocalActivity,
     replaying_when_invoked: bool,
     wf_time_when_started: Option<SystemTime>,
 }
 
 #[derive(Debug, derive_more::Display)]
 pub(super) enum LocalActivityCommand {
-    RequestActivityExecution(ScheduleActivity),
+    RequestActivityExecution(ScheduleLocalActivity),
     #[display(fmt = "Resolved")]
     Resolved(ResolveDat),
     /// The fake marker is used to avoid special casing marker recorded event handling.

--- a/src/machines/local_activity_state_machine.rs
+++ b/src/machines/local_activity_state_machine.rs
@@ -587,7 +587,7 @@ mod tests {
         },
     };
 
-    async fn la_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn la_wf(ctx: WfContext) -> WorkflowResult<()> {
         ctx.local_activity(LocalActivityOptions::default()).await;
         Ok(().into())
     }
@@ -700,7 +700,7 @@ mod tests {
         wfm.shutdown().await.unwrap();
     }
 
-    async fn two_la_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn two_la_wf(ctx: WfContext) -> WorkflowResult<()> {
         ctx.local_activity(LocalActivityOptions::default()).await;
         ctx.local_activity(LocalActivityOptions::default()).await;
         Ok(().into())
@@ -793,7 +793,7 @@ mod tests {
         wfm.shutdown().await.unwrap();
     }
 
-    async fn two_la_wf_parallel(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn two_la_wf_parallel(ctx: WfContext) -> WorkflowResult<()> {
         tokio::join!(
             ctx.local_activity(LocalActivityOptions::default()),
             ctx.local_activity(LocalActivityOptions::default())
@@ -878,7 +878,7 @@ mod tests {
         wfm.shutdown().await.unwrap();
     }
 
-    async fn la_timer_la(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn la_timer_la(ctx: WfContext) -> WorkflowResult<()> {
         ctx.local_activity(LocalActivityOptions::default()).await;
         ctx.timer(Duration::from_secs(5)).await;
         ctx.local_activity(LocalActivityOptions::default()).await;

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -66,6 +66,7 @@ pub enum WFCommand {
     /// Returned when we need to wait for the lang sdk to send us something
     NoCommandsFromLang,
     AddActivity(ScheduleActivity),
+    AddLocalActivity(ScheduleLocalActivity),
     RequestCancelActivity(RequestCancelActivity),
     AddTimer(StartTimer),
     CancelTimer(CancelTimer),
@@ -120,6 +121,7 @@ impl TryFrom<WorkflowCommand> for WFCommand {
             workflow_command::Variant::CancelUnstartedChildWorkflowExecution(s) => {
                 Ok(Self::CancelUnstartedChild(s))
             }
+            workflow_command::Variant::ScheduleLocalActivity(s) => Ok(Self::AddLocalActivity(s)),
         }
     }
 }

--- a/src/machines/patch_state_machine.rs
+++ b/src/machines/patch_state_machine.rs
@@ -552,7 +552,7 @@ mod tests {
     // history that then suddenly doesn't have the marker.
     #[tokio::test]
     async fn same_change_multiple_spots(#[case] have_marker_in_hist: bool, #[case] replay: bool) {
-        let wfn = WorkflowFunction::new(move |mut ctx: WfContext| async move {
+        let wfn = WorkflowFunction::new(move |ctx: WfContext| async move {
             if ctx.patched(MY_PATCH_ID) {
                 ctx.activity(ActivityOptions::default()).await;
             } else {

--- a/src/machines/signal_external_state_machine.rs
+++ b/src/machines/signal_external_state_machine.rs
@@ -297,7 +297,7 @@ mod tests {
 
     const SIGNAME: &str = "signame";
 
-    async fn signal_sender(mut ctx: WfContext) -> WorkflowResult<()> {
+    async fn signal_sender(ctx: WfContext) -> WorkflowResult<()> {
         let res = ctx
             .signal_workflow("fake_wid", "fake_rid", SIGNAME, b"hi!")
             .await;
@@ -356,9 +356,9 @@ mod tests {
         t.add_full_wf_task();
         t.add_workflow_execution_completed();
 
-        let wff = WorkflowFunction::new(|mut ctx: WfContext| async move {
+        let wff = WorkflowFunction::new(|ctx: WfContext| async move {
             let sig = ctx.signal_workflow("fake_wid", "fake_rid", SIGNAME, b"hi!");
-            sig.cancel(&mut ctx);
+            sig.cancel(&ctx);
             let _res = sig.await;
             Ok(().into())
         });

--- a/src/machines/timer_state_machine.rs
+++ b/src/machines/timer_state_machine.rs
@@ -294,7 +294,7 @@ mod test {
             timer to fire. In the all-in-one-go test, the timer is created and resolved in the same
             task, hence no extra loop.
         */
-        let func = WorkflowFunction::new(|mut command_sink: WfContext| async move {
+        let func = WorkflowFunction::new(|command_sink: WfContext| async move {
             command_sink.timer(Duration::from_secs(5)).await;
             Ok(().into())
         });
@@ -338,7 +338,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn mismatched_timer_ids_errors() {
-        let func = WorkflowFunction::new(|mut command_sink: WfContext| async move {
+        let func = WorkflowFunction::new(|command_sink: WfContext| async move {
             command_sink.timer(Duration::from_secs(5)).await;
             Ok(().into())
         });
@@ -355,11 +355,11 @@ mod test {
 
     #[fixture]
     fn cancellation_setup() -> ManagedWFFunc {
-        let func = WorkflowFunction::new(|mut ctx: WfContext| async move {
+        let func = WorkflowFunction::new(|ctx: WfContext| async move {
             let cancel_timer_fut = ctx.timer(Duration::from_secs(500));
             ctx.timer(Duration::from_secs(5)).await;
             // Cancel the first timer after having waited on the second
-            cancel_timer_fut.cancel(&mut ctx);
+            cancel_timer_fut.cancel(&ctx);
             cancel_timer_fut.await;
             Ok(().into())
         });
@@ -405,10 +405,10 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn cancel_before_sent_to_server() {
-        let func = WorkflowFunction::new(|mut ctx: WfContext| async move {
+        let func = WorkflowFunction::new(|ctx: WfContext| async move {
             let cancel_timer_fut = ctx.timer(Duration::from_secs(500));
             // Immediately cancel the timer
-            cancel_timer_fut.cancel(&mut ctx);
+            cancel_timer_fut.cancel(&ctx);
             cancel_timer_fut.await;
             Ok(().into())
         });

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -271,12 +271,17 @@ impl WorkflowMachines {
         resolution: LocalResolution,
     ) -> Result<()> {
         match resolution {
-            LocalResolution::LocalActivity { result, runtime } => {
+            LocalResolution::LocalActivity {
+                result,
+                runtime,
+                attempt,
+                backoff,
+            } => {
                 let act_id = CommandID::LocalActivity(seq_id);
                 let mk = self.get_machine_key(act_id)?;
                 let mach = self.machine_mut(mk);
                 if let Machines::LocalActivityMachine(ref mut lam) = *mach {
-                    let resps = lam.try_resolve(seq_id, result, runtime)?;
+                    let resps = lam.try_resolve(seq_id, result, runtime, attempt, backoff)?;
                     self.process_machine_responses(mk, resps)?;
                 } else {
                     return Err(WFMachinesError::Nondeterminism(format!(

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -38,7 +38,7 @@ use temporal_sdk_core_protos::{
         },
         workflow_commands::{
             request_cancel_external_workflow_execution as cancel_we,
-            signal_external_workflow_execution as sig_we, ScheduleActivity,
+            signal_external_workflow_execution as sig_we, ScheduleLocalActivity,
         },
         FromPayloadsExt,
     },
@@ -107,7 +107,7 @@ pub(crate) struct WorkflowMachines {
     encountered_change_markers: HashMap<String, ChangeInfo>,
 
     /// Queued local activity requests which need to be executed
-    local_activity_requests: Vec<ScheduleActivity>,
+    local_activity_requests: Vec<ScheduleLocalActivity>,
     /// Seq #s of local activities which we have sent to be executed but have not yet resolved
     executing_local_activities: HashSet<u32>,
     /// Maps local activity sequence numbers to their resolutions as found when looking ahead at
@@ -167,7 +167,7 @@ pub enum MachineResponse {
 
     /// Queue a local activity to be processed by the worker
     #[display(fmt = "QueueLocalActivity")]
-    QueueLocalActivity(ScheduleActivity),
+    QueueLocalActivity(ScheduleLocalActivity),
     /// Set the workflow time to the provided time
     #[display(fmt = "UpdateWFTime({:?})", "_0")]
     UpdateWFTime(Option<SystemTime>),
@@ -839,23 +839,20 @@ impl WorkflowMachines {
                 }
                 WFCommand::AddActivity(attrs) => {
                     let seq = attrs.seq;
-                    if attrs.local {
-                        let (la, mach_resp) = new_local_activity(
-                            attrs,
-                            self.replaying,
-                            self.local_activity_resolutions.remove(&seq),
-                            self.current_wf_time,
-                        )?;
-                        let machkey = self.all_machines.insert(la.into());
-                        self.id_to_machine
-                            .insert(CommandID::LocalActivity(seq), machkey);
-                        self.process_machine_responses(machkey, mach_resp)?;
-                    } else {
-                        self.add_cmd_to_wf_task(
-                            new_activity(attrs),
-                            Some(CommandID::Activity(seq)),
-                        );
-                    };
+                    self.add_cmd_to_wf_task(new_activity(attrs), Some(CommandID::Activity(seq)));
+                }
+                WFCommand::AddLocalActivity(attrs) => {
+                    let seq = attrs.seq;
+                    let (la, mach_resp) = new_local_activity(
+                        attrs,
+                        self.replaying,
+                        self.local_activity_resolutions.remove(&seq),
+                        self.current_wf_time,
+                    )?;
+                    let machkey = self.all_machines.insert(la.into());
+                    self.id_to_machine
+                        .insert(CommandID::LocalActivity(seq), machkey);
+                    self.process_machine_responses(machkey, mach_resp)?;
                 }
                 WFCommand::RequestCancelActivity(attrs) => {
                     jobs.extend(self.process_cancellation(CommandID::Activity(attrs.seq))?);

--- a/src/prototype_rust_sdk.rs
+++ b/src/prototype_rust_sdk.rs
@@ -576,7 +576,7 @@ mod tests {
     use super::*;
     use crate::test_help::{build_fake_core, canned_histories, DEFAULT_WORKFLOW_TYPE, TEST_Q};
 
-    pub async fn timer_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+    pub async fn timer_wf(ctx: WfContext) -> WorkflowResult<()> {
         ctx.timer(Duration::from_secs(1)).await;
         Ok(().into())
     }

--- a/src/prototype_rust_sdk/workflow_context.rs
+++ b/src/prototype_rust_sdk/workflow_context.rs
@@ -221,8 +221,7 @@ impl WfContext {
     }
 
     /// Request to run a local activity with no implementation of timer-backoff based retrying.
-    /// TODO: Should not be public in non-prototype SDK
-    pub(crate) fn local_activity_no_timer_retry(
+    fn local_activity_no_timer_retry(
         &self,
         opts: LocalActivityOptions,
     ) -> impl CancellableFuture<ActivityResolution> {

--- a/src/prototype_rust_sdk/workflow_context/options.rs
+++ b/src/prototype_rust_sdk/workflow_context/options.rs
@@ -80,7 +80,7 @@ impl IntoWorkflowCommand for ActivityOptions {
 }
 
 /// Options for scheduling a local activity
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct LocalActivityOptions {
     /// Identifier to use for tracking the activity in Workflow history.
     /// The `activityId` can be accessed by the activity function.
@@ -94,6 +94,9 @@ pub struct LocalActivityOptions {
     pub input: Payload,
     /// Retry policy
     pub retry_policy: RetryPolicy,
+    /// Override attempt number rather than using 1.
+    /// Ideally we would not expose this in a released Rust SDK, but it's needed for test.
+    pub attempt: Option<u32>,
 }
 
 impl IntoWorkflowCommand for LocalActivityOptions {
@@ -101,6 +104,7 @@ impl IntoWorkflowCommand for LocalActivityOptions {
     fn into_command(self, seq: u32) -> ScheduleLocalActivity {
         ScheduleLocalActivity {
             seq,
+            attempt: self.attempt.unwrap_or(1),
             activity_id: match self.activity_id {
                 None => seq.to_string(),
                 Some(aid) => aid,

--- a/src/prototype_rust_sdk/workflow_context/options.rs
+++ b/src/prototype_rust_sdk/workflow_context/options.rs
@@ -97,6 +97,8 @@ pub struct LocalActivityOptions {
     /// Override attempt number rather than using 1.
     /// Ideally we would not expose this in a released Rust SDK, but it's needed for test.
     pub attempt: Option<u32>,
+    /// Retry backoffs over this amount will use a timer rather than a local retry
+    pub timer_backoff_threshold: Option<Duration>,
 }
 
 impl IntoWorkflowCommand for LocalActivityOptions {
@@ -112,6 +114,7 @@ impl IntoWorkflowCommand for LocalActivityOptions {
             activity_type: self.activity_type,
             arguments: vec![self.input],
             retry_policy: Some(self.retry_policy),
+            local_retry_threshold: self.timer_backoff_threshold.map(Into::into),
             ..Default::default()
         }
     }

--- a/src/prototype_rust_sdk/workflow_context/options.rs
+++ b/src/prototype_rust_sdk/workflow_context/options.rs
@@ -2,7 +2,10 @@ use std::time::Duration;
 use temporal_sdk_core_protos::coresdk::{
     child_workflow::ChildWorkflowCancellationType,
     common::{Payload, RetryPolicy},
-    workflow_commands::{ActivityCancellationType, ScheduleActivity, StartChildWorkflowExecution},
+    workflow_commands::{
+        ActivityCancellationType, ScheduleActivity, ScheduleLocalActivity,
+        StartChildWorkflowExecution,
+    },
 };
 
 pub trait IntoWorkflowCommand {
@@ -94,10 +97,9 @@ pub struct LocalActivityOptions {
 }
 
 impl IntoWorkflowCommand for LocalActivityOptions {
-    type WFCommandType = ScheduleActivity;
-    fn into_command(self, seq: u32) -> ScheduleActivity {
-        ScheduleActivity {
-            local: true,
+    type WFCommandType = ScheduleLocalActivity;
+    fn into_command(self, seq: u32) -> ScheduleLocalActivity {
+        ScheduleLocalActivity {
             seq,
             activity_id: match self.activity_id {
                 None => seq.to_string(),

--- a/src/prototype_rust_sdk/workflow_future.rs
+++ b/src/prototype_rust_sdk/workflow_future.rs
@@ -1,5 +1,5 @@
-use crate::protosext::TryIntoOrNone;
 use crate::{
+    protosext::TryIntoOrNone,
     prototype_rust_sdk::{
         conversions::anyhow_to_fail, workflow_context::WfContextSharedData, CancellableID,
         RustWfCmd, UnblockEvent, WfContext, WfExitValue, WorkflowFunction, WorkflowResult,
@@ -31,7 +31,7 @@ use temporal_sdk_core_protos::{
             CancelSignalWorkflow, CancelTimer, CancelUnstartedChildWorkflowExecution,
             CancelWorkflowExecution, CompleteWorkflowExecution, FailWorkflowExecution,
             RequestCancelActivity, RequestCancelExternalWorkflowExecution, ScheduleActivity,
-            StartChildWorkflowExecution, StartTimer,
+            ScheduleLocalActivity, StartChildWorkflowExecution, StartTimer,
         },
         workflow_completion::WfActivationCompletion,
     },
@@ -365,7 +365,10 @@ impl Future for WorkflowFuture {
                             workflow_command::Variant::ScheduleActivity(ScheduleActivity {
                                 seq,
                                 ..
-                            }) => CommandID::Activity(seq),
+                            })
+                            | workflow_command::Variant::ScheduleLocalActivity(
+                                ScheduleLocalActivity { seq, .. },
+                            ) => CommandID::Activity(seq),
                             workflow_command::Variant::SetPatchMarker(_) => {
                                 panic!("Set patch marker should be a nonblocking command")
                             }

--- a/src/test_help/history_builder.rs
+++ b/src/test_help/history_builder.rs
@@ -265,9 +265,11 @@ impl TestHistoryBuilder {
             details: build_local_activity_marker_details(
                 LocalActivityMarkerData {
                     seq,
+                    attempt: 1,
                     activity_id: activity_id.to_string(),
                     activity_type: "some_act_type".to_string(),
                     complete_time,
+                    backoff: None,
                 },
                 payload,
             ),

--- a/src/worker/activities/local_activities.rs
+++ b/src/worker/activities/local_activities.rs
@@ -1,6 +1,6 @@
-use crate::protosext::TryIntoOrNone;
 use crate::{
-    machines::LocalActivityExecutionResult, retry_logic::RetryPolicyExt, task_token::TaskToken,
+    machines::LocalActivityExecutionResult, protosext::TryIntoOrNone, retry_logic::RetryPolicyExt,
+    task_token::TaskToken,
 };
 use parking_lot::Mutex;
 use std::{

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -185,7 +185,10 @@ impl Worker {
                     config.default_heartbeat_throttle_interval,
                 )
             }),
-            local_act_mgr: LocalActivityManager::new(config.max_outstanding_local_activities),
+            local_act_mgr: LocalActivityManager::new(
+                config.max_outstanding_local_activities,
+                sg.options.namespace.clone(),
+            ),
             workflows_semaphore: Semaphore::new(config.max_outstanding_workflow_tasks),
             config,
             shutdown_requested: shut_rx,

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -283,32 +283,18 @@ impl Worker {
         if task_token.is_local_activity_task() {
             let as_la_res: LocalActivityExecutionResult = status.try_into()?;
             match self.local_act_mgr.complete(&task_token, &as_la_res) {
-                LACompleteAction::Report(LocalInFlightActInfo {
-                    la_info,
-                    dispatch_time,
-                    ..
-                }) => {
-                    if let Err(e) = self
-                        .wft_manager
-                        .notify_of_local_result(
-                            &la_info.workflow_exec_info.run_id,
-                            la_info.schedule_cmd.seq,
-                            LocalResolution::LocalActivity {
-                                result: as_la_res,
-                                runtime: dispatch_time.elapsed(),
-                            },
-                        )
+                LACompleteAction::Report(info) => {
+                    self.complete_local_act(&task_token, as_la_res, info, None)
                         .await
-                    {
-                        error!(
-                            "Problem completing local activity {}: {:?} -- will evict the workflow",
-                            task_token, e
-                        );
-                        self.request_wf_eviction(
-                            &la_info.workflow_exec_info.run_id,
-                            "Issue while completing local activity",
-                        );
-                    }
+                }
+                LACompleteAction::LangDoesTimerBackoff(backoff, info) => {
+                    // This la needs to write a failure marker, and then we will tell lang how
+                    // long of a timer to schedule to back off for. We do this because there are
+                    // no other situations where core generates "internal" commands so it is much
+                    // simpler for lang to reply with the timer / next LA command than to do it
+                    // internally. Plus, this backoff hack we'd like to eliminate eventually.
+                    self.complete_local_act(&task_token, as_la_res, info, Some(backoff))
+                        .await
                 }
                 LACompleteAction::WillBeRetried => {
                     // Nothing to do here
@@ -331,7 +317,6 @@ impl Worker {
             Ok(())
         }
     }
-
     pub(crate) async fn next_workflow_activation(&self) -> Result<WfActivation, PollWfError> {
         // The poll needs to be in a loop because we can't guarantee tail call optimization in Rust
         // (simply) and we really, really need that for long-poll retries.
@@ -729,6 +714,38 @@ impl Worker {
             self.request_wf_eviction(run_id, "Error reporting WFT to server");
         }
         res.map_err(Into::into)
+    }
+
+    async fn complete_local_act(
+        &self,
+        task_token: &TaskToken,
+        la_res: LocalActivityExecutionResult,
+        info: LocalInFlightActInfo,
+        backoff: Option<prost_types::Duration>,
+    ) {
+        if let Err(e) = self
+            .wft_manager
+            .notify_of_local_result(
+                &info.la_info.workflow_exec_info.run_id,
+                info.la_info.schedule_cmd.seq,
+                LocalResolution::LocalActivity {
+                    result: la_res,
+                    runtime: info.dispatch_time.elapsed(),
+                    attempt: info.attempt,
+                    backoff,
+                },
+            )
+            .await
+        {
+            error!(
+                "Problem completing local activity {}: {:?} -- will evict the workflow",
+                task_token, e
+            );
+            self.request_wf_eviction(
+                &info.la_info.workflow_exec_info.run_id,
+                "Issue while completing local activity",
+            );
+        }
     }
 
     /// Return the sticky execution attributes that should be used to complete workflow tasks

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -87,6 +87,8 @@ pub(crate) enum LocalResolution {
     LocalActivity {
         result: LocalActivityExecutionResult,
         runtime: Duration,
+        attempt: u32,
+        backoff: Option<prost_types::Duration>,
     },
 }
 
@@ -329,6 +331,8 @@ pub mod managed_wf {
                         .try_into()
                         .expect("LA execution result must be a valid LA result"),
                     runtime: Duration::from_secs(1),
+                    attempt: 1,
+                    backoff: None,
                 },
             )
         }

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -94,7 +94,7 @@ async fn out_of_order_completion_doesnt_hang() {
     jh.await.unwrap();
 }
 
-pub async fn many_parallel_timers_longhist(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn many_parallel_timers_longhist(ctx: WfContext) -> WorkflowResult<()> {
     for _ in 0..20 {
         let mut futs = vec![];
         for _ in 0..1000 {

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -100,7 +100,7 @@ async fn parallel_workflows_same_queue() {
 }
 
 static RUN_CT: AtomicUsize = AtomicUsize::new(0);
-pub async fn cache_evictions_wf(mut command_sink: WfContext) -> WorkflowResult<()> {
+pub async fn cache_evictions_wf(command_sink: WfContext) -> WorkflowResult<()> {
     RUN_CT.fetch_add(1, Ordering::SeqCst);
     command_sink.timer(Duration::from_secs(1)).await;
     Ok(().into())

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -23,7 +23,7 @@ use temporal_sdk_core_protos::{
 use test_utils::{init_core_and_create_wf, schedule_activity_cmd, CoreTestHelpers, CoreWfStarter};
 use tokio::time::sleep;
 
-pub async fn one_activity_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn one_activity_wf(ctx: WfContext) -> WorkflowResult<()> {
     ctx.activity(ActivityOptions {
         activity_type: "echo_activity".to_string(),
         start_to_close_timeout: Some(Duration::from_secs(5)),

--- a/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -4,7 +4,7 @@ use test_utils::CoreWfStarter;
 
 const RECEIVER_WFID: &str = "sends-cancel-receiver";
 
-async fn cancel_sender(mut ctx: WfContext) -> WorkflowResult<()> {
+async fn cancel_sender(ctx: WfContext) -> WorkflowResult<()> {
     let run_id = std::str::from_utf8(&ctx.get_args()[0].data)
         .unwrap()
         .to_owned();

--- a/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -10,7 +10,7 @@ async fn child_wf(_ctx: WfContext) -> WorkflowResult<()> {
     Ok(().into())
 }
 
-async fn parent_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+async fn parent_wf(ctx: WfContext) -> WorkflowResult<()> {
     let child = ctx.child_workflow(ChildWorkflowOptions {
         workflow_id: "child-1".to_owned(),
         workflow_type: CHILD_WF_TYPE.to_owned(),
@@ -18,7 +18,7 @@ async fn parent_wf(mut ctx: WfContext) -> WorkflowResult<()> {
     });
 
     let started = child
-        .start(&mut ctx)
+        .start(&ctx)
         .await
         .into_started()
         .expect("Child chould start OK");

--- a/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -3,7 +3,7 @@ use temporal_sdk_core::prototype_rust_sdk::{WfContext, WfExitValue, WorkflowResu
 use temporal_sdk_core_protos::coresdk::workflow_commands::ContinueAsNewWorkflowExecution;
 use test_utils::CoreWfStarter;
 
-async fn continue_as_new_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+async fn continue_as_new_wf(ctx: WfContext) -> WorkflowResult<()> {
     let run_ct = ctx.get_args()[0].data[0];
     ctx.timer(Duration::from_millis(500)).await;
     Ok(if run_ct < 5 {

--- a/tests/integ_tests/workflow_tests/determinism.rs
+++ b/tests/integ_tests/workflow_tests/determinism.rs
@@ -6,7 +6,7 @@ use temporal_sdk_core::prototype_rust_sdk::{ActivityOptions, WfContext, Workflow
 use test_utils::CoreWfStarter;
 
 static RUN_CT: AtomicUsize = AtomicUsize::new(1);
-pub async fn timer_wf_nondeterministic(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn timer_wf_nondeterministic(ctx: WfContext) -> WorkflowResult<()> {
     let run_ct = RUN_CT.fetch_add(1, Ordering::Relaxed);
 
     match run_ct {

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -1,14 +1,15 @@
+use anyhow::anyhow;
 use futures::future::join_all;
 use std::time::Duration;
 use temporal_sdk_core::prototype_rust_sdk::{LocalActivityOptions, WfContext, WorkflowResult};
-use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
+use temporal_sdk_core_protos::coresdk::{common::RetryPolicy, AsJsonPayloadExt};
 use test_utils::CoreWfStarter;
 
 pub async fn echo(e: String) -> anyhow::Result<String> {
     Ok(e)
 }
 
-pub async fn one_local_activity_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn one_local_activity_wf(ctx: WfContext) -> WorkflowResult<()> {
     let initial_workflow_time = ctx.workflow_time().expect("Workflow time should be set");
     ctx.local_activity(LocalActivityOptions {
         activity_type: "echo_activity".to_string(),
@@ -37,7 +38,7 @@ async fn one_local_activity() {
     starter.shutdown().await;
 }
 
-pub async fn local_act_concurrent_with_timer_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn local_act_concurrent_with_timer_wf(ctx: WfContext) -> WorkflowResult<()> {
     let la = ctx.local_activity(LocalActivityOptions {
         activity_type: "echo_activity".to_string(),
         input: "hi!".as_json_payload().expect("serializes fine"),
@@ -64,7 +65,7 @@ async fn local_act_concurrent_with_timer() {
     starter.shutdown().await;
 }
 
-pub async fn local_act_then_timer_then_wait(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn local_act_then_timer_then_wait(ctx: WfContext) -> WorkflowResult<()> {
     let la = ctx.local_activity(LocalActivityOptions {
         activity_type: "echo_activity".to_string(),
         input: "hi!".as_json_payload().expect("serializes fine"),
@@ -111,7 +112,7 @@ async fn long_running_local_act_with_timer() {
     starter.shutdown().await;
 }
 
-pub async fn local_act_fanout_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn local_act_fanout_wf(ctx: WfContext) -> WorkflowResult<()> {
     let las: Vec<_> = (1..=50)
         .map(|i| {
             ctx.local_activity(LocalActivityOptions {
@@ -136,6 +137,41 @@ async fn local_act_fanout() {
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), local_act_fanout_wf);
     worker.register_activity("echo_activity", echo);
+
+    worker
+        .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    starter.shutdown().await;
+}
+
+#[tokio::test]
+async fn local_act_retry_timer_backoff() {
+    let wf_name = "local_act_retry_timer_backoff";
+    let mut starter = CoreWfStarter::new(wf_name);
+    let mut worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
+        ctx.local_activity(LocalActivityOptions {
+            activity_type: "echo".to_string(),
+            input: "hi".as_json_payload().expect("serializes fine"),
+            retry_policy: RetryPolicy {
+                initial_interval: Some(Duration::from_micros(15).into()),
+                // We want two local backoffs that are short. Third backoff will use timer
+                backoff_coefficient: 1_000.,
+                maximum_interval: Some(Duration::from_millis(1500).into()),
+                maximum_attempts: 4,
+                non_retryable_error_types: vec![],
+            },
+            timer_backoff_threshold: Some(Duration::from_secs(1)),
+            ..Default::default()
+        })
+        .await;
+        Ok(().into())
+    });
+    worker.register_activity("echo", |_: String| async {
+        Result::<(), _>::Err(anyhow!("Oh no I failed!"))
+    });
 
     worker
         .submit_wf(wf_name.to_owned(), wf_name.to_owned(), vec![])

--- a/tests/integ_tests/workflow_tests/patches.rs
+++ b/tests/integ_tests/workflow_tests/patches.rs
@@ -7,7 +7,7 @@ use test_utils::CoreWfStarter;
 
 const MY_PATCH_ID: &str = "integ_test_change_name";
 
-pub async fn changes_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn changes_wf(ctx: WfContext) -> WorkflowResult<()> {
     if ctx.patched(MY_PATCH_ID) {
         ctx.timer(Duration::from_millis(100)).await;
     } else {
@@ -40,7 +40,7 @@ async fn writes_change_markers() {
 /// This one simulates a run as if the worker had the "old" code, then it fails at the end as
 /// a cheapo way of being re-run, at which point it runs with change checks and the "new" code.
 static DID_DIE: AtomicBool = AtomicBool::new(false);
-pub async fn no_change_then_change_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn no_change_then_change_wf(ctx: WfContext) -> WorkflowResult<()> {
     if DID_DIE.load(Ordering::Acquire) {
         assert!(!ctx.patched(MY_PATCH_ID));
     }
@@ -74,7 +74,7 @@ async fn can_add_change_markers() {
 }
 
 static DID_DIE_2: AtomicBool = AtomicBool::new(false);
-pub async fn replay_with_change_marker_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+pub async fn replay_with_change_marker_wf(ctx: WfContext) -> WorkflowResult<()> {
     assert!(ctx.patched(MY_PATCH_ID));
     ctx.timer(Duration::from_millis(200)).await;
     if !DID_DIE_2.load(Ordering::Acquire) {

--- a/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/tests/integ_tests/workflow_tests/stickyness.rs
@@ -25,7 +25,7 @@ async fn timer_workflow_not_sticky() {
 
 static TIMED_OUT_ONCE: AtomicBool = AtomicBool::new(false);
 static RUN_CT: AtomicUsize = AtomicUsize::new(0);
-async fn timer_timeout_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+async fn timer_timeout_wf(ctx: WfContext) -> WorkflowResult<()> {
     RUN_CT.fetch_add(1, Ordering::SeqCst);
     let t = ctx.timer(Duration::from_secs(1));
     if !TIMED_OUT_ONCE.load(Ordering::SeqCst) {
@@ -64,7 +64,7 @@ async fn cache_miss_ok() {
     let mut worker = starter.worker().await;
 
     let barr: &'static Barrier = Box::leak(Box::new(Barrier::new(2)));
-    worker.register_wf(wf_name.to_owned(), move |mut ctx: WfContext| async move {
+    worker.register_wf(wf_name.to_owned(), move |ctx: WfContext| async move {
         barr.wait().await;
         ctx.timer(Duration::from_secs(1)).await;
         Ok(().into())

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -6,7 +6,7 @@ use temporal_sdk_core_protos::coresdk::{
 };
 use test_utils::{init_core_and_create_wf, start_timer_cmd, CoreTestHelpers, CoreWfStarter};
 
-pub async fn timer_wf(mut command_sink: WfContext) -> WorkflowResult<()> {
+pub async fn timer_wf(command_sink: WfContext) -> WorkflowResult<()> {
     command_sink.timer(Duration::from_secs(1)).await;
     Ok(().into())
 }
@@ -98,7 +98,7 @@ async fn timer_immediate_cancel_workflow() {
     .unwrap();
 }
 
-async fn parallel_timer_wf(mut command_sink: WfContext) -> WorkflowResult<()> {
+async fn parallel_timer_wf(command_sink: WfContext) -> WorkflowResult<()> {
     let t1 = command_sink.timer(Duration::from_secs(1));
     let t2 = command_sink.timer(Duration::from_secs(1));
     let _ = tokio::join!(t1, t2);

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -27,7 +27,7 @@ async fn activity_load() {
     let task_queue = starter.get_task_queue().to_owned();
 
     let pd = payload_dat.clone();
-    let wf_fn = move |mut ctx: WfContext| {
+    let wf_fn = move |ctx: WfContext| {
         let task_queue = task_queue.clone();
         let payload_dat = pd.clone();
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Long backoff periods while retrying LAs are implemented in other SDKs (or should be) by scheduling a timer rather than WFT heartbeating for a huge period of time.

This is more complex to do totally internally to core than would be ideal because Core never expected to create most types of commands internally. To solve this, we send a special type of activity resolution to lang that says "You should schedule a timer and *then* try to run this activity again".

Much blood is also spilled creating a new `ScheduleLocalActivity` type since `ScheduleActivity` was getting too cluttered with local-specific stuff and the local version had a bunch of things that don't apply.

## Why?
Parity

## Checklist
Need to add some more tests

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
