### PR TITLE
Fix WFT failures sometimes getting stuck in a spam loop

### DIFF
--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -451,6 +451,7 @@ pub mod coresdk {
     }
 
     pub mod workflow_completion {
+        use crate::temporal::api::failure;
         tonic::include_proto!("coresdk.workflow_completion");
 
         impl wf_activation_completion::Status {
@@ -459,6 +460,12 @@ pub mod coresdk {
                     Self::Successful(_) => true,
                     Self::Failed(_) => false,
                 }
+            }
+        }
+
+        impl From<failure::v1::Failure> for Failure {
+            fn from(f: failure::v1::Failure) -> Self {
+                Failure { failure: Some(f) }
             }
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 //! Error types exposed by public APIs
 
-use crate::{machines::WFMachinesError, task_token::TaskToken, WorkerLookupErr};
+use crate::{machines::WFMachinesError, WorkerLookupErr};
 use temporal_sdk_core_protos::coresdk::{
     activity_result::ActivityExecutionResult, workflow_completion::WfActivationCompletion,
 };
@@ -13,8 +13,6 @@ pub(crate) struct WorkflowUpdateError {
     /// The run id of the erring workflow
     #[allow(dead_code)] // Useful in debug output
     pub run_id: String,
-    /// The task token associated with this update, if one existed yet.
-    pub task_token: Option<TaskToken>,
 }
 
 impl From<WorkflowMissingError> for WorkflowUpdateError {
@@ -22,7 +20,6 @@ impl From<WorkflowMissingError> for WorkflowUpdateError {
         Self {
             source: WFMachinesError::Fatal("Workflow machines missing".to_string()),
             run_id: wme.run_id,
-            task_token: None,
         }
     }
 }

--- a/src/test_help/mod.rs
+++ b/src/test_help/mod.rs
@@ -146,6 +146,7 @@ pub struct FakeWfResponses {
 pub struct MocksHolder<SG> {
     sg: SG,
     mock_pollers: HashMap<String, MockWorker>,
+    // bidirectional mapping of run id / task token
     pub outstanding_task_map: Option<Arc<RwLock<BiMap<String, TaskToken>>>>,
 }
 
@@ -380,16 +381,6 @@ pub fn build_mock_pollers(mut cfg: MockPollCfg) -> MocksHolder<MockServerGateway
                 );
             }
         }
-
-        // TODO: Fix -- or not? Sticky invalidation could make this pointless anyway
-        // Verify response batches only ever return longer histories (IE: Are sorted ascending)
-        // assert!(
-        //     hist.response_batches
-        //         .as_slice()
-        //         .windows(2)
-        //         .all(|w| w[0] <= w[1]),
-        //     "response batches must have increasing wft numbers"
-        // );
 
         if cfg.enforce_correct_number_of_polls {
             *correct_num_polls.get_or_insert(0) += hist.response_batches.len();

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -370,11 +370,12 @@ impl Worker {
         completion: WfActivationCompletion,
     ) -> Result<(), CompleteWfError> {
         let wfstatus = completion.status;
-        let did_complete_wft = match wfstatus {
+        let report_outcome = match wfstatus {
             Some(wf_activation_completion::Status::Successful(success)) => {
                 self.wf_activation_success(&completion.run_id, success)
                     .await
             }
+
             Some(wf_activation_completion::Status::Failed(failure)) => {
                 self.wf_activation_failed(
                     &completion.run_id,
@@ -383,12 +384,14 @@ impl Worker {
                 )
                 .await
             }
-            None => Err(CompleteWfError::MalformedWorkflowCompletion {
-                reason: "Workflow completion had empty status field".to_owned(),
-                completion: None,
-            }),
+            None => {
+                return Err(CompleteWfError::MalformedWorkflowCompletion {
+                    reason: "Workflow completion had empty status field".to_owned(),
+                    completion: None,
+                })
+            }
         }?;
-        self.after_workflow_activation(&completion.run_id, did_complete_wft);
+        self.after_workflow_activation(&completion.run_id, report_outcome);
         Ok(())
     }
 
@@ -543,7 +546,7 @@ impl Worker {
         &self,
         run_id: &str,
         success: workflow_completion::Success,
-    ) -> Result<bool, CompleteWfError> {
+    ) -> Result<WFTReportOutcome, CompleteWfError> {
         // Convert to wf commands
         let cmds = success
             .commands
@@ -598,7 +601,10 @@ impl Worker {
                     Ok(())
                 })
                 .await?;
-                Ok(true)
+                Ok(WFTReportOutcome {
+                    reported_to_server: true,
+                    failed: false,
+                })
             }
             Ok(Some(ServerCommandsWithWorkflowInfo {
                 task_token,
@@ -608,9 +614,15 @@ impl Worker {
                 self.server_gateway
                     .respond_legacy_query(task_token, result)
                     .await?;
-                Ok(true)
+                Ok(WFTReportOutcome {
+                    reported_to_server: true,
+                    failed: false,
+                })
             }
-            Ok(None) => Ok(false),
+            Ok(None) => Ok(WFTReportOutcome {
+                reported_to_server: false,
+                failed: false,
+            }),
             Err(update_err) => {
                 // Automatically fail the workflow task in the event we couldn't update machines
                 let fail_cause = if matches!(&update_err.source, WFMachinesError::Nondeterminism(_))
@@ -638,7 +650,7 @@ impl Worker {
         run_id: &str,
         cause: WorkflowTaskFailedCause,
         failure: workflow_completion::Failure,
-    ) -> Result<bool, CompleteWfError> {
+    ) -> Result<WFTReportOutcome, CompleteWfError> {
         warn!(run_id, failure=?failure, "Failing workflow activation");
 
         Ok(match self.wft_manager.failed_activation(run_id) {
@@ -649,24 +661,34 @@ impl Worker {
                         .await
                 })
                 .await?;
-                true
+                WFTReportOutcome {
+                    reported_to_server: true,
+                    failed: true,
+                }
             }
             FailedActivationOutcome::ReportLegacyQueryFailure(task_token) => {
                 self.server_gateway
                     .respond_legacy_query(task_token, legacy_query_failure(failure))
                     .await?;
-                true
+                WFTReportOutcome {
+                    reported_to_server: true,
+                    failed: true,
+                }
             }
-            FailedActivationOutcome::NoReport => {
-                self.return_workflow_task_permit();
-                false
-            }
+            FailedActivationOutcome::NoReport => WFTReportOutcome {
+                reported_to_server: false,
+                failed: true,
+            },
         })
     }
 
-    fn after_workflow_activation(&self, run_id: &str, did_complete_wft: bool) {
-        self.wft_manager.after_wft_report(run_id, did_complete_wft);
-        if did_complete_wft {
+    fn after_workflow_activation(&self, run_id: &str, report_outcome: WFTReportOutcome) {
+        self.wft_manager
+            .after_wft_report(run_id, report_outcome.reported_to_server);
+        if report_outcome.reported_to_server || report_outcome.failed {
+            // If we failed the WFT but didn't report anything, we still want to release the WFT
+            // permit since the server will eventually time out the task and we've already evicted
+            // the run.
             self.return_workflow_task_permit();
         }
         self.wfts_drained_notify.notify_waiters();
@@ -782,6 +804,11 @@ impl WorkerConfig {
             .saturating_sub(self.max_nonsticky_polls())
             .max(1)
     }
+}
+
+struct WFTReportOutcome {
+    reported_to_server: bool,
+    failed: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
While working on LA implementation, discovered that all-internal state machine errors would not avoid spamming WFT failures properly. Fixed that.

## Why?
:bug: 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
