### PR TITLE
Fix heartbeats not flushing on activity completion

### DIFF
--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -653,7 +653,7 @@ async fn complete_act_with_fail_flushes_heartbeat() {
         [PollActivityTaskQueueResponse {
             task_token: vec![1],
             activity_id: "act1".to_string(),
-            heartbeat_timeout: Some(Duration::from_millis(1).into()),
+            heartbeat_timeout: Some(Duration::from_secs(10).into()),
             ..Default::default()
         }],
     ));

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -1,3 +1,4 @@
+use crate::telemetry::test_telem_console;
 use crate::{
     job_assert,
     test_help::{
@@ -627,6 +628,8 @@ async fn can_heartbeat_acts_during_shutdown() {
 /// activity, that we flush those details before reporting the failure completion.
 #[tokio::test]
 async fn complete_act_with_fail_flushes_heartbeat() {
+    test_telem_console();
+    let last_hb = 50;
     let mut mock_gateway = mock_gateway();
     mock_gateway
         .expect_record_activity_heartbeat()
@@ -654,8 +657,8 @@ async fn complete_act_with_fail_flushes_heartbeat() {
     ));
 
     let act = core.poll_activity_task(TEST_Q).await.unwrap();
-    // Record some heartbeats
-    for i in 1..=10 {
+    // Record a bunch of heartbeats
+    for i in 1..=last_hb {
         core.record_activity_heartbeat(ActivityHeartbeat {
             task_token: act.task_token.clone(),
             task_queue: TEST_Q.to_string(),

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -205,7 +205,7 @@ impl WorkerActivityTasks {
             ]);
             act_metrics.act_execution_latency(act_info.base.start_time.elapsed());
             self.activities_semaphore.add_permits(1);
-            self.heartbeat_manager.evict(task_token.clone());
+            self.heartbeat_manager.evict(task_token.clone()).await;
             let known_not_found = act_info.known_not_found;
             drop(act_info); // TODO: Get rid of dashmap. If we hold ref across await, bad stuff.
             self.complete_notify.notify_waiters();

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -9,6 +9,7 @@ use temporal_sdk_core_protos::{
     coresdk::{activity_task::ActivityCancelReason, common, ActivityHeartbeat, IntoPayloadsExt},
     temporal::api::workflowservice::v1::RecordActivityTaskHeartbeatResponse,
 };
+use tokio::sync::Notify;
 use tokio::{
     sync::{
         mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
@@ -24,7 +25,7 @@ pub(crate) struct ActivityHeartbeatManager {
     /// Cancellations that have been received when heartbeating are queued here and can be consumed
     /// by [fetch_cancellations]
     incoming_cancels: Mutex<UnboundedReceiver<PendingActivityCancel>>,
-    cancellation_token: CancellationToken,
+    shutdown_token: CancellationToken,
     /// Used during `shutdown` to await until all inflight requests are sent.
     join_handle: Mutex<Option<JoinHandle<()>>>,
     heartbeat_tx: UnboundedSender<HeartbeatAction>,
@@ -33,7 +34,10 @@ pub(crate) struct ActivityHeartbeatManager {
 #[derive(Debug)]
 enum HeartbeatAction {
     SendHeartbeat(ValidActivityHeartbeat),
-    Evict(TaskToken),
+    Evict {
+        token: TaskToken,
+        on_complete: Arc<Notify>,
+    },
     CompleteReport(TaskToken),
     CompleteThrottle(TaskToken),
 }
@@ -50,7 +54,11 @@ enum HeartbeatExecutorAction {
     /// Heartbeats are throttled for this task token, sleep until duration or wait to be cancelled
     Sleep(TaskToken, Duration, CancellationToken),
     /// Report heartbeat to the server
-    Report(TaskToken, Vec<common::Payload>),
+    Report {
+        task_token: TaskToken,
+        details: Vec<common::Payload>,
+        on_reported: Option<Arc<Notify>>,
+    },
 }
 
 /// Errors thrown when heartbeating
@@ -68,9 +76,9 @@ pub enum ActivityHeartbeatError {
     ShuttingDown,
 }
 
-/// Handle that is used by the core for all interactions with the manager, allows sending new
-/// heartbeats or requesting and awaiting for the shutdown. When shutdown is requested, signal gets
-/// sent to all processors, which allows them to complete gracefully.
+/// Manages activity heartbeating for a worker. Allows sending new heartbeats or requesting and
+/// awaiting for the shutdown. When shutdown is requested, signal gets sent to all processors, which
+/// allows them to complete gracefully.
 impl ActivityHeartbeatManager {
     /// Records a new heartbeat, the first call will result in an immediate call to the server,
     /// while rapid successive calls would accumulate for up to `delay` and then latest heartbeat
@@ -84,7 +92,7 @@ impl ActivityHeartbeatManager {
         hb: ActivityHeartbeat,
         throttle_interval: Duration,
     ) -> Result<(), ActivityHeartbeatError> {
-        if self.cancellation_token.is_cancelled() {
+        if self.shutdown_token.is_cancelled() {
             return Err(ActivityHeartbeatError::ShuttingDown);
         }
         self.heartbeat_tx
@@ -99,9 +107,15 @@ impl ActivityHeartbeatManager {
     }
 
     /// Tell the heartbeat manager we are done forever with a certain task, so it may be forgotten.
+    /// This will also force-flush the most recently provided details.
     /// Record *should* not be called with the same TaskToken after calling this.
-    pub(super) fn evict(&self, task_token: TaskToken) {
-        let _ = self.heartbeat_tx.send(HeartbeatAction::Evict(task_token));
+    pub(super) async fn evict(&self, task_token: TaskToken) {
+        let completed = Arc::new(Notify::new());
+        let _ = self.heartbeat_tx.send(HeartbeatAction::Evict {
+            token: task_token,
+            on_complete: completed.clone(),
+        });
+        completed.notified().await;
     }
 
     /// Returns a future that resolves any time there is a new activity cancel that must be
@@ -114,7 +128,7 @@ impl ActivityHeartbeatManager {
     /// Initiates shutdown procedure by stopping lifecycle loop and awaiting for all in-flight
     /// heartbeat requests to be flushed to the server.
     pub(super) async fn shutdown(&self) {
-        let _ = self.cancellation_token.cancel();
+        let _ = self.shutdown_token.cancel();
         let mut handle = self.join_handle.lock().await;
         if let Some(h) = handle.take() {
             h.await.expect("shutdown should exit cleanly");
@@ -183,7 +197,11 @@ impl HeartbeatStreamState {
                     throttled_cancellation_token: None,
                 };
                 e.insert(state);
-                Some(HeartbeatExecutorAction::Report(hb.task_token, hb.details))
+                Some(HeartbeatExecutorAction::Report {
+                    task_token: hb.task_token,
+                    details: hb.details,
+                    on_reported: None,
+                })
             }
             Entry::Occupied(mut o) => {
                 let state = o.get_mut();
@@ -219,7 +237,11 @@ impl HeartbeatStreamState {
                     // Reset the cancellation token and schedule another report
                     state.throttled_cancellation_token = None;
                     state.last_send_requested = Instant::now();
-                    Some(HeartbeatExecutorAction::Report(tt, details))
+                    Some(HeartbeatExecutorAction::Report {
+                        task_token: tt,
+                        details,
+                        on_reported: None,
+                    })
                 } else {
                     // Nothing to report, forget this task token
                     e.remove();
@@ -230,15 +252,29 @@ impl HeartbeatStreamState {
         }
     }
 
-    /// Activity should not be tracked anymore, cancel throttle timer if running
-    fn evict(&mut self, tt: TaskToken) -> Option<HeartbeatExecutorAction> {
-        if let Some(token) = self
-            .tt_to_state
-            .remove(&tt)
-            .and_then(|st| st.throttled_cancellation_token)
-        {
-            let _ = token.cancel();
-        };
+    /// Activity should not be tracked anymore, cancel throttle timer if running.
+    ///
+    /// Will return a report action if there are recorded details present, to ensure we flush the
+    /// latest details before we cease tracking this activity.
+    fn evict(
+        &mut self,
+        tt: TaskToken,
+        on_complete: Arc<Notify>,
+    ) -> Option<HeartbeatExecutorAction> {
+        if let Some(state) = self.tt_to_state.remove(&tt) {
+            if let Some(cancel_tok) = state.throttled_cancellation_token {
+                let _ = cancel_tok.cancel();
+            }
+            if let Some(last_deets) = state.last_recorded_details {
+                return Some(HeartbeatExecutorAction::Report {
+                    task_token: tt,
+                    details: last_deets,
+                    on_reported: Some(on_complete),
+                });
+            }
+        }
+        // Since there's nothing to flush immediately report back that eviction is finished
+        on_complete.notify_one();
         None
     }
 }
@@ -247,14 +283,14 @@ impl ActivityHeartbeatManager {
     /// Creates a new instance of an activity heartbeat manager and returns a handle to the user,
     /// which allows to send new heartbeats and initiate the shutdown.
     pub fn new(sg: Arc<impl ServerGatewayApis + Send + Sync + 'static + ?Sized>) -> Self {
-        let (heartbeat_stream_state, heartbeat_tx_source, cancellation_token) =
+        let (heartbeat_stream_state, heartbeat_tx_source, shutdown_token) =
             HeartbeatStreamState::new();
         let (cancels_tx, cancels_rx) = unbounded_channel();
         let heartbeat_tx = heartbeat_tx_source.clone();
 
         let join_handle = tokio::spawn(
             // The stream of incoming heartbeats uses unfold to carry state across each item in the
-            // stream The closure checks if, for any given activity, we should heartbeat or not
+            // stream. The closure checks if, for any given activity, we should heartbeat or not
             // depending on its delay and when we last issued a heartbeat for it.
             futures::stream::unfold(heartbeat_stream_state, move |mut hb_states| {
                 async move {
@@ -275,12 +311,13 @@ impl ActivityHeartbeatManager {
                             HeartbeatAction::SendHeartbeat(hb) => hb_states.record(hb),
                             HeartbeatAction::CompleteReport(tt) => hb_states.handle_report_completed(tt),
                             HeartbeatAction::CompleteThrottle(tt) => hb_states.handle_throttle_completed(tt),
-                            HeartbeatAction::Evict(tt) => hb_states.evict(tt),
+                            HeartbeatAction::Evict{ token, on_complete } => hb_states.evict(token, on_complete),
                         },
                         hb_states,
                     ))
                 }
             })
+                // TODO: ???
             .filter_map(|opt| async { opt })
             .for_each_concurrent(None, move |action| {
                 let heartbeat_tx = heartbeat_tx_source.clone();
@@ -296,7 +333,7 @@ impl ActivityHeartbeatManager {
                                 },
                             };
                         }
-                        HeartbeatExecutorAction::Report(tt, details) => {
+                        HeartbeatExecutorAction::Report { task_token: tt, details, on_reported } => {
                             match sg
                                 .record_activity_heartbeat(tt.clone(), details.into_payloads())
                                 .await
@@ -313,9 +350,9 @@ impl ActivityHeartbeatManager {
                                             );
                                     }
                                 }
-                                // Send cancels for any activity that learns its workflow already finished
-                                // (which is one thing not found implies - other reasons would seem equally
-                                // valid).
+                                // Send cancels for any activity that learns its workflow already
+                                // finished (which is one thing not found implies - other reasons
+                                // would seem equally valid).
                                 Err(s) if s.code() == tonic::Code::NotFound => {
                                     cancels_tx
                                         .send(PendingActivityCancel::new(
@@ -328,6 +365,9 @@ impl ActivityHeartbeatManager {
                                     warn!("Error when recording heartbeat: {:?}", e);
                                 }
                             };
+                            if let Some(onrep) = on_reported {
+                                onrep.notify_one();
+                            }
                             let _ = heartbeat_tx.send(HeartbeatAction::CompleteReport(tt));
                         }
                     }
@@ -338,7 +378,7 @@ impl ActivityHeartbeatManager {
         Self {
             incoming_cancels: Mutex::new(cancels_rx),
             join_handle: Mutex::new(Some(join_handle)),
-            cancellation_token,
+            shutdown_token,
             heartbeat_tx,
         }
     }
@@ -448,7 +488,7 @@ mod test {
         record_heartbeat(&hm, fake_task_token.clone(), 0, Duration::from_millis(100));
         // Let it propagate
         sleep(Duration::from_millis(10)).await;
-        hm.evict(fake_task_token.clone().into());
+        hm.evict(fake_task_token.clone().into()).await;
         record_heartbeat(&hm, fake_task_token, 0, Duration::from_millis(100));
         // Let it propagate
         sleep(Duration::from_millis(10)).await;

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -9,11 +9,10 @@ use temporal_sdk_core_protos::{
     coresdk::{activity_task::ActivityCancelReason, common, ActivityHeartbeat, IntoPayloadsExt},
     temporal::api::workflowservice::v1::RecordActivityTaskHeartbeatResponse,
 };
-use tokio::sync::Notify;
 use tokio::{
     sync::{
         mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-        Mutex,
+        Mutex, Notify,
     },
     task::JoinHandle,
 };

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -316,7 +316,7 @@ impl ActivityHeartbeatManager {
                     ))
                 }
             })
-                // TODO: ???
+            // Filters out `None`s
             .filter_map(|opt| async { opt })
             .for_each_concurrent(None, move |action| {
                 let heartbeat_tx = heartbeat_tx_source.clone();

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1028,6 +1028,12 @@ pub mod coresdk {
         }
     }
 
+    impl From<&str> for Failure {
+        fn from(v: &str) -> Self {
+            Failure::application_failure(v.to_string(), false)
+        }
+    }
+
     impl From<anyhow::Error> for Failure {
         fn from(ae: anyhow::Error) -> Self {
             Failure::application_failure(ae.to_string(), false)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make completion of activities wait on the eviction/flushing of heartbeats before sending a complete.

## Why?
See https://github.com/temporalio/sdk-core/issues/264

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/264

2. How was this tested:
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
