### PR TITLE
Fix legacy queries not being failed properly if error during replay

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -159,7 +159,7 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
 
     let wf_id = "fakeid";
     let mock = mock_workflow_client();
-    let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 2], mock);
+    let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 2, 2], mock);
     mh.enforce_correct_number_of_polls = false;
     let mut worker = mock_sdk_cfg(mh, |wc| wc.max_cached_workflows = 1);
     let core = worker.core_worker.clone();

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -622,6 +622,18 @@ impl ManagedRunHandle {
             || act_work
             || evict_work
     }
+
+    /// Returns true if the handle is currently processing a WFT which contains a legacy query.
+    fn pending_work_is_legacy_query(&self) -> bool {
+        // Either we know because there is a pending legacy query, or it's already been drained and
+        // sent as an activation.
+        matches!(self.activation, Some(OutstandingActivation::LegacyQuery))
+            || self
+                .wft
+                .as_ref()
+                .map(|t| t.has_pending_legacy_query())
+                .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, derive_more::Display)]
@@ -653,6 +665,14 @@ pub(crate) struct OutstandingTask {
     /// The WFT permit owned by this task, ensures we don't exceed max concurrent WFT, and makes
     /// sure the permit is automatically freed when we delete the task.
     pub _permit: OwnedMeteredSemPermit,
+}
+
+impl OutstandingTask {
+    pub fn has_pending_legacy_query(&self) -> bool {
+        self.pending_queries
+            .iter()
+            .any(|q| q.query_id == LEGACY_QUERY_ID)
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -61,6 +61,7 @@ pub fn init_core_replay_preloaded(
     test_name: &str,
     history: &History,
 ) -> (Arc<dyn CoreWorker>, String) {
+    telemetry_init(&get_integ_telem_options()).expect("Telemetry inits cleanly");
     let worker_cfg = WorkerConfigBuilder::default()
         .namespace(NAMESPACE)
         .task_queue(test_name)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
If something went wrong during the processing of a legacy query WFT before core sent the activation to process the query to lang, we would try to respond to the WFT and fail it, rather than responding on the special legacy query API. This fixes that.

## Why?
Wouldn't properly fail queries when, for example, they triggered a nondeterministic path during replay.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added new test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
