### PR TITLE
Implement Upsert Search Attributes

### DIFF
--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -278,4 +278,6 @@ message CancelSignalWorkflow {
 message UpsertWorkflowSearchAttributes {
     /// Lang's incremental sequence number as passed to `UpsertWorkflowSearchAttributes`
     uint32 seq = 1;
+    /// SearchAttributes fields
+    map<string, common.Payload> indexed_fields = 2;
 }

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -31,7 +31,7 @@ message WorkflowCommand {
         CancelSignalWorkflow cancel_signal_workflow = 15;
         ScheduleLocalActivity schedule_local_activity = 16;
         RequestCancelLocalActivity request_cancel_local_activity = 17;
-        UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 14;
+        UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 18;
     }
 }
 
@@ -276,6 +276,6 @@ message CancelSignalWorkflow {
 }
 
 message UpsertWorkflowSearchAttributes {
-    /// Lang's incremental sequence number as passed to `StartTimer`
+    /// Lang's incremental sequence number as passed to `UpsertWorkflowSearchAttributes`
     uint32 seq = 1;
 }

--- a/protos/local/workflow_commands.proto
+++ b/protos/local/workflow_commands.proto
@@ -31,9 +31,7 @@ message WorkflowCommand {
         CancelSignalWorkflow cancel_signal_workflow = 15;
         ScheduleLocalActivity schedule_local_activity = 16;
         RequestCancelLocalActivity request_cancel_local_activity = 17;
-
-        // To be added as/if needed:
-        //  UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 14;
+        UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 14;
     }
 }
 
@@ -274,5 +272,10 @@ message SignalExternalWorkflowExecution {
 /// Can be used to cancel not-already-sent `SignalExternalWorkflowExecution` commands
 message CancelSignalWorkflow {
     /// Lang's incremental sequence number as passed to `SignalExternalWorkflowExecution`
+    uint32 seq = 1;
+}
+
+message UpsertWorkflowSearchAttributes {
+    /// Lang's incremental sequence number as passed to `StartTimer`
     uint32 seq = 1;
 }

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -82,7 +82,7 @@ pub enum WFCommand {
     RequestCancelExternalWorkflow(RequestCancelExternalWorkflowExecution),
     SignalExternalWorkflow(SignalExternalWorkflowExecution),
     CancelSignalWorkflow(CancelSignalWorkflow),
-    UpsertSearchAttributes(UpsertSearchAttributes),
+    UpsertSearchAttributes(UpsertWorkflowSearchAttributes),
 }
 
 #[derive(thiserror::Error, Debug, derive_more::From)]
@@ -127,7 +127,7 @@ impl TryFrom<WorkflowCommand> for WFCommand {
             workflow_command::Variant::RequestCancelLocalActivity(s) => {
                 Ok(Self::RequestCancelLocalActivity(s))
             }
-            workflow_command::Variant::UpsertSearchAttributes(s) => Ok(Self::UpsertSearchAttributes(s)),
+            workflow_command::Variant::UpsertSearchAttributes(s) => Ok(Self::UpsertWorkflowSearchAttributes(s)),
         }
     }
 }

--- a/src/machines/mod.rs
+++ b/src/machines/mod.rs
@@ -82,6 +82,7 @@ pub enum WFCommand {
     RequestCancelExternalWorkflow(RequestCancelExternalWorkflowExecution),
     SignalExternalWorkflow(SignalExternalWorkflowExecution),
     CancelSignalWorkflow(CancelSignalWorkflow),
+    UpsertSearchAttributes(UpsertSearchAttributes),
 }
 
 #[derive(thiserror::Error, Debug, derive_more::From)]
@@ -126,6 +127,7 @@ impl TryFrom<WorkflowCommand> for WFCommand {
             workflow_command::Variant::RequestCancelLocalActivity(s) => {
                 Ok(Self::RequestCancelLocalActivity(s))
             }
+            workflow_command::Variant::UpsertSearchAttributes(s) => Ok(Self::UpsertSearchAttributes(s)),
         }
     }
 }

