### PR TITLE
Local Activity Cancellation

### DIFF
--- a/fsm/rustfsm_trait/src/lib.rs
+++ b/fsm/rustfsm_trait/src/lib.rs
@@ -86,6 +86,12 @@ pub enum MachineError<E: Error> {
     Underlying(E),
 }
 
+impl<E: Error> From<E> for MachineError<E> {
+    fn from(e: E) -> Self {
+        Self::Underlying(e)
+    }
+}
+
 impl<E: Error> Display for MachineError<E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -76,7 +76,7 @@ message ScheduleActivity {
     /// configuration. Retries are happening up to schedule_to_close_timeout. To disable retries set
     /// retry_policy.maximum_attempts to 1.
     common.RetryPolicy retry_policy = 12;
-    /// Defines behaviour of the underlying workflow when activity cancellation has been requested.
+    /// Defines how the workflow will wait (or not) for cancellation of the activity to be confirmed
     ActivityCancellationType cancellation_type = 13;
 }
 
@@ -111,6 +111,10 @@ message ScheduleLocalActivity {
     /// schedule a timer and retry the activity after. Otherwise, backoff will happen internally in
     /// core.
     google.protobuf.Duration local_retry_threshold = 11;
+    /// Defines how the workflow will wait (or not) for cancellation of the activity to be
+    /// confirmed. Lang should default this to `WAIT_CANCELLATION_COMPLETED`, even though proto
+    /// will default to `TRY_CANCEL` automatically.
+    ActivityCancellationType cancellation_type = 13;
 }
 
 enum ActivityCancellationType {

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -93,23 +93,26 @@ message ScheduleLocalActivity {
     /// Arguments/input to the activity.
     repeated common.Payload arguments = 6;
     /// Indicates how long the caller is willing to wait for local activity completion. Limits how
-    /// long retries will be attempted. Either this or start_to_close_timeout_seconds must be
-    /// specified. When not specified defaults to the workflow execution timeout.
+    /// long retries will be attempted. When not specified defaults to the workflow execution
+    /// timeout (which may be unset).
     google.protobuf.Duration schedule_to_close_timeout = 7;
     /// Limits time the local activity can idle internally before being executed. That can happen if
     /// the worker is currently at max concurrent local activity executions. This timeout is always
     /// non retryable as all a retry would achieve is to put it back into the same queue. Defaults
-    /// to schedule_to_close_timeout or workflow execution timeout if not specified.
+    /// to `schedule_to_close_timeout` if not specified and that is set. Must be <=
+    /// `schedule_to_close_timeout` when set, if not, it will be clamped down.
     google.protobuf.Duration schedule_to_start_timeout = 8;
     /// Maximum time the local activity is allowed to execute after the task is dispatched. This
-    /// timeout is always retryable. Either this or schedule_to_close_timeout must be specified.
+    /// timeout is always retryable. Either or both of `schedule_to_close_timeout` and this must be
+    /// specified. If set, this must be <= `schedule_to_close_timeout`, if not, it will be clamped
+    /// down.
     google.protobuf.Duration start_to_close_timeout = 9;
     /// Specify a retry policy for the local activity. By default local activities will be retried
     /// indefinitely.
     common.RetryPolicy retry_policy = 10;
     /// If the activity is retrying and backoff would exceed this value, lang will be told to
     /// schedule a timer and retry the activity after. Otherwise, backoff will happen internally in
-    /// core.
+    /// core. Defaults to 1 minute.
     google.protobuf.Duration local_retry_threshold = 11;
     /// Defines how the workflow will wait (or not) for cancellation of the activity to be
     /// confirmed. Lang should default this to `WAIT_CANCELLATION_COMPLETED`, even though proto

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -30,6 +30,7 @@ message WorkflowCommand {
         SignalExternalWorkflowExecution signal_external_workflow_execution = 14;
         CancelSignalWorkflow cancel_signal_workflow = 15;
         ScheduleLocalActivity schedule_local_activity = 16;
+        RequestCancelLocalActivity request_cancel_local_activity = 17;
 
         // To be added as/if needed:
         //  UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 14;
@@ -129,6 +130,11 @@ enum ActivityCancellationType {
 
 message RequestCancelActivity {
     /// Lang's incremental sequence number as passed to `ScheduleActivity`
+    uint32 seq = 1;
+}
+
+message RequestCancelLocalActivity {
+    /// Lang's incremental sequence number as passed to `ScheduleLocalActivity`
     uint32 seq = 1;
 }
 

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -78,9 +78,6 @@ message ScheduleActivity {
     common.RetryPolicy retry_policy = 12;
     /// Defines behaviour of the underlying workflow when activity cancellation has been requested.
     ActivityCancellationType cancellation_type = 13;
-    // If set true, this activity will be local. Only this worker will execute it and heartbeating
-    // will not apply.
-    bool local = 14;
 }
 
 message ScheduleLocalActivity {

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -79,18 +79,7 @@ pub mod coresdk {
 
             pub fn cancel_from_details(payload: Option<Payload>) -> Self {
                 Self {
-                    status: Some(aer::Status::Cancelled(Cancellation {
-                        failure: Some(APIFailure {
-                            // CanceledFailure
-                            message: "Activity cancelled".to_string(),
-                            failure_info: Some(failure::FailureInfo::CanceledFailureInfo(
-                                CanceledFailureInfo {
-                                    details: payload.map(Into::into),
-                                },
-                            )),
-                            ..Default::default()
-                        }),
-                    })),
+                    status: Some(aer::Status::Cancelled(Cancellation::from_details(payload))),
                 }
             }
 
@@ -136,6 +125,22 @@ pub mod coresdk {
 
             pub fn cancelled(&self) -> bool {
                 matches!(self.status, Some(activity_resolution::Status::Cancelled(_)))
+            }
+        }
+
+        impl Cancellation {
+            pub fn from_details(payload: Option<Payload>) -> Self {
+                Cancellation {
+                    failure: Some(APIFailure {
+                        message: "Activity cancelled".to_string(),
+                        failure_info: Some(failure::FailureInfo::CanceledFailureInfo(
+                            CanceledFailureInfo {
+                                details: payload.map(Into::into),
+                            },
+                        )),
+                        ..Default::default()
+                    }),
+                }
             }
         }
     }

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -99,6 +99,10 @@ pub mod coresdk {
                     status: Some(aer::Status::WillCompleteAsync(WillCompleteAsync {})),
                 }
             }
+
+            pub fn is_cancelled(&self) -> bool {
+                matches!(self.status, Some(aer::Status::Cancelled(_)))
+            }
         }
 
         impl From<Result<APIPayload, APIFailure>> for ActivityExecutionResult {
@@ -128,6 +132,10 @@ pub mod coresdk {
 
             pub fn failed(&self) -> bool {
                 matches!(self.status, Some(activity_resolution::Status::Failed(_)))
+            }
+
+            pub fn cancelled(&self) -> bool {
+                matches!(self.status, Some(activity_resolution::Status::Cancelled(_)))
             }
         }
     }

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -523,6 +523,12 @@ pub mod coresdk {
             }
         }
 
+        impl Display for RequestCancelLocalActivity {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "RequestCancelLocalActivity({})", self.seq)
+            }
+        }
+
         impl Display for CancelTimer {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 write!(f, "CancelTimer({})", self.seq)

--- a/src/machines/local_activity_state_machine.rs
+++ b/src/machines/local_activity_state_machine.rs
@@ -531,9 +531,11 @@ impl WFMachinesAdapter for LocalActivityMachine {
                     LocalActivityExecutionResult::Failed(fail) => {
                         maybe_failure = fail.failure;
                     }
-                    LocalActivityExecutionResult::Cancelled(_, no_marker) => {
+                    LocalActivityExecutionResult::Cancelled(fail, no_marker) => {
                         if no_marker {
                             record_marker = false;
+                        } else {
+                            maybe_failure = fail.failure;
                         }
                     }
                 };

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -68,6 +68,7 @@ pub enum WFCommand {
     AddActivity(ScheduleActivity),
     AddLocalActivity(ScheduleLocalActivity),
     RequestCancelActivity(RequestCancelActivity),
+    RequestCancelLocalActivity(RequestCancelLocalActivity),
     AddTimer(StartTimer),
     CancelTimer(CancelTimer),
     CompleteWorkflow(CompleteWorkflowExecution),
@@ -122,6 +123,9 @@ impl TryFrom<WorkflowCommand> for WFCommand {
                 Ok(Self::CancelUnstartedChild(s))
             }
             workflow_command::Variant::ScheduleLocalActivity(s) => Ok(Self::AddLocalActivity(s)),
+            workflow_command::Variant::RequestCancelLocalActivity(s) => {
+                Ok(Self::RequestCancelLocalActivity(s))
+            }
         }
     }
 }

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -702,6 +702,7 @@ impl WorkflowMachines {
                     }));
             } else if e.is_local_activity_marker() {
                 if let Some(la_dat) = e.clone().into_local_activity_marker_details() {
+                    warn!("LA marker");
                     self.local_activity_resolutions
                         .insert(la_dat.marker_dat.seq, la_dat.into());
                 } else {

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -1006,7 +1006,7 @@ impl WorkflowMachines {
                         // We removed it. Notify the machine that the activity cancelled.
                         if let Machines::LocalActivityMachine(lam) = self.machine_mut(m_key) {
                             let more_responses = lam.try_resolve(
-                                LocalActivityExecutionResult::Cancelled(Default::default(), true),
+                                LocalActivityExecutionResult::empty_cancel(true),
                                 Duration::from_secs(0),
                                 removed_act.attempt,
                                 None,

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -1,37 +1,37 @@
+mod local_acts;
+
 use crate::{
     machines::{
-        activity_state_machine::new_activity,
-        cancel_external_state_machine::new_external_cancel,
+        activity_state_machine::new_activity, cancel_external_state_machine::new_external_cancel,
         cancel_workflow_state_machine::cancel_workflow,
         child_workflow_state_machine::new_child_workflow,
         complete_workflow_state_machine::complete_workflow,
         continue_as_new_workflow_state_machine::continue_as_new,
         fail_workflow_state_machine::fail_workflow,
-        local_activity_state_machine::{new_local_activity, ResolveDat},
-        patch_state_machine::has_change,
-        signal_external_state_machine::new_external_signal,
-        timer_state_machine::new_timer,
-        workflow_task_state_machine::WorkflowTaskMachine,
-        LocalActivityExecutionResult, MachineKind, Machines, NewMachineWithCommand, ProtoCommand,
-        TemporalStateMachine, WFCommand,
+        local_activity_state_machine::new_local_activity, patch_state_machine::has_change,
+        signal_external_state_machine::new_external_signal, timer_state_machine::new_timer,
+        workflow_machines::local_acts::LocalActivityData,
+        workflow_task_state_machine::WorkflowTaskMachine, LocalActivityExecutionResult,
+        MachineKind, Machines, NewMachineWithCommand, ProtoCommand, TemporalStateMachine,
+        WFCommand,
     },
     protosext::HistoryEventExt,
     telemetry::{metrics::MetricsContext, VecDisplayer},
-    worker::NewLocalAct,
+    worker::{ExecutingLAId, LocalActRequest},
     workflow::{CommandID, DrivenWorkflow, HistoryUpdate, LocalResolution, WorkflowFetcher},
 };
 use prost_types::TimestampOutOfSystemRangeError;
 use slotmap::SlotMap;
 use std::{
     borrow::{Borrow, BorrowMut},
-    collections::{hash_map::DefaultHasher, HashMap, HashSet, VecDeque},
+    collections::{hash_map::DefaultHasher, HashMap, VecDeque},
     convert::TryInto,
     hash::{Hash, Hasher},
     time::{Duration, Instant, SystemTime},
 };
 use temporal_sdk_core_protos::{
     coresdk::{
-        common::{NamespacedWorkflowExecution, Payload, WorkflowExecution},
+        common::{NamespacedWorkflowExecution, Payload},
         workflow_activation::{
             wf_activation_job::{self, Variant},
             NotifyHasPatch, StartWorkflow, UpdateRandomSeed, WfActivation,
@@ -106,13 +106,8 @@ pub(crate) struct WorkflowMachines {
     /// Information about patch markers we have already seen while replaying history
     encountered_change_markers: HashMap<String, ChangeInfo>,
 
-    /// Queued local activity requests which need to be executed
-    local_activity_requests: Vec<ScheduleLocalActivity>,
-    /// Seq #s of local activities which we have sent to be executed but have not yet resolved
-    executing_local_activities: HashSet<u32>,
-    /// Maps local activity sequence numbers to their resolutions as found when looking ahead at
-    /// next WFT
-    local_activity_resolutions: HashMap<u32, ResolveDat>,
+    /// Contains extra local-activity related data
+    local_activity_data: LocalActivityData,
 
     /// The workflow that is being driven by this instance of the machines
     drive_me: DrivenWorkflow,
@@ -239,9 +234,7 @@ impl WorkflowMachines {
             commands: Default::default(),
             current_wf_task_commands: Default::default(),
             encountered_change_markers: Default::default(),
-            local_activity_requests: Default::default(),
-            executing_local_activities: Default::default(),
-            local_activity_resolutions: Default::default(),
+            local_activity_data: LocalActivityData::default(),
             have_seen_terminal_event: false,
         }
     }
@@ -290,35 +283,21 @@ impl WorkflowMachines {
                         seq
                     )));
                 }
-                self.executing_local_activities.remove(&seq);
+                self.local_activity_data.done_executing(seq);
             }
         }
         Ok(())
     }
 
-    /// Fetch all queued local activities that need executing, mark them as sent
-    pub(crate) fn drain_queued_local_activities(&mut self) -> Vec<NewLocalAct> {
-        let key_and_act = std::mem::take(&mut self.local_activity_requests);
-        key_and_act
-            .into_iter()
-            .map(|act| {
-                self.executing_local_activities.insert(act.seq);
-                NewLocalAct {
-                    schedule_cmd: act,
-                    workflow_type: self.workflow_type.clone(),
-                    workflow_exec_info: WorkflowExecution {
-                        workflow_id: self.workflow_id.clone(),
-                        run_id: self.run_id.clone(),
-                    },
-                    schedule_time: SystemTime::now(),
-                }
-            })
-            .collect()
+    /// Drain all queued local activities that need executing or cancellation
+    pub(crate) fn drain_queued_local_activities(&mut self) -> Vec<LocalActRequest> {
+        self.local_activity_data
+            .take_all_reqs(&self.workflow_type, &self.workflow_id, &self.run_id)
     }
 
     /// Returns the number of local activities we know we need to execute but have not yet finished
     pub(crate) fn outstanding_local_activity_count(&self) -> usize {
-        self.executing_local_activities.len() + self.local_activity_requests.len()
+        self.local_activity_data.outstanding_la_count()
     }
 
     /// Returns the start attributes for the workflow if it has started
@@ -701,16 +680,7 @@ impl WorkflowMachines {
                         patch_id,
                     }));
             } else if e.is_local_activity_marker() {
-                if let Some(la_dat) = e.clone().into_local_activity_marker_details() {
-                    warn!("LA marker");
-                    self.local_activity_resolutions
-                        .insert(la_dat.marker_dat.seq, la_dat.into());
-                } else {
-                    return Err(WFMachinesError::Fatal(format!(
-                        "Local activity marker was unparseable: {:?}",
-                        e
-                    )));
-                }
+                self.local_activity_data.process_peekahead_marker(e)?;
             }
         }
 
