### PR TITLE
add activity context for rust sdk

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -13,7 +13,7 @@ use std::{
     time::Duration,
 };
 use temporal_client::WorkflowOptions;
-use temporal_sdk::{LocalActivityOptions, WfContext, WorkflowResult, ActContext};
+use temporal_sdk::{ActContext, LocalActivityOptions, WfContext, WorkflowResult};
 use temporal_sdk_core_protos::{
     coresdk::{common::RetryPolicy, AsJsonPayloadExt},
     temporal::api::{enums::v1::EventType, failure::v1::Failure},
@@ -124,7 +124,10 @@ async fn local_act_many_concurrent() {
     let mut worker = TestWorker::new(Arc::new(core), TEST_Q.to_string());
 
     worker.register_wf(DEFAULT_WORKFLOW_TYPE.to_owned(), local_act_fanout_wf);
-    worker.register_activity("echo", |_ctx: ActContext, str: String| async move { Ok(str) });
+    worker.register_activity(
+        "echo",
+        |_ctx: ActContext, str: String| async move { Ok(str) },
+    );
     worker
         .submit_wf(
             wf_id.to_owned(),

--- a/sdk/src/activity_context.rs
+++ b/sdk/src/activity_context.rs
@@ -107,21 +107,16 @@ impl ActContext {
         }
     }
 
-    /// Retrieve the rest of the parameters
-    /// #NOTE the first parameter is popped for convenience, the rest is still stored in the
-    /// activity state.  There are no variadic parameters in Rust.
-    pub fn inputs(&mut self) -> &mut [Payload] {
+    /// Retrieve extra parameters.  The first input is always popped and passed to the
+    /// ActivityFuntion for the currently executing activity.  However, if more parameters are
+    /// passed, perhaps from another language's SDK, explicit access is available from extra_inputs
+    pub fn extra_inputs(&mut self) -> &mut [Payload] {
         &mut self.input
     }
 
     /// Extract heartbeat details from last failed attempt. This is used in combination with retry policy.
     pub fn get_heartbeat_details(&self) -> &[Payload] {
         &self.heartbeat_details
-    }
-
-    /// Helper function to check if details exist from previous execution of this activity
-    pub fn has_heartbeat_details(&self) -> bool {
-        !self.heartbeat_details.is_empty()
     }
 
     /// RecordHeartbeat sends heartbeat for the currently executing activity

--- a/sdk/src/activity_context.rs
+++ b/sdk/src/activity_context.rs
@@ -1,0 +1,202 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration as StdDuration, SystemTime};
+
+use prost_types::{Duration, Timestamp};
+use temporal_sdk_core_api::Worker;
+use temporal_sdk_core_protos::coresdk::{
+    activity_task,
+    common::{Payload, RetryPolicy, WorkflowExecution},
+    ActivityHeartbeat,
+};
+
+/// Used within activities to get info, heartbeat management etc.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct ActContext {
+    pub(crate) worker: Arc<dyn Worker>,
+    pub(crate) input: Vec<Payload>,
+    pub(crate) heartbeat_details: Vec<Payload>,
+    /// #NOTE future usage?
+    pub(crate) header_fields: HashMap<String, Payload>,
+    pub(crate) info: ActivityInfo,
+}
+
+#[derive(Clone)]
+pub struct ActivityInfo {
+    pub task_token: Vec<u8>,
+    pub workflow_type: String,
+    pub workflow_namespace: String,
+    pub workflow_execution: Option<WorkflowExecution>,
+    pub activity_id: String,
+    pub activity_type: String,
+    pub task_queue: String,
+    pub heartbeat_timeout: Option<Duration>,
+    /// Time of activity scheduled by a workflow
+    pub scheduled_time: Option<Timestamp>,
+    /// Time of activity start
+    pub started_time: Option<Timestamp>,
+    /// Time of activity timeout
+    pub deadline: Option<Timestamp>,
+    /// Attempt starts from 1, and increased by 1 for every retry if retry policy is specified.
+    pub attempt: u32,
+
+    /// #NOTE Not in sdk-go
+    pub current_attempt_scheduled_time: Option<Timestamp>,
+    pub retry_policy: Option<RetryPolicy>,
+    pub is_local: bool,
+}
+
+impl ActContext {
+    /// Construct new Activity Context
+    pub fn new(
+        worker: Arc<dyn Worker>,
+        task_queue: String,
+        task_token: Vec<u8>,
+        task: activity_task::Start,
+    ) -> Self {
+        let activity_task::Start {
+            workflow_namespace,
+            workflow_type,
+            workflow_execution,
+            activity_id,
+            activity_type,
+            header_fields,
+            input,
+            heartbeat_details,
+            scheduled_time,
+            current_attempt_scheduled_time,
+            started_time,
+            attempt,
+            schedule_to_close_timeout,
+            start_to_close_timeout,
+            heartbeat_timeout,
+            retry_policy,
+            is_local,
+        } = task;
+        let deadline = calculate_deadline(
+            scheduled_time.as_ref(),
+            started_time.as_ref(),
+            start_to_close_timeout.as_ref(),
+            schedule_to_close_timeout.as_ref(),
+        );
+
+        ActContext {
+            worker,
+            input,
+            heartbeat_details,
+            header_fields,
+            info: ActivityInfo {
+                task_token,
+                task_queue,
+                workflow_type,
+                workflow_namespace,
+                workflow_execution,
+                activity_id,
+                activity_type,
+                heartbeat_timeout,
+                scheduled_time,
+                started_time,
+                deadline,
+                attempt,
+
+                current_attempt_scheduled_time,
+                retry_policy,
+                is_local,
+            },
+        }
+    }
+
+    /// Retrieve the rest of the parameters
+    /// #NOTE the first parameter is popped for convenience, the rest is still stored in the
+    /// activity state.  There are no variadic parameters in Rust.
+    pub fn inputs(&self) -> &[Payload] {
+        &self.input
+    }
+
+    /// Extract heartbeat details from last failed attempt. This is used in combination with retry policy.
+    pub fn get_heartbeat_details(&self) -> &[Payload] {
+        &self.heartbeat_details
+    }
+
+    /// Helper function to check if details exist from previous execution of this activity
+    pub fn has_heartbeat_details(&self) -> bool {
+        !self.heartbeat_details.is_empty()
+    }
+
+    /// RecordHeartbeat sends heartbeat for the currently executing activity
+    pub fn record_heartbeat(&self, details: Vec<Payload>) {
+        self.worker.record_activity_heartbeat(ActivityHeartbeat {
+            task_token: self.info.task_token.clone(),
+            details,
+        })
+    }
+
+    /// Get activity info of the executing activity
+    pub fn get_info(&self) -> &ActivityInfo {
+        &self.info
+    }
+}
+
+/// Deadline calculation.  This is a port of
+/// https://github.com/temporalio/sdk-go/blob/8651550973088f27f678118f997839fb1bb9e62f/internal/activity.go#L225
+fn calculate_deadline(
+    scheduled_time: Option<&Timestamp>,
+    started_time: Option<&Timestamp>,
+    start_to_close_timeout: Option<&Duration>,
+    schedule_to_close_timeout: Option<&Duration>,
+) -> Option<Timestamp> {
+    match (
+        scheduled_time,
+        started_time,
+        start_to_close_timeout,
+        schedule_to_close_timeout,
+    ) {
+        (
+            Some(scheduled),
+            Some(started),
+            Some(start_to_close_timeout),
+            Some(schedule_to_close_timeout),
+        ) => {
+            let scheduled: SystemTime = maybe_convert_timestamp(scheduled)?;
+            let started: SystemTime = maybe_convert_timestamp(started)?;
+            let start_to_close_timeout: StdDuration =
+                start_to_close_timeout.clone().try_into().ok()?;
+            let schedule_to_close_timeout: StdDuration =
+                schedule_to_close_timeout.clone().try_into().ok()?;
+
+            let start_to_close_deadline: SystemTime =
+                started.checked_add(start_to_close_timeout)?;
+            if schedule_to_close_timeout > StdDuration::ZERO {
+                let schedule_to_close_deadline =
+                    scheduled.checked_add(schedule_to_close_timeout)?;
+                // Minimum of the two deadlines.
+                if schedule_to_close_deadline < start_to_close_deadline {
+                    Some(schedule_to_close_deadline.into())
+                } else {
+                    Some(start_to_close_deadline.into())
+                }
+            } else {
+                Some(start_to_close_deadline.into())
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Helper function lifted from prost_types::Timestamp implementation to prevent double cloning in
+/// error construction
+fn maybe_convert_timestamp(timestamp: &Timestamp) -> Option<SystemTime> {
+    let mut timestamp = timestamp.clone();
+    timestamp.normalize();
+
+    let system_time = if timestamp.seconds >= 0 {
+        std::time::UNIX_EPOCH.checked_add(StdDuration::from_secs(timestamp.seconds as u64))
+    } else {
+        std::time::UNIX_EPOCH.checked_sub(StdDuration::from_secs((-timestamp.seconds) as u64))
+    };
+
+    system_time.and_then(|system_time| {
+        system_time.checked_add(StdDuration::from_nanos(timestamp.nanos as u64))
+    })
+}

--- a/sdk/src/activity_context.rs
+++ b/sdk/src/activity_context.rs
@@ -110,8 +110,8 @@ impl ActContext {
     /// Retrieve the rest of the parameters
     /// #NOTE the first parameter is popped for convenience, the rest is still stored in the
     /// activity state.  There are no variadic parameters in Rust.
-    pub fn inputs(&self) -> &[Payload] {
-        &self.input
+    pub fn inputs(&mut self) -> &mut [Payload] {
+        &mut self.input
     }
 
     /// Extract heartbeat details from last failed attempt. This is used in combination with retry policy.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -9,7 +9,7 @@
 //! An example of running an activity worker:
 //! ```no_run
 //! use std::{sync::Arc, str::FromStr};
-//! use temporal_sdk::{sdk_client_options, Worker};
+//! use temporal_sdk::{sdk_client_options, Worker, ActContext};
 //! use temporal_sdk_core::{init_worker, Url};
 //! use temporal_sdk_core_api::worker::{WorkerConfig, WorkerConfigBuilder};
 //!
@@ -23,7 +23,7 @@
 //!     let mut worker = Worker::new_from_core(Arc::new(core_worker), "task_queue");
 //!     worker.register_activity(
 //!         "echo_activity",
-//!         |echo_me: String| async move { Ok(echo_me) },
+//!         |_ctx: ActContext, echo_me: String| async move { Ok(echo_me) },
 //!     );
 //!     worker.run().await?;
 //!     Ok(())

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -358,7 +358,7 @@ impl ActivityHalf {
         task_queue: String,
         activity: ActivityTask,
     ) -> Result<(), anyhow::Error> {
-        match activity.variant.clone() {
+        match activity.variant {
             Some(activity_task::Variant::Start(start)) => {
                 let act_fn = self
                     .activity_fns
@@ -375,10 +375,9 @@ impl ActivityHalf {
                 self.task_tokens_to_cancels
                     .insert(task_token.clone().into(), ct.clone());
 
-                let mut ctx =
+                let (ctx, arg) =
                     ActContext::new(worker.clone(), ct, task_queue, task_token.clone(), start);
                 tokio::spawn(async move {
-                    let arg = ctx.input.pop().unwrap_or_default();
                     let output = (act_fn.act_func)(ctx, arg).await;
                     let result = match output {
                         Ok(res) => ActivityExecutionResult::ok(res),

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
-use temporal_sdk::{ActivityOptions, WfContext, WorkflowResult, ActContext};
+use temporal_sdk::{ActContext, ActivityOptions, WfContext, WorkflowResult};
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::{

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
-use temporal_sdk::{ActivityOptions, WfContext, WorkflowResult};
+use temporal_sdk::{ActivityOptions, WfContext, WorkflowResult, ActContext};
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::{
@@ -47,7 +47,7 @@ async fn one_activity() {
     worker.register_wf(wf_name.to_owned(), one_activity_wf);
     worker.register_activity(
         "echo_activity",
-        |echo_me: String| async move { Ok(echo_me) },
+        |_ctx: ActContext, echo_me: String| async move { Ok(echo_me) },
     );
 
     worker

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -3,7 +3,7 @@ use futures::future::join_all;
 use std::time::Duration;
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{
-    act_cancelled, act_is_cancelled, ActivityCancelledError, CancellableFuture,
+    act_cancelled, act_is_cancelled, ActContext, ActivityCancelledError, CancellableFuture,
     LocalActivityOptions, WfContext, WorkflowResult,
 };
 use temporal_sdk_core_protos::coresdk::{
@@ -12,7 +12,7 @@ use temporal_sdk_core_protos::coresdk::{
 use temporal_sdk_core_test_utils::CoreWfStarter;
 use tokio_util::sync::CancellationToken;
 
-pub async fn echo(e: String) -> anyhow::Result<String> {
+pub async fn echo(_ctx: ActContext, e: String) -> anyhow::Result<String> {
     Ok(e)
 }
 
@@ -119,7 +119,7 @@ async fn long_running_local_act_with_timer() {
     starter.wft_timeout(Duration::from_secs(1));
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), local_act_then_timer_then_wait);
-    worker.register_activity("echo_activity", |str: String| async {
+    worker.register_activity("echo_activity", |_ctx: ActContext, str: String| async {
         tokio::time::sleep(Duration::from_secs(4)).await;
         Ok(str)
     });
@@ -199,7 +199,7 @@ async fn local_act_retry_timer_backoff() {
         assert!(res.failed());
         Ok(().into())
     });
-    worker.register_activity("echo", |_: String| async {
+    worker.register_activity("echo", |_: ActContext, _: String| async {
         Result::<(), _>::Err(anyhow!("Oh no I failed!"))
     });
 
@@ -245,7 +245,7 @@ async fn cancel_immediate(#[case] cancel_type: ActivityCancellationType) {
     let manual_cancel = CancellationToken::new();
     let manual_cancel_act = manual_cancel.clone();
 
-    worker.register_activity("echo", move |_: String| {
+    worker.register_activity("echo", move |_: ActContext, _: String| {
         let manual_cancel_act = manual_cancel_act.clone();
         async move {
             tokio::select! {
@@ -329,7 +329,7 @@ async fn cancel_after_act_starts(
     let manual_cancel = CancellationToken::new();
     let manual_cancel_act = manual_cancel.clone();
 
-    worker.register_activity("echo", move |_: String| {
+    worker.register_activity("echo", move |_: ActContext, _: String| {
         let manual_cancel_act = manual_cancel_act.clone();
         async move {
             if cancel_on_backoff.is_some() {
@@ -406,7 +406,7 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
         assert!(res.timed_out());
         Ok(().into())
     });
-    worker.register_activity("echo", |_: String| async {
+    worker.register_activity("echo", |_: ActContext, _: String| async {
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(100)) => {},
             _ = act_cancelled() => {
@@ -462,7 +462,7 @@ async fn schedule_to_close_timeout_across_timer_backoff(#[case] cached: bool) {
         assert!(res.timed_out());
         Ok(().into())
     });
-    worker.register_activity("echo", |_: String| async {
+    worker.register_activity("echo", |_: ActContext, _: String| async {
         Result::<(), _>::Err(anyhow!("Oh no I failed!"))
     });
 
@@ -486,7 +486,7 @@ async fn eviction_wont_make_local_act_get_dropped() {
     starter.wft_timeout(Duration::from_secs(1));
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), local_act_then_timer_then_wait);
-    worker.register_activity("echo_activity", |str: String| async {
+    worker.register_activity("echo_activity", |_ctx: ActContext, str: String| async {
         tokio::time::sleep(Duration::from_secs(4)).await;
         Ok(str)
     });
@@ -540,7 +540,7 @@ async fn timer_backoff_concurrent_with_non_timer_backoff() {
         assert!(r2.failed());
         Ok(().into())
     });
-    worker.register_activity("echo", |_: String| async {
+    worker.register_activity("echo", |_: ActContext, _: String| async {
         Result::<(), _>::Err(anyhow!("Oh no I failed!"))
     });
 


### PR DESCRIPTION
## What was changed
An activity context that tries to be as close to the go sdk as possible.  Implementation added in sdk/src/activity_context.rs.  sdk/src/lib.rs was also modified to support the new context for each activity worker function.

1. Closes https://github.com/temporalio/sdk-core/issues/301

2. How was this tested:
- Ran Unit Tests
- Ran Integration tests
- Sanity Tested with External Project on Docker-compose temporal environment

3. Any docs updates needed?
Not that I know of.  Would be happy to contribute with some direction.
