### PR TITLE
Add `temporal_` metric prefix, fix LA slot metric

### DIFF
--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -347,7 +347,7 @@ impl AggregatorSelector for SDKAggSelector {
             let dname = descriptor
                 .name()
                 .strip_prefix(metric_prefix())
-                .unwrap_or(descriptor.name());
+                .unwrap_or_else(|| descriptor.name());
             // Some recorders are just gauges
             match dname {
                 STICKY_CACHE_SIZE_NAME | NUM_POLLERS_NAME | TASK_SLOTS_AVAILABLE_NAME => {

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -1,4 +1,5 @@
 use super::TELEM_SERVICE_NAME;
+use crate::telemetry::GLOBAL_TELEM_DAT;
 use opentelemetry::{
     global,
     metrics::{Counter, Descriptor, InstrumentKind, Meter, ValueRecorder},
@@ -16,9 +17,6 @@ use std::{borrow::Cow, sync::Arc, time::Duration};
 /// appropriate k/vs have already been set.
 #[derive(Default, Clone, Debug)]
 pub(crate) struct MetricsContext {
-    // TODO: Ideally this would hold bound metrics, but using them is basically impossible because
-    //   of lifetime issues: https://github.com/open-telemetry/opentelemetry-rust/issues/629
-    //   Use once fixed.
     kvs: Arc<Vec<KeyValue>>,
 }
 
@@ -159,6 +157,18 @@ lazy_static::lazy_static! {
         global::meter(TELEM_SERVICE_NAME)
     };
 }
+fn metric_prefix() -> &'static str {
+    GLOBAL_TELEM_DAT
+        .get()
+        .map(|gtd| {
+            if gtd.no_temporal_prefix_for_metrics {
+                ""
+            } else {
+                "temporal_"
+            }
+        })
+        .unwrap_or("")
+}
 
 /// Define a temporal metric. All metrics are kept private to this file, and should be accessed
 /// through functions on the [MetricsContext]
@@ -166,14 +176,14 @@ macro_rules! tm {
     (ctr, $ident:ident, $name:expr) => {
         lazy_static::lazy_static! {
             static ref $ident: Counter<u64> = {
-                METRIC_METER.u64_counter($name).init()
+                METRIC_METER.u64_counter(metric_prefix().to_string() + $name).init()
             };
         }
     };
     (vr_u64, $ident:ident, $name:expr) => {
         lazy_static::lazy_static! {
             static ref $ident: ValueRecorder<u64> = {
-                METRIC_METER.u64_value_recorder($name).init()
+                METRIC_METER.u64_value_recorder(metric_prefix().to_string() + $name).init()
             };
         }
     };
@@ -334,8 +344,12 @@ impl AggregatorSelector for SDKAggSelector {
         }
 
         if *descriptor.instrument_kind() == InstrumentKind::ValueRecorder {
+            let dname = descriptor
+                .name()
+                .strip_prefix(metric_prefix())
+                .unwrap_or(descriptor.name());
             // Some recorders are just gauges
-            match descriptor.name() {
+            match dname {
                 STICKY_CACHE_SIZE_NAME | NUM_POLLERS_NAME | TASK_SLOTS_AVAILABLE_NAME => {
                     return Some(Arc::new(last_value()))
                 }
@@ -343,7 +357,7 @@ impl AggregatorSelector for SDKAggSelector {
             }
 
             // Other recorders will select their appropriate buckets
-            let buckets = match descriptor.name() {
+            let buckets = match dname {
                 WF_E2E_LATENCY_NAME => WF_LATENCY_MS_BUCKETS,
                 WF_TASK_EXECUTION_LATENCY_NAME | WF_TASK_REPLAY_LATENCY_NAME => WF_TASK_MS_BUCKETS,
                 WF_TASK_SCHED_TO_START_LATENCY_NAME | ACT_SCHED_TO_START_LATENCY_NAME => {

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -188,8 +188,10 @@ pub fn telemetry_init(opts: &TelemetryOptions) -> Result<&'static GlobalTelemDat
                 .worker_threads(2)
                 .enable_all()
                 .build()?;
-            let mut globaldat = GlobalTelemDat::default();
-            globaldat.no_temporal_prefix_for_metrics = opts.no_temporal_prefix_for_metrics;
+            let mut globaldat = GlobalTelemDat {
+                no_temporal_prefix_for_metrics: opts.no_temporal_prefix_for_metrics,
+                ..Default::default()
+            };
 
             if let Some(ref logger) = opts.logging {
                 match logger {

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -18,9 +18,12 @@ use opentelemetry::{
 };
 use opentelemetry_otlp::WithExportConfig;
 use parking_lot::{const_mutex, Mutex};
-use std::collections::HashMap;
-use std::convert::TryInto;
-use std::{collections::VecDeque, net::SocketAddr, time::Duration};
+use std::{
+    collections::{HashMap, VecDeque},
+    convert::TryInto,
+    net::SocketAddr,
+    time::Duration,
+};
 use temporal_sdk_core_api::CoreTelemetry;
 use tonic::metadata::MetadataMap;
 use tracing_subscriber::{filter::ParseError, layer::SubscriberExt, EnvFilter};
@@ -93,6 +96,11 @@ pub struct TelemetryOptions {
     /// Optional metrics exporter - set as None to disable.
     #[builder(setter(into, strip_option), default)]
     pub metrics: Option<MetricsExporter>,
+
+    /// If set true, do not prefix metrics with `temporal_`. Will be removed eventually as
+    /// the prefix is consistent with other SDKs.
+    #[builder(default)]
+    pub no_temporal_prefix_for_metrics: bool,
 }
 
 impl TelemetryOptions {
@@ -119,6 +127,7 @@ pub struct GlobalTelemDat {
     core_export_logger: Option<CoreExportLogger>,
     runtime: Option<tokio::runtime::Runtime>,
     prom_srv: Option<PromServer>,
+    no_temporal_prefix_for_metrics: bool,
 }
 
 impl GlobalTelemDat {
@@ -180,6 +189,7 @@ pub fn telemetry_init(opts: &TelemetryOptions) -> Result<&'static GlobalTelemDat
                 .enable_all()
                 .build()?;
             let mut globaldat = GlobalTelemDat::default();
+            globaldat.no_temporal_prefix_for_metrics = opts.no_temporal_prefix_for_metrics;
 
             if let Some(ref logger) = opts.logging {
                 match logger {
@@ -318,6 +328,7 @@ pub(crate) fn test_telem_console() {
         logging: Some(Logger::Console),
         tracing: None,
         metrics: None,
+        no_temporal_prefix_for_metrics: false,
     })
     .unwrap();
 }
@@ -333,6 +344,7 @@ pub(crate) fn test_telem_collector() {
             headers: Default::default(),
         })),
         metrics: None,
+        no_temporal_prefix_for_metrics: false,
     })
     .unwrap();
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -450,10 +450,12 @@ pub fn get_integ_telem_options() -> TelemetryOptions {
         .ok()
         .map(|x| x.parse::<Url>().unwrap())
     {
-        ob.tracing(TraceExporter::Otel(OtelCollectorOptions {
+        let opts = OtelCollectorOptions {
             url,
             headers: Default::default(),
-        }));
+        };
+        ob.tracing(TraceExporter::Otel(opts.clone()));
+        ob.metrics(MetricsExporter::Otel(opts));
     }
     if let Some(addr) = env::var(PROM_ENABLE_ENV_VAR)
         .ok()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add `temporal_` prefix (by default, disableable) to metrics. 
Fix LA slots metric being recorded wrong. Use new better owned permit approach.

## Why?
This is consistent with other SDKs.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
