### PR TITLE
Fix extra WFT permits being added in some situations

### DIFF
--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -436,6 +436,7 @@ impl Worker {
             Ok(())
         }
     }
+
     pub(crate) async fn next_workflow_activation(&self) -> Result<WorkflowActivation, PollWfError> {
         // The poll needs to be in a loop because we can't guarantee tail call optimization in Rust
         // (simply) and we really, really need that for long-poll retries.
@@ -664,9 +665,9 @@ impl Worker {
                 Some(a)
             }
             NewWfTaskOutcome::TaskBuffered => {
-                // If the task was buffered, it's not actually outstanding, so we can
-                // immediately return a permit.
-                self.return_workflow_task_permit();
+                // Though the task is not outstanding in the lang sense, it is outstanding from the
+                // server perspective. We used to return a permit here, but that doesn't actually
+                // make much sense.
                 None
             }
             NewWfTaskOutcome::Autocomplete | NewWfTaskOutcome::LocalActsOutstanding => {

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -96,7 +96,10 @@ impl WorkflowManager {
 
     /// Let this workflow know that something we've been waiting locally on has resolved, like a
     /// local activity or side effect
-    pub fn notify_of_local_result(&mut self, resolved: LocalResolution) -> Result<()> {
+    ///
+    /// Returns true if the resolution did anything. EX: If the activity is already canceled and
+    /// used the TryCancel or Abandon modes, the resolution is uninteresting.
+    pub fn notify_of_local_result(&mut self, resolved: LocalResolution) -> Result<bool> {
         self.machines.local_resolution(resolved)
     }
 
@@ -407,7 +410,7 @@ pub mod managed_wf {
             &mut self,
             seq_num: u32,
             result: ActivityExecutionResult,
-        ) -> Result<()> {
+        ) -> Result<bool> {
             self.mgr
                 .notify_of_local_result(LocalResolution::LocalActivity(LocalActivityResolution {
                     seq: seq_num,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* Fixed a few situations where extra permits could get added when they shouldn't have been.
* Further mitigate this by not ever going over permit cap
* Noticed and fixed a situation where local activities that were abandoned completing after cancel would enqueue a pending activation that did nothing.
* Also mitigate that by ignoring pending activations that do nothing.

## Why?
Bugfixing

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
