### PR TITLE
Perf: Avoid cloning events

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -76,6 +76,7 @@ version = "0.1"
 [dev-dependencies]
 assert_matches = "1.4"
 bimap = "0.6.1"
+criterion = "0.3"
 mockall = "0.11"
 rstest = "0.12"
 temporal-sdk-core-test-utils = { path = "../test-utils" }
@@ -95,3 +96,7 @@ test = false
 name = "load_tests"
 path = "../tests/load_tests.rs"
 test = false
+
+[[bench]]
+name = "workflow_replay"
+harness = false

--- a/core/benches/workflow_replay.rs
+++ b/core/benches/workflow_replay.rs
@@ -1,0 +1,81 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures::StreamExt;
+use std::time::Duration;
+use temporal_sdk::{TestRustWorker, WfContext, WorkflowFunction};
+use temporal_sdk_core::{telemetry_init, TelemetryOptionsBuilder};
+use temporal_sdk_core_protos::DEFAULT_WORKFLOW_TYPE;
+use temporal_sdk_core_test_utils::{canned_histories, init_core_replay_preloaded};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    telemetry_init(
+        &TelemetryOptionsBuilder::default()
+            .totally_disable(true)
+            .build()
+            .unwrap(),
+    )
+    .unwrap();
+    let _g = tokio_runtime.enter();
+
+    let num_timers = 10;
+    let t = canned_histories::long_sequential_timers(num_timers as usize);
+    let hist = t.get_full_history_info().unwrap().into();
+
+    c.bench_function("Small history replay", |b| {
+        b.iter(|| {
+            tokio_runtime.block_on(async {
+                let func = timers_wf(num_timers);
+                let (worker, _) = init_core_replay_preloaded("replay_bench", &hist);
+                let mut worker = TestRustWorker::new(worker, "replay_bench".to_string(), None);
+                worker.register_wf(DEFAULT_WORKFLOW_TYPE, func);
+                worker.incr_expected_run_count(1);
+                worker.run_until_done().await.unwrap();
+            })
+        })
+    });
+
+    let num_tasks = 50;
+    let t = canned_histories::lots_of_big_signals(num_tasks);
+    let hist = t.get_full_history_info().unwrap().into();
+
+    c.bench_function("Large payloads history replay", |b| {
+        b.iter(|| {
+            tokio_runtime.block_on(async {
+                let func = big_signals_wf(num_tasks);
+                let (worker, _) = init_core_replay_preloaded("large_hist_bench", &hist);
+                let mut worker = TestRustWorker::new(worker, "large_hist_bench".to_string(), None);
+                worker.register_wf(DEFAULT_WORKFLOW_TYPE, func);
+                worker.incr_expected_run_count(1);
+                worker.run_until_done().await.unwrap();
+            })
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);
+
+fn timers_wf(num_timers: u32) -> WorkflowFunction {
+    WorkflowFunction::new(move |ctx: WfContext| async move {
+        for _ in 1..=num_timers {
+            ctx.timer(Duration::from_secs(1)).await;
+        }
+        Ok(().into())
+    })
+}
+
+fn big_signals_wf(num_tasks: usize) -> WorkflowFunction {
+    WorkflowFunction::new(move |ctx: WfContext| async move {
+        let mut sigs = ctx.make_signal_channel("bigsig");
+        for _ in 1..=num_tasks {
+            for _ in 1..=5 {
+                let _ = sigs.next().await.unwrap();
+            }
+        }
+
+        Ok(().into())
+    })
+}

--- a/core/src/workflow/machines/activity_state_machine.rs
+++ b/core/src/workflow/machines/activity_state_machine.rs
@@ -737,9 +737,8 @@ fn convert_payloads(
 ) -> Result<Option<Payload>, WFMachinesError> {
     result.map(TryInto::try_into).transpose().map_err(|pe| {
         WFMachinesError::Fatal(format!(
-            "Not exactly one payload in activity result ({}) for event: {}",
-            pe,
-            event_info.map(|e| e.event.clone()).unwrap_or_default()
+            "Not exactly one payload in activity result ({}) for event: {:?}",
+            pe, event_info
         ))
     })
 }

--- a/core/src/workflow/machines/child_workflow_state_machine.rs
+++ b/core/src/workflow/machines/child_workflow_state_machine.rs
@@ -606,9 +606,8 @@ fn convert_payloads(
 ) -> Result<Option<Payload>, WFMachinesError> {
     result.map(TryInto::try_into).transpose().map_err(|pe| {
         WFMachinesError::Fatal(format!(
-            "Not exactly one payload in child workflow result ({}) for event: {}",
-            pe,
-            event_info.map(|e| e.event.clone()).unwrap_or_default()
+            "Not exactly one payload in child workflow result ({}) for event: {:?}",
+            pe, event_info
         ))
     })
 }

--- a/core/src/workflow/machines/mod.rs
+++ b/core/src/workflow/machines/mod.rs
@@ -40,9 +40,10 @@ use std::{
     convert::{TryFrom, TryInto},
     fmt::{Debug, Display},
 };
-use temporal_sdk_core_protos::temporal::api::enums::v1::EventType;
 use temporal_sdk_core_protos::temporal::api::{
-    command::v1::Command as ProtoCommand, enums::v1::CommandType, history::v1::HistoryEvent,
+    command::v1::Command as ProtoCommand,
+    enums::v1::{CommandType, EventType},
+    history::v1::HistoryEvent,
 };
 use timer_state_machine::TimerMachine;
 use upsert_search_attributes_state_machine::UpsertSearchAttributesMachine;

--- a/core/src/workflow/machines/workflow_machines.rs
+++ b/core/src/workflow/machines/workflow_machines.rs
@@ -465,19 +465,18 @@ impl WorkflowMachines {
             Some(EventType::WorkflowExecutionStarted) => {
                 if let Some(history_event::Attributes::WorkflowExecutionStartedEventAttributes(
                     attrs,
-                )) = &event.attributes
+                )) = event.attributes
                 {
                     self.run_id = attrs.original_execution_run_id.clone();
-                    if let Some(st) = event.event_time.as_ref() {
-                        let as_systime: SystemTime = st.clone().try_into()?;
+                    if let Some(st) = event.event_time {
+                        let as_systime: SystemTime = st.try_into()?;
                         self.workflow_start_time = Some(as_systime);
                     }
                     // Notify the lang sdk that it's time to kick off a workflow
                     self.drive_me.start(
                         self.workflow_id.clone(),
                         str_to_randomness_seed(&attrs.original_execution_run_id),
-                        // TODO: No clone
-                        attrs.clone(),
+                        attrs,
                     );
                 } else {
                     return Err(WFMachinesError::Fatal(format!(
@@ -495,9 +494,9 @@ impl WorkflowMachines {
             Some(EventType::WorkflowExecutionSignaled) => {
                 if let Some(history_event::Attributes::WorkflowExecutionSignaledEventAttributes(
                     attrs,
-                )) = &event.attributes
+                )) = event.attributes
                 {
-                    self.drive_me.signal(attrs.clone().into());
+                    self.drive_me.signal(attrs.into());
                 } else {
                     // err
                 }
@@ -507,9 +506,9 @@ impl WorkflowMachines {
                     history_event::Attributes::WorkflowExecutionCancelRequestedEventAttributes(
                         attrs,
                     ),
-                ) = &event.attributes
+                ) = event.attributes
                 {
-                    self.drive_me.cancel(attrs.clone().into());
+                    self.drive_me.cancel(attrs.into());
                 } else {
                     // err
                 }

--- a/core/src/workflow/machines/workflow_task_state_machine.rs
+++ b/core/src/workflow/machines/workflow_task_state_machine.rs
@@ -64,8 +64,8 @@ impl WFMachinesAdapter for WorkflowTaskMachine {
                 task_started_event_id,
                 time,
             } => {
-                let (event, has_next_event) = if let Some(ei) = event_info {
-                    (ei.event, ei.has_next_event)
+                let (event_id, event_type, has_next_event) = if let Some(ei) = event_info {
+                    (ei.event_id, ei.event_type, ei.has_next_event)
                 } else {
                     return Err(WFMachinesError::Fatal(
                         "WF Task machine should never issue a task started trigger \
@@ -74,8 +74,8 @@ impl WFMachinesAdapter for WorkflowTaskMachine {
                     ));
                 };
 
-                let cur_event_past_or_at_start = event.event_id >= task_started_event_id;
-                if event.event_type() == EventType::WorkflowTaskStarted
+                let cur_event_past_or_at_start = event_id >= task_started_event_id;
+                if event_type == EventType::WorkflowTaskStarted
                     && (!cur_event_past_or_at_start || has_next_event)
                 {
                     return Ok(vec![]);

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     worker::{LocalActRequest, LocalActivityResolution},
 };
 use machines::WorkflowMachines;
+use std::time::Duration;
 use std::{result, sync::mpsc::Sender};
 use temporal_sdk_core_protos::{
     coresdk::{workflow_activation::WorkflowActivation, workflow_commands::*},
@@ -269,6 +270,14 @@ enum CommandID {
     ChildWorkflowStart(u32),
     SignalExternal(u32),
     CancelExternal(u32),
+}
+
+/// Details remembered from the workflow execution started event that we may need to recall later.
+/// Is a subset of `WorkflowExecutionStartedEventAttributes`, but avoids holding on to huge fields.
+#[derive(Debug, Clone)]
+pub struct WorkflowStartedInfo {
+    workflow_task_timeout: Option<Duration>,
+    workflow_execution_timeout: Option<Duration>,
 }
 
 #[cfg(test)]

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -461,9 +461,8 @@ impl WorkflowTaskManager {
 
                         let wft_timeout: Duration = wfm
                             .machines
-                            .started_attrs()
-                            .and_then(|attrs| attrs.workflow_task_timeout.clone())
-                            .and_then(|tt| tt.try_into().ok())
+                            .get_started_info()
+                            .and_then(|attrs| attrs.workflow_task_timeout)
                             .ok_or_else(|| {
                                 WFMachinesError::Fatal(
                                     "Workflow's start attribs were missing a well formed task timeout"

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -218,6 +218,7 @@ impl TestRustWorker {
                             )
                             .await?;
                         if wf_half.incomplete_workflows.load(Ordering::SeqCst) == 0 {
+                            info!("All expected workflows complete");
                             // Die rebel scum - evict all workflows (which are complete now),
                             // and turn off activity polling.
                             let _ = shutdown_tx.send(true);
@@ -301,10 +302,11 @@ impl WorkflowHalf {
             variant: Some(Variant::StartWorkflow(sw)),
         }) = activation.jobs.get(0)
         {
+            let workflow_type = &sw.workflow_type;
             let wf_function = self
                 .workflow_fns
-                .get(&sw.workflow_type)
-                .ok_or_else(|| anyhow!("Workflow type not found"))?;
+                .get(workflow_type)
+                .ok_or_else(|| anyhow!("Workflow type {workflow_type} not found"))?;
 
             let (wff, activations) = wf_function.start_workflow(
                 worker.get_config().namespace.clone(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Stops unnecessary cloning of events during WFT application, which can potentially be costly for events with large payloads.

Also added some basic benchmarking

## Why?
Perf baybeee, and it was easy/fun.