@@ -806,7 +776,7 @@ impl WorkflowMachines {
                     });
                 }
                 MachineResponse::QueueLocalActivity(act) => {
-                    self.local_activity_requests.push(act);
+                    self.local_activity_data.enqueue(act);
                 }
                 MachineResponse::RequestCancelLocalActivity(_) => {
                     panic!(
@@ -853,7 +823,7 @@ impl WorkflowMachines {
                     let (la, mach_resp) = new_local_activity(
                         attrs,
                         self.replaying,
-                        self.local_activity_resolutions.remove(&seq),
+                        self.local_activity_data.take_preresolution(seq),
                         self.current_wf_time,
                     )?;
                     let machkey = self.all_machines.insert(la.into());
@@ -1005,7 +975,7 @@ impl WorkflowMachines {
                     // We need to do this because otherwise we might need to perform additional
                     // activations during replay that didn't happen during execution, just like
                     // we sometimes pre-resolve activities when first requested.
-                    if let Some(preres) = self.local_activity_resolutions.remove(&seq) {
+                    if let Some(preres) = self.local_activity_data.take_preresolution(seq) {
                         if let Machines::LocalActivityMachine(lam) = self.machine_mut(m_key) {
                             let more_responses = lam.try_resolve_with_dat(preres)?;
                             self.process_machine_responses(m_key, more_responses)?;
@@ -1014,11 +984,8 @@ impl WorkflowMachines {
                         }
                     }
                     // If it's in the request queue, just rip it out.
-                    else if let Some(removed_act) = self
-                        .local_activity_requests
-                        .iter()
-                        .position(|req| req.seq == seq)
-                        .map(|i| self.local_activity_requests.remove(i))
+                    else if let Some(removed_act) =
+                        self.local_activity_data.remove_from_queue(seq)
                     {
                         // We removed it. Notify the machine that the activity cancelled.
                         if let Machines::LocalActivityMachine(lam) = self.machine_mut(m_key) {
@@ -1032,9 +999,14 @@ impl WorkflowMachines {
                         } else {
                             panic!("A non local-activity machine returned a request cancel LA response");
                         }
+                    } else {
+                        // Finally, if we know about the LA at all, it's currently running, so
+                        // queue the cancel request to be given to the LA manager.
+                        self.local_activity_data.enqueue_cancel(ExecutingLAId {
+                            run_id: self.run_id.clone(),
+                            seq_num: seq,
+                        });
                     }
-
-                    // TODO: Actually send cancel request to LA manager
                 }
                 v => {
                     return Err(WFMachinesError::Fatal(format!(

--- a/src/machines/workflow_machines/local_acts.rs
+++ b/src/machines/workflow_machines/local_acts.rs
@@ -74,7 +74,7 @@ impl LocalActivityData {
                 .insert(la_dat.marker_dat.seq, la_dat.into());
         } else {
             return Err(WFMachinesError::Fatal(format!(
-                "Local activity marker was unparseable: {:?}",
+                "Local activity marker was unparsable: {:?}",
                 e
             )));
         }

--- a/src/machines/workflow_machines/local_acts.rs
+++ b/src/machines/workflow_machines/local_acts.rs
@@ -1,0 +1,94 @@
+use crate::{
+    machines::{local_activity_state_machine::ResolveDat, WFMachinesError},
+    protosext::HistoryEventExt,
+    worker::{ExecutingLAId, LocalActRequest, NewLocalAct},
+};
+use std::{
+    collections::{HashMap, HashSet},
+    time::SystemTime,
+};
+use temporal_sdk_core_protos::{
+    coresdk::{common::WorkflowExecution, workflow_commands::ScheduleLocalActivity},
+    temporal::api::history::v1::HistoryEvent,
+};
+
+#[derive(Default)]
+pub(super) struct LocalActivityData {
+    /// Queued local activity requests which need to be executed
+    new_requests: Vec<ScheduleLocalActivity>,
+    /// Queued cancels that need to be dispatched
+    cancel_requests: Vec<ExecutingLAId>,
+    /// Seq #s of local activities which we have sent to be executed but have not yet resolved
+    executing: HashSet<u32>,
+    /// Maps local activity sequence numbers to their resolutions as found when looking ahead at
+    /// next WFT
+    resolutions: HashMap<u32, ResolveDat>,
+}
+
+impl LocalActivityData {
+    pub(super) fn enqueue(&mut self, act: ScheduleLocalActivity) {
+        self.new_requests.push(act);
+    }
+
+    pub(super) fn enqueue_cancel(&mut self, cancel: ExecutingLAId) {
+        self.cancel_requests.push(cancel);
+    }
+
+    pub(super) fn done_executing(&mut self, seq: u32) {
+        self.executing.remove(&seq);
+    }
+
+    /// Drain all requests to execute or cancel LAs. Additional info is passed in to be able to
+    /// augment the data this struct has to form complete request data.
+    pub(super) fn take_all_reqs(
+        &mut self,
+        wf_type: &str,
+        wf_id: &str,
+        run_id: &str,
+    ) -> Vec<LocalActRequest> {
+        self.cancel_requests
+            .drain(..)
+            .map(LocalActRequest::Cancel)
+            .chain(self.new_requests.drain(..).map(|sa| {
+                self.executing.insert(sa.seq);
+                LocalActRequest::New(NewLocalAct {
+                    schedule_cmd: sa,
+                    workflow_type: wf_type.to_string(),
+                    workflow_exec_info: WorkflowExecution {
+                        workflow_id: wf_id.to_string(),
+                        run_id: run_id.to_string(),
+                    },
+                    schedule_time: SystemTime::now(),
+                })
+            }))
+            .collect()
+    }
+
+    pub(super) fn outstanding_la_count(&self) -> usize {
+        self.executing.len() + self.new_requests.len()
+    }
+
+    pub(super) fn process_peekahead_marker(&mut self, e: &HistoryEvent) -> super::Result<()> {
+        if let Some(la_dat) = e.clone().into_local_activity_marker_details() {
+            self.resolutions
+                .insert(la_dat.marker_dat.seq, la_dat.into());
+        } else {
+            return Err(WFMachinesError::Fatal(format!(
+                "Local activity marker was unparseable: {:?}",
+                e
+            )));
+        }
+        Ok(())
+    }
+
+    pub(super) fn take_preresolution(&mut self, seq: u32) -> Option<ResolveDat> {
+        self.resolutions.remove(&seq)
+    }
+
+    pub(super) fn remove_from_queue(&mut self, seq: u32) -> Option<ScheduleLocalActivity> {
+        self.new_requests
+            .iter()
+            .position(|req| req.seq == seq)
+            .map(|i| self.new_requests.remove(i))
+    }
+}

--- a/src/machines/workflow_machines/local_acts.rs
+++ b/src/machines/workflow_machines/local_acts.rs
@@ -35,6 +35,8 @@ impl LocalActivityData {
     }
 
     pub(super) fn done_executing(&mut self, seq: u32) {
+        // This seems nonsense, but can happen during abandonment
+        self.new_requests.retain(|req| req.seq != seq);
         self.executing.remove(&seq);
     }
 

--- a/src/machines/workflow_machines/local_acts.rs
+++ b/src/machines/workflow_machines/local_acts.rs
@@ -1,6 +1,6 @@
 use crate::{
     machines::{local_activity_state_machine::ResolveDat, WFMachinesError},
-    protosext::HistoryEventExt,
+    protosext::{HistoryEventExt, ValidScheduleLA},
     worker::{ExecutingLAId, LocalActRequest, NewLocalAct},
 };
 use std::{
@@ -8,14 +8,13 @@ use std::{
     time::SystemTime,
 };
 use temporal_sdk_core_protos::{
-    coresdk::{common::WorkflowExecution, workflow_commands::ScheduleLocalActivity},
-    temporal::api::history::v1::HistoryEvent,
+    coresdk::common::WorkflowExecution, temporal::api::history::v1::HistoryEvent,
 };
 
 #[derive(Default)]
 pub(super) struct LocalActivityData {
     /// Queued local activity requests which need to be executed
-    new_requests: Vec<ScheduleLocalActivity>,
+    new_requests: Vec<ValidScheduleLA>,
     /// Queued cancels that need to be dispatched
     cancel_requests: Vec<ExecutingLAId>,
     /// Seq #s of local activities which we have sent to be executed but have not yet resolved
@@ -26,7 +25,7 @@ pub(super) struct LocalActivityData {
 }
 
 impl LocalActivityData {
-    pub(super) fn enqueue(&mut self, act: ScheduleLocalActivity) {
+    pub(super) fn enqueue(&mut self, act: ValidScheduleLA) {
         self.new_requests.push(act);
     }
 
@@ -87,7 +86,7 @@ impl LocalActivityData {
         self.resolutions.remove(&seq)
     }
 
-    pub(super) fn remove_from_queue(&mut self, seq: u32) -> Option<ScheduleLocalActivity> {
+    pub(super) fn remove_from_queue(&mut self, seq: u32) -> Option<ValidScheduleLA> {
         self.new_requests
             .iter()
             .position(|req| req.seq == seq)

--- a/src/protosext/mod.rs
+++ b/src/protosext/mod.rs
@@ -258,7 +258,10 @@ impl TryFrom<activity_execution_result::Status> for LocalActivityExecutionResult
         match s {
             Status::Completed(c) => Ok(LocalActivityExecutionResult::Completed(c)),
             Status::Failed(f) => Ok(LocalActivityExecutionResult::Failed(f)),
-            Status::Cancelled(c) => Ok(LocalActivityExecutionResult::Cancelled(c, false)),
+            Status::Cancelled(cancel) => Ok(LocalActivityExecutionResult::Cancelled {
+                cancel,
+                do_not_record_marker: false,
+            }),
             Status::WillCompleteAsync(_) => {
                 Err(CompleteActivityError::MalformedActivityCompletion {
                     reason: "Local activities cannot be completed async".to_string(),

--- a/src/protosext/mod.rs
+++ b/src/protosext/mod.rs
@@ -250,10 +250,7 @@ impl TryFrom<activity_execution_result::Status> for LocalActivityExecutionResult
         match s {
             Status::Completed(c) => Ok(LocalActivityExecutionResult::Completed(c)),
             Status::Failed(f) => Ok(LocalActivityExecutionResult::Failed(f)),
-            Status::Cancelled(_) => Err(CompleteActivityError::MalformedActivityCompletion {
-                reason: "Cancellation not yet implemented for local activities".to_string(),
-                completion: None,
-            }),
+            Status::Cancelled(c) => Ok(LocalActivityExecutionResult::Cancelled(c, false)),
             Status::WillCompleteAsync(_) => {
                 Err(CompleteActivityError::MalformedActivityCompletion {
                     reason: "Local activities cannot be completed async".to_string(),

--- a/src/prototype_rust_sdk.rs
+++ b/src/prototype_rust_sdk.rs
@@ -445,6 +445,8 @@ pub enum CancellableID {
     Timer(u32),
     /// Activity sequence number
     Activity(u32),
+    /// Activity sequence number
+    LocalActivity(u32),
     /// Start child sequence number
     ChildWorkflow(u32),
     /// Signal workflow

--- a/src/prototype_rust_sdk/workflow_context/options.rs
+++ b/src/prototype_rust_sdk/workflow_context/options.rs
@@ -8,6 +8,8 @@ use temporal_sdk_core_protos::coresdk::{
     },
 };
 
+// TODO: Before release, probably best to avoid using proto types entirely here. They're awkward.
+
 pub trait IntoWorkflowCommand {
     type WFCommandType;
 
@@ -99,6 +101,8 @@ pub struct LocalActivityOptions {
     pub attempt: Option<u32>,
     /// Retry backoffs over this amount will use a timer rather than a local retry
     pub timer_backoff_threshold: Option<Duration>,
+    /// How the activity will cancel
+    pub cancel_type: ActivityCancellationType,
 }
 
 impl IntoWorkflowCommand for LocalActivityOptions {
@@ -115,6 +119,7 @@ impl IntoWorkflowCommand for LocalActivityOptions {
             arguments: vec![self.input],
             retry_policy: Some(self.retry_policy),
             local_retry_threshold: self.timer_backoff_threshold.map(Into::into),
+            cancellation_type: self.cancel_type.into(),
             ..Default::default()
         }
     }

--- a/src/prototype_rust_sdk/workflow_future.rs
+++ b/src/prototype_rust_sdk/workflow_future.rs
@@ -281,12 +281,18 @@ impl Future for WorkflowFuture {
                 .poll_unpin(cx)
             {
                 Poll::Ready(Err(e)) => {
+                    let errmsg = format!(
+                        "Workflow function panicked: {:?}",
+                        // Panics are typically strings
+                        e.downcast::<String>()
+                    );
+                    warn!("{}", errmsg);
                     self.outgoing_completions
                         .send(WfActivationCompletion::fail(
                             &self.task_queue,
                             run_id,
                             Failure {
-                                message: format!("Workflow function panicked: {:?}", e),
+                                message: errmsg,
                                 ..Default::default()
                             },
                         ))

--- a/src/prototype_rust_sdk/workflow_future.rs
+++ b/src/prototype_rust_sdk/workflow_future.rs
@@ -18,6 +18,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+use temporal_sdk_core_protos::coresdk::workflow_commands::RequestCancelLocalActivity;
 use temporal_sdk_core_protos::{
     coresdk::{
         common::Payload,
@@ -316,6 +317,13 @@ impl Future for WorkflowFuture {
                                 activation_cmds.push(
                                     workflow_command::Variant::RequestCancelActivity(
                                         RequestCancelActivity { seq },
+                                    ),
+                                );
+                            }
+                            CancellableID::LocalActivity(seq) => {
+                                activation_cmds.push(
+                                    workflow_command::Variant::RequestCancelLocalActivity(
+                                        RequestCancelLocalActivity { seq },
                                     ),
                                 );
                             }

--- a/src/prototype_rust_sdk/workflow_future.rs
+++ b/src/prototype_rust_sdk/workflow_future.rs
@@ -18,7 +18,6 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use temporal_sdk_core_protos::coresdk::workflow_commands::RequestCancelLocalActivity;
 use temporal_sdk_core_protos::{
     coresdk::{
         common::Payload,
@@ -31,8 +30,9 @@ use temporal_sdk_core_protos::{
             request_cancel_external_workflow_execution as cancel_we, workflow_command,
             CancelSignalWorkflow, CancelTimer, CancelUnstartedChildWorkflowExecution,
             CancelWorkflowExecution, CompleteWorkflowExecution, FailWorkflowExecution,
-            RequestCancelActivity, RequestCancelExternalWorkflowExecution, ScheduleActivity,
-            ScheduleLocalActivity, StartChildWorkflowExecution, StartTimer,
+            RequestCancelActivity, RequestCancelExternalWorkflowExecution,
+            RequestCancelLocalActivity, ScheduleActivity, ScheduleLocalActivity,
+            StartChildWorkflowExecution, StartTimer,
         },
         workflow_completion::WfActivationCompletion,
     },

--- a/src/test_help/history_builder.rs
+++ b/src/test_help/history_builder.rs
@@ -9,7 +9,6 @@ use crate::{
 use anyhow::bail;
 use prost_types::Timestamp;
 use std::time::{Duration, SystemTime};
-use temporal_sdk_core_protos::temporal::api::failure::v1::{failure, CanceledFailureInfo};
 use temporal_sdk_core_protos::{
     coresdk::{
         common::{
@@ -22,7 +21,7 @@ use temporal_sdk_core_protos::{
     temporal::api::{
         common::v1::{Payload, Payloads, WorkflowExecution, WorkflowType},
         enums::v1::{EventType, WorkflowTaskFailedCause},
-        failure::v1::Failure,
+        failure::v1::{failure, CanceledFailureInfo, Failure},
         history::v1::{history_event::Attributes, *},
     },
 };

--- a/src/test_help/history_builder.rs
+++ b/src/test_help/history_builder.rs
@@ -9,6 +9,7 @@ use crate::{
 use anyhow::bail;
 use prost_types::Timestamp;
 use std::time::{Duration, SystemTime};
+use temporal_sdk_core_protos::temporal::api::failure::v1::{failure, CanceledFailureInfo};
 use temporal_sdk_core_protos::{
     coresdk::{
         common::{
@@ -306,6 +307,24 @@ impl TestHistoryBuilder {
         failure: Failure,
     ) {
         self.add_local_activity_marker(seq, activity_id, None, Some(failure), None);
+    }
+
+    pub(crate) fn add_local_activity_cancel_marker(&mut self, seq: u32, activity_id: &str) {
+        self.add_local_activity_marker(
+            seq,
+            activity_id,
+            None,
+            Some(Failure {
+                message: "cancelled bro".to_string(),
+                source: "".to_string(),
+                stack_trace: "".to_string(),
+                cause: None,
+                failure_info: Some(failure::FailureInfo::CanceledFailureInfo(
+                    CanceledFailureInfo { details: None },
+                )),
+            }),
+            None,
+        );
     }
 
     pub(crate) fn add_signal_wf(

--- a/src/worker/activities.rs
+++ b/src/worker/activities.rs
@@ -2,8 +2,8 @@ mod activity_heartbeat_manager;
 mod local_activities;
 
 pub(crate) use local_activities::{
-    ExecutingLAId, LACompleteAction, LocalActRequest, LocalActivityManager, LocalInFlightActInfo,
-    NewLocalAct,
+    ExecutingLAId, LACompleteAction, LocalActRequest, LocalActivityManager,
+    LocalActivityResolution, LocalInFlightActInfo, NewLocalAct,
 };
 
 use crate::{

--- a/src/worker/activities.rs
+++ b/src/worker/activities.rs
@@ -2,7 +2,8 @@ mod activity_heartbeat_manager;
 mod local_activities;
 
 pub(crate) use local_activities::{
-    LACompleteAction, LocalActivityManager, LocalInFlightActInfo, NewLocalAct,
+    ExecutingLAId, LACompleteAction, LocalActRequest, LocalActivityManager, LocalInFlightActInfo,
+    NewLocalAct,
 };
 
 use crate::{

--- a/src/worker/activities/local_activities.rs
+++ b/src/worker/activities/local_activities.rs
@@ -164,10 +164,10 @@ impl LocalActivityManager {
                         t.abort();
                         immediate_resolutions.push(LocalActivityResolution {
                             seq: id.seq_num,
-                            result: LocalActivityExecutionResult::Cancelled(
-                                Cancellation::from_details(None),
-                                false,
-                            ),
+                            result: LocalActivityExecutionResult::Cancelled {
+                                cancel: Cancellation::from_details(None),
+                                do_not_record_marker: false,
+                            },
                             runtime: Duration::from_secs(0),
                             attempt: 0,
                             backoff: None,
@@ -287,7 +287,7 @@ impl LocalActivityManager {
 
             match status {
                 LocalActivityExecutionResult::Completed(_)
-                | LocalActivityExecutionResult::Cancelled(_, _) => {
+                | LocalActivityExecutionResult::Cancelled { .. } => {
                     self.complete_notify.notify_one();
                     LACompleteAction::Report(info)
                 }
@@ -562,7 +562,7 @@ mod tests {
         assert_eq!(immediate_res.len(), 1);
         assert_matches!(
             immediate_res[0].result,
-            LocalActivityExecutionResult::Cancelled(_, _)
+            LocalActivityExecutionResult::Cancelled { .. }
         );
     }
 

--- a/src/worker/activities/local_activities.rs
+++ b/src/worker/activities/local_activities.rs
@@ -175,7 +175,8 @@ impl LocalActivityManager {
             self.semaphore.add_permits(1);
 
             match status {
-                LocalActivityExecutionResult::Completed(_) => {
+                LocalActivityExecutionResult::Completed(_)
+                | LocalActivityExecutionResult::Cancelled(_, _) => {
                     self.complete_notify.notify_one();
                     LACompleteAction::Report(info)
                 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -5,7 +5,7 @@ mod wft_delivery;
 
 pub use config::{WorkerConfig, WorkerConfigBuilder};
 
-pub(crate) use activities::NewLocalAct;
+pub(crate) use activities::{ExecutingLAId, LocalActRequest, NewLocalAct};
 pub(crate) use dispatcher::WorkerDispatcher;
 
 use crate::{

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -5,7 +5,7 @@ mod wft_delivery;
 
 pub use config::{WorkerConfig, WorkerConfigBuilder};
 
-pub(crate) use activities::{ExecutingLAId, LocalActRequest, NewLocalAct};
+pub(crate) use activities::{ExecutingLAId, LocalActRequest, LocalActivityResolution, NewLocalAct};
 pub(crate) use dispatcher::WorkerDispatcher;
 
 use crate::{
@@ -742,13 +742,13 @@ impl Worker {
             .wft_manager
             .notify_of_local_result(
                 &info.la_info.workflow_exec_info.run_id,
-                LocalResolution::LocalActivity {
+                LocalResolution::LocalActivity(LocalActivityResolution {
                     seq: info.la_info.schedule_cmd.seq,
                     result: la_res,
                     runtime: info.dispatch_time.elapsed(),
                     attempt: info.attempt,
                     backoff,
-                },
+                }),
             )
             .await
         {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -742,8 +742,8 @@ impl Worker {
             .wft_manager
             .notify_of_local_result(
                 &info.la_info.workflow_exec_info.run_id,
-                info.la_info.schedule_cmd.seq,
                 LocalResolution::LocalActivity {
+                    seq: info.la_info.schedule_cmd.seq,
                     result: la_res,
                     runtime: info.dispatch_time.elapsed(),
                     attempt: info.attempt,

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -198,8 +198,7 @@ pub mod managed_wf {
         test_help::{TestHistoryBuilder, TEST_Q},
         workflow::WorkflowFetcher,
     };
-    use std::convert::TryInto;
-    use std::time::Duration;
+    use std::{convert::TryInto, time::Duration};
     use temporal_sdk_core_protos::coresdk::{
         activity_result::ActivityExecutionResult,
         common::Payload,

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         LocalActivityExecutionResult, ProtoCommand, WFCommand, WFMachinesError, WorkflowMachines,
     },
     telemetry::metrics::MetricsContext,
-    worker::NewLocalAct,
+    worker::LocalActRequest,
 };
 use std::{sync::mpsc::Sender, time::Duration};
 use temporal_sdk_core_protos::coresdk::workflow_activation::WfActivation;
@@ -161,7 +161,7 @@ impl WorkflowManager {
 
     /// Remove and return all queued local activities. Once this is called, they need to be
     /// dispatched for execution.
-    pub fn drain_queued_local_activities(&mut self) -> Vec<NewLocalAct> {
+    pub fn drain_queued_local_activities(&mut self) -> Vec<LocalActRequest> {
         self.machines.drain_queued_local_activities()
     }
 
@@ -303,7 +303,7 @@ pub mod managed_wf {
             self.mgr.get_server_commands()
         }
 
-        pub(crate) fn drain_queued_local_activities(&mut self) -> Vec<NewLocalAct> {
+        pub(crate) fn drain_queued_local_activities(&mut self) -> Vec<LocalActRequest> {
             self.mgr.drain_queued_local_activities()
         }
 

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -85,6 +85,7 @@ pub struct OutgoingServerCommands {
 #[derive(Debug)]
 pub(crate) enum LocalResolution {
     LocalActivity {
+        seq: u32,
         result: LocalActivityExecutionResult,
         runtime: Duration,
         attempt: u32,
@@ -107,8 +108,8 @@ impl WorkflowManager {
 
     /// Let this workflow know that something we've been waiting locally on has resolved, like a
     /// local activity or side effect
-    pub fn notify_of_local_result(&mut self, seq_id: u32, resolved: LocalResolution) -> Result<()> {
-        self.machines.local_resolution(seq_id, resolved)
+    pub fn notify_of_local_result(&mut self, resolved: LocalResolution) -> Result<()> {
+        self.machines.local_resolution(resolved)
     }
 
     /// Fetch the next workflow activation for this workflow if one is required. Doing so will apply
@@ -320,9 +321,9 @@ pub mod managed_wf {
             seq_num: u32,
             result: ActivityExecutionResult,
         ) -> Result<()> {
-            self.mgr.notify_of_local_result(
-                seq_num,
-                LocalResolution::LocalActivity {
+            self.mgr
+                .notify_of_local_result(LocalResolution::LocalActivity {
+                    seq: seq_num,
                     // We accept normal execution results and do this conversion because there
                     // are more helpers for constructing them.
                     result: result
@@ -333,8 +334,7 @@ pub mod managed_wf {
                     runtime: Duration::from_secs(1),
                     attempt: 1,
                     backoff: None,
-                },
-            )
+                })
         }
 
         /// During testing it can be useful to run through all activations to simulate replay

--- a/src/workflow/workflow_tasks/mod.rs
+++ b/src/workflow/workflow_tasks/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     protosext::{ValidPollWFTQResponse, WfActivationExt},
     task_token::TaskToken,
     telemetry::metrics::MetricsContext,
-    worker::NewLocalAct,
+    worker::LocalActRequest,
     workflow::{
         workflow_tasks::{
             cache_manager::WorkflowCacheManager, concurrency_manager::WorkflowConcurrencyManager,
@@ -369,7 +369,7 @@ impl WorkflowTaskManager {
         &self,
         run_id: &str,
         mut commands: Vec<WFCommand>,
-        local_activity_request_sink: impl FnOnce(Vec<NewLocalAct>),
+        local_activity_request_sink: impl FnOnce(Vec<LocalActRequest>),
     ) -> Result<Option<ServerCommandsWithWorkflowInfo>, WorkflowUpdateError> {
         // No-command replies to evictions can simply skip everything
         if commands.is_empty() && self.activation_has_eviction(run_id) {

--- a/src/workflow/workflow_tasks/mod.rs
+++ b/src/workflow/workflow_tasks/mod.rs
@@ -673,12 +673,11 @@ impl WorkflowTaskManager {
     pub(crate) async fn notify_of_local_result(
         &self,
         run_id: &str,
-        seq_id: u32,
         resolved: LocalResolution,
     ) -> Result<(), WorkflowUpdateError> {
         self.workflow_machines
             .access_sync(run_id, |wfm: &mut WorkflowManager| {
-                wfm.notify_of_local_result(seq_id, resolved)
+                wfm.notify_of_local_result(resolved)
             })?
             .map_err(|wfme| WorkflowUpdateError {
                 source: wfme,

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -122,5 +122,4 @@ async fn can_paginate_long_history() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -126,7 +126,6 @@ async fn workflow_lru_cache_evictions() {
             .unwrap();
     }
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
     // The wf must have started more than # workflows times, since all but one must experience
     // an eviction
     assert!(RUN_CT.load(Ordering::SeqCst) > n_workflows);

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -50,7 +50,6 @@ async fn one_activity() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }
 
 #[tokio::test]

--- a/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -49,5 +49,4 @@ async fn sends_cancel_to_other_wf() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -50,6 +50,4 @@ async fn cancel_during_timer() {
         desc.workflow_execution_info.unwrap().status,
         WorkflowExecutionStatus::Canceled as i32
     );
-
-    starter.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -42,6 +42,4 @@ async fn child_workflow_happy_path() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-
-    starter.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -37,6 +37,4 @@ async fn continue_as_new_happy_path() {
         .terminate_workflow_execution(wf_name.to_owned(), None)
         .await
         .unwrap();
-
-    starter.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests/determinism.rs
+++ b/tests/integ_tests/workflow_tests/determinism.rs
@@ -43,7 +43,6 @@ async fn test_determinism_error_then_recovers() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
     // 4 because we still add on the 3rd and final attempt
     assert_eq!(RUN_CT.load(Ordering::Relaxed), 4);
 }

--- a/tests/integ_tests/workflow_tests/patches.rs
+++ b/tests/integ_tests/workflow_tests/patches.rs
@@ -34,7 +34,6 @@ async fn writes_change_markers() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }
 
 /// This one simulates a run as if the worker had the "old" code, then it fails at the end as
@@ -70,7 +69,6 @@ async fn can_add_change_markers() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }
 
 static DID_DIE_2: AtomicBool = AtomicBool::new(false);
@@ -96,5 +94,4 @@ async fn replaying_with_patch_marker() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests/signals.rs
+++ b/tests/integ_tests/workflow_tests/signals.rs
@@ -38,7 +38,6 @@ async fn sends_signal_to_missing_wf() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }
 
 async fn signal_receiver(ctx: WfContext) -> WorkflowResult<()> {
@@ -66,7 +65,6 @@ async fn sends_signal_to_other_wf() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }
 
 async fn signals_child(ctx: WfContext) -> WorkflowResult<()> {
@@ -98,5 +96,4 @@ async fn sends_signal_to_child() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/tests/integ_tests/workflow_tests/stickyness.rs
@@ -20,7 +20,6 @@ async fn timer_workflow_not_sticky() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }
 
 static TIMED_OUT_ONCE: AtomicBool = AtomicBool::new(false);
@@ -51,7 +50,6 @@ async fn timer_workflow_timeout_on_sticky() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
     // If it didn't run twice it didn't time out
     assert_eq!(RUN_CT.load(Ordering::SeqCst), 2);
 }
@@ -83,5 +81,4 @@ async fn cache_miss_ok() {
         barr.wait().await;
     });
     r1.unwrap();
-    starter.shutdown().await;
 }

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -23,7 +23,6 @@ async fn timer_workflow_workflow_driver() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }
 
 #[tokio::test]
@@ -117,5 +116,4 @@ async fn parallel_timers() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    starter.shutdown().await;
 }

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -105,5 +105,4 @@ async fn activity_load() {
         all_acts
     };
     dbg!(running.elapsed());
-    core.shutdown().await;
 }


### PR DESCRIPTION
Implement cancellation of local activities

Draft until:

- [ ] Test timeouts ( NEXT PR )
- [ ] Ensure workflows with outstanding LAs can't be evicted ( NEXT PR )
- [x] Implement different cancel types