### PR TITLE
Make shutdown wait on outstanding activity tasks

### DIFF
--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -216,9 +216,13 @@ impl Worker {
         self.wf_task_source
             .wait_for_tasks_from_complete_to_drain()
             .await;
-        // wait until all outstanding workflow tasks have been completed before shutting down
+        // wait until all outstanding workflow tasks have been completed
         while !self.all_wfts_drained() {
             self.wfts_drained_notify.notified().await;
+        }
+        // Wait for activities to finish
+        if let Some(acts) = self.at_task_mgr.as_ref() {
+            acts.wait_all_finished().await;
         }
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
Shutdown would finish while activities are still running, missing giving the worker a chance to complete any that are outstanding. This can easily hang forever now, so a timeout must be imposed on shutdowns. This can easily be added to core but is currently done in TS.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/246

2. How was this tested:
Tests added / updated

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
