### PR TITLE
More cache and query fixes

### DIFF
--- a/core/src/core_tests/determinism.rs
+++ b/core/src/core_tests/determinism.rs
@@ -58,7 +58,7 @@ async fn test_panic_wf_task_rejected_properly() {
 #[case::with_cache(true)]
 #[case::without_cache(false)]
 #[tokio::test]
-async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] _use_cache: bool) {
+async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] use_cache: bool) {
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
     let t = canned_histories::single_timer_wf_completes("1");
@@ -75,7 +75,9 @@ async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] _use_cache
     mh.expect_fail_wft_matcher =
         Box::new(|_, cause, _| matches!(cause, WorkflowTaskFailedCause::NonDeterministicError));
     let mut worker = mock_sdk_cfg(mh, |cfg| {
-        cfg.max_cached_workflows = 2;
+        if use_cache {
+            cfg.max_cached_workflows = 2;
+        }
     });
 
     let started_count: &'static _ = Box::leak(Box::new(AtomicUsize::new(0)));

--- a/core/src/core_tests/determinism.rs
+++ b/core/src/core_tests/determinism.rs
@@ -27,7 +27,6 @@ pub async fn timer_wf_fails_once(ctx: WfContext) -> WorkflowResult<()> {
 /// failures) are turned into unspecified WFT failures.
 #[tokio::test]
 async fn test_panic_wf_task_rejected_properly() {
-    crate::telemetry::test_telem_console();
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
     let t = canned_histories::workflow_fails_with_failure_after_timer("1");
@@ -60,7 +59,6 @@ async fn test_panic_wf_task_rejected_properly() {
 #[case::without_cache(false)]
 #[tokio::test]
 async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] _use_cache: bool) {
-    crate::telemetry::test_telem_console();
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
     let t = canned_histories::single_timer_wf_completes("1");

--- a/core/src/core_tests/determinism.rs
+++ b/core/src/core_tests/determinism.rs
@@ -1,21 +1,15 @@
 use crate::{
     replay::DEFAULT_WORKFLOW_TYPE,
-    test_help::{
-        build_mock_pollers, canned_histories, mock_worker, MockPollCfg, ResponseType, TEST_Q,
-    },
+    test_help::{canned_histories, mock_sdk, mock_sdk_cfg, MockPollCfg, ResponseType},
     worker::client::mocks::mock_workflow_client,
 };
 use std::{
-    sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     time::Duration,
 };
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{WfContext, WorkflowResult};
 use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowTaskFailedCause;
-use temporal_sdk_core_test_utils::TestWorker;
 
 static DID_FAIL: AtomicBool = AtomicBool::new(false);
 pub async fn timer_wf_fails_once(ctx: WfContext) -> WorkflowResult<()> {
@@ -33,6 +27,7 @@ pub async fn timer_wf_fails_once(ctx: WfContext) -> WorkflowResult<()> {
 /// failures) are turned into unspecified WFT failures.
 #[tokio::test]
 async fn test_panic_wf_task_rejected_properly() {
+    crate::telemetry::test_telem_console();
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
     let t = canned_histories::workflow_fails_with_failure_after_timer("1");
@@ -43,9 +38,7 @@ async fn test_panic_wf_task_rejected_properly() {
     mh.num_expected_fails = Some(1);
     mh.expect_fail_wft_matcher =
         Box::new(|_, cause, _| matches!(cause, WorkflowTaskFailedCause::Unspecified));
-    let mock = build_mock_pollers(mh);
-    let core = mock_worker(mock);
-    let mut worker = TestWorker::new(Arc::new(core), TEST_Q.to_string());
+    let mut worker = mock_sdk(mh);
 
     worker.register_wf(wf_type.to_owned(), timer_wf_fails_once);
     worker
@@ -66,7 +59,8 @@ async fn test_panic_wf_task_rejected_properly() {
 #[case::with_cache(true)]
 #[case::without_cache(false)]
 #[tokio::test]
-async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] use_cache: bool) {
+async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] _use_cache: bool) {
+    crate::telemetry::test_telem_console();
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
     let t = canned_histories::single_timer_wf_completes("1");
@@ -82,14 +76,9 @@ async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] use_cache:
     mh.num_expected_fails = Some(1);
     mh.expect_fail_wft_matcher =
         Box::new(|_, cause, _| matches!(cause, WorkflowTaskFailedCause::NonDeterministicError));
-    let mut mock = build_mock_pollers(mh);
-    if use_cache {
-        mock.worker_cfg(|cfg| {
-            cfg.max_cached_workflows = 2;
-        });
-    }
-    let core = mock_worker(mock);
-    let mut worker = TestWorker::new(Arc::new(core), TEST_Q.to_string());
+    let mut worker = mock_sdk_cfg(mh, |cfg| {
+        cfg.max_cached_workflows = 2;
+    });
 
     let started_count: &'static _ = Box::leak(Box::new(AtomicUsize::new(0)));
     worker.register_wf(wf_type.to_owned(), move |ctx: WfContext| async move {

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -1,15 +1,12 @@
 use crate::{
     replay::{default_wes_attribs, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE},
-    test_help::{build_mock_pollers, mock_worker, MockPollCfg, ResponseType, TEST_Q},
+    test_help::{mock_sdk, mock_sdk_cfg, MockPollCfg, ResponseType},
     worker::client::mocks::mock_workflow_client,
 };
 use anyhow::anyhow;
 use futures::future::join_all;
 use std::{
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 use temporal_client::WorkflowOptions;
@@ -18,7 +15,6 @@ use temporal_sdk_core_protos::{
     coresdk::{common::RetryPolicy, AsJsonPayloadExt},
     temporal::api::{enums::v1::EventType, failure::v1::Failure},
 };
-use temporal_sdk_core_test_utils::TestWorker;
 use tokio::sync::Barrier;
 
 async fn echo(_ctx: ActContext, e: String) -> anyhow::Result<String> {
@@ -52,12 +48,11 @@ async fn local_act_two_wfts_before_marker(#[case] replay: bool, #[case] cached: 
         vec![1.into(), 2.into(), ResponseType::AllHistory]
     };
     let mh = MockPollCfg::from_resp_batches(wf_id, t, resps, mock);
-    let mut mock = build_mock_pollers(mh);
-    if cached {
-        mock.worker_cfg(|cfg| cfg.max_cached_workflows = 1);
-    }
-    let core = mock_worker(mock);
-    let mut worker = TestWorker::new(Arc::new(core), TEST_Q.to_string());
+    let mut worker = mock_sdk_cfg(mh, |cfg| {
+        if cached {
+            cfg.max_cached_workflows = 1;
+        }
+    });
 
     worker.register_wf(
         DEFAULT_WORKFLOW_TYPE.to_owned(),
@@ -119,9 +114,7 @@ async fn local_act_many_concurrent() {
     let wf_id = "fakeid";
     let mock = mock_workflow_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 3], mock);
-    let mock = build_mock_pollers(mh);
-    let core = mock_worker(mock);
-    let mut worker = TestWorker::new(Arc::new(core), TEST_Q.to_string());
+    let mut worker = mock_sdk(mh);
 
     worker.register_wf(DEFAULT_WORKFLOW_TYPE.to_owned(), local_act_fanout_wf);
     worker.register_activity(
@@ -170,10 +163,9 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
     // and might poll an extra time
     let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 2, 2, 2], mock);
     mh.enforce_correct_number_of_polls = false;
-    let mut mock = build_mock_pollers(mh);
-    mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
-    let core = Arc::new(mock_worker(mock));
-    let mut worker = TestWorker::new(core.clone(), TEST_Q.to_string());
+    let mut worker = mock_sdk_cfg(mh, |wc| wc.max_cached_workflows = 1);
+    let core = worker.orig_core_worker.clone();
+
     let shutdown_barr: &'static Barrier = Box::leak(Box::new(Barrier::new(2)));
 
     worker.register_wf(
@@ -229,9 +221,7 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
     let wf_id = "fakeid";
     let mock = mock_workflow_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [1], mock);
-    let mock = build_mock_pollers(mh);
-    let core = mock_worker(mock);
-    let mut worker = TestWorker::new(Arc::new(core), TEST_Q.to_string());
+    let mut worker = mock_sdk(mh);
 
     worker.register_wf(
         DEFAULT_WORKFLOW_TYPE.to_owned(),
@@ -312,10 +302,7 @@ async fn local_act_retry_long_backoff_uses_timer() {
         [1.into(), 2.into(), ResponseType::AllHistory],
         mock,
     );
-    let mut mock = build_mock_pollers(mh);
-    mock.worker_cfg(|w| w.max_cached_workflows = 1);
-    let core = mock_worker(mock);
-    let mut worker = TestWorker::new(Arc::new(core), TEST_Q.to_string());
+    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
 
     worker.register_wf(
         DEFAULT_WORKFLOW_TYPE.to_owned(),

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -271,7 +271,7 @@ pub(crate) fn test_telem_console() {
 pub(crate) fn test_telem_collector() {
     telemetry_init(&TelemetryOptions {
         otel_collector_url: Some("grpc://localhost:4317".parse().unwrap()),
-        tracing_filter: "temporal_sdk_core=DEBUG".to_string(),
+        tracing_filter: "temporal_sdk_core=DEBUG,temporal_sdk=DEBUG".to_string(),
         log_forwarding_level: LevelFilter::Off,
         prometheus_export_bind_address: None,
         totally_disable: false,

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -12,11 +12,11 @@ use bimap::BiMap;
 use futures::FutureExt;
 use mockall::TimesRange;
 use parking_lot::RwLock;
-use std::time::Duration;
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     ops::RangeFull,
     sync::Arc,
+    time::Duration,
 };
 use temporal_sdk_core_api::Worker as WorkerTrait;
 use temporal_sdk_core_protos::{

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -919,7 +919,6 @@ impl Worker {
                         Ok(())
                     }
                     tonic::Code::NotFound => {
-                        // TODO: Remove outstanding workflow task from workflow task manager
                         warn!(error = %err, run_id, "Task not found when completing");
                         should_evict = Some(EvictionReason::TaskNotFound);
                         Ok(())

--- a/core/src/workflow/machines/workflow_machines.rs
+++ b/core/src/workflow/machines/workflow_machines.rs
@@ -477,6 +477,10 @@ impl WorkflowMachines {
                     if let Some(st) = event.event_time {
                         let as_systime: SystemTime = st.try_into()?;
                         self.workflow_start_time = Some(as_systime);
+                        // Set the workflow time to be the event time of the first event, so that
+                        // if there is a query issued before first WFT started event, there is some
+                        // workflow time set.
+                        self.set_current_time(as_systime);
                     }
                     // Notify the lang sdk that it's time to kick off a workflow
                     self.drive_me.start(

--- a/core/src/workflow/workflow_tasks/mod.rs
+++ b/core/src/workflow/workflow_tasks/mod.rs
@@ -623,14 +623,11 @@ impl WorkflowTaskManager {
                     query_responses,
                 },
             };
-            if !self.pending_activations.has_pending(run_id)
-                && !server_cmds.replaying
-                && !is_query_playback
-                && !no_commands_and_evicting
-            {
-                Some(to_be_sent)
-            } else if has_query_responses {
-                // If there were query responses, we should send regardless of the other conditions.
+            let should_respond = !(self.pending_activations.has_pending(run_id)
+                || server_cmds.replaying
+                || is_query_playback
+                || no_commands_and_evicting);
+            if should_respond || has_query_responses {
                 Some(to_be_sent)
             } else {
                 None

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1"
 anyhow = "1.0"
 base64 = "0.13"
 crossbeam = "0.8"

--- a/sdk/src/interceptors.rs
+++ b/sdk/src/interceptors.rs
@@ -6,9 +6,11 @@ use temporal_sdk_core_protos::coresdk::workflow_completion::WorkflowActivationCo
 /// Implementors can intercept certain actions that happen within the Worker.
 ///
 /// Advanced usage only.
+#[async_trait::async_trait(?Send)]
 pub trait WorkerInterceptor {
-    /// Called every time a workflow activation completes
-    fn on_workflow_activation_completion(&self, completion: &WorkflowActivationCompletion);
+    /// Called every time a workflow activation completes (just before sending the completion to
+    /// core).
+    async fn on_workflow_activation_completion(&self, completion: &WorkflowActivationCompletion);
     /// Called after the worker has initiated shutdown and the workflow/activity polling loops
     /// have exited, but just before waiting for the inner core worker shutdown
     fn on_shutdown(&self, sdk_worker: &Worker);

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -52,9 +52,10 @@ use crate::{
     workflow_context::{ChildWfCommon, PendingChildWorkflow},
 };
 use anyhow::{anyhow, bail};
-use futures::{future::BoxFuture, FutureExt};
+use futures::{future::BoxFuture, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use once_cell::sync::OnceCell;
 use std::{
+    cell::RefCell,
     collections::HashMap,
     fmt::{Debug, Display, Formatter},
     future::Future,
@@ -85,11 +86,12 @@ use temporal_sdk_core_protos::{
 };
 use tokio::{
     sync::{
-        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        mpsc::{unbounded_channel, UnboundedSender},
         oneshot,
     },
     task::JoinError,
 };
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -123,15 +125,13 @@ struct CommonWorker {
 
 struct WorkflowHalf {
     /// Maps run id to cached workflow state
-    workflows: HashMap<String, WorkflowData>,
+    workflows: RefCell<HashMap<String, WorkflowData>>,
     /// Maps workflow type to the function for executing workflow runs with that ID
-    workflow_fns: HashMap<String, WorkflowFunction>,
+    workflow_fns: RefCell<HashMap<String, WorkflowFunction>>,
 }
 struct WorkflowData {
     /// Channel used to send the workflow activations
     activation_chan: UnboundedSender<WorkflowActivation>,
-    /// Join handle for the spawned workflow future
-    join_handle: BoxFuture<'static, Result<WorkflowResult<()>, JoinError>>,
     /// Token used to terminate workflow function
     shutdown: CancellationToken,
 }
@@ -184,6 +184,7 @@ impl Worker {
     ) {
         self.workflow_half
             .workflow_fns
+            .get_mut()
             .insert(workflow_type.into(), wf_function.into());
     }
 
@@ -206,29 +207,62 @@ impl Worker {
     /// or may return early with an error in the event of some unresolvable problem.
     pub async fn run(&mut self) -> Result<(), anyhow::Error> {
         let shutdown_token = CancellationToken::new();
-        // let workflow_activations
         let (common, wf_half, act_half) = self.split_apart();
-        let (completions_tx, mut completions_rx) = unbounded_channel();
+        let (wf_future_tx, wf_future_rx) = unbounded_channel();
+        let (completions_tx, completions_rx) = unbounded_channel();
+        // TODO: Turn into join handle joiner
+        // let wf_future_joiner = async {
+        //     UnboundedReceiverStream::new(wf_future_rx)
+        //         .map(Ok)
+        //         .try_for_each_concurrent(None, |act_fut| act_fut)
+        //         .await
+        // };
+        let wf_completion_processor = async {
+            let r = UnboundedReceiverStream::new(completions_rx)
+                .map(Ok)
+                .try_for_each_concurrent(None, |completion| async {
+                    if let Some(ref i) = common.worker_interceptor {
+                        i.on_workflow_activation_completion(&completion).await;
+                    }
+                    common.worker.complete_workflow_activation(completion).await
+                })
+                .map_err(Into::into)
+                .await;
+            info!("Done completion processor");
+            r
+        };
         tokio::try_join!(
             // Workflow polling loop
             async {
                 loop {
+                    info!("Pollin'");
                     let activation = match common.worker.poll_workflow_activation().await {
                         Err(PollWfError::ShutDown) => {
-                            break Result::<_, anyhow::Error>::Ok(());
+                            break;
                         }
                         o => o?,
                     };
-                    wf_half
-                        .workflow_activation_handler(
-                            common,
-                            &shutdown_token,
-                            &completions_tx,
-                            &mut completions_rx,
-                            activation,
-                        )
-                        .await?;
+                    if let Some(activation_fut) = wf_half.workflow_activation_handler(
+                        common,
+                        &shutdown_token,
+                        activation,
+                        &completions_tx,
+                    )? {
+                        if wf_future_tx.send(activation_fut).is_err() {
+                            panic!(
+                                "Receive half of completion processor channel cannot be dropped"
+                            );
+                        }
+                    }
                 }
+                info!("Left workflow polling loop");
+                // Tell still-alive workflows to evict themselves
+                shutdown_token.cancel();
+                // It's important to drop these so the future and completion processors will
+                // terminate.
+                drop(wf_future_tx);
+                drop(completions_tx);
+                Result::<_, anyhow::Error>::Ok(())
             },
             // Only poll on the activity queue if activity functions have been registered. This
             // makes tests which use mocks dramatically more manageable.
@@ -249,20 +283,22 @@ impl Worker {
                         }
                     }
                 };
+                info!("Left activity polling loop");
                 Result::<_, anyhow::Error>::Ok(())
-            }
+            },
+            // wf_future_joiner,
+            wf_completion_processor,
         )?;
 
         info!("Polling loops exited");
-        shutdown_token.cancel();
         if let Some(i) = self.common.worker_interceptor.as_ref() {
             i.on_shutdown(self);
         }
         self.common.worker.shutdown().await;
         // Clean up any still-extant workflows
-        for (_, wf_dat) in self.workflow_half.workflows.drain() {
-            wf_dat.join_handle.await??;
-        }
+        // for (_, wf_dat) in self.workflow_half.workflows.get_mut().drain() {
+        //     wf_dat.join_handle.await??;
+        // }
         Ok(())
     }
 
@@ -281,7 +317,7 @@ impl Worker {
     /// Returns number of currently cached workflows as understood by the SDK. Importantly, this
     /// is not the same as understood by core, though they *should* always be in sync.
     pub fn cached_workflows(&self) -> usize {
-        self.workflow_half.workflows.len()
+        self.workflow_half.workflows.borrow().len()
     }
 
     fn split_apart(&mut self) -> (&mut CommonWorker, &mut WorkflowHalf, &mut ActivityHalf) {
@@ -294,19 +330,21 @@ impl Worker {
 }
 
 impl WorkflowHalf {
-    async fn workflow_activation_handler(
-        &mut self,
+    fn workflow_activation_handler(
+        &self,
         common: &CommonWorker,
         shutdown_token: &CancellationToken,
-        completions_tx: &UnboundedSender<WorkflowActivationCompletion>,
-        completions_rx: &mut UnboundedReceiver<WorkflowActivationCompletion>,
         activation: WorkflowActivation,
-    ) -> Result<(), anyhow::Error> {
+        completions_tx: &UnboundedSender<WorkflowActivationCompletion>,
+    ) -> Result<Option<impl Future<Output = Result<WorkflowResult<()>, JoinError>>>, anyhow::Error>
+    {
+        let mut res = None;
         let shall_be_evicted = activation
             .jobs
             .iter()
             .any(|j| matches!(j.variant, Some(Variant::RemoveFromCache(_))));
         let run_id = activation.run_id.clone();
+
         // If the activation is to start a workflow, create a new workflow driver for it,
         // using the function associated with that workflow id
         if let Some(WorkflowActivationJob {
@@ -314,8 +352,8 @@ impl WorkflowHalf {
         }) = activation.jobs.get(0)
         {
             let workflow_type = &sw.workflow_type;
-            let wf_function = self
-                .workflow_fns
+            let wf_fns_borrow = self.workflow_fns.borrow();
+            let wf_function = wf_fns_borrow
                 .get(workflow_type)
                 .ok_or_else(|| anyhow!("Workflow type {workflow_type} not found"))?;
 
@@ -332,22 +370,24 @@ impl WorkflowHalf {
             let jh = tokio::spawn(async move {
                 tokio::select! {
                     r = wff => r,
+                    // TODO: This probably shouldn't abort early, as it could cause an in-progress
+                    //  complete to abort. Send synthetic remove activation
                     _ = task_shutdown.cancelled() => Ok(WfExitValue::Evicted)
                 }
             });
-            self.workflows.insert(
+            res = Some(jh);
+            self.workflows.borrow_mut().insert(
                 run_id.clone(),
                 WorkflowData {
                     activation_chan: activations,
                     shutdown,
-                    join_handle: jh.boxed(),
                 },
             );
         }
 
         // The activation is expected to apply to some workflow we know about. Use it to
         // unblock things and advance the workflow.
-        if let Some(dat) = self.workflows.get_mut(&run_id) {
+        if let Some(dat) = self.workflows.borrow_mut().get_mut(&run_id) {
             dat.activation_chan
                 .send(activation)
                 .expect("Workflow should exist if we're sending it an activation");
@@ -355,28 +395,7 @@ impl WorkflowHalf {
             bail!("Got activation for unknown workflow");
         };
 
-        let completion = completions_rx.recv().await.expect("No workflows left?");
-        if let Some(ref i) = common.worker_interceptor {
-            i.on_workflow_activation_completion(&completion).await;
-        }
-        common
-            .worker
-            .complete_workflow_activation(completion)
-            .await?;
-
-        // Join the workflow handle if it was to be evicted
-        if shall_be_evicted {
-            if let Some(dat) = self.workflows.remove(&run_id) {
-                dat.shutdown.cancel();
-                // TODO: Probably need to not double-q here. Shouldn't blow up whole workflow
-                //  handler b/c of a panic in one.
-                let res = dat.join_handle.await??;
-                if !matches!(res, WfExitValue::Evicted) {
-                    error!("Workflow was supposed to evict, but exited with non-evict status!");
-                }
-            }
-        }
-        Ok(())
+        Ok(res)
     }
 }
 

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -478,6 +478,7 @@ impl Future for WorkflowFuture {
             self.send_completion(run_id, activation_cmds);
 
             if die_of_eviction_when_done {
+                warn!("WF Future dying of eviction");
                 return Ok(WfExitValue::Evicted).into();
             }
 

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -478,7 +478,6 @@ impl Future for WorkflowFuture {
             self.send_completion(run_id, activation_cmds);
 
             if die_of_eviction_when_done {
-                warn!("WF Future dying of eviction");
                 return Ok(WfExitValue::Evicted).into();
             }
 

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -574,7 +574,7 @@ async fn slow_completes_with_small_cache() {
     impl WorkerInterceptor for SlowCompleter {
         async fn on_workflow_activation_completion(&self, _: &WorkflowActivationCompletion) {
             // They don't need to be much slower
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
         fn on_shutdown(&self, _: &temporal_sdk::Worker) {}
     }

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -28,14 +28,13 @@ use temporal_sdk::{
     interceptors::WorkerInterceptor, ActContext, ActivityOptions, WfContext, WorkflowResult,
 };
 use temporal_sdk_core_api::{errors::PollWfError, Worker};
-use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::ActivityExecutionResult,
         workflow_activation::{workflow_activation_job, WorkflowActivation, WorkflowActivationJob},
         workflow_commands::{ActivityCancellationType, FailWorkflowExecution, StartTimer},
         workflow_completion::WorkflowActivationCompletion,
-        ActivityTaskCompletion, IntoCompletion,
+        ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
     },
     temporal::api::failure::v1::Failure,
 };

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -24,8 +24,11 @@ use std::{
     time::Duration,
 };
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
-use temporal_sdk::{interceptors::WorkerInterceptor, WfContext, WorkflowResult};
+use temporal_sdk::{
+    interceptors::WorkerInterceptor, ActContext, ActivityOptions, WfContext, WorkflowResult,
+};
 use temporal_sdk_core_api::{errors::PollWfError, Worker};
+use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::ActivityExecutionResult,
@@ -129,8 +132,9 @@ async fn workflow_lru_cache_evictions() {
             .unwrap();
     }
     struct CacheAsserter {}
+    #[async_trait::async_trait(?Send)]
     impl WorkerInterceptor for CacheAsserter {
-        fn on_workflow_activation_completion(&self, _: &WorkflowActivationCompletion) {}
+        async fn on_workflow_activation_completion(&self, _: &WorkflowActivationCompletion) {}
         fn on_shutdown(&self, sdk_worker: &temporal_sdk::Worker) {
             assert_eq!(sdk_worker.cached_workflows(), 1)
         }
@@ -524,4 +528,58 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     // Do it all over again, without timing out this time
     let wf_task = poll_sched_act_poll().await;
     core.complete_execution(&wf_task.run_id).await;
+}
+
+/// We had a bug related to polling being faster than completion causing issues with cache
+/// overflow. This test intentionally makes completes slower than polls to evaluate that.
+///
+/// It's expected that this test may generate some task timeouts.
+#[tokio::test]
+async fn slow_completes_with_small_cache() {
+    let wf_name = "slow_completes_with_small_cache";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.max_wft(5).max_cached_workflows(5);
+    let mut worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
+        for _ in 0..3 {
+            ctx.activity(ActivityOptions {
+                activity_type: "echo_activity".to_string(),
+                start_to_close_timeout: Some(Duration::from_secs(5)),
+                input: "hi!".as_json_payload().expect("serializes fine"),
+                ..Default::default()
+            })
+            .await;
+            ctx.timer(Duration::from_secs(1)).await;
+        }
+        Ok(().into())
+    });
+    worker.register_activity(
+        "echo_activity",
+        |_ctx: ActContext, echo_me: String| async move { Ok(echo_me) },
+    );
+    for i in 0..20 {
+        worker
+            .submit_wf(
+                format!("{}_{}", wf_name, i),
+                wf_name.to_owned(),
+                vec![],
+                WorkflowOptions::default(),
+            )
+            .await
+            .unwrap();
+    }
+
+    struct SlowCompleter {}
+    #[async_trait::async_trait(?Send)]
+    impl WorkerInterceptor for SlowCompleter {
+        async fn on_workflow_activation_completion(&self, _: &WorkflowActivationCompletion) {
+            // They don't need to be much slower
+            // tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+        fn on_shutdown(&self, _: &temporal_sdk::Worker) {}
+    }
+    worker
+        .run_until_done_intercepted(Some(SlowCompleter {}))
+        .await
+        .unwrap();
 }

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -280,8 +280,9 @@ async fn cancel_immediate(#[case] cancel_type: ActivityCancellationType) {
 struct LACancellerInterceptor {
     token: CancellationToken,
 }
+#[async_trait::async_trait(?Send)]
 impl WorkerInterceptor for LACancellerInterceptor {
-    fn on_workflow_activation_completion(&self, _: &WorkflowActivationCompletion) {}
+    async fn on_workflow_activation_completion(&self, _: &WorkflowActivationCompletion) {}
     fn on_shutdown(&self, _: &temporal_sdk::Worker) {
         self.token.cancel()
     }


### PR DESCRIPTION
This needs a follow up PR to fix a problem that doesn't impact correctness, but could cause bad slowdowns:

Right now we'll evict potentially in the middle of replay. In some cases, that will also cause us to drop the workflow task on the floor, timing it out. This can be fixed by never issuing an eviction until replay is complete and WFT is responded to, but that will require a lot of changes to test code which assumes this all over the place.

## What was changed
* Fixed bug with local activity shutdown
* Fixed another possible empty-commands response while querying if there is also outstanding eviction
* Fixed problem where workflow time is unset if queried before first WFT is started
* Refactored Rust SDK to poll independently of completions

## Why?
* Bugfixing

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
New and existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
