### PR TITLE
Fix possible application of already-processed history events

### DIFF
--- a/src/core_tests/queries.rs
+++ b/src/core_tests/queries.rs
@@ -285,10 +285,17 @@ async fn legacy_query_failure_on_wft_failure() {
     core.shutdown().await;
 }
 
+#[rstest::rstest]
 #[tokio::test]
-async fn legacy_query_with_full_history_after_complete() {
+async fn legacy_query_after_complete(#[values(false, true)] full_history: bool) {
     let wfid = "fake_wf_id";
-    let t = canned_histories::single_timer_wf_completes("1");
+    let t = if full_history {
+        canned_histories::single_timer_wf_completes("1")
+    } else {
+        let mut t = canned_histories::single_timer("1");
+        t.add_workflow_task_completed();
+        t
+    };
     let query_with_hist_task = {
         let mut pr = hist_to_poll_resp(
             &t,

--- a/src/test_help/history_info.rs
+++ b/src/test_help/history_info.rs
@@ -39,6 +39,7 @@ impl HistoryInfo {
             return Err(HistoryInfoError::HistoryEndsUnexpectedly);
         }
 
+        let is_all_hist = to_wf_task_num.is_none();
         let to_wf_task_num = to_wf_task_num.unwrap_or(usize::MAX);
         let mut workflow_task_started_event_id = 0;
         let mut wf_task_count = 0;
@@ -82,7 +83,7 @@ impl HistoryInfo {
             }
 
             if next_event.is_none() {
-                if event.is_final_wf_execution_event() {
+                if event.is_final_wf_execution_event() || is_all_hist {
                     // Since this is the end of execution, we are pretending that the SDK is
                     // replaying *complete* history, which would mean the previously started ID is
                     // in fact the last task.

--- a/src/workflow/workflow_tasks/mod.rs
+++ b/src/workflow/workflow_tasks/mod.rs
@@ -376,20 +376,24 @@ impl WorkflowTaskManager {
             return Ok(None);
         }
 
-        let (task_token, start_time) = if let Some(entry) = self.workflow_machines.get_task(run_id)
-        {
-            (entry.info.task_token.clone(), entry.start_time)
-        } else {
-            if !self.activation_has_eviction(run_id) {
-                // Don't bother warning if this was an eviction, since it's normal to issue
-                // eviction activations without an associated workflow task in that case.
-                warn!(
-                    run_id,
-                    "Attempted to complete activation for run without associated workflow task"
-                );
-            }
-            return Ok(None);
-        };
+        let (task_token, is_leg_query_task, start_time) =
+            if let Some(entry) = self.workflow_machines.get_task(run_id) {
+                (
+                    entry.info.task_token.clone(),
+                    entry.legacy_query.is_some(),
+                    entry.start_time,
+                )
+            } else {
+                if !self.activation_has_eviction(run_id) {
+                    // Don't bother warning if this was an eviction, since it's normal to issue
+                    // eviction activations without an associated workflow task in that case.
+                    warn!(
+                        run_id,
+                        "Attempted to complete activation for run without associated workflow task"
+                    );
+                }
+                return Ok(None);
+            };
 
         // If the only command from the activation is a legacy query response, that means we need
         // to respond differently than a typical activation.
@@ -474,11 +478,16 @@ impl WorkflowTaskManager {
             let must_heartbeat = self
                 .wait_for_local_acts_or_heartbeat(run_id, wft_heartbeat_deadline)
                 .await;
+            let is_query_playback = is_leg_query_task && query_responses.is_empty();
 
             // We only actually want to send commands back to the server if there are no more
             // pending activations and we are caught up on replay. We don't want to complete a wft
-            // if already saw the final event in the workflow.
-            if !self.pending_activations.has_pending(run_id) && !server_cmds.replaying {
+            // if we already saw the final event in the workflow, or if we are playing back for the
+            // express purpose of fulfilling a query
+            if !self.pending_activations.has_pending(run_id)
+                && !server_cmds.replaying
+                && !is_query_playback
+            {
                 Some(ServerCommandsWithWorkflowInfo {
                     task_token,
                     action: ActivationAction::WftComplete {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
If a workflow is blocked waiting on something and produced an empty WFT, and then is queried, the empty WFT can be double-applied. This fixes that (and any scenario where the WF is cached and we might try to apply events we've already processed) 

## Why?
:bug: 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
