### PR TITLE
Fix possible too-early shutdown case

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::retry::RetryGateway;
 
 use crate::metrics::{svc_operation, MetricsContext};
 use backoff::{ExponentialBackoff, SystemClock};
-use futures::{future::BoxFuture, task::Context, Future, FutureExt};
+use futures::{future::BoxFuture, task::Context, FutureExt};
 use http::uri::InvalidUri;
 use opentelemetry::metrics::Meter;
 use std::{
@@ -48,6 +48,9 @@ use tonic::{
 use tower::ServiceBuilder;
 use url::Url;
 use uuid::Uuid;
+
+#[cfg(any(feature = "mocks", test))]
+use futures::Future;
 
 static LONG_POLL_METHOD_NAMES: [&str; 2] = ["PollWorkflowTaskQueue", "PollActivityTaskQueue"];
 /// The server times out polls after 60 seconds. Set our timeout to be slightly beyond that.

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -408,7 +408,6 @@ async fn complete_with_task_not_found_during_shutdwn() {
         complete_order.borrow_mut().push(2);
     };
     let complete_fut = async {
-        tokio::time::sleep(Duration::from_millis(50)).await;
         core.complete_workflow_activation(WfActivationCompletion::from_cmds(
             TEST_Q,
             res.run_id,

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use futures::FutureExt;
 use rstest::{fixture, rstest};
+use std::cell::RefCell;
 use std::time::Duration;
 use temporal_client::MockManualGateway;
 use temporal_sdk_core_protos::{
@@ -372,4 +373,51 @@ async fn can_shutdown_local_act_only_worker_when_act_polling(
             );
         }
     );
+}
+
+#[tokio::test]
+async fn complete_with_task_not_found_during_shutdwn() {
+    let t = canned_histories::single_timer("1");
+    let mut mock = mock_gateway();
+    mock.expect_complete_workflow_task()
+        .times(1)
+        .returning(|_| Err(tonic::Status::not_found("Workflow task not found.")));
+    let mh = MockPollCfg::from_resp_batches("fakeid", t, [1], mock);
+    let core = mock_core(build_mock_pollers(mh));
+
+    let res = core.poll_workflow_activation(TEST_Q).await.unwrap();
+    assert_eq!(res.jobs.len(), 1);
+
+    let complete_order = RefCell::new(vec![]);
+    // Initiate shutdown before completing the activation
+    let shutdown_fut = async {
+        core.shutdown().await;
+        complete_order.borrow_mut().push(3);
+    };
+    let poll_fut = async {
+        // This should *not* return shutdown, but instead should do nothing until the complete
+        // goes through, at which point it will return the eviction.
+        let res = core.poll_workflow_activation(TEST_Q).await.unwrap();
+        assert_matches!(
+            res.jobs[0].variant,
+            Some(wf_activation_job::Variant::RemoveFromCache(_))
+        );
+        core.complete_workflow_activation(WfActivationCompletion::empty(TEST_Q, res.run_id))
+            .await
+            .unwrap();
+        complete_order.borrow_mut().push(2);
+    };
+    let complete_fut = async {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        core.complete_workflow_activation(WfActivationCompletion::from_cmds(
+            TEST_Q,
+            res.run_id,
+            vec![start_timer_cmd(1, Duration::from_secs(1))],
+        ))
+        .await
+        .unwrap();
+        complete_order.borrow_mut().push(1);
+    };
+    tokio::join!(shutdown_fut, poll_fut, complete_fut);
+    assert_eq!(&complete_order.into_inner(), &[1, 2, 3])
 }

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -797,9 +797,9 @@ impl Worker {
             })
     }
 
-    /// Resolves when shutdown has been requested and there are no more outstanding WFTs
+    /// Resolves when there are no more outstanding WFTs
     async fn all_wfts_drained(&self) {
-        while !(*self.shutdown_requested.borrow() && self.outstanding_workflow_tasks() == 0) {
+        while self.outstanding_workflow_tasks() != 0 {
             self.wfts_drained_notify.notified().await;
         }
     }

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -219,9 +219,7 @@ impl Worker {
             .wait_for_tasks_from_complete_to_drain()
             .await;
         // wait until all outstanding workflow tasks have been completed
-        while !self.all_wfts_drained() {
-            self.wfts_drained_notify.notified().await;
-        }
+        self.all_wfts_drained().await;
         // Wait for activities to finish
         if let Some(acts) = self.at_task_mgr.as_ref() {
             acts.wait_all_finished().await;
@@ -422,7 +420,15 @@ impl Worker {
             tokio::select! {
                 biased;
 
-                r = self.workflow_poll().map_err(Into::into) => return r,
+                r = self.workflow_poll().map_err(Into::into) => {
+                    if matches!(r, Err(PollWfError::ShutDown)) {
+                        // Don't actually return shutdown until workflow tasks are drained.
+                        // Outstanding tasks being completed will generate new pending activations
+                        // which will cause us to abort this function.
+                        self.all_wfts_drained().await;
+                    }
+                    return r
+                },
                 _ = shutdown_requested.changed() => {},
             }
         }
@@ -791,9 +797,11 @@ impl Worker {
             })
     }
 
-    /// Returns true if shutdown has been requested and there are no more outstanding WFTs
-    fn all_wfts_drained(&self) -> bool {
-        *self.shutdown_requested.borrow() && self.outstanding_workflow_tasks() == 0
+    /// Resolves when shutdown has been requested and there are no more outstanding WFTs
+    async fn all_wfts_drained(&self) {
+        while !(*self.shutdown_requested.borrow() && self.outstanding_workflow_tasks() == 0) {
+            self.wfts_drained_notify.notified().await;
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix scenario where workflow activation polling could return shutdown earlier than it should, when there are still outstanding workflow tasks.

## Why?
Need to complete outstanding tasks

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
