### PR TITLE
Removed typo in workflow state machines.

### DIFF
--- a/core/src/workflow/machines/workflow_machines.rs
+++ b/core/src/workflow/machines/workflow_machines.rs
@@ -525,7 +525,7 @@ impl WorkflowMachines {
             }
             _ => {
                 return Err(WFMachinesError::Fatal(format!(
-                    "The event is non a non-stateful event, but we tried to handle it as one: {}",
+                    "The event is not a non-stateful event, but we tried to handle it as one: {}",
                     event
                 )));
             }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
When terminating a workflow, the error message read "The event is non a non-stateful event, but we tried to handle it as one.". Should be "The event is not a non-stateful event, but we tried to handle it as one"

## Why?
<!-- Tell your future self why have you made these changes -->
For verbosity.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
No.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
