### PR TITLE
Fix possibly unflushed heartbeats if they are the first heartbeat

### DIFF
--- a/core/src/telemetry/prometheus_server.rs
+++ b/core/src/telemetry/prometheus_server.rs
@@ -1,5 +1,7 @@
-use crate::telemetry::default_resource;
-use crate::telemetry::metrics::{SDKAggSelector, DEFAULT_MS_BUCKETS};
+use crate::telemetry::{
+    default_resource,
+    metrics::{SDKAggSelector, DEFAULT_MS_BUCKETS},
+};
 use hyper::{
     header::CONTENT_TYPE,
     service::{make_service_fn, service_fn},

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1222,6 +1222,12 @@ pub mod coresdk {
         }
     }
 
+    impl From<String> for Failure {
+        fn from(v: String) -> Self {
+            Failure::application_failure(v, false)
+        }
+    }
+
     impl From<anyhow::Error> for Failure {
         fn from(ae: anyhow::Error) -> Self {
             Failure::application_failure(ae.to_string(), false)

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -45,8 +45,10 @@ pub use workflow_context::{
     Signal, SignalData, SignalWorkflowOptions, WfContext,
 };
 
-use crate::interceptors::WorkerInterceptor;
-use crate::workflow_context::{ChildWfCommon, PendingChildWorkflow};
+use crate::{
+    interceptors::WorkerInterceptor,
+    workflow_context::{ChildWfCommon, PendingChildWorkflow},
+};
 use anyhow::{anyhow, bail};
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use once_cell::sync::OnceCell;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -10,24 +10,30 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use log::LevelFilter;
 use prost::Message;
 use rand::{distributions::Standard, Rng};
-use std::cell::RefCell;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{
-    convert::TryFrom, env, future::Future, net::SocketAddr, path::PathBuf, sync::Arc,
+    cell::RefCell,
+    convert::TryFrom,
+    env,
+    future::Future,
+    net::SocketAddr,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 use temporal_client::{RetryGateway, ServerGateway, ServerGatewayApis, WorkflowOptions};
-use temporal_sdk::interceptors::WorkerInterceptor;
-use temporal_sdk::{IntoActivityFunc, Worker, WorkflowFunction};
+use temporal_sdk::{interceptors::WorkerInterceptor, IntoActivityFunc, Worker, WorkflowFunction};
 use temporal_sdk_core::{
     init_replay_worker, init_worker, replay::mock_gateway_from_history, telemetry_init,
     ServerGatewayOptions, ServerGatewayOptionsBuilder, TelemetryOptions, TelemetryOptionsBuilder,
     WorkerConfig, WorkerConfigBuilder,
 };
 use temporal_sdk_core_api::Worker as CoreWorker;
-use temporal_sdk_core_protos::coresdk::common::Payload;
 use temporal_sdk_core_protos::{
     coresdk::{
+        common::Payload,
         workflow_commands::{
             workflow_command, ActivityCancellationType, CompleteWorkflowExecution,
             ScheduleActivity, StartTimer,

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -1,13 +1,15 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
+use temporal_sdk_core_protos::coresdk::activity_task::activity_task;
 use temporal_sdk_core_protos::coresdk::{
     activity_result::{
         self, activity_resolution as act_res, ActivityExecutionResult, ActivityResolution,
     },
     activity_task::activity_task as act_task,
-    common::Payload,
+    common::{Payload, RetryPolicy},
     workflow_activation::{workflow_activation_job, ResolveActivity, WorkflowActivationJob},
-    workflow_commands::ActivityCancellationType,
+    workflow_commands::{ActivityCancellationType, ScheduleActivity},
+    workflow_completion::WorkflowActivationCompletion,
     ActivityHeartbeat, ActivityTaskCompletion, IntoCompletion,
 };
 use temporal_sdk_core_test_utils::{
@@ -80,6 +82,81 @@ async fn activity_heartbeat() {
             assert_eq!(*seq, 0);
             assert_eq!(r, &response_payload);
         }
+    );
+    core.complete_execution(&task.run_id).await;
+}
+
+#[tokio::test]
+async fn many_act_fails_with_heartbeats() {
+    let (core, task_q) = init_core_and_create_wf("many_act_fails_with_heartbeats").await;
+    let activity_id = "act-1";
+    let task = core.poll_workflow_activation().await.unwrap();
+    // Complete workflow task and schedule activity
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+        task.run_id,
+        ScheduleActivity {
+            seq: 0,
+            activity_id: activity_id.to_string(),
+            activity_type: "test_act".to_string(),
+            task_queue: task_q,
+            start_to_close_timeout: Some(Duration::from_secs(10).into()),
+            retry_policy: Some(RetryPolicy {
+                initial_interval: Some(Duration::from_millis(10).into()),
+                backoff_coefficient: 1.0,
+                maximum_attempts: 4,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    // Multiple times, poll for the activity, heartbeat, and then immediately fail
+    // Poll activity and verify that it's been scheduled with correct parameters
+    for i in 0u8..=3 {
+        let task = core.poll_activity_task().await.unwrap();
+        let hb_details = assert_matches!(task.variant, Some(activity_task::Variant::Start(s)) => s);
+
+        core.record_activity_heartbeat(ActivityHeartbeat {
+            task_token: task.task_token.clone(),
+            details: vec![[i].into()],
+        });
+
+        let compl = if i == 3 {
+            // Verify last hb was recorded
+            assert_eq!(hb_details.heartbeat_details, [[2].into()]);
+            ActivityTaskCompletion {
+                task_token: task.task_token,
+                result: Some(ActivityExecutionResult::ok("passed".into())),
+            }
+        } else {
+            if i != 0 {
+                assert_eq!(hb_details.heartbeat_details, [[i - 1].into()]);
+            }
+            ActivityTaskCompletion {
+                task_token: task.task_token,
+                result: Some(ActivityExecutionResult::fail(format!("Die on {i}").into())),
+            }
+        };
+        core.complete_activity_task(compl).await.unwrap();
+    }
+    let task = core.poll_workflow_activation().await.unwrap();
+
+    assert_matches!(
+        task.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::ResolveActivity(
+                ResolveActivity {
+                    result: Some(ActivityResolution {
+                        status: Some(act_res::Status::Completed(activity_result::Success { .. })),
+                        ..
+                    }),
+                    ..
+                }
+            )),
+        },]
     );
     core.complete_execution(&task.run_id).await;
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
It was possible for the very first heartbeat of a new activity task to not be flushed if all the activity does is record the heartbeat and then exit extremely fast, while the server also is slow and takes longer to record the heartbeat than it does to complete the activity.

This happens:

```
| record hb RPC started
|
|    complete activity RPC 
|    |
|    |
|    done
|
| activity not found ?!??
```
Which arguably is also a bit of a server-side bug, but regardless now we make sure the record RPC _completes_ before allowing activity completion.

## Why?
Bugfix.
Chad noticed while working on Python https://github.com/temporalio/sdk-typescript/issues/538

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
New UT/IT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
