### PR TITLE
Fix queries containing *no* history not working

### DIFF
--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -627,7 +627,8 @@ impl WorkflowTaskManager {
         let poll_resp_is_incremental =
             poll_resp_is_incremental || poll_wf_resp.history.events.len() == 0;
 
-        let mut did_miss_cache = false;
+        let mut did_miss_cache = !poll_resp_is_incremental;
+
         let page_token = if !self.workflow_machines.exists(&run_id) && poll_resp_is_incremental {
             debug!(run_id=?run_id, "Workflow task has partial history, but workflow is not in \
                    cache. Will fetch history");

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -625,7 +625,7 @@ impl WorkflowTaskManager {
             .map(|ev| ev.event_id > 1)
             .unwrap_or_default();
         let poll_resp_is_incremental =
-            poll_resp_is_incremental || poll_wf_resp.history.events.len() == 0;
+            poll_resp_is_incremental || poll_wf_resp.history.events.is_empty();
 
         let mut did_miss_cache = !poll_resp_is_incremental;
 

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -624,6 +624,8 @@ impl WorkflowTaskManager {
             .get(0)
             .map(|ev| ev.event_id > 1)
             .unwrap_or_default();
+        let poll_resp_is_incremental =
+            poll_resp_is_incremental || poll_wf_resp.history.events.len() == 0;
 
         let mut did_miss_cache = false;
         let page_token = if !self.workflow_machines.exists(&run_id) && poll_resp_is_incremental {

--- a/sdk-core-protos/src/history_info.rs
+++ b/sdk-core-protos/src/history_info.rs
@@ -117,17 +117,13 @@ impl HistoryInfo {
     /// Remove events from the beginning of this history such that it looks like what would've been
     /// delivered on a sticky queue where the previously started task was the one before the last
     /// task in this history.
-    ///
-    /// This is not *fully* accurate in that it will include commands that were part of the last
-    /// WFT completion, which the server would typically not include, but it's good enough for
-    /// testing.
     pub fn make_incremental(&mut self) {
         let last_complete_ix = self
             .events
             .iter()
             .rposition(|he| he.event_type() == EventType::WorkflowTaskCompleted)
             .expect("Must be a WFT completed event in history");
-        self.events.drain(0..=last_complete_ix);
+        self.events.drain(0..last_complete_ix);
     }
 
     pub fn events(&self) -> &[HistoryEvent] {
@@ -223,7 +219,7 @@ mod tests {
     fn incremental_works() {
         let t = single_timer("timer1");
         let hi = t.get_one_wft(2).unwrap();
-        assert_eq!(hi.events().len(), 4);
-        assert_eq!(hi.events()[0].event_id, 5);
+        assert_eq!(hi.events().len(), 5);
+        assert_eq!(hi.events()[0].event_id, 4);
     }
 }


### PR DESCRIPTION
Super similar to the recent other fix, which failed to account for
the fact that queries might come in with *no* history if the server
still thinks we have the workflow in cache.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Super similar to the recent other fix, which failed to account for
the fact that queries might come in with *no* history if the server
still thinks we have the workflow in cache.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
