### PR TITLE
Fetch history on wft cache miss

### DIFF
--- a/core-api/src/errors.rs
+++ b/core-api/src/errors.rs
@@ -90,10 +90,6 @@ pub enum WFMachinesError {
 
     #[error("Unrecoverable network error while fetching history: {0}")]
     HistoryFetchingError(tonic::Status),
-
-    /// Should always be caught internally and turned into a workflow task failure
-    #[error("Unable to process partial event history because workflow is no longer cached.")]
-    CacheMiss,
 }
 
 impl WFMachinesError {
@@ -103,7 +99,6 @@ impl WFMachinesError {
             WFMachinesError::Fatal(_) | WFMachinesError::HistoryFetchingError(_) => {
                 EvictionReason::Fatal
             }
-            WFMachinesError::CacheMiss => EvictionReason::CacheMiss,
         }
     }
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,7 +43,7 @@ serde = "1.0"
 slotmap = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs"] }
-tokio-util = { version = "0.6.9" }
+tokio-util = { version = "0.7" }
 tokio-stream = "0.1"
 tonic = { version = "0.6", features = ["tls", "tls-roots"] }
 tracing = { version = "0.1", features = ["log-always"] }

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -1,4 +1,3 @@
-use crate::telemetry::test_telem_console;
 use crate::{
     errors::PollWfError,
     job_assert,
@@ -20,6 +19,8 @@ use std::{
 };
 use temporal_client::mocks::mock_gateway;
 use temporal_sdk_core_api::Worker as WorkerTrait;
+use temporal_sdk_core_protos::coresdk::workflow_activation::remove_from_cache::EvictionReason;
+use temporal_sdk_core_protos::temporal::api::workflowservice::v1::GetWorkflowExecutionHistoryResponse;
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::{self as ar, activity_resolution, ActivityResolution},
@@ -1563,85 +1564,14 @@ async fn failing_wft_doesnt_eat_permit_forever() {
 }
 
 #[tokio::test]
-async fn cache_miss_doesnt_eat_permit_forever() {
-    let mut t = TestHistoryBuilder::default();
-    t.add_by_type(EventType::WorkflowExecutionStarted);
-    t.add_full_wf_task();
-    t.add_we_signaled("sig", vec![]);
-    t.add_full_wf_task();
-    t.add_workflow_execution_completed();
-
-    let mut mh = MockPollCfg::from_resp_batches(
-        "fake_wf_id",
-        t,
-        [
-            ResponseType::ToTaskNum(1),
-            ResponseType::OneTask(2),
-            ResponseType::ToTaskNum(1),
-            ResponseType::OneTask(2),
-            ResponseType::ToTaskNum(1),
-            ResponseType::OneTask(2),
-            // Last one to complete successfully
-            ResponseType::ToTaskNum(1),
-        ],
-        mock_gateway(),
-    );
-    mh.num_expected_fails = Some(3);
-    mh.expect_fail_wft_matcher =
-        Box::new(|_, cause, _| matches!(cause, WorkflowTaskFailedCause::ResetStickyTaskQueue));
-    let mut mock = build_mock_pollers(mh);
-    mock.worker_cfg(|cfg| {
-        cfg.max_outstanding_workflow_tasks = 2;
-    });
-    let worker = mock_worker(mock);
-
-    // Spin missing the cache to verify that we don't get stuck
-    for _ in 1..=3 {
-        // Start
-        let activation = worker.poll_workflow_activation().await.unwrap();
-        worker
-            .complete_workflow_activation(WorkflowActivationCompletion::empty(activation.run_id))
-            .await
-            .unwrap();
-        // Evict
-        let activation = worker.poll_workflow_activation().await.unwrap();
-        assert_matches!(
-            activation.jobs.as_slice(),
-            [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
-            },]
-        );
-        worker
-            .complete_workflow_activation(WorkflowActivationCompletion::empty(activation.run_id))
-            .await
-            .unwrap();
-        assert_eq!(worker.outstanding_workflow_tasks(), 0);
-        assert_eq!(worker.available_wft_permits(), 2);
-        // When we loop back up, the poll will trigger a cache miss, which we should immediately
-        // reply to WFT with failure, and then poll again, which will deliver the from-the-start
-        // history
-    }
-    let activation = worker.poll_workflow_activation().await.unwrap();
-    worker
-        .complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
-            activation.run_id,
-            CompleteWorkflowExecution { result: None }.into(),
-        ))
-        .await
-        .unwrap();
-
-    worker.shutdown().await;
-}
-
-#[tokio::test]
 async fn cache_miss_will_fetch_history() {
-    test_telem_console();
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     t.add_we_signaled("sig", vec![]);
     t.add_full_wf_task();
     t.add_workflow_execution_completed();
+    let get_exec_resp: GetWorkflowExecutionHistoryResponse = t.get_history_info(2).unwrap().into();
 
     let mut mh = MockPollCfg::from_resp_batches(
         "fake_wf_id",
@@ -1650,28 +1580,48 @@ async fn cache_miss_will_fetch_history() {
         mock_gateway(),
     );
     mh.num_expected_fails = Some(0);
-    let mock = build_mock_pollers(mh);
+    mh.mock_gateway
+        .expect_get_workflow_execution_history()
+        .times(1)
+        .returning(move |_, _, _| Ok(get_exec_resp.clone()));
+    let mut mock = build_mock_pollers(mh);
+    mock.worker_cfg(|cfg| {
+        cfg.max_cached_workflows = 1;
+    });
     let worker = mock_worker(mock);
 
-    // Start TODO: Assert
-    let activation = worker.poll_workflow_activation().await.unwrap();
-    worker
-        .complete_workflow_activation(WorkflowActivationCompletion::empty(activation.run_id))
-        .await
-        .unwrap();
-    // Evict (cache is off)
     let activation = worker.poll_workflow_activation().await.unwrap();
     assert_matches!(
         activation.jobs.as_slice(),
         [WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
-        },]
+            variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+        }]
     );
     worker
-        .complete_workflow_activation(WorkflowActivationCompletion::empty(activation.run_id))
+        .complete_workflow_activation(WorkflowActivationCompletion::empty(&activation.run_id))
         .await
         .unwrap();
+    // Force an eviction
+    worker.request_wf_eviction(
+        &activation.run_id,
+        "whatever",
+        EvictionReason::LangRequested,
+    );
+    // Handle the eviction, and the restart
+    for _ in 1..=2 {
+        let activation = worker.poll_workflow_activation().await.unwrap();
+        worker
+            .complete_workflow_activation(WorkflowActivationCompletion::empty(activation.run_id))
+            .await
+            .unwrap();
+    }
     let activation = worker.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        activation.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::SignalWorkflow(_)),
+        }]
+    );
     worker
         .complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
             activation.run_id,
@@ -1680,7 +1630,6 @@ async fn cache_miss_will_fetch_history() {
         .await
         .unwrap();
     assert_eq!(worker.outstanding_workflow_tasks(), 0);
-
     worker.shutdown().await;
 }
 

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -19,14 +19,12 @@ use std::{
 };
 use temporal_client::mocks::mock_gateway;
 use temporal_sdk_core_api::Worker as WorkerTrait;
-use temporal_sdk_core_protos::coresdk::workflow_activation::remove_from_cache::EvictionReason;
-use temporal_sdk_core_protos::temporal::api::workflowservice::v1::GetWorkflowExecutionHistoryResponse;
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::{self as ar, activity_resolution, ActivityResolution},
         workflow_activation::{
-            workflow_activation_job, FireTimer, ResolveActivity, StartWorkflow, UpdateRandomSeed,
-            WorkflowActivationJob,
+            remove_from_cache::EvictionReason, workflow_activation_job, FireTimer, ResolveActivity,
+            StartWorkflow, UpdateRandomSeed, WorkflowActivationJob,
         },
         workflow_commands::{
             ActivityCancellationType, CancelTimer, CompleteWorkflowExecution,
@@ -38,7 +36,9 @@ use temporal_sdk_core_protos::{
         enums::v1::{EventType, WorkflowTaskFailedCause},
         failure::v1::Failure,
         history::v1::{history_event, TimerFiredEventAttributes},
-        workflowservice::v1::RespondWorkflowTaskCompletedResponse,
+        workflowservice::v1::{
+            GetWorkflowExecutionHistoryResponse, RespondWorkflowTaskCompletedResponse,
+        },
     },
 };
 use temporal_sdk_core_test_utils::{fanout_tasks, start_timer_cmd};

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -664,7 +664,9 @@ impl Worker {
             }
             NewWfTaskOutcome::CacheMiss => {
                 debug!(workflow_execution=?we, "Unable to process workflow task with partial \
-                history because workflow cache does not contain workflow anymore.");
+                history because workflow cache does not contain the workflow. Will fetch history");
+                // Fetch history and apply it to restore the workflow state, then attempt to
+                // complete the workflow task.
                 self.server_gateway
                     .fail_workflow_task(
                         tt,

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -636,7 +636,6 @@ impl Worker {
         work: ValidPollWFTQResponse,
     ) -> Result<Option<WorkflowActivation>, PollWfError> {
         let we = work.workflow_execution.clone();
-        let tt = work.task_token.clone();
         let res = self
             .wft_manager
             .apply_new_poll_resp(work, self.server_gateway.clone())
@@ -660,26 +659,6 @@ impl Worker {
                     status: Some(workflow_completion::Success::from_variants(vec![]).into()),
                 })
                 .await?;
-                None
-            }
-            NewWfTaskOutcome::CacheMiss => {
-                debug!(workflow_execution=?we, "Unable to process workflow task with partial \
-                history because workflow cache does not contain the workflow. Will fetch history");
-                // Fetch history and apply it to restore the workflow state, then attempt to
-                // complete the workflow task.
-                self.server_gateway
-                    .fail_workflow_task(
-                        tt,
-                        WorkflowTaskFailedCause::ResetStickyTaskQueue,
-                        Some(Failure {
-                            message: "Unable to process workflow task with partial history \
-                                      because workflow cache does not contain workflow anymore."
-                                .to_string(),
-                            ..Default::default()
-                        }),
-                    )
-                    .await?;
-                self.return_workflow_task_permit();
                 None
             }
             NewWfTaskOutcome::Evict(e) => {

--- a/core/src/workflow/machines/workflow_machines.rs
+++ b/core/src/workflow/machines/workflow_machines.rs
@@ -304,7 +304,11 @@ impl WorkflowMachines {
     /// Handle a single event from the workflow history. `has_next_event` should be false if `event`
     /// is the last event in the history.
     ///
-    /// TODO: Describe what actually happens in here
+    /// This function will attempt to apply the event to the workflow state machines. If there is
+    /// not a matching machine for the event, a nondeterminism error is returned. Otherwise, the
+    /// event is applied to the machine, which may also return a nondeterminism error if the machine
+    /// does not match the expected type. A fatal error may be returned if the machine is in an
+    /// invalid state.
     #[instrument(level = "debug", skip(self, event), fields(event=%event))]
     fn handle_event(&mut self, event: &HistoryEvent, has_next_event: bool) -> Result<()> {
         if event.is_final_wf_execution_event() {
@@ -329,20 +333,20 @@ impl WorkflowMachines {
                 // We remove the machine while we it handles events, then return it, to avoid
                 // borrowing from ourself mutably.
                 let maybe_machine = self.machines_by_event_id.remove(&initial_cmd_id);
-                if let Some(sm) = maybe_machine {
-                    self.submachine_handle_event(sm, event, has_next_event)?;
-                } else {
-                    return Err(WFMachinesError::Nondeterminism(format!(
-                        "During event handling, this event had an initial command ID but we could \
-                        not find a matching command for it: {:?}",
-                        event
-                    )));
-                }
-
-                // Restore machine if not in it's final state
-                if let Some(sm) = maybe_machine {
-                    if !self.machine(sm).is_final_state() {
-                        self.machines_by_event_id.insert(initial_cmd_id, sm);
+                match maybe_machine {
+                    Some(sm) => {
+                        self.submachine_handle_event(sm, event, has_next_event)?;
+                        // Restore machine if not in it's final state
+                        if !self.machine(sm).is_final_state() {
+                            self.machines_by_event_id.insert(initial_cmd_id, sm);
+                        }
+                    }
+                    None => {
+                        return Err(WFMachinesError::Nondeterminism(format!(
+                            "During event handling, this event had an initial command ID but we \
+                            could not find a matching command for it: {:?}",
+                            event
+                        )));
                     }
                 }
             }

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -3,6 +3,7 @@
 mod cache_manager;
 mod concurrency_manager;
 
+use crate::workflow::history_update::NextPageToken;
 use crate::{
     pending_activations::PendingActivations,
     protosext::{ValidPollWFTQResponse, WorkflowActivationExt},
@@ -120,8 +121,6 @@ pub(crate) enum NewWfTaskOutcome {
     /// The workflow task should be auto-completed with an empty command list, as it must be replied
     /// to but there is no meaningful work for lang to do.
     Autocomplete,
-    /// Workflow task had partial history and workflow was not present in the cache.
-    CacheMiss,
     /// The workflow task ran into problems while being applied and we must now evict the workflow
     Evict(WorkflowUpdateError),
     /// No action should be taken. Possibly we are waiting for local activities to complete
@@ -327,9 +326,6 @@ impl WorkflowTaskManager {
             match self.instantiate_or_update_workflow(work, gateway).await {
                 Ok((info, next_activation)) => (info, next_activation),
                 Err(e) => {
-                    if let WFMachinesError::CacheMiss = e.source {
-                        return NewWfTaskOutcome::CacheMiss;
-                    }
                     return NewWfTaskOutcome::Evict(e);
                 }
             };
@@ -593,20 +589,49 @@ impl WorkflowTaskManager {
             task_token: poll_wf_resp.task_token,
         };
 
+        let poll_resp_is_incremental = poll_wf_resp
+            .history
+            .events
+            .get(0)
+            .map(|ev| ev.event_id > 1)
+            .unwrap_or_default();
+
+        let history_update = if !self.workflow_machines.exists(&run_id) && poll_resp_is_incremental
+        {
+            debug!(run_id=?run_id, "Workflow task has partial history, but workflow is not in \
+                   cache. Will fetch history");
+            self.metrics.sticky_cache_miss();
+            // If the workflow is missing from the cache, we need to instantiate a paginator that
+            // will start from the beginning of the workflow history.
+            HistoryUpdate::new(
+                HistoryPaginator::new(
+                    poll_wf_resp.history,
+                    poll_wf_resp.workflow_execution.workflow_id.clone(),
+                    poll_wf_resp.workflow_execution.run_id.clone(),
+                    NextPageToken::FetchFromStart,
+                    gateway.clone(),
+                ),
+                poll_wf_resp.previous_started_event_id,
+            )
+        } else {
+            // Otherwise we can start with the history from the workflow task
+            HistoryUpdate::new(
+                HistoryPaginator::new(
+                    poll_wf_resp.history,
+                    poll_wf_resp.workflow_execution.workflow_id.clone(),
+                    poll_wf_resp.workflow_execution.run_id.clone(),
+                    poll_wf_resp.next_page_token,
+                    gateway.clone(),
+                ),
+                poll_wf_resp.previous_started_event_id,
+            )
+        };
+
         match self
             .workflow_machines
             .create_or_update(
                 &run_id,
-                HistoryUpdate::new(
-                    HistoryPaginator::new(
-                        poll_wf_resp.history,
-                        poll_wf_resp.workflow_execution.workflow_id.clone(),
-                        poll_wf_resp.workflow_execution.run_id.clone(),
-                        poll_wf_resp.next_page_token,
-                        gateway.clone(),
-                    ),
-                    poll_wf_resp.previous_started_event_id,
-                ),
+                history_update,
                 &poll_wf_resp.workflow_execution.workflow_id,
                 gateway.namespace(),
                 &poll_wf_resp.workflow_type,

--- a/sdk-core-protos/src/history_info.rs
+++ b/sdk-core-protos/src/history_info.rs
@@ -1,3 +1,4 @@
+use crate::temporal::api::workflowservice::v1::GetWorkflowExecutionHistoryResponse;
 use crate::temporal::api::{
     common::v1::WorkflowType,
     enums::v1::{EventType, TaskQueueKind},
@@ -117,6 +118,10 @@ impl HistoryInfo {
     /// Remove events from the beginning of this history such that it looks like what would've been
     /// delivered on a sticky queue where the previously started task was the one before the last
     /// task in this history.
+    ///
+    /// This is not *fully* accurate in that it will include commands that were part of the last
+    /// WFT completion, which the server would typically not include, but it's good enough for
+    /// testing.
     pub fn make_incremental(&mut self) {
         let last_complete_ix = self
             .events
@@ -179,6 +184,15 @@ impl HistoryInfo {
 impl From<HistoryInfo> for History {
     fn from(i: HistoryInfo) -> Self {
         Self { events: i.events }
+    }
+}
+
+impl From<HistoryInfo> for GetWorkflowExecutionHistoryResponse {
+    fn from(i: HistoryInfo) -> Self {
+        Self {
+            history: Some(i.into()),
+            ..Default::default()
+        }
     }
 }
 

--- a/sdk-core-protos/src/history_info.rs
+++ b/sdk-core-protos/src/history_info.rs
@@ -1,10 +1,9 @@
-use crate::temporal::api::workflowservice::v1::GetWorkflowExecutionHistoryResponse;
 use crate::temporal::api::{
     common::v1::WorkflowType,
     enums::v1::{EventType, TaskQueueKind},
     history::v1::{history_event, History, HistoryEvent},
     taskqueue::v1::TaskQueue,
-    workflowservice::v1::PollWorkflowTaskQueueResponse,
+    workflowservice::v1::{GetWorkflowExecutionHistoryResponse, PollWorkflowTaskQueueResponse},
 };
 use anyhow::{anyhow, bail};
 use rand::{thread_rng, Rng};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix unnecessarily failing WFTs when missing the cache by fetching history. This is what other SDKs do.

## Why?
Less noise for user, marginally more efficient.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/274

2. How was this tested:
Added UT, existing IT.

3. Any docs updates needed?
no
