### PR TITLE
Stop evict issue during replay & use `return_new_workflow_task` by default

### DIFF
--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -555,9 +555,9 @@ impl Worker {
         reason: EvictionReason,
     ) -> bool {
         match self.wft_manager.request_eviction(run_id, message, reason) {
-            EvictionRequestResult::EvictionIssued(_) => true,
+            EvictionRequestResult::EvictionRequested(_) => true,
             EvictionRequestResult::NotFound => false,
-            EvictionRequestResult::EvictionAlreadyOutstanding(_) => false,
+            EvictionRequestResult::EvictionAlreadyRequested(_) => false,
         }
     }
 
@@ -785,7 +785,7 @@ impl Worker {
                     commands,
                     query_responses,
                     sticky_attributes: None,
-                    return_new_workflow_task: force_new_wft,
+                    return_new_workflow_task: true,
                     force_create_new_workflow_task: force_new_wft,
                 };
                 let sticky_attrs = self.get_sticky_attrs();

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -162,7 +162,7 @@ async fn workflow_load() {
 
     let client = starter.get_client().await;
     let sig_sender = async {
-        for _ in 1..=90 {
+        loop {
             let sends: FuturesUnordered<_> = (0..200)
                 .map(|i| {
                     client.signal_workflow_execution(
@@ -174,11 +174,10 @@ async fn workflow_load() {
                 })
                 .collect();
             sends.map(|_| Ok(())).forward(sink::drain()).await.unwrap();
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(2)).await;
         }
     };
 
-    worker.incr_expected_run_count(200);
     let run_fut = worker.run_until_done();
     tokio::select! {r1 = run_fut => {r1.unwrap()}, _ = sig_sender => {}};
 }


### PR DESCRIPTION
…fault

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* Do not issue evictions in the middle of replay. This really only serves to cause thrashing if a worker is getting overloaded.
* Use `return_new_workflow_task` when completing tasks by default. Noticeable performance improvement under high load.

## Why?
Better behavior for high-load workers

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
