### PR TITLE
Fix bug where partial-task queries could cause us to empty-reply to WFT

### DIFF
--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -1,4 +1,3 @@
-use crate::telemetry::test_telem_console;
 use crate::{
     test_help::{
         canned_histories, hist_to_poll_resp, mock_worker, MocksHolder, ResponseType, TEST_Q,
@@ -386,7 +385,6 @@ async fn legacy_query_after_complete(#[values(false, true)] full_history: bool) 
 
 #[tokio::test]
 async fn query_cache_miss_causes_page_fetch_dont_reply_wft_too_early() {
-    test_telem_console();
     let wfid = "fake_wf_id";
     let query_resp = "response";
     let t = canned_histories::single_timer("1");

--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -447,8 +447,6 @@ async fn query_cache_miss_causes_page_fetch_dont_reply_wft_too_early() {
     .await
     .unwrap();
 
-    warn!("Done first compl");
-
     let task = core.poll_workflow_activation().await.unwrap();
     assert_matches!(
         task.jobs.as_slice(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Queries arriving with a partial workflow task which also missed the cache would trigger a page fetch and then we would erroneously attach the query job to the activation right then. Instead, replay must complete as normal before we finish the query. Fix that.

## Why?
Bugs bad!

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
