### PR TITLE
Ensure `service.name` is set for metrics as well

### DIFF
--- a/core/src/telemetry/prometheus_server.rs
+++ b/core/src/telemetry/prometheus_server.rs
@@ -1,3 +1,4 @@
+use crate::telemetry::default_resource;
 use crate::telemetry::metrics::{SDKAggSelector, DEFAULT_MS_BUCKETS};
 use hyper::{
     header::CONTENT_TYPE,
@@ -22,6 +23,7 @@ impl PromServer {
             .with_aggregator_selector(SDKAggSelector)
             .with_host(addr.ip().to_string())
             .with_port(addr.port())
+            .with_resource(default_resource())
             .try_init()?;
         Ok(Self {
             exporter: Arc::new(exporter),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This attribute was only being set for traces

## Why?
Helps users filter for temporal metrics

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