--- a/src/machines/upsert_search_attributes_state_machine.rs
+++ b/src/machines/upsert_search_attributes_state_machine.rs
@@ -1,4 +1,17 @@
 use rustfsm::{fsm, TransitionResult};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        // workflow_activation::FireTimer,
+        // workflow_commands::{UpsertCommandCreated, UpsertCommandRecorded, UpsertSearchAttributesCommand},
+        workflow_commands::{UpsertWorkflowSearchAttributes},
+        HistoryEventId,
+    },
+    temporal::api::{
+        command::v1::Command,
+        enums::v1::{CommandType, EventType},
+        history::v1::{history_event, HistoryEvent, TimerFiredEventAttributes},
+    },
+};
 
 fsm! {
     pub(super) name UpsertSearchAttributesMachine; command UpsertSearchAttributesCommand; error UpsertSearchAttributesMachineError;
@@ -13,6 +26,42 @@ fsm! {
 pub(super) enum UpsertSearchAttributesMachineError {}
 
 pub(super) enum UpsertSearchAttributesCommand {}
+
+
+
+/// Creates a new, scheduled, timer as a [CancellableCommand]
+pub(super) fn upsert_search_attrs(attribs: UpsertWorkflowSearchAttributes) -> NewMachineWithCommand {
+    let (state_machine, add_cmd) = UpsertMachine::new_upsert(attribs);
+    NewMachineWithCommand {
+        command: add_cmd,
+        machine: state_machine.into(),
+    }
+}
+
+impl UpsertMachine {
+    /// Create a new timer and immediately schedule it
+    fn new_upsert(attribs: UpsertWorkflowSearchAttributes) -> (Self, Command) {
+        let mut s = Self::new(attribs);
+        OnEventWrapper::on_event_mut(&mut s, TimerMachineEvents::Schedule)
+            .expect("Upserting search attrs doesn't fail");
+        let cmd = Command {
+            command_type: CommandType::UpsertSearchAttributesCommand as i32,
+            attributes: Some(s.shared_state().attrs.clone().into()),
+        };
+        (s, cmd)
+    }
+
+    fn new(attribs: UpsertWorkflowSearchAttributes) -> Self {
+        Self {
+            state: Created {}.into(),
+            shared_state: SharedState {
+                attrs: attribs,
+                cancelled_before_sent: false,
+            },
+        }
+    }
+}
+
 
 #[derive(Default, Clone)]
 pub(super) struct Created {}

--- a/src/machines/upsert_search_attributes_state_machine.rs
+++ b/src/machines/upsert_search_attributes_state_machine.rs
@@ -21,7 +21,7 @@ impl Created {
     pub(super) fn on_schedule(
         self,
     ) -> UpsertSearchAttributesMachineTransition<UpsertCommandCreated> {
-        unimplemented!()
+        TransitionResult::default()
     }
 }
 
@@ -32,7 +32,7 @@ impl UpsertCommandCreated {
     pub(super) fn on_upsert_workflow_search_attributes(
         self,
     ) -> UpsertSearchAttributesMachineTransition<UpsertCommandRecorded> {
-        unimplemented!()
+        TransitionResult::ok(vec![], UpsertCommandRecorded::default())
     }
 }
 

--- a/src/machines/workflow_machines.rs
+++ b/src/machines/workflow_machines.rs
@@ -10,6 +10,7 @@ use crate::{
         fail_workflow_state_machine::fail_workflow,
         local_activity_state_machine::new_local_activity, patch_state_machine::has_change,
         signal_external_state_machine::new_external_signal, timer_state_machine::new_timer,
+        upsert_search_attributes_state_machine::upsert_search_attrs,
         workflow_machines::local_acts::LocalActivityData,
         workflow_task_state_machine::WorkflowTaskMachine, LocalActivityExecutionResult,
         MachineKind, Machines, NewMachineWithCommand, ProtoCommand, TemporalStateMachine,
@@ -974,6 +975,10 @@ impl WorkflowMachines {
                 WFCommand::QueryResponse(_) => {
                     // Nothing to do here, queries are handled above the machine level
                     unimplemented!("Query responses should not make it down into the machines")
+                }
+                WFCommand::UpsertSearchAttributes(attrs) => {
+                    let seq = attrs.seq;
+                    self.add_cmd_to_wf_task(upsert_search_attrs(attrs), Some(CommandID::SearchAttributes(seq)));
                 }
                 WFCommand::NoCommandsFromLang => (),
             }

--- a/src/prototype_rust_sdk.rs
+++ b/src/prototype_rust_sdk.rs
@@ -513,6 +513,8 @@ pub enum CancellableID {
         /// Set to true if this workflow is a child of the issuing workflow
         only_child: bool,
     },
+    /// Upsert workflow search attributes
+    UpsertSearchAttributes(u32),
 }
 
 #[derive(derive_more::From)]

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -27,6 +27,7 @@ pub(crate) enum CommandID {
     ChildWorkflowComplete(u32),
     SignalExternal(u32),
     CancelExternal(u32),
+    SearchAttributes(u32),
 }
 
 /// Manages an instance of a [WorkflowMachines], which is not thread-safe, as well as other data


### PR DESCRIPTION
## What was changed

Implement Upsert Search Attributes functionality

## Why?
we need it

## developer onboarding

i recorded this with spencer 
https://temporal-io.zoom.us/rec/share/NAlRLjQaHS_sjkT4V05hLy3YSx0Sbez4ITAkz1z836vTuLtA0VE11n3MDpZ4F4z1.G8__GNkVIW8gTeo8?startTime=1641331908000

## Process

1. implement https://github.com/temporalio/sdk-core/blob/master/src/machines/upsert_search_attributes_state_machine.rs - [reference](https://github.com/temporalio/sdk-core/blob/master/src/machines/timer_state_machine.rs)
2. use `upsert_search_attrs` in https://github.com/temporalio/sdk-core/blob/master/src/machines/workflow_machines.rs
	- needed to add a `SearchAttributes` CommandID along the way https://github.com/temporalio/sdk-core/blob/5925d0ad3a53d19b59a5d1ba76b3929830a1b52c/src/workflow/mod.rs#L22
3. (failed path) boilerplate for creating diff kinds of protobufs: https://github.com/temporalio/sdk-core/blob/master/sdk-core-protos/src/lib.rs
	- has autogenerated boilerplate for upsertworkflowsearchattributes
4. add new WFCommand variant to both enum and tryfrom - https://github.com/temporalio/sdk-core/blob/master/src/machines/mod.rs
5. implement https://github.com/temporalio/sdk-core/blob/5925d0ad3a53d19b59a5d1ba76b3929830a1b52c/protos/local/workflow_commands.proto#L37.
	    - add UpsertWorkflowSearchAttributes enum and define the message
	    - add a key:payload mapping
	   - reference [Java SDK impl](https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/internal/statemachines/UpsertSearchAttributesStateMachine.java)
	   - reference inlined temporal/api repo subtree
		   - https://github.com/temporalio/sdk-core/blob/master/protos/api_upstream/temporal/api/command/v1/message.proto#L143
		   - https://github.com/temporalio/sdk-core/blob/master/protos/api_upstream/temporal/api/common/v1/message.proto#L60
6. tests!! the "modern" way of doing tests in the Core is exemplified here:
		  - https://github.com/temporalio/sdk-core/blob/5925d0ad3a53d19b59a5d1ba76b3929830a1b52c/src/machines/timer_state_machine.rs#L407-L426
		  - (basically write them in the same file as the state machine and build the Rust proto-SDK as you go)
7. the Rust proto-SDK starts here: https://github.com/temporalio/sdk-core/blob/master/src/prototype_rust_sdk.rs
		    - and continues here: https://github.com/temporalio/sdk-core/tree/master/src/prototype_rust_sdk
		    - we implement user facing APIs in https://github.com/temporalio/sdk-core/blob/master/src/prototype_rust_sdk/workflow_context.rs