### PR TITLE
Add upsert search2

### DIFF
--- a/core/src/workflow/machines/mod.rs
+++ b/core/src/workflow/machines/mod.rs
@@ -15,7 +15,6 @@ mod patch_state_machine;
 mod side_effect_state_machine;
 mod signal_external_state_machine;
 mod timer_state_machine;
-#[allow(unused)]
 mod upsert_search_attributes_state_machine;
 mod workflow_task_state_machine;
 

--- a/core/src/workflow/machines/mod.rs
+++ b/core/src/workflow/machines/mod.rs
@@ -45,6 +45,7 @@ use temporal_sdk_core_protos::temporal::api::{
     command::v1::Command as ProtoCommand, enums::v1::CommandType, history::v1::HistoryEvent,
 };
 use timer_state_machine::TimerMachine;
+use upsert_search_attributes_state_machine::UpsertSearchAttributesMachine;
 use workflow_machines::MachineResponse;
 use workflow_task_state_machine::WorkflowTaskMachine;
 
@@ -65,6 +66,7 @@ enum MachineKind {
     SignalExternalWorkflow,
     CancelExternalWorkflow,
     LocalActivity,
+    UpsertSearchAttributes,
 }
 
 #[enum_dispatch::enum_dispatch]
@@ -82,6 +84,7 @@ enum Machines {
     SignalExternalMachine,
     TimerMachine,
     WorkflowTaskMachine,
+    UpsertSearchAttributesMachine,
 }
 
 /// Extends [rustfsm::StateMachine] with some functionality specific to the temporal SDK.

--- a/core/src/workflow/machines/transition_coverage.rs
+++ b/core/src/workflow/machines/transition_coverage.rs
@@ -77,6 +77,7 @@ mod machine_coverage_report {
         fail_workflow_state_machine::FailWorkflowMachine,
         local_activity_state_machine::LocalActivityMachine, patch_state_machine::PatchMachine,
         signal_external_state_machine::SignalExternalMachine, timer_state_machine::TimerMachine,
+        upsert_search_attributes_state_machine::UpsertSearchAttributesMachine,
         workflow_task_state_machine::WorkflowTaskMachine,
     };
     use rustfsm::StateMachine;
@@ -113,6 +114,7 @@ mod machine_coverage_report {
         let mut signal_ext = SignalExternalMachine::visualizer().to_owned();
         let mut cancel_ext = CancelExternalMachine::visualizer().to_owned();
         let mut la_mach = LocalActivityMachine::visualizer().to_owned();
+        let mut upsert_search_attr = UpsertSearchAttributesMachine::visualizer().to_owned();
 
         // This isn't at all efficient but doesn't need to be.
         // Replace transitions in the vizzes with green color if they are covered.
@@ -133,6 +135,9 @@ mod machine_coverage_report {
                 m @ "SignalExternalMachine" => cover_transitions(m, &mut signal_ext, coverage),
                 m @ "CancelExternalMachine" => cover_transitions(m, &mut cancel_ext, coverage),
                 m @ "LocalActivityMachine" => cover_transitions(m, &mut la_mach, coverage),
+                m @ "UpsertSearchAttributesMachine" => {
+                    cover_transitions(m, &mut upsert_search_attr, coverage)
+                }
                 m => panic!("Unknown machine {}", m),
             }
         }

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use rustfsm::{fsm, TransitionResult};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::UpsertWorkflowSearchAttributes,

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -1,7 +1,26 @@
 use rustfsm::{fsm, TransitionResult};
