### PR TITLE
Support modifying Client headers

### DIFF
--- a/bridge-ffi/Cargo.toml
+++ b/bridge-ffi/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["staticlib"]
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
+parking_lot = "0.12"
 prost = "0.9"
 temporal-sdk-core = { version = "0.1", path = "../core" }
 temporal-sdk-core-api = { version = "0.1", path = "../core-api" }

--- a/bridge-ffi/Cargo.toml
+++ b/bridge-ffi/Cargo.toml
@@ -14,7 +14,6 @@ crate-type = ["staticlib"]
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
-parking_lot = "0.12"
 prost = "0.9"
 temporal-sdk-core = { version = "0.1", path = "../core" }
 temporal-sdk-core-api = { version = "0.1", path = "../core-api" }

--- a/bridge-ffi/src/lib.rs
+++ b/bridge-ffi/src/lib.rs
@@ -397,7 +397,7 @@ pub extern "C" fn tmprl_client_init(
 
     let user_data = UserDataHandle(user_data);
     runtime.tokio_runtime.spawn(async move {
-        match req.connect(namespace, None).await {
+        match req.connect(namespace, None, None).await {
             Ok(client) => unsafe {
                 callback(
                     user_data.into(),

--- a/bridge-ffi/src/wrappers.rs
+++ b/bridge-ffi/src/wrappers.rs
@@ -1,6 +1,5 @@
 use log::LevelFilter;
-use parking_lot::Mutex;
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{net::SocketAddr, str::FromStr};
 use temporal_sdk_core::{TelemetryOptionsBuilder, Url};
 use temporal_sdk_core_protos::coresdk::bridge;
 
@@ -74,8 +73,8 @@ impl TryFrom<ClientOptions> for temporal_sdk_core::ClientOptions {
         if !req.client_version.is_empty() {
             client_opts.client_version(req.client_version);
         }
-        if !req.headers.is_empty() {
-            client_opts.headers(Arc::new(Mutex::new(req.headers)));
+        if !req.static_headers.is_empty() {
+            client_opts.static_headers(req.static_headers);
         }
         if !req.identity.is_empty() {
             client_opts.identity(req.identity);

--- a/bridge-ffi/src/wrappers.rs
+++ b/bridge-ffi/src/wrappers.rs
@@ -73,9 +73,6 @@ impl TryFrom<ClientOptions> for temporal_sdk_core::ClientOptions {
         if !req.client_version.is_empty() {
             client_opts.client_version(req.client_version);
         }
-        if !req.static_headers.is_empty() {
-            client_opts.static_headers(req.static_headers);
-        }
         if !req.identity.is_empty() {
             client_opts.identity(req.identity);
         }

--- a/bridge-ffi/src/wrappers.rs
+++ b/bridge-ffi/src/wrappers.rs
@@ -1,5 +1,6 @@
 use log::LevelFilter;
-use std::{net::SocketAddr, str::FromStr};
+use parking_lot::Mutex;
+use std::{net::SocketAddr, str::FromStr, sync::Arc};
 use temporal_sdk_core::{TelemetryOptionsBuilder, Url};
 use temporal_sdk_core_protos::coresdk::bridge;
 
@@ -73,8 +74,8 @@ impl TryFrom<ClientOptions> for temporal_sdk_core::ClientOptions {
         if !req.client_version.is_empty() {
             client_opts.client_version(req.client_version);
         }
-        if !req.static_headers.is_empty() {
-            client_opts.static_headers(req.static_headers);
+        if !req.headers.is_empty() {
+            client_opts.headers(Arc::new(Mutex::new(req.headers)));
         }
         if !req.identity.is_empty() {
             client_opts.identity(req.identity);

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3"
 futures-retry = "0.6.0"
 http = "0.2"
 opentelemetry = { version = "0.17", features = ["metrics"] }
+parking_lot = "0.12"
 prost-types = "0.9"
 thiserror = "1.0"
 tokio = "1.1"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -31,7 +31,7 @@ use std::{
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
     str::FromStr,
-    sync::{Arc},
+    sync::Arc,
     time::{Duration, Instant},
 };
 use temporal_sdk_core_protos::{
@@ -299,9 +299,12 @@ impl ClientOptions {
         &self,
         namespace: impl Into<String>,
         metrics_meter: Option<&Meter>,
-        headers: Option<Arc<Mutex<HashMap<String, String>>>>
+        headers: Option<Arc<Mutex<HashMap<String, String>>>>,
     ) -> Result<RetryClient<Client>, ClientInitError> {
-        let client = self.connect_no_namespace(metrics_meter, headers).await?.into_inner();
+        let client = self
+            .connect_no_namespace(metrics_meter, headers)
+            .await?
+            .into_inner();
         let client = Client::new(client, namespace.into());
         let retry_client = RetryClient::new(client, self.retry_config.clone());
         Ok(retry_client)
@@ -314,7 +317,7 @@ impl ClientOptions {
     pub async fn connect_no_namespace(
         &self,
         metrics_meter: Option<&Meter>,
-        headers: Option<Arc<Mutex<HashMap<String, String>>>>
+        headers: Option<Arc<Mutex<HashMap<String, String>>>>,
     ) -> Result<RetryClient<ConfiguredClient<WorkflowServiceClientWithMetrics>>, ClientInitError>
     {
         let channel = Channel::from_shared(self.target_url.to_string())?;
@@ -327,7 +330,10 @@ impl ClientOptions {
             })
             .service(channel);
         let headers = headers.unwrap_or_default();
-        let interceptor = ServiceCallInterceptor { opts: self.clone(), headers: headers.clone() };
+        let interceptor = ServiceCallInterceptor {
+            opts: self.clone(),
+            headers: headers.clone(),
+        };
 
         let mut client = ConfiguredClient {
             headers,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -81,7 +81,7 @@ pub struct ClientOptions {
     /// in all RPC calls. The server decides if the client is supported based on this.
     pub client_version: String,
 
-    /// TODO: Other non-required headers which should be attached to every request
+    /// Other non-required static headers which should be attached to every request
     #[builder(default)]
     pub static_headers: HashMap<String, String>,
 
@@ -259,6 +259,8 @@ pub struct ConfiguredClient<C> {
 }
 
 impl<C> ConfiguredClient<C> {
+    /// Set dynamic HTTP request headers.
+    /// Any values set here will override `static_headers` defined in [ClientOptions].
     pub fn set_dynamic_headers(&self, headers: HashMap<String, String>) {
         let mut guard = self.dynamic_headers.lock();
         *guard = headers;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -259,8 +259,7 @@ pub struct ConfiguredClient<C> {
 }
 
 impl<C> ConfiguredClient<C> {
-    /// Set dynamic HTTP request headers.
-    /// Any values set here will override `static_headers` defined in [ClientOptions].
+    /// Set dynamic HTTP request headers overwriting previous headers
     pub fn set_dynamic_headers(&self, headers: HashMap<String, String>) {
         let mut guard = self.dynamic_headers.lock();
         *guard = headers;

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -558,7 +558,7 @@ mod tests {
     #[allow(dead_code)]
     async fn raw_client_retry_compiles() {
         let opts = ClientOptionsBuilder::default().build().unwrap();
-        let raw_client = opts.connect_no_namespace(None).await.unwrap();
+        let raw_client = opts.connect_no_namespace(None, None).await.unwrap();
         let mut retry_client = RetryClient::new(raw_client, opts.retry_config);
 
         let the_request = ListNamespacesRequest::default();

--- a/protos/local/temporal/sdk/core/bridge/bridge.proto
+++ b/protos/local/temporal/sdk/core/bridge/bridge.proto
@@ -32,7 +32,6 @@ message CreateClientRequest {
   string namespace = 2;
   string client_name = 3;
   string client_version = 4;
-  map<string, string> static_headers = 5;
   string identity = 6;
   string worker_binary_id = 7;
   TlsConfig tls_config = 8;

--- a/protos/local/temporal/sdk/core/bridge/bridge.proto
+++ b/protos/local/temporal/sdk/core/bridge/bridge.proto
@@ -32,7 +32,7 @@ message CreateClientRequest {
   string namespace = 2;
   string client_name = 3;
   string client_version = 4;
-  map<string, string> headers = 5;
+  map<string, string> static_headers = 5;
   string identity = 6;
   string worker_binary_id = 7;
   TlsConfig tls_config = 8;

--- a/protos/local/temporal/sdk/core/bridge/bridge.proto
+++ b/protos/local/temporal/sdk/core/bridge/bridge.proto
@@ -32,7 +32,7 @@ message CreateClientRequest {
   string namespace = 2;
   string client_name = 3;
   string client_version = 4;
-  map<string, string> static_headers = 5;
+  map<string, string> headers = 5;
   string identity = 6;
   string worker_binary_id = 7;
   TlsConfig tls_config = 8;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -16,7 +16,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let server_options = sdk_client_options(Url::from_str("http://localhost:7233")?).build()?;
-//!     let client = server_options.connect("my_namespace", None).await?;
+//!     let client = server_options.connect("my_namespace", None, None).await?;
 //!     let worker_config = WorkerConfigBuilder::default().build()?;
 //!     let core_worker = init_worker(worker_config, client);
 //!

--- a/test-utils/src/histfetch.rs
+++ b/test-utils/src/histfetch.rs
@@ -11,7 +11,7 @@ use temporal_sdk_core_test_utils::get_integ_server_options;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let gw_opts = get_integ_server_options();
-    let client = gw_opts.connect("default", None).await?;
+    let client = gw_opts.connect("default", None, None).await?;
     let wf_id = std::env::args()
         .nth(1)
         .expect("must provide workflow id as only argument");

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -240,7 +240,7 @@ impl CoreWfStarter {
                 telemetry_init(&self.telemetry_options).expect("Telemetry inits cleanly");
                 let client = Arc::new(
                     get_integ_server_options()
-                        .connect(self.worker_config.namespace.clone(), None)
+                        .connect(self.worker_config.namespace.clone(), None, None)
                         .await
                         .expect("Must connect"),
                 );

--- a/tests/integ_tests/client_tests.rs
+++ b/tests/integ_tests/client_tests.rs
@@ -17,7 +17,7 @@ async fn can_use_retry_client() {
 #[tokio::test]
 async fn can_use_retry_raw_client() {
     let opts = get_integ_server_options();
-    let raw_client = opts.connect_no_namespace(None).await.unwrap();
+    let raw_client = opts.connect_no_namespace(None, None).await.unwrap();
     let mut retry_client = RetryClient::new(raw_client, opts.retry_config);
     retry_client
         .describe_namespace(DescribeNamespaceRequest {
@@ -31,6 +31,6 @@ async fn can_use_retry_raw_client() {
 #[tokio::test]
 async fn calls_get_system_info() {
     let opts = get_integ_server_options();
-    let raw_client = opts.connect_no_namespace(None).await.unwrap();
+    let raw_client = opts.connect_no_namespace(None, None).await.unwrap();
     assert!(raw_client.get_client().capabilities().is_some());
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -84,7 +84,8 @@ mod integ_tests {
             })
             .build()
             .unwrap();
-        let con = sgo.connect(NAMESPACE.to_string(), None, None)
+        let con = sgo
+            .connect(NAMESPACE.to_string(), None, None)
             .await
             .unwrap();
         con.list_namespaces().await.unwrap();

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -84,7 +84,9 @@ mod integ_tests {
             })
             .build()
             .unwrap();
-        let con = sgo.connect(NAMESPACE.to_string(), None, None).await.unwrap();
+        let con = sgo.connect(NAMESPACE.to_string(), None, None)
+            .await
+            .unwrap();
         con.list_namespaces().await.unwrap();
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -28,7 +28,7 @@ mod integ_tests {
         let opts = get_integ_server_options();
         let telem_d = telemetry_init(&get_integ_telem_options()).unwrap();
         let mut retrying_client = opts
-            .connect_no_namespace(telem_d.get_metric_meter())
+            .connect_no_namespace(telem_d.get_metric_meter(), None)
             .await
             .unwrap();
 
@@ -84,7 +84,7 @@ mod integ_tests {
             })
             .build()
             .unwrap();
-        let con = sgo.connect(NAMESPACE.to_string(), None).await.unwrap();
+        let con = sgo.connect(NAMESPACE.to_string(), None, None).await.unwrap();
         con.list_namespaces().await.unwrap();
     }
 }


### PR DESCRIPTION
Does not address need to set per-call headers, make the Client headers mutable so they can be updated from Lang
Related: #303 