### PR TITLE
Fix problems with exceeding cache limit

### DIFF
--- a/.buildkite/docker/docker-compose.yaml
+++ b/.buildkite/docker/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
   #      - '9042:9042'
 
   temporal:
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.16.0
     ports:
       - "7233:7233"
       - "7234:7234"
@@ -26,12 +26,13 @@ services:
       - cassandra
 
   temporal-web:
-    image: temporalio/web:1.13.0
+    image: temporalio/ui:0.10.2
     logging:
       driver: none
     ports:
-      - "8088:8088"
+      - "8080:8080"
     environment:
-      - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
     depends_on:
       - temporal

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/protos/*.rs
 !src/protos/mod.rs
 /tarpaulin-report.html
 /machine_coverage/
+/bindings/

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -20,6 +20,8 @@ pub struct WorkerConfig {
     /// The maximum allowed number of workflow tasks that will ever be given to this worker at one
     /// time. Note that one workflow task may require multiple activations - so the WFT counts as
     /// "outstanding" until all activations it requires have been completed.
+    ///
+    /// Cannot be larger than `max_cached_workflows`.
     #[builder(default = "100")]
     pub max_outstanding_workflow_tasks: usize,
     /// The maximum number of activity tasks that will ever be given to this worker concurrently
@@ -89,6 +91,11 @@ impl WorkerConfigBuilder {
     fn validate(&self) -> Result<(), String> {
         if self.max_concurrent_wft_polls == Some(0) {
             return Err("`max_concurrent_wft_polls` must be at least 1".to_owned());
+        }
+        if self.max_outstanding_workflow_tasks > self.max_cached_workflows {
+            return Err(
+                "`max_outstanding_workflow_tasks` cannot exceed `max_cached_workflows`".to_owned(),
+            );
         }
         Ok(())
     }

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -94,7 +94,9 @@ impl WorkerConfigBuilder {
         }
         if self.max_outstanding_workflow_tasks > self.max_cached_workflows {
             return Err(
-                "`max_outstanding_workflow_tasks` cannot exceed `max_cached_workflows`".to_owned(),
+                "Maximum concurrent workflow tasks cannot exceed the maximum number of cached \
+                 workflows"
+                    .to_owned(),
             );
         }
         Ok(())

--- a/core/src/core_tests/determinism.rs
+++ b/core/src/core_tests/determinism.rs
@@ -32,7 +32,7 @@ pub async fn timer_wf_fails_once(ctx: WfContext) -> WorkflowResult<()> {
 /// Verifies that workflow panics (which in this case the Rust SDK turns into workflow activation
 /// failures) are turned into unspecified WFT failures.
 #[tokio::test]
-async fn test_wf_task_rejected_properly() {
+async fn test_panic_wf_task_rejected_properly() {
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
     let t = canned_histories::workflow_fails_with_failure_after_timer("1");

--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -80,6 +80,10 @@ async fn legacy_query(#[case] include_history: bool) {
     };
     let clear_eviction = || async {
         let t = worker.poll_workflow_activation().await.unwrap();
+        assert_matches!(
+            t.jobs[0].variant,
+            Some(workflow_activation_job::Variant::RemoveFromCache(_))
+        );
         worker
             .complete_workflow_activation(WorkflowActivationCompletion::empty(t.run_id))
             .await
@@ -127,10 +131,10 @@ async fn legacy_query(#[case] include_history: bool) {
 
     let task = worker.poll_workflow_activation().await.unwrap();
     assert_matches!(
-        task.jobs.as_slice(),
-        [WorkflowActivationJob {
+        task.jobs.as_slice()[0],
+        WorkflowActivationJob {
             variant: Some(workflow_activation_job::Variant::FireTimer(_)),
-        }]
+        }
     );
     worker
         .complete_workflow_activation(WorkflowActivationCompletion::from_cmds(

--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -131,10 +131,10 @@ async fn legacy_query(#[case] include_history: bool) {
 
     let task = worker.poll_workflow_activation().await.unwrap();
     assert_matches!(
-        task.jobs.as_slice()[0],
-        WorkflowActivationJob {
+        task.jobs.as_slice(),
+        [WorkflowActivationJob {
             variant: Some(workflow_activation_job::Variant::FireTimer(_)),
-        }
+        }]
     );
     worker
         .complete_workflow_activation(WorkflowActivationCompletion::from_cmds(

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -21,38 +21,6 @@ use temporal_sdk_core_test_utils::start_timer_cmd;
 use tokio::sync::{watch, Barrier};
 
 #[tokio::test]
-async fn multi_workers() {
-    // TODO: Turn this into a test with multiple independent workers
-    // Make histories for 5 different workflows on 5 different task queues
-    // let hists = (0..5).into_iter().map(|i| {
-    //     let wf_id = format!("fake-wf-{}", i);
-    //     let hist = canned_histories::single_timer("1");
-    //     FakeWfResponses {
-    //         wf_id,
-    //         hist,
-    //         response_batches: vec![1.into(), 2.into()],
-    //         task_q: format!("q-{}", i),
-    //     }
-    // });
-    // let mock = build_multihist_mock_sg(hists, false, None);
-    //
-    // let core = &mock_worker(mock);
-    //
-    // for i in 0..5 {
-    //     let tq = format!("q-{}", i);
-    //     let res = core.poll_workflow_activation().await.unwrap();
-    //     assert_matches!(
-    //         res.jobs[0].variant,
-    //         Some(workflow_activation_job::Variant::StartWorkflow(_))
-    //     );
-    //     core.complete_workflow_activation(WorkflowActivationCompletion::empty(res.run_id))
-    //         .await
-    //         .unwrap();
-    // }
-    // core.shutdown().await;
-}
-
-#[tokio::test]
 async fn after_shutdown_of_worker_get_shutdown_err() {
     let t = canned_histories::single_timer("1");
     let worker = build_fake_worker("fake_wf_id", t, &[1]);

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -163,7 +163,7 @@ async fn can_shutdown_local_act_only_worker_when_act_polling() {
 }
 
 #[tokio::test]
-async fn complete_with_task_not_found_during_shutdwn() {
+async fn complete_with_task_not_found_during_shutdown() {
     let t = canned_histories::single_timer("1");
     let mut mock = mock_workflow_client();
     mock.expect_complete_workflow_task()
@@ -204,5 +204,7 @@ async fn complete_with_task_not_found_during_shutdwn() {
         complete_order.borrow_mut().push(1);
     };
     tokio::join!(shutdown_fut, poll_fut, complete_fut);
-    assert_eq!(&complete_order.into_inner(), &[1, 2, 3])
+    // Shutdown will currently complete first before the actual eviction reply since the
+    // workflow task is marked complete as soon as we get not found back from the server.
+    assert_eq!(&complete_order.into_inner(), &[1, 3, 2])
 }

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -1722,6 +1722,7 @@ async fn poll_faster_than_complete_wont_overflow_cache() {
         .collect();
     let mut mock = mock_workflow_client();
     mock.expect_complete_workflow_task()
+        .times(3)
         .returning(|_| Ok(Default::default()));
     let mut mock = MocksHolder::from_client_with_responses(mock, tasks, []);
     mock.worker_cfg(|wc| {

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -1835,4 +1835,13 @@ async fn poll_faster_than_complete_wont_overflow_cache() {
     // The final task yet again pushed us one above the cache limit since it was for a new run
     // and we have only evicted one
     assert_eq!(core.cached_workflows(), 4);
+
+    // Hence the next poll should be another evict
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
+        }]
+    );
 }

--- a/core/src/pending_activations.rs
+++ b/core/src/pending_activations.rs
@@ -22,6 +22,7 @@ struct PaInner {
     queue: VecDeque<ActivationKey>,
 }
 
+#[derive(Debug)]
 pub struct PendingActInfo {
     pub needs_eviction: Option<RemoveFromCache>,
     pub run_id: String,
@@ -63,6 +64,7 @@ impl PendingActivations {
             });
             inner.by_run_id.insert(run_id.to_string(), key);
             inner.queue.push_back(key);
+            // inner.queue.push_front(key);
         };
     }
 
@@ -106,6 +108,14 @@ impl PendingActivations {
         if let Some(k) = inner.by_run_id.remove(run_id) {
             inner.activations.remove(k);
         }
+    }
+
+    pub fn is_some_eviction(&self) -> bool {
+        self.inner
+            .read()
+            .activations
+            .values()
+            .any(|act| act.needs_eviction.is_some())
     }
 }
 

--- a/core/src/pending_activations.rs
+++ b/core/src/pending_activations.rs
@@ -41,6 +41,7 @@ impl PendingActivations {
             inner.queue.push_back(key);
         };
     }
+
     pub fn notify_needs_eviction(&self, run_id: &str, message: String, reason: EvictionReason) {
         let mut inner = self.inner.write();
 

--- a/core/src/pending_activations.rs
+++ b/core/src/pending_activations.rs
@@ -64,7 +64,6 @@ impl PendingActivations {
             });
             inner.by_run_id.insert(run_id.to_string(), key);
             inner.queue.push_back(key);
-            // inner.queue.push_front(key);
         };
     }
 
@@ -110,6 +109,7 @@ impl PendingActivations {
         }
     }
 
+    /// Returns true if any pending activation contains an eviction
     pub fn is_some_eviction(&self) -> bool {
         self.inner
             .read()

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -498,10 +498,13 @@ pub(crate) async fn poll_and_reply_clears_outstanding_evicts<'a>(
                 }
             };
 
+            let ends_execution = reply.has_execution_ending();
+
             worker.complete_workflow_activation(reply).await.unwrap();
 
-            // Restart assertions from the beginning if it was an eviction
-            if contains_eviction.is_some() {
+            // Restart assertions from the beginning if it was an eviction (and workflow execution
+            // isn't over)
+            if contains_eviction.is_some() && !ends_execution {
                 continue 'outer;
             }
 

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -656,6 +656,9 @@ impl Worker {
             ))
         })?;
 
+        // Only permanently take a permit in the event the poll finished completely
+        sem.forget();
+
         let work = if self.config.max_cached_workflows > 0 {
             // Add the workflow to cache management. We do not even attempt insert if cache
             // size is zero because we do not want to generate eviction requests for
@@ -669,8 +672,6 @@ impl Worker {
             work
         };
 
-        // Only permanently take a permit in the event the poll finished completely
-        sem.forget();
         Ok(Some(work))
     }
 

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -258,6 +258,11 @@ impl Worker {
         Self::new(config, None, Arc::new(client.into()), Default::default())
     }
 
+    /// Returns number of currently cached workflows
+    pub fn cached_workflows(&self) -> usize {
+        self.wft_manager.cached_workflows()
+    }
+
     pub(crate) fn new_with_pollers(
         config: WorkerConfig,
         sticky_queue_name: Option<String>,

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -452,7 +452,6 @@ impl Worker {
             }
 
             if self.config.max_cached_workflows > 0 {
-                warn!("Is there outstanding evict activation? {}", self.work);
                 tokio::select! {
                     biased;
                     // We must loop up if there's a new pending activation, since those are for

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -907,6 +907,7 @@ impl Worker {
                         Ok(())
                     }
                     tonic::Code::NotFound => {
+                        // TODO: Remove outstanding workflow task from workflow task manager
                         warn!(error = %err, run_id, "Task not found when completing");
                         should_evict = Some(EvictionReason::TaskNotFound);
                         Ok(())
@@ -980,7 +981,7 @@ impl Worker {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 struct WFTReportOutcome {
     reported_to_server: bool,
     failed: bool,

--- a/core/src/workflow/machines/mod.rs
+++ b/core/src/workflow/machines/mod.rs
@@ -175,7 +175,7 @@ where
         event: HistoryEvent,
         has_next_event: bool,
     ) -> Result<Vec<MachineResponse>, WFMachinesError> {
-        debug!(
+        trace!(
             event = %event,
             machine_name = %self.name(),
             state = %self.state(),

--- a/core/src/workflow/machines/workflow_machines.rs
+++ b/core/src/workflow/machines/workflow_machines.rs
@@ -456,7 +456,7 @@ impl WorkflowMachines {
         event: HistoryEvent,
         has_next_event: bool,
     ) -> Result<()> {
-        debug!(
+        trace!(
             event = %event,
             "handling non-stateful event"
         );

--- a/core/src/workflow/workflow_tasks/cache_manager.rs
+++ b/core/src/workflow/workflow_tasks/cache_manager.rs
@@ -1,5 +1,9 @@
 use crate::{telemetry::metrics::MetricsContext, workflow::WorkflowCachingPolicy};
+use futures::future;
 use lru::LruCache;
+use std::future::Future;
+use std::sync::Arc;
+use tokio::sync::{watch, Mutex};
 
 /// Helps to maintain an LRU ordering in which workflow runs have been accessed so that old runs may
 /// be evicted once we reach the cap.
@@ -7,6 +11,10 @@ use lru::LruCache;
 pub(crate) struct WorkflowCacheManager {
     cache: LruCache<String, ()>,
     metrics: MetricsContext,
+    watch_tx: watch::Sender<usize>,
+    watch_rx: watch::Receiver<usize>,
+    cap_mutex: Arc<tokio::sync::Mutex<()>>,
+    outstanding_eviction: Option<String>,
 }
 
 impl WorkflowCacheManager {
@@ -17,9 +25,14 @@ impl WorkflowCacheManager {
             } => max_cached_workflows,
             _ => 0,
         };
+        let (watch_tx, watch_rx) = watch::channel(0);
         Self {
             cache: LruCache::new(cap),
             metrics,
+            watch_tx,
+            watch_rx,
+            cap_mutex: Arc::new(Mutex::new(())),
+            outstanding_eviction: None,
         }
     }
 
@@ -28,9 +41,42 @@ impl WorkflowCacheManager {
         Self::new(policy, Default::default())
     }
 
+    /// Returns total cache capacity
+    pub fn capacity(&self) -> usize {
+        self.cache.cap()
+    }
+
+    /// Resolves once there is an open slot in the cache
+    pub fn wait_for_capacity(
+        &self,
+    ) -> future::Either<impl Future<Output = ()>, impl Future<Output = ()>> {
+        if self.cache.cap() == 0 {
+            return future::Either::Left(future::ready(()));
+        }
+
+        let mut rx = self.watch_rx.clone();
+        let cap = self.cache.cap();
+        let mx = self.cap_mutex.clone();
+        future::Either::Right(async move {
+            let _l = mx.lock();
+            // Must use strict `>` because we need to be able to exceed the cache size by one
+            // temporarily, to allow for the fact that if we poll while at the limit, we might
+            // get a task for a new run we haven't seen before - which will cause us to issue an
+            // evict, thus temporarily exceeding the limit. Until the evict is completed, this
+            // will block and hence we won't exceed further.
+            while *rx.borrow_and_update() > cap {
+                let _ = rx.changed().await;
+            }
+        })
+    }
+
     /// Inserts a record associated with the run id into the lru cache.
     /// Once cache reaches capacity, overflow records will be returned back to the caller.
     pub fn insert(&mut self, run_id: &str) -> Option<String> {
+        if matches!(self.outstanding_eviction.as_ref(), Some(r) if r == run_id) {
+            return None;
+        }
+
         let res = if self.cache.len() < self.cache.cap() {
             // Blindly add a record into the cache, since it still has capacity.
             self.cache.put(run_id.to_owned(), ());
@@ -44,7 +90,11 @@ impl WorkflowCacheManager {
             not_cached.then(|| maybe_got_evicted).flatten()
         };
 
-        self.metrics.cache_size(self.cache.len() as u64);
+        self.size_changed();
+
+        if let Some(rid) = res.as_ref() {
+            self.outstanding_eviction = Some(rid.clone())
+        }
 
         res
     }
@@ -55,8 +105,19 @@ impl WorkflowCacheManager {
     }
 
     pub fn remove(&mut self, run_id: &str) {
+        let outstanding = self.outstanding_eviction.take();
+        if matches!(outstanding.as_ref(), Some(r) if r != run_id) {
+            // TODO: This isn't an error since eviction could be completed out-of-order?
+            error!("Evicted not-outstanding run");
+        }
         self.cache.pop(run_id);
-        self.metrics.cache_size(self.cache.len() as u64);
+        self.size_changed();
+    }
+
+    fn size_changed(&self) {
+        let size = self.cache.len();
+        self.metrics.cache_size(size as u64);
+        let _ = self.watch_tx.send(size);
     }
 }
 

--- a/core/src/workflow/workflow_tasks/concurrency_manager.rs
+++ b/core/src/workflow/workflow_tasks/concurrency_manager.rs
@@ -7,7 +7,6 @@ use crate::{
     },
 };
 use futures::future::{BoxFuture, FutureExt};
-use itertools::Itertools;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
     collections::HashMap,

--- a/core/src/workflow/workflow_tasks/concurrency_manager.rs
+++ b/core/src/workflow/workflow_tasks/concurrency_manager.rs
@@ -7,6 +7,7 @@ use crate::{
     },
 };
 use futures::future::{BoxFuture, FutureExt};
+use itertools::Itertools;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
     collections::HashMap,
@@ -313,6 +314,7 @@ impl WorkflowConcurrencyManager {
         val.and_then(|v| v.buffered_resp.take())
     }
 
+    /// Sounds the total number of outstanding workflow tasks
     pub fn outstanding_wft(&self) -> usize {
         self.runs
             .read()
@@ -324,6 +326,13 @@ impl WorkflowConcurrencyManager {
     /// Returns number of currently cached workflows
     pub fn cached_workflows(&self) -> usize {
         self.runs.read().len()
+    }
+
+    pub fn are_outstanding_evictions(&self) -> bool {
+        self.runs
+            .read()
+            .values()
+            .any(|mr| mr.activation.map(|a| a.has_eviction()).unwrap_or_default())
     }
 }
 

--- a/core/src/workflow/workflow_tasks/concurrency_manager.rs
+++ b/core/src/workflow/workflow_tasks/concurrency_manager.rs
@@ -320,6 +320,11 @@ impl WorkflowConcurrencyManager {
             .filter(|(_, run)| run.wft.is_some())
             .count()
     }
+
+    /// Returns number of currently cached workflows
+    pub fn cached_workflows(&self) -> usize {
+        self.runs.read().len()
+    }
 }
 
 #[cfg(test)]

--- a/core/src/workflow/workflow_tasks/concurrency_manager.rs
+++ b/core/src/workflow/workflow_tasks/concurrency_manager.rs
@@ -327,6 +327,7 @@ impl WorkflowConcurrencyManager {
         self.runs.read().len()
     }
 
+    /// Returns true if any outstanding activation contains an eviction
     pub fn are_outstanding_evictions(&self) -> bool {
         self.runs
             .read()

--- a/core/src/workflow/workflow_tasks/concurrency_manager.rs
+++ b/core/src/workflow/workflow_tasks/concurrency_manager.rs
@@ -154,7 +154,7 @@ impl WorkflowConcurrencyManager {
     pub fn complete_wft(
         &self,
         run_id: &str,
-        send_wft_complete_to_srv: bool,
+        sent_wft_complete_to_srv: bool,
     ) -> Option<OutstandingTask> {
         // If the WFT completion wasn't sent to the server, but we did see the final event, we still
         // want to clear the workflow task. This can really only happen in replay testing, where we
@@ -164,7 +164,7 @@ impl WorkflowConcurrencyManager {
         let saw_final = self
             .access_sync(run_id, |wfm| wfm.machines.have_seen_terminal_event)
             .unwrap_or_default();
-        if !saw_final && !send_wft_complete_to_srv {
+        if !saw_final && !sent_wft_complete_to_srv {
             return None;
         }
 

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -421,9 +421,10 @@ impl WorkflowTaskManager {
     ) -> Result<Option<ServerCommandsWithWorkflowInfo>, WorkflowUpdateError> {
         // There used to be code here that would return right away if the run reply had no commands
         // and the activation that was just completed only had an eviction in it. That was bad
-        // because we wouldn't have yet sent the commands since there was a pending activation
-        // (the eviction) and then we would *skip* doing anything with them here, because there
-        // were no new commands. In general it seems best to avoid short-circuiting here.
+        // because we wouldn't have yet sent any previously buffered commands since there was a
+        // pending activation (the eviction) and then we would *skip* doing anything with them here,
+        // because there were no new commands. In general it seems best to avoid short-circuiting
+        // here.
 
         let activation_was_only_eviction = self.activation_has_only_eviction(run_id);
         let (task_token, is_leg_query_task, start_time) =

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -203,10 +203,11 @@ impl WorkflowTaskManager {
         self.workflow_machines.cached_workflows()
     }
 
+    /// Resolves once there is either capacity in the cache, or there are no pending evictions.
+    /// Inversely: Waits while there are pending evictions and the cache is full.
+    /// Waiting while there are no pending evictions must be avoided because it would block forever,
+    /// since there is no way for the cache size to be reduced.
     pub async fn wait_for_cache_capacity(&self) {
-        // We should wait for cache capacity if there is either a pending eviction that hasn't been
-        // issued, or an eviction that has been sent to lang. We also can exit waiting early if
-        // that is no longer true.
         let are_no_pending_evictions = || {
             !self.pending_activations.is_some_eviction()
                 && !self.workflow_machines.are_outstanding_evictions()

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -187,6 +187,11 @@ impl WorkflowTaskManager {
         }
     }
 
+    /// Returns number of currently cached workflows
+    pub fn cached_workflows(&self) -> usize {
+        self.workflow_machines.cached_workflows()
+    }
+
     pub(crate) fn next_pending_activation(&self) -> Option<WorkflowActivation> {
         // Dispatch pending legacy queries first
         if let leg_q @ Some(_) = self.pending_legacy_queries.pop() {

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -204,13 +204,36 @@ impl WorkflowTaskManager {
         self.workflow_machines.cached_workflows()
     }
 
-    /// Resolves once there is an open slot in the cache
-    pub async fn wait_for_cache_capacity(&self) {
-        let fut = {
-            let lock = self.cache_manager.lock();
-            lock.wait_for_capacity()
-        };
-        fut.await;
+    /// Add a new run (as just received from polling) to the cache. If doing so would overflow the
+    /// cache, an eviction is queued to make room and the passed-in task is buffered and `None` is
+    /// returned.
+    ///
+    /// If the task is for a run already in the cache, the poll response is returned right away
+    /// and should be issued.
+    pub fn add_new_run_to_cache(
+        &self,
+        poll_resp: ValidPollWFTQResponse,
+    ) -> Option<ValidPollWFTQResponse> {
+        let maybe_evicted = self
+            .cache_manager
+            .lock()
+            .insert(&poll_resp.workflow_execution.run_id);
+
+        if let Some(evicted) = maybe_evicted {
+            self.request_eviction(&evicted, "Workflow cache full", EvictionReason::CacheFull);
+            debug!("Received a WFT for a new run while at the cache limit. Buffering the task.");
+            // Buffer the task
+            if let Some(not_buffered) = self
+                .workflow_machines
+                .buffer_resp_if_outstanding_work(poll_resp)
+            {
+                self.make_buffered_poll_ready(not_buffered);
+            }
+
+            return None;
+        }
+
+        Some(poll_resp)
     }
 
     pub(crate) fn next_pending_activation(&self) -> Option<WorkflowActivation> {
@@ -683,23 +706,6 @@ impl WorkflowTaskManager {
                         .into_iter()
                         .map(|q| workflow_activation_job::Variant::QueryWorkflow(q).into());
                     activation.jobs.extend(query_jobs);
-                }
-
-                {
-                    // Add the workflow to cache management. We do not even attempt insert if cache
-                    // size is zero because we do not want to generate eviction requests for
-                    // workflows which may immediately generate pending activations.
-                    let mut c_lock = self.cache_manager.lock();
-                    if c_lock.capacity() > 0 {
-                        let maybe_evicted = c_lock.insert(&run_id);
-                        if let Some(evicted_run_id) = maybe_evicted {
-                            self.request_eviction(
-                                &evicted_run_id,
-                                "Workflow cache full",
-                                EvictionReason::CacheFull,
-                            );
-                        }
-                    }
                 }
 
                 Ok((wft_info, activation))

--- a/sdk/src/interceptors.rs
+++ b/sdk/src/interceptors.rs
@@ -1,5 +1,6 @@
 //! User-definable interceptors are defined in this module
 
+use crate::Worker;
 use temporal_sdk_core_protos::coresdk::workflow_completion::WorkflowActivationCompletion;
 
 /// Implementors can intercept certain actions that happen within the Worker.
@@ -8,4 +9,7 @@ use temporal_sdk_core_protos::coresdk::workflow_completion::WorkflowActivationCo
 pub trait WorkerInterceptor {
     /// Called every time a workflow activation completes
     fn on_workflow_activation_completion(&self, completion: &WorkflowActivationCompletion);
+    /// Called after the worker has initiated shutdown and the workflow/activity polling loops
+    /// have exited, but just before waiting for the inner core worker shutdown
+    fn on_shutdown(&self, sdk_worker: &Worker);
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -206,7 +206,6 @@ impl Worker {
         let shutdown_token_c = shutdown_token.clone();
         let pollers = async move {
             let (common, wf_half, act_half) = self.split_apart();
-            // TODO: This channel can just be moved inside the activation handler?
             let (completions_tx, mut completions_rx) = unbounded_channel();
             let (wf_poll_res, act_poll_res) = tokio::join!(
                 // Workflow polling loop

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -374,6 +374,7 @@ impl WorkflowHalf {
                 }
             }
         }
+        info!("SDK cache size: {}", self.workflows.len());
         Ok(())
     }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -373,14 +373,13 @@ impl WorkflowHalf {
             if let Some(dat) = self.workflows.remove(&run_id) {
                 dat.shutdown.cancel();
                 // TODO: Probably need to not double-q here. Shouldn't blow up whole workflow
-                // handler b/c of a panic in one.
+                //  handler b/c of a panic in one.
                 let res = dat.join_handle.await??;
                 if !matches!(res, WfExitValue::Evicted) {
                     error!("Workflow was supposed to evict, but exited with non-evict status!");
                 }
             }
         }
-        info!("SDK cache size: {}", self.workflows.len());
         Ok(())
     }
 }

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -135,7 +135,10 @@ async fn workflow_lru_cache_evictions() {
             assert_eq!(sdk_worker.cached_workflows(), 1)
         }
     }
-    worker.run_until_done_intercepted(Some(CacheAsserter{})).await.unwrap();
+    worker
+        .run_until_done_intercepted(Some(CacheAsserter {}))
+        .await
+        .unwrap();
     // The wf must have started more than # workflows times, since all but one must experience
     // an eviction
     assert!(RUN_CT.load(Ordering::SeqCst) > n_workflows);

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -114,7 +114,7 @@ async fn activity_load() {
 async fn workflow_load() {
     const SIGNAME: &str = "signame";
     let wf_name = "workflow_load";
-    let mut starter = CoreWfStarter::new_tq_name("workflow_load_ew2B4apK");
+    let mut starter = CoreWfStarter::new("workflow_load");
     starter
         .max_wft(5)
         .max_cached_workflows(5)
@@ -126,7 +126,7 @@ async fn workflow_load() {
         let drained_fut = sigchan.forward(sink::drain());
 
         let real_stuff = async move {
-            for _ in 0..100 {
+            for _ in 0..20 {
                 ctx.activity(ActivityOptions {
                     activity_type: "echo_activity".to_string(),
                     start_to_close_timeout: Some(Duration::from_secs(5)),
@@ -148,17 +148,17 @@ async fn workflow_load() {
         "echo_activity",
         |echo_me: String| async move { Ok(echo_me) },
     );
-    // for i in 0..200 {
-    //     worker
-    //         .submit_wf(
-    //             format!("{}_{}", wf_name, i),
-    //             wf_name.to_owned(),
-    //             vec![],
-    //             WorkflowOptions::default(),
-    //         )
-    //         .await
-    //         .unwrap();
-    // }
+    for i in 0..200 {
+        worker
+            .submit_wf(
+                format!("{}_{}", wf_name, i),
+                wf_name.to_owned(),
+                vec![],
+                WorkflowOptions::default(),
+            )
+            .await
+            .unwrap();
+    }
 
     let client = starter.get_client().await;
     let sig_sender = async {

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -180,6 +180,5 @@ async fn workflow_load() {
 
     worker.incr_expected_run_count(200);
     let run_fut = worker.run_until_done();
-    let (r1, _) = tokio::join!(run_fut, sig_sender);
-    r1.unwrap();
+    tokio::select! {r1 = run_fut => {r1.unwrap()}, _ = sig_sender => {}};
 }

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -1,18 +1,18 @@
 use assert_matches::assert_matches;
-use futures::future::join_all;
+use futures::{future::join_all, sink, stream::FuturesUnordered, StreamExt};
 use std::time::{Duration, Instant};
-use temporal_client::WorkflowOptions;
+use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{ActivityOptions, WfContext};
 use temporal_sdk_core_protos::coresdk::{
     activity_result::ActivityExecutionResult, activity_task::activity_task as act_task,
-    workflow_commands::ActivityCancellationType, ActivityTaskCompletion,
+    workflow_commands::ActivityCancellationType, ActivityTaskCompletion, AsJsonPayloadExt,
 };
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
-const CONCURRENCY: usize = 1000;
-
 #[tokio::test]
 async fn activity_load() {
+    const CONCURRENCY: usize = 1000;
+
     let mut starter = CoreWfStarter::new("activity_load");
     starter
         .max_wft(CONCURRENCY)
@@ -108,4 +108,78 @@ async fn activity_load() {
         all_acts
     };
     dbg!(running.elapsed());
+}
+
+#[tokio::test]
+async fn workflow_load() {
+    const SIGNAME: &str = "signame";
+    let wf_name = "workflow_load";
+    let mut starter = CoreWfStarter::new_tq_name("workflow_load_ew2B4apK");
+    starter
+        .max_wft(5)
+        .max_cached_workflows(5)
+        .max_at_polls(10)
+        .max_at(100);
+    let mut worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
+        let sigchan = ctx.make_signal_channel(SIGNAME).map(Ok);
+        let drained_fut = sigchan.forward(sink::drain());
+
+        let real_stuff = async move {
+            for _ in 0..100 {
+                ctx.activity(ActivityOptions {
+                    activity_type: "echo_activity".to_string(),
+                    start_to_close_timeout: Some(Duration::from_secs(5)),
+                    input: "hi!".as_json_payload().expect("serializes fine"),
+                    ..Default::default()
+                })
+                .await;
+                ctx.timer(Duration::from_secs(1)).await;
+            }
+        };
+        tokio::select! {
+            _ = drained_fut => {}
+            _ = real_stuff => {}
+        }
+
+        Ok(().into())
+    });
+    worker.register_activity(
+        "echo_activity",
+        |echo_me: String| async move { Ok(echo_me) },
+    );
+    // for i in 0..200 {
+    //     worker
+    //         .submit_wf(
+    //             format!("{}_{}", wf_name, i),
+    //             wf_name.to_owned(),
+    //             vec![],
+    //             WorkflowOptions::default(),
+    //         )
+    //         .await
+    //         .unwrap();
+    // }
+
+    let client = starter.get_client().await;
+    let sig_sender = async {
+        for _ in 1..=90 {
+            let sends: FuturesUnordered<_> = (0..200)
+                .map(|i| {
+                    client.signal_workflow_execution(
+                        format!("{}_{}", wf_name, i),
+                        "".to_string(),
+                        SIGNAME.to_string(),
+                        None,
+                    )
+                })
+                .collect();
+            sends.map(|_| Ok(())).forward(sink::drain()).await.unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    };
+
+    worker.incr_expected_run_count(200);
+    let run_fut = worker.run_until_done();
+    let (r1, _) = tokio::join!(run_fut, sig_sender);
+    r1.unwrap();
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* If a new task would overflow the cache, buffer it an instead return an eviction from polling
* Do not allow configuring worker with more concurrent WFTs than the cache limit
* Also fix a bug where we could potentially fail to send a WFT complete to server if the run had a pending eviction

## Why?
If lang polls faster than it completes, it was possible for it to exceed the cache limit. See added unit test for an example.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/298
2. How was this tested:
Added unit test, new load tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