+use super::{
+    NewMachineWithCommand
+};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        // workflow_activation::FireTimer,
+        // workflow_commands::{UpsertCommandCreated, UpsertCommandRecorded, UpsertSearchAttributesCommand},
+        workflow_commands::{UpsertSearchAttributes},
+        HistoryEventId,
+    },
+    temporal::api::{
+        command::v1::Command,
+        enums::v1::{CommandType, EventType},
+        history::v1::{history_event, HistoryEvent, TimerFiredEventAttributes},
+    },
+};
 
 fsm! {
-    pub(super) name UpsertSearchAttributesMachine; command UpsertSearchAttributesCommand; error UpsertSearchAttributesMachineError;
+    pub(super) name UpsertSearchAttributesMachine;
+    command UpsertSearchAttributesCommand;
+    error UpsertSearchAttributesMachineError;
+    shared_state SharedState;
 
     Created --(Schedule, on_schedule) --> UpsertCommandCreated;
 
@@ -15,13 +34,50 @@ pub(super) enum UpsertSearchAttributesMachineError {}
 pub(super) enum UpsertSearchAttributesCommand {}
 
 #[derive(Default, Clone)]
+pub(super) struct SharedState {
+    attrs: UpsertWorkflowSearchAttributes,
+    cancelled_before_sent: bool,
+}
+
+/// Creates a upsert workflow attribute command as a [CancellableCommand]
+pub(super) fn upsert_search_attrs(attribs: UpsertWorkflowSearchAttributes) -> NewMachineWithCommand {
+    let (state_machine, add_cmd) = UpsertSearchAttributesMachine::new_upsert(attribs);
+    NewMachineWithCommand {
+        command: add_cmd,
+        machine: state_machine.into(),
+    }
+}
+
+impl UpsertSearchAttributesMachine {
+    /// Create a new UpsertSearchAttributesCommand
+    fn new_upsert(attribs: UpsertWorkflowSearchAttributes) -> (Self, Command) {
+        let mut s = Self::new(attribs);
+        let cmd = Command {
+            command_type: CommandType::UpsertSearchAttributesCommand as i32,
+            attributes: Some(s.shared_state().attrs.clone().into()),
+        };
+        (s, cmd)
+    }
+
+    fn new(attribs: UpsertWorkflowSearchAttributes) -> Self {
+        Self {
+            state: Created {}.into(),
+            shared_state: SharedState {
+                attrs: attribs,
+                cancelled_before_sent: false,
+            },
+        }
+    }
+}
+
+#[derive(Default, Clone)]
 pub(super) struct Created {}
 
 impl Created {
     pub(super) fn on_schedule(
         self,
     ) -> UpsertSearchAttributesMachineTransition<UpsertCommandCreated> {
-        unimplemented!()
+        TransitionResult::default()
     }
 }
 
@@ -32,7 +88,7 @@ impl UpsertCommandCreated {
     pub(super) fn on_upsert_workflow_search_attributes(
         self,
     ) -> UpsertSearchAttributesMachineTransition<UpsertCommandRecorded> {
-        unimplemented!()
+        TransitionResult::ok(vec![], UpsertCommandRecorded::default())
     }
 }
 

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -213,17 +213,16 @@ mod tests {
             cmd.command_type,
             CommandType::UpsertWorkflowSearchAttributes as i32
         );
-        match cmd.attributes.unwrap() {
-            Attributes::UpsertWorkflowSearchAttributesCommandAttributes(msg) => {
-                let fields = &msg.search_attributes.unwrap().indexed_fields;
-                assert_eq!(fields.len(), 2);
-                let pay1 = fields.get(k1).unwrap();
-                let pay2 = fields.get(k2).unwrap();
-                assert_eq!(pay1.data[0], 0x01);
-                assert_eq!(pay2.data[0], 0x02);
-            }
-            _ => panic!("expected command to contain an UpsertWorkflowSearchAttributresCommandAttributes value")
-        }
+        assert_matches!(
+        cmd.attributes.unwrap(),
+        Attributes::UpsertWorkflowSearchAttributesCommandAttributes(msg) => {
+            let fields = &msg.search_attributes.unwrap().indexed_fields;
+            let payload1 = fields.get(k1).unwrap();
+            let payload2 = fields.get(k2).unwrap();
+            assert_eq!(payload1.data[0], 0x01);
+            assert_eq!(payload2.data[0], 0x02);
+            assert_eq!(fields.len(), 2);
+        });
         wfm.shutdown().await.unwrap();
     }
 

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -110,9 +110,9 @@ impl WFMachinesAdapter for UpsertSearchAttributesMachine {
 
 impl Cancellable for UpsertSearchAttributesMachine {}
 
-/// Converts the generic history event with type EventType::UpsertWorkflowSearchAttributes into the
-/// UpsertSearchAttributesMachine-specific event type
-/// UpsertSearchAttributesMachineEvents::CommandRecorded.
+// Converts the generic history event with type EventType::UpsertWorkflowSearchAttributes into the
+// UpsertSearchAttributesMachine-specific event type
+// UpsertSearchAttributesMachineEvents::CommandRecorded.
 impl TryFrom<HistoryEvent> for UpsertSearchAttributesMachineEvents {
     type Error = WFMachinesError;
 
@@ -128,8 +128,8 @@ impl TryFrom<HistoryEvent> for UpsertSearchAttributesMachineEvents {
     }
 }
 
-/// Converts generic state machine command type CommandType::UpsertWorkflowSearchAttributes into
-/// the UpsertSearchAttributesMachine-specific event
+// Converts generic state machine command type CommandType::UpsertWorkflowSearchAttributes into
+// the UpsertSearchAttributesMachine-specific event
 impl TryFrom<CommandType> for UpsertSearchAttributesMachineEvents {
     type Error = WFMachinesError;
 
@@ -145,14 +145,14 @@ impl TryFrom<CommandType> for UpsertSearchAttributesMachineEvents {
     }
 }
 
-/// There is no Command/Response associated with this transition
+// There is no Command/Response associated with this transition
 impl From<CommandIssued> for Done {
     fn from(_: CommandIssued) -> Self {
         Self {}
     }
 }
 
-/// There is no Command/Response associated with this transition
+// There is no Command/Response associated with this transition
 impl From<Created> for CommandIssued {
     fn from(_: Created) -> Self {
         Self {}

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -147,14 +147,14 @@ impl TryFrom<CommandType> for UpsertSearchAttributesMachineEvents {
     }
 }
 
-/// There is no Command/Reponse associated with this transition
+/// There is no Command/Response associated with this transition
 impl From<CommandIssued> for Done {
     fn from(_: CommandIssued) -> Self {
         Self {}
     }
 }
 
-/// There is no Command/Reponse associated with this transition
+/// There is no Command/Response associated with this transition
 impl From<Created> for CommandIssued {
     fn from(_: Created) -> Self {
         Self {}

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -212,7 +212,7 @@ mod tests {
     #[tokio::test]
     async fn upsert_search_attrs_sm() {
         let mut sm = UpsertSearchAttributesMachine::new();
-        assert_eq!(Created {}.to_string(), sm.state());
+        assert_eq!(Created {}.to_string(), sm.state().to_string());
 
         let cmd_scheduled_sm_event = CommandType::UpsertWorkflowSearchAttributes
             .try_into()
@@ -226,10 +226,10 @@ mod tests {
 
         OnEventWrapper::on_event_mut(&mut sm, cmd_scheduled_sm_event)
             .expect("CommandScheduled should transition Created -> CommandIssued");
-        assert_eq!(CommandIssued {}.to_string(), sm.state());
+        assert_eq!(CommandIssued {}.to_string(), sm.state().to_string());
 
         OnEventWrapper::on_event_mut(&mut sm, cmd_recorded_sm_event)
             .expect("CommandRecorded should transition CommandIssued -> Done");
-        assert_eq!(Done {}.to_string(), sm.state());
+        assert_eq!(Done {}.to_string(), sm.state().to_string());
     }
 }

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -1,123 +1,239 @@
-use rustfsm::{fsm, StateMachine, TransitionResult};
-use super::{
-    workflow_machines::{MachineResponse, WFMachinesError},
-    NewMachineWithCommand
-};
 use std::convert::TryFrom;
+
+use rustfsm::{fsm, StateMachine, TransitionResult};
 use temporal_sdk_core_protos::{
-    coresdk::{
-        workflow_commands::{UpsertWorkflowSearchAttributes},
+    coresdk::workflow_commands::{
+        workflow_command::Variant::UpsertWorkflowSearchAttributesCommandAttributes,
+        UpsertWorkflowSearchAttributes,
     },
     temporal::api::{
+        command::v1::command::Attributes,
         command::v1::Command,
+        common::v1::SearchAttributes,
         enums::v1::{CommandType, EventType},
-        history::v1::{history_event, HistoryEvent},
+        history::v1::HistoryEvent,
     },
+};
+
+use crate::workflow::machines::{Cancellable, EventInfo, MachineKind, Machines, WFMachinesAdapter};
+
+use super::{
+    workflow_machines::{MachineResponse, WFMachinesError},
+    NewMachineWithCommand,
 };
 
 fsm! {
     pub(super) name UpsertSearchAttributesMachine;
-    command UpsertSearchAttributesCommand;
+    command UpsertSearchAttributesMachineCommand;
     error WFMachinesError;
     shared_state SharedState;
 
-    Created --(Schedule, on_schedule) --> UpsertCommandCreated;
+    // Machine is instantiated into the Created state and then transitions into the CommandIssued
+    // state when it receives the CommandScheduled event that is a result of looping back the
+    // Command initially packaged with NewMachineWithCommand (see upsert_search_attrs)
+    Created --(CommandScheduled) --> CommandIssued;
 
-    UpsertCommandCreated --(CommandUpsertWorkflowSearchAttributes) --> UpsertCommandCreated;
-    UpsertCommandCreated --(UpsertWorkflowSearchAttributes, on_upsert_workflow_search_attributes) --> UpsertCommandRecorded;
+    // Having sent the command to the server, the machine transitions into a terminal state (Done)
+    // upon observing a history event indicating that the command has been recorded. Note that this
+    // does not imply that the command has been _executed_, only that it _will be_ executed at some
+    // point in the future.
+    CommandIssued --(CommandRecorded) --> Done;
 }
 
-pub(super) enum UpsertSearchAttributesCommand {}
-
-#[derive(Default, Clone)]
-pub(super) struct SharedState {
-    attrs: UpsertWorkflowSearchAttributes
-}
-
-/// Creates a upsert workflow attribute command as a [CancellableCommand]
-pub(super) fn upsert_search_attrs(attribs: UpsertWorkflowSearchAttributes) -> NewMachineWithCommand {
-    let (state_machine, add_cmd) = UpsertSearchAttributesMachine::new_upsert(attribs);
+// Instantiates an UpsertSearchAttributesMachine and packs it together with an initial command
+// to apply the provided search attribute update.
+pub(super) fn upsert_search_attrs(
+    attribs: UpsertWorkflowSearchAttributes,
+) -> NewMachineWithCommand {
+    let mut sm = UpsertSearchAttributesMachine::new();
+    let cmd = Command {
+        command_type: CommandType::UpsertWorkflowSearchAttributes as i32,
+        attributes: Some(attribs.into()),
+    };
     NewMachineWithCommand {
-        command: add_cmd,
-        machine: state_machine.into(),
+        command: cmd,
+        machine: sm.into(),
     }
 }
+
+// Unused but must exist
+type SharedState = ();
+
+// The state-machine-specific set of commands that are the results of state transition in the
+// UpsertSearchAttributesMachine.
+#[derive(Debug, derive_more::Display)]
+pub(super) enum UpsertSearchAttributesMachineCommand {
+    #[display(fmt = "SendUpsertCommand")]
+    SendUpsertCommand(Attributes),
+}
+
+// The state of the UpsertSearchAttributesMachine at time zero (i.e. at instantiation)
+#[derive(Debug, Default, Clone, derive_more::Display)]
+pub(super) struct Created {}
+
+// Once the UpsertSearchAttributesMachine has been known to have issued the upsert command to
+// higher-level machinery, it transitions into this state.
+#[derive(Debug, Default, Clone, derive_more::Display)]
+pub(super) struct CommandIssued {}
+
+// Once the server has recorded its receipt of the search attribute update, the
+// UpsertSearchAttributesMachine transitions into this terminal state.
+#[derive(Debug, Default, Clone, derive_more::Display)]
+pub(super) struct Done {}
 
 impl UpsertSearchAttributesMachine {
-    /// Create a new UpsertSearchAttributesCommand
-    fn new_upsert(attribs: UpsertWorkflowSearchAttributes) -> (Self, Command) {
-        let mut s = Self::new(attribs);
-        let cmd = Command {
-            command_type: CommandType::UpsertWorkflowSearchAttributes as i32,
-            attributes: Some(s.shared_state().attrs.clone().into()),
-        };
-        (s, cmd)
-    }
-
-    fn new(attribs: UpsertWorkflowSearchAttributes) -> Self {
+    fn new() -> Self {
         Self {
             state: Created {}.into(),
-            shared_state: SharedState {
-                attrs: attribs
-            },
+            shared_state: (),
         }
+    }
+
+    fn state(&self) -> String {
+        self.state.to_string()
     }
 }
 
+impl WFMachinesAdapter for UpsertSearchAttributesMachine {
+    // Transforms an UpsertSearchAttributesMachine-specific command (i.e. an instance of the type
+    // UpsertSearchAttributesMachineCommand) to a more generic form supported by the abstract
+    // StateMachine type.
+    fn adapt_response(
+        &self,
+        my_command: Self::Command,
+        _event_info: Option<EventInfo>,
+    ) -> Result<Vec<MachineResponse>, Self::Error> {
+        let UpsertSearchAttributesMachineCommand::SendUpsertCommand(attrs) = my_command;
+        Ok(vec![MachineResponse::IssueNewCommand(Command {
+            command_type: CommandType::UpsertWorkflowSearchAttributes as i32,
+            attributes: Some(attrs),
+        })])
+    }
 
+    // Filters for EventType::UpsertWorkflowSearchAttributes
+    fn matches_event(&self, event: &HistoryEvent) -> bool {
+        matches!(
+            event.event_type(),
+            EventType::UpsertWorkflowSearchAttributes
+        )
+    }
 
+    fn kind(&self) -> MachineKind {
+        MachineKind::UpsertSearchAttributes
+    }
+}
+
+impl Cancellable for UpsertSearchAttributesMachine {}
+
+// Converts the generic history event with type EventType::UpsertWorkflowSearchAttributes into the
+// UpsertSearchAttributesMachine-specific event type
+// UpsertSearchAttributesMachineEvents::CommandRecorded.
 impl TryFrom<HistoryEvent> for UpsertSearchAttributesMachineEvents {
     type Error = WFMachinesError;
 
     fn try_from(e: HistoryEvent) -> Result<Self, Self::Error> {
-        Ok(match e.event_type() {
+        match e.event_type() {
             EventType::UpsertWorkflowSearchAttributes => {
-                Self::UpsertWorkflowSearchAttributes
+                Ok(UpsertSearchAttributesMachineEvents::CommandRecorded)
             }
-            _ => {
-                return Err(WFMachinesError::Nondeterminism(format!(
-                    "UpsertWorkflowSearchAttributes machine does not handle this event: {}",
-                    e
-                )))
-            }
-        })
+            _ => Err(Self::Error::Nondeterminism(format!(
+                "UpsertWorkflowSearchAttributesMachine does not handle {e}"
+            ))),
+        }
     }
 }
 
+// Converts generic state machine command type CommandType::UpsertWorkflowSearchAttributes into
+// the UpsertSearchAttributesMachine-specific event
 impl TryFrom<CommandType> for UpsertSearchAttributesMachineEvents {
-    type Error = ();
+    type Error = WFMachinesError;
 
     fn try_from(c: CommandType) -> Result<Self, Self::Error> {
-        Ok(match c {
+        match c {
             CommandType::UpsertWorkflowSearchAttributes => {
-                Self::UpsertWorkflowSearchAttributes
+                Ok(UpsertSearchAttributesMachineEvents::CommandScheduled)
             }
-            _ => return Err(()),
-        })
+            _ => Err(Self::Error::Nondeterminism(format!(
+                "UpsertWorkflowSearchAttributesMachine does not handle command type {c:?}"
+            ))),
+        }
     }
 }
 
-#[derive(Default, Clone)]
-pub(super) struct Created {}
-
-impl Created {
-    pub(super) fn on_schedule(
-        self,
-    ) -> UpsertSearchAttributesMachineTransition<UpsertCommandCreated> {
-        TransitionResult::default()
+// There is no Command/Reponse associated with this transition
+impl From<CommandIssued> for Done {
+    fn from(_: CommandIssued) -> Self {
+        Self {}
     }
 }
 
-#[derive(Default, Clone)]
-pub(super) struct UpsertCommandCreated {}
-
-impl UpsertCommandCreated {
-    pub(super) fn on_upsert_workflow_search_attributes(
-        self,
-    ) -> UpsertSearchAttributesMachineTransition<UpsertCommandRecorded> {
-        TransitionResult::ok(vec![], UpsertCommandRecorded::default())
+// There is no Command/Reponse associated with this transition
+impl From<Created> for CommandIssued {
+    fn from(_: Created) -> Self {
+        Self {}
     }
 }
 
-#[derive(Default, Clone)]
-pub(super) struct UpsertCommandRecorded {}
+#[cfg(test)]
+mod tests {
+    use temporal_sdk::{WfContext, WorkflowFunction};
+    use temporal_sdk_core_protos::coresdk::common::Payload;
+
+    use crate::{replay::TestHistoryBuilder, workflow::managed_wf::ManagedWFFunc};
+
+    use super::super::OnEventWrapper;
+    use super::*;
+
+    #[tokio::test]
+    async fn upsert_search_attrs_from_workflow() {
+        let mut t = TestHistoryBuilder::default();
+        t.add_by_type(EventType::WorkflowExecutionStarted);
+        t.add_full_wf_task();
+        t.add_workflow_execution_completed();
+
+        let wff = WorkflowFunction::new(|ctx: WfContext| async move {
+            ctx.upsert_search_attributes([(
+                String::from("foo"),
+                Payload {
+                    metadata: Default::default(),
+                    data: vec![],
+                },
+            )]);
+            Ok(().into())
+        });
+        let mut wfm = ManagedWFFunc::new(t, wff, vec![]);
+
+        wfm.get_next_activation().await.unwrap();
+        let commands = wfm.get_server_commands().commands;
+        assert!(!commands.is_empty());
+        assert_eq!(
+            commands[0].command_type,
+            CommandType::UpsertWorkflowSearchAttributes as i32
+        );
+        wfm.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn upsert_search_attrs_sm() {
+        let mut sm = UpsertSearchAttributesMachine::new();
+        assert_eq!(Created {}.to_string(), sm.state());
+
+        let cmd_scheduled_sm_event = CommandType::UpsertWorkflowSearchAttributes
+            .try_into()
+            .unwrap();
+        let recorded_history_event = HistoryEvent {
+            event_type: EventType::UpsertWorkflowSearchAttributes as i32,
+            ..Default::default()
+        };
+        assert!(sm.matches_event(&recorded_history_event));
+        let cmd_recorded_sm_event = recorded_history_event.try_into().unwrap();
+
+        OnEventWrapper::on_event_mut(&mut sm, cmd_scheduled_sm_event)
+            .expect("CommandScheduled should transition Created -> CommandIssued");
+        assert_eq!(CommandIssued {}.to_string(), sm.state());
+
+        OnEventWrapper::on_event_mut(&mut sm, cmd_recorded_sm_event)
+            .expect("CommandRecorded should transition CommandIssued -> Done");
+        assert_eq!(Done {}.to_string(), sm.state());
+    }
+}

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -1,3 +1,8 @@
+use super::{
+    workflow_machines::{MachineResponse, WFMachinesError},
+    NewMachineWithCommand,
+};
+use crate::workflow::machines::{Cancellable, EventInfo, MachineKind, WFMachinesAdapter};
 use rustfsm::{fsm, TransitionResult};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::UpsertWorkflowSearchAttributes,
@@ -6,13 +11,6 @@ use temporal_sdk_core_protos::{
         enums::v1::{CommandType, EventType},
         history::v1::HistoryEvent,
     },
-};
-
-use crate::workflow::machines::{Cancellable, EventInfo, MachineKind, WFMachinesAdapter};
-
-use super::{
-    workflow_machines::{MachineResponse, WFMachinesError},
-    NewMachineWithCommand,
 };
 
 fsm! {
@@ -165,13 +163,13 @@ impl From<Created> for CommandIssued {
 mod tests {
     use rustfsm::StateMachine;
     use temporal_sdk::{WfContext, WorkflowFunction};
-    use temporal_sdk_core_protos::coresdk::common::Payload;
-    use temporal_sdk_core_protos::temporal::api::command::v1::command::Attributes;
+    use temporal_sdk_core_protos::{
+        coresdk::common::Payload, temporal::api::command::v1::command::Attributes,
+    };
 
     use crate::{replay::TestHistoryBuilder, workflow::managed_wf::ManagedWFFunc};
 
-    use super::super::OnEventWrapper;
-    use super::*;
+    use super::{super::OnEventWrapper, *};
 
     #[tokio::test]
     async fn upsert_search_attrs_from_workflow() {

--- a/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -40,8 +40,8 @@ fsm! {
     CommandIssued --(CommandRecorded) --> Done;
 }
 
-// Instantiates an UpsertSearchAttributesMachine and packs it together with an initial command
-// to apply the provided search attribute update.
+/// Instantiates an UpsertSearchAttributesMachine and packs it together with an initial command
+/// to apply the provided search attribute update.
 pub(super) fn upsert_search_attrs(
     attribs: UpsertWorkflowSearchAttributes,
 ) -> NewMachineWithCommand {
@@ -56,28 +56,28 @@ pub(super) fn upsert_search_attrs(
     }
 }
 
-// Unused but must exist
+/// Unused but must exist
 type SharedState = ();
 
-// The state-machine-specific set of commands that are the results of state transition in the
-// UpsertSearchAttributesMachine.
+/// The state-machine-specific set of commands that are the results of state transition in the
+/// UpsertSearchAttributesMachine.
 #[derive(Debug, derive_more::Display)]
 pub(super) enum UpsertSearchAttributesMachineCommand {
     #[display(fmt = "SendUpsertCommand")]
     SendUpsertCommand(Attributes),
 }
 
-// The state of the UpsertSearchAttributesMachine at time zero (i.e. at instantiation)
+/// The state of the UpsertSearchAttributesMachine at time zero (i.e. at instantiation)
 #[derive(Debug, Default, Clone, derive_more::Display)]
 pub(super) struct Created {}
 
-// Once the UpsertSearchAttributesMachine has been known to have issued the upsert command to
-// higher-level machinery, it transitions into this state.
+/// Once the UpsertSearchAttributesMachine has been known to have issued the upsert command to
+/// higher-level machinery, it transitions into this state.
 #[derive(Debug, Default, Clone, derive_more::Display)]
 pub(super) struct CommandIssued {}
 
-// Once the server has recorded its receipt of the search attribute update, the
-// UpsertSearchAttributesMachine transitions into this terminal state.
+/// Once the server has recorded its receipt of the search attribute update, the
+/// UpsertSearchAttributesMachine transitions into this terminal state.
 #[derive(Debug, Default, Clone, derive_more::Display)]
 pub(super) struct Done {}
 
@@ -88,16 +88,12 @@ impl UpsertSearchAttributesMachine {
             shared_state: (),
         }
     }
-
-    fn state(&self) -> String {
-        self.state.to_string()
-    }
 }
 
 impl WFMachinesAdapter for UpsertSearchAttributesMachine {
-    // Transforms an UpsertSearchAttributesMachine-specific command (i.e. an instance of the type
-    // UpsertSearchAttributesMachineCommand) to a more generic form supported by the abstract
-    // StateMachine type.
+    /// Transforms an UpsertSearchAttributesMachine-specific command (i.e. an instance of the type
+    /// UpsertSearchAttributesMachineCommand) to a more generic form supported by the abstract
+    /// StateMachine type.
     fn adapt_response(
         &self,
         my_command: Self::Command,
@@ -110,7 +106,7 @@ impl WFMachinesAdapter for UpsertSearchAttributesMachine {
         })])
     }
 
-    // Filters for EventType::UpsertWorkflowSearchAttributes
+    /// Filters for EventType::UpsertWorkflowSearchAttributes
     fn matches_event(&self, event: &HistoryEvent) -> bool {
         matches!(
             event.event_type(),
@@ -125,9 +121,9 @@ impl WFMachinesAdapter for UpsertSearchAttributesMachine {
 
 impl Cancellable for UpsertSearchAttributesMachine {}
 
-// Converts the generic history event with type EventType::UpsertWorkflowSearchAttributes into the
-// UpsertSearchAttributesMachine-specific event type
-// UpsertSearchAttributesMachineEvents::CommandRecorded.
+/// Converts the generic history event with type EventType::UpsertWorkflowSearchAttributes into the
+/// UpsertSearchAttributesMachine-specific event type
+/// UpsertSearchAttributesMachineEvents::CommandRecorded.
 impl TryFrom<HistoryEvent> for UpsertSearchAttributesMachineEvents {
     type Error = WFMachinesError;
 
@@ -143,8 +139,8 @@ impl TryFrom<HistoryEvent> for UpsertSearchAttributesMachineEvents {
     }
 }
 
-// Converts generic state machine command type CommandType::UpsertWorkflowSearchAttributes into
-// the UpsertSearchAttributesMachine-specific event
+/// Converts generic state machine command type CommandType::UpsertWorkflowSearchAttributes into
+/// the UpsertSearchAttributesMachine-specific event
 impl TryFrom<CommandType> for UpsertSearchAttributesMachineEvents {
     type Error = WFMachinesError;
 
@@ -160,14 +156,14 @@ impl TryFrom<CommandType> for UpsertSearchAttributesMachineEvents {
     }
 }
 
-// There is no Command/Reponse associated with this transition
+/// There is no Command/Reponse associated with this transition
 impl From<CommandIssued> for Done {
     fn from(_: CommandIssued) -> Self {
         Self {}
     }
 }
 
-// There is no Command/Reponse associated with this transition
+/// There is no Command/Reponse associated with this transition
 impl From<Created> for CommandIssued {
     fn from(_: Created) -> Self {
         Self {}

--- a/core/src/workflow/machines/workflow_machines.rs
+++ b/core/src/workflow/machines/workflow_machines.rs
@@ -10,7 +10,8 @@ use super::{
     continue_as_new_workflow_state_machine::continue_as_new,
     fail_workflow_state_machine::fail_workflow, local_activity_state_machine::new_local_activity,
     patch_state_machine::has_change, signal_external_state_machine::new_external_signal,
-    timer_state_machine::new_timer, workflow_machines::local_acts::LocalActivityData,
+    timer_state_machine::new_timer, upsert_search_attributes_state_machine::upsert_search_attrs,
+    workflow_machines::local_acts::LocalActivityData,
     workflow_task_state_machine::WorkflowTaskMachine, MachineKind, Machines, NewMachineWithCommand,
     TemporalStateMachine,
 };
@@ -791,6 +792,10 @@ impl WorkflowMachines {
                 WFCommand::AddTimer(attrs) => {
                     let seq = attrs.seq;
                     self.add_cmd_to_wf_task(new_timer(attrs), Some(CommandID::Timer(seq)));
+                }
+                WFCommand::UpsertSearchAttributes(attrs) => {
+                    let seq = attrs.seq;
+                    self.add_cmd_to_wf_task(upsert_search_attrs(attrs), Some(CommandID::Timer(seq)));
                 }
                 WFCommand::CancelTimer(attrs) => {
                     jobs.extend(self.process_cancellation(CommandID::Timer(attrs.seq))?);

--- a/core/src/workflow/machines/workflow_machines.rs
+++ b/core/src/workflow/machines/workflow_machines.rs
@@ -795,7 +795,10 @@ impl WorkflowMachines {
                 }
                 WFCommand::UpsertSearchAttributes(attrs) => {
                     let seq = attrs.seq;
-                    self.add_cmd_to_wf_task(upsert_search_attrs(attrs), Some(CommandID::Timer(seq)));
+                    self.add_cmd_to_wf_task(
+                        upsert_search_attrs(attrs),
+                        Some(CommandID::Timer(seq)),
+                    );
                 }
                 WFCommand::CancelTimer(attrs) => {
                     jobs.extend(self.process_cancellation(CommandID::Timer(attrs.seq))?);

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -254,7 +254,9 @@ impl TryFrom<WorkflowCommand> for WFCommand {
             workflow_command::Variant::RequestCancelLocalActivity(s) => {
                 Ok(Self::RequestCancelLocalActivity(s))
             }
-            workflow_command::Variant::UpsertWorkflowSearchAttributesCommandAttributes(s) => Ok(Self::UpsertSearchAttributes(s))
+            workflow_command::Variant::UpsertWorkflowSearchAttributesCommandAttributes(s) => {
+                Ok(Self::UpsertSearchAttributes(s))
+            }
         }
     }
 }

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -254,7 +254,7 @@ impl TryFrom<WorkflowCommand> for WFCommand {
             workflow_command::Variant::RequestCancelLocalActivity(s) => {
                 Ok(Self::RequestCancelLocalActivity(s))
             }
-            workflow_command::Variant::UpsertSearchAttributes(s) => Ok(Self::UpsertWorkflowSearchAttributes(s))
+            workflow_command::Variant::UpsertWorkflowSearchAttributesCommandAttributes(s) => Ok(Self::UpsertSearchAttributes(s))
         }
     }
 }

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -213,6 +213,7 @@ pub enum WFCommand {
     RequestCancelExternalWorkflow(RequestCancelExternalWorkflowExecution),
     SignalExternalWorkflow(SignalExternalWorkflowExecution),
     CancelSignalWorkflow(CancelSignalWorkflow),
+    UpsertSearchAttributes(UpsertWorkflowSearchAttributes),
 }
 
 impl TryFrom<WorkflowCommand> for WFCommand {
@@ -253,6 +254,7 @@ impl TryFrom<WorkflowCommand> for WFCommand {
             workflow_command::Variant::RequestCancelLocalActivity(s) => {
                 Ok(Self::RequestCancelLocalActivity(s))
             }
+            workflow_command::Variant::UpsertSearchAttributes(s) => Ok(Self::UpsertWorkflowSearchAttributes(s))
         }
     }
 }

--- a/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -32,9 +32,7 @@ message WorkflowCommand {
         CancelSignalWorkflow cancel_signal_workflow = 15;
         ScheduleLocalActivity schedule_local_activity = 16;
         RequestCancelLocalActivity request_cancel_local_activity = 17;
-
-        // To be added as/if needed:
-        //  UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 14;
+        UpsertWorkflowSearchAttributes upsert_workflow_search_attributes_command_attributes = 18;
     }
 }
 
@@ -279,4 +277,11 @@ message SignalExternalWorkflowExecution {
 message CancelSignalWorkflow {
     /// Lang's incremental sequence number as passed to `SignalExternalWorkflowExecution`
     uint32 seq = 1;
+}
+
+message UpsertWorkflowSearchAttributes {
+    /// Lang's incremental sequence number as passed to `UpsertWorkflowSearchAttributes`
+    uint32 seq = 1;
+    /// SearchAttributes fields - equivalent to indexed_fields on api. Key = search index, Value = value?
+    map<string, common.Payload> search_attributes = 2;
 }

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -718,6 +718,12 @@ pub mod coresdk {
             }
         }
 
+        impl Display for UpsertWorkflowSearchAttributes {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "UpsertWorkflowSearchAttributes({})", self.seq) // todo: customize this better
+            }
+        }
+
         impl Display for SignalExternalWorkflowExecution {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 write!(f, "SignalExternalWorkflowExecution({})", self.seq)
@@ -1306,6 +1312,14 @@ pub mod temporal {
                         Self::StartTimerCommandAttributes(StartTimerCommandAttributes {
                             timer_id: s.seq.to_string(),
                             start_to_fire_timeout: s.start_to_fire_timeout,
+                        })
+                    }
+                }
+
+                impl From<workflow_commands::UpsertWorkflowSearchAttributes> for command::Attributes {
+                    fn from(s: workflow_commands::UpsertWorkflowSearchAttributes) -> Self {
+                        Self::UpsertWorkflowSearchAttributesCommandAttributes(UpsertWorkflowSearchAttributesCommandAttributes {
+                            search_attributes: Some(s.search_attributes.into()),
                         })
                     }
                 }

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1318,9 +1318,11 @@ pub mod temporal {
 
                 impl From<workflow_commands::UpsertWorkflowSearchAttributes> for command::Attributes {
                     fn from(s: workflow_commands::UpsertWorkflowSearchAttributes) -> Self {
-                        Self::UpsertWorkflowSearchAttributesCommandAttributes(UpsertWorkflowSearchAttributesCommandAttributes {
-                            search_attributes: Some(s.search_attributes.into()),
-                        })
+                        Self::UpsertWorkflowSearchAttributesCommandAttributes(
+                            UpsertWorkflowSearchAttributesCommandAttributes {
+                                search_attributes: Some(s.search_attributes.into()),
+                            },
+                        )
                     }
                 }
 

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -22,6 +22,7 @@ use std::{
     task::Poll,
     time::{Duration, SystemTime},
 };
+use temporal_sdk_core_protos::coresdk::workflow_commands::UpsertWorkflowSearchAttributes;
 use temporal_sdk_core_protos::coresdk::{
     activity_result::{activity_resolution, ActivityResolution},
     child_workflow::ChildWorkflowResult,
@@ -56,6 +57,7 @@ struct WfCtxProtectedDat {
     next_child_workflow_sequence_number: u32,
     next_cancel_external_wf_sequence_number: u32,
     next_signal_external_wf_sequence_number: u32,
+    next_upsert_search_attrs_sequence_number: u32,
 }
 
 impl WfCtxProtectedDat {
@@ -82,6 +84,11 @@ impl WfCtxProtectedDat {
     fn next_signal_external_wf_seq(&mut self) -> u32 {
         let seq = self.next_signal_external_wf_sequence_number;
         self.next_signal_external_wf_sequence_number += 1;
+        seq
+    }
+    fn next_upsert_search_attrs_wf_seq(&mut self) -> u32 {
+        let seq = self.next_upsert_search_attrs_sequence_number;
+        self.next_upsert_search_attrs_sequence_number += 1;
         seq
     }
 }
@@ -121,6 +128,7 @@ impl WfContext {
                     next_child_workflow_sequence_number: 1,
                     next_cancel_external_wf_sequence_number: 1,
                     next_signal_external_wf_sequence_number: 1,
+                    next_upsert_search_attrs_sequence_number: 1,
                 }),
             },
             rx,
@@ -276,6 +284,18 @@ impl WfContext {
             run_id: run_id.into(),
         });
         self.send_signal_wf(signal_name, payload, target)
+    }
+
+    /// Add or create a set of search attributes
+    pub fn upsert_search_attributes(&self, attr_iter: impl IntoIterator<Item = (String, Payload)>) {
+        self.send(RustWfCmd::NewNonblockingCmd(
+            workflow_command::Variant::UpsertWorkflowSearchAttributesCommandAttributes(
+                UpsertWorkflowSearchAttributes {
+                    seq: self.seq_nums.write().next_upsert_search_attrs_wf_seq(),
+                    search_attributes: HashMap::from_iter(attr_iter.into_iter()),
+                },
+            ),
+        ))
     }
 
     /// Return a stream that produces values when the named signal is sent to this workflow

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -22,7 +22,6 @@ use std::{
     task::Poll,
     time::{Duration, SystemTime},
 };
-use temporal_sdk_core_protos::coresdk::workflow_commands::UpsertWorkflowSearchAttributes;
 use temporal_sdk_core_protos::coresdk::{
     activity_result::{activity_resolution, ActivityResolution},
     child_workflow::ChildWorkflowResult,
@@ -32,7 +31,7 @@ use temporal_sdk_core_protos::coresdk::{
         request_cancel_external_workflow_execution as cancel_we,
         signal_external_workflow_execution as sig_we, workflow_command,
         RequestCancelExternalWorkflowExecution, SetPatchMarker, SignalExternalWorkflowExecution,
-        StartTimer,
+        StartTimer, UpsertWorkflowSearchAttributes,
     },
 };
 use tokio::sync::{mpsc, oneshot, watch};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds support for sending search attribute upsert commands to the server through the UpsertSearchAttributesMachine state machine implementation and related types/transforms.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature was missing from sdk-core

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
New unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
