### PR TITLE
Fix resets of workflows causing a panic

### DIFF
--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -8,12 +8,14 @@ use crate::{
     ActivityHeartbeat, MetricsContext, Worker, WorkerConfigBuilder,
 };
 use futures::FutureExt;
-use std::sync::Arc;
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, HashMap, VecDeque},
     rc::Rc,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 use temporal_client::mocks::{mock_gateway, mock_manual_gateway};

--- a/core/src/workflow/machines/workflow_machines.rs
+++ b/core/src/workflow/machines/workflow_machines.rs
@@ -467,7 +467,6 @@ impl WorkflowMachines {
                     attrs,
                 )) = event.attributes
                 {
-                    self.run_id = attrs.original_execution_run_id.clone();
                     if let Some(st) = event.event_time {
                         let as_systime: SystemTime = st.try_into()?;
                         self.workflow_start_time = Some(as_systime);

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -309,6 +309,7 @@ impl WorkflowTaskManager {
             task_token = %&work.task_token,
             history_length = %work.history.events.len(),
             attempt = %work.attempt,
+            run_id = %work.workflow_execution.run_id,
             "Applying new workflow task from server"
         );
         let task_start_time = Instant::now();

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -260,8 +260,10 @@ pub mod coresdk {
             coresdk::{AsJsonPayloadExt, IntoPayloadsExt},
             temporal::api::common::v1::{Payload as ApiPayload, Payloads},
         };
-        use std::collections::HashMap;
-        use std::fmt::{Display, Formatter};
+        use std::{
+            collections::HashMap,
+            fmt::{Display, Formatter},
+        };
 
         impl<T> From<T> for Payload
         where

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -7,6 +7,7 @@ mod determinism;
 mod local_activities;
 mod patches;
 mod replay;
+mod resets;
 mod signals;
 mod stickyness;
 mod timers;

--- a/tests/integ_tests/workflow_tests/resets.rs
+++ b/tests/integ_tests/workflow_tests/resets.rs
@@ -1,0 +1,84 @@
+use futures::StreamExt;
+use std::{sync::Arc, time::Duration};
+use temporal_client::{ServerGatewayApis, WorkflowOptions, WorkflowService};
+use temporal_sdk::WfContext;
+use temporal_sdk_core_protos::temporal::api::{
+    common::v1::WorkflowExecution, workflowservice::v1::ResetWorkflowExecutionRequest,
+};
+use temporal_sdk_core_test_utils::{CoreWfStarter, NAMESPACE};
+use tokio::sync::Notify;
+
+const POST_RESET_SIG: &str = "post-reset";
+
+#[tokio::test]
+async fn reset_workflow() {
+    let wf_name = "reset_me_wf";
+    let mut starter = CoreWfStarter::new(wf_name);
+    let mut worker = starter.worker().await;
+    let notify = Arc::new(Notify::new());
+
+    let wf_notify = notify.clone();
+    worker.register_wf(wf_name.to_owned(), move |ctx: WfContext| {
+        let notify = wf_notify.clone();
+        async move {
+            // Make a couple workflow tasks
+            ctx.timer(Duration::from_secs(1)).await;
+            ctx.timer(Duration::from_secs(1)).await;
+            // Tell outer scope to send the reset
+            notify.notify_one();
+            let _ = ctx
+                .make_signal_channel(POST_RESET_SIG)
+                .next()
+                .await
+                .unwrap();
+            Ok(().into())
+        }
+    });
+
+    let run_id = worker
+        .submit_wf(
+            wf_name.to_owned(),
+            wf_name.to_owned(),
+            vec![],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    let client = starter.get_client().await;
+    let resetter_fut = async {
+        notify.notified().await;
+        // Do the reset
+        client
+            .get_client()
+            .raw_retry_client()
+            .reset_workflow_execution(ResetWorkflowExecutionRequest {
+                namespace: NAMESPACE.to_owned(),
+                workflow_execution: Some(WorkflowExecution {
+                    workflow_id: wf_name.to_owned(),
+                    run_id: run_id.clone(),
+                }),
+                // End of first WFT
+                workflow_task_finish_event_id: 4,
+                request_id: "test-req-id".to_owned(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        // Unblock the workflow by sending the signal. Run ID will have changed after reset so
+        // we use empty run id
+        client
+            .signal_workflow_execution(
+                wf_name.to_owned(),
+                "".to_owned(),
+                POST_RESET_SIG.to_owned(),
+                None,
+            )
+            .await
+            .unwrap();
+    };
+    let run_fut = worker.run_until_done();
+    let (_, rr) = tokio::join!(resetter_fut, run_fut);
+    rr.unwrap();
+}


### PR DESCRIPTION
Problem was the internal run id was always being set to the original
run id, so when it changed because of a reset, lookup of the workflow
state failed

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Problem was the internal run id was always being set to the original
run id, so when it changed because of a reset, lookup of the workflow
state failed 

## Why?
Resets need to work!

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/284

2. How was this tested:
Added integration test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
