### PR TITLE
Fix possible panic when racing WFT permits

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -161,7 +161,10 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
     let mock = mock_workflow_client();
     let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 2, 2], mock);
     mh.enforce_correct_number_of_polls = false;
-    let mut worker = mock_sdk_cfg(mh, |wc| wc.max_cached_workflows = 1);
+    let mut worker = mock_sdk_cfg(mh, |wc| {
+        wc.max_cached_workflows = 1;
+        wc.max_outstanding_workflow_tasks = 1;
+    });
     let core = worker.core_worker.clone();
 
     let shutdown_barr: &'static Barrier = Box::leak(Box::new(Barrier::new(2)));

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -82,7 +82,6 @@ type BoxedActivationStream = BoxStream<'static, Result<ActivationOrAuto, PollWfE
 
 /// Centralizes all state related to workflows and workflow tasks
 pub(crate) struct Workflows {
-    new_wft_tx: UnboundedSender<ValidPollWFTQResponse>,
     local_tx: UnboundedSender<LocalInput>,
     processing_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
     activation_stream: tokio::sync::Mutex<(
@@ -117,13 +116,11 @@ impl Workflows {
             + 'static,
         activity_tasks_handle: Option<ActivitiesFromWFTsHandle>,
     ) -> Self {
-        let (new_wft_tx, new_wft_rx) = unbounded_channel();
         let (local_tx, local_rx) = unbounded_channel();
         let shutdown_tok = basics.shutdown_token.clone();
         let mut stream = WFStream::build(
             basics,
             wft_stream,
-            new_wft_rx,
             UnboundedReceiverStream::new(local_rx),
             client.clone(),
             local_activity_request_sink,
@@ -153,7 +150,6 @@ impl Workflows {
             }
         });
         Self {
-            new_wft_tx,
             local_tx,
             processing_task: tokio::sync::Mutex::new(Some(processing_task)),
             activation_stream: tokio::sync::Mutex::new((
@@ -193,15 +189,6 @@ impl Workflows {
         }
     }
 
-    /// Queue a new WFT received from server for processing (ex: when a new WFT is obtained in
-    /// response to a completion). Most tasks should just come from the stream passed in during
-    /// construction.
-    pub fn new_wft(&self, wft: ValidPollWFTQResponse) {
-        self.new_wft_tx
-            .send(wft)
-            .expect("Rcv half of new WFT channel not closed");
-    }
-
     /// Queue an activation completion for processing, returning a future that will resolve with
     /// the outcome of that completion. See [ActivationCompletedOutcome].
     ///
@@ -232,6 +219,7 @@ impl Workflows {
         let completion_outcome = rx
             .await
             .expect("Send half of activation complete response not dropped");
+        let mut wft_from_complete = None;
         let reported_wft_to_server = match completion_outcome.outcome {
             ActivationCompleteOutcome::ReportWFTSuccess(report) => match report {
                 ServerCommandsWithWorkflowInfo {
@@ -256,8 +244,8 @@ impl Workflows {
                         force_create_new_workflow_task: force_new_wft,
                     };
                     let sticky_attrs = self.sticky_attrs.clone();
-                    // Do not return new WFT if we would not cache, because returned new WFTs are always
-                    // partial.
+                    // Do not return new WFT if we would not cache, because returned new WFTs are
+                    // always partial.
                     if sticky_attrs.is_none() {
                         completion.return_new_workflow_task = false;
                     }
@@ -266,7 +254,7 @@ impl Workflows {
                     self.handle_wft_reporting_errs(&run_id, || async {
                         let maybe_wft = self.client.complete_workflow_task(completion).await?;
                         if let Some(wft) = maybe_wft.workflow_task {
-                            self.new_wft(validate_wft(wft)?);
+                            wft_from_complete = Some(validate_wft(wft)?);
                         }
                         self.handle_eager_activities(
                             reserved_act_permits,
@@ -309,6 +297,7 @@ impl Workflows {
         self.post_activation(PostActivationMsg {
             run_id,
             reported_wft_to_server,
+            wft_from_complete,
         });
 
         Ok(completion_outcome.most_recently_processed_event)
@@ -518,7 +507,7 @@ struct ManagedRunHandle {
     /// run. This can happen when lang takes too long to complete a task and the task times out, for
     /// example. Upon next completion, the buffered response will be removed and can be made ready
     /// to be returned from polling
-    buffered_resp: Option<ValidPollWFTQResponse>,
+    buffered_resp: Option<PermittedWFT>,
     /// True if this machine has seen an event which ends the execution
     have_seen_terminal_event: bool,
     /// The most recently processed event id this machine has seen. 0 means it has seen nothing.
@@ -687,6 +676,13 @@ impl ActivationOrAuto {
         }
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct PermittedWFT {
+    wft: ValidPollWFTQResponse,
+    permit: OwnedMeteredSemPermit,
+}
+
 #[derive(Debug)]
 pub(crate) struct OutstandingTask {
     pub info: WorkflowTaskInfo,
@@ -695,10 +691,8 @@ pub(crate) struct OutstandingTask {
     pub pending_queries: Vec<QueryWorkflow>,
     pub start_time: Instant,
     /// The WFT permit owned by this task, ensures we don't exceed max concurrent WFT, and makes
-    /// sure the permit is automatically freed when we delete the task. Should always be `Some`
-    /// in normal operation, but in the event there is a bug with permit tracking, it's better to
-    /// allow temporarily exceeding the limit than panicking.
-    pub _permit: Option<OwnedMeteredSemPermit>,
+    /// sure the permit is automatically freed when we delete the task.
+    pub permit: OwnedMeteredSemPermit,
 }
 
 impl OutstandingTask {
@@ -806,6 +800,7 @@ struct LocalResolutionMsg {
 struct PostActivationMsg {
     run_id: String,
     reported_wft_to_server: bool,
+    wft_from_complete: Option<ValidPollWFTQResponse>,
 }
 #[derive(Debug, Clone)]
 struct RequestEvictMsg {

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -695,8 +695,10 @@ pub(crate) struct OutstandingTask {
     pub pending_queries: Vec<QueryWorkflow>,
     pub start_time: Instant,
     /// The WFT permit owned by this task, ensures we don't exceed max concurrent WFT, and makes
-    /// sure the permit is automatically freed when we delete the task.
-    pub _permit: OwnedMeteredSemPermit,
+    /// sure the permit is automatically freed when we delete the task. Should always be `Some`
+    /// in normal operation, but in the event there is a bug with permit tracking, it's better to
+    /// allow temporarily exceeding the limit than panicking.
+    pub _permit: Option<OwnedMeteredSemPermit>,
 }
 
 impl OutstandingTask {

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -21,10 +21,7 @@ use temporal_sdk_core_protos::{
     },
     temporal::api::{enums::v1::WorkflowTaskFailedCause, failure::v1::Failure as TFailure},
 };
-use tokio::sync::{
-    mpsc::{unbounded_channel, UnboundedReceiver},
-    oneshot,
-};
+use tokio::sync::{mpsc::unbounded_channel, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tracing::{Level, Span};
@@ -36,14 +33,13 @@ use tracing::{Level, Span};
 pub(crate) struct WFStream {
     runs: RunCache,
     /// Buffered polls for new runs which need a cache slot to open up before we can handle them
-    buffered_polls_need_cache_slot: VecDeque<ValidPollWFTQResponse>,
+    buffered_polls_need_cache_slot: VecDeque<PermittedWFT>,
 
     /// Client for accessing server for history pagination etc.
     client: Arc<WorkerClientBag>,
 
     /// Ensures we stay at or below this worker's maximum concurrent workflow task limit
     wft_semaphore: MeteredSemaphore,
-    saw_last_allowed_wft: bool,
     shutdown_token: CancellationToken,
 
     metrics: MetricsContext,
@@ -51,7 +47,7 @@ pub(crate) struct WFStream {
 /// All possible inputs to the [WFStream]
 #[derive(derive_more::From)]
 enum WFStreamInput {
-    NewWft(ValidPollWFTQResponse),
+    NewWft(PermittedWFT),
     Local(LocalInput),
     // The stream given to us which represents the poller (or a mock) terminated.
     PollerDead,
@@ -83,13 +79,13 @@ pub(super) enum LocalInputs {
 #[derive(Debug, derive_more::From)]
 #[allow(clippy::large_enum_variant)] // PollerDead only ever gets used once, so not important.
 enum ExternalPollerInputs {
-    NewWft(ValidPollWFTQResponse),
+    NewWft(PermittedWFT),
     PollerDead,
 }
 impl From<ExternalPollerInputs> for WFStreamInput {
     fn from(l: ExternalPollerInputs) -> Self {
         match l {
-            ExternalPollerInputs::NewWft(n) => WFStreamInput::NewWft(n),
+            ExternalPollerInputs::NewWft(v) => WFStreamInput::NewWft(v),
             ExternalPollerInputs::PollerDead => WFStreamInput::PollerDead,
         }
     }
@@ -114,7 +110,6 @@ impl WFStream {
     pub(super) fn build(
         basics: WorkflowBasics,
         external_wfts: impl Stream<Item = ValidPollWFTQResponse> + Send + 'static,
-        wfts_from_complete: UnboundedReceiver<ValidPollWFTQResponse>,
         local_rx: impl Stream<Item = LocalInput> + Send + 'static,
         client: Arc<WorkerClientBag>,
         local_activity_request_sink: impl Fn(Vec<LocalActRequest>) -> Vec<LocalActivityResolution>
@@ -122,13 +117,18 @@ impl WFStream {
             + Sync
             + 'static,
     ) -> impl Stream<Item = Result<ActivationOrAuto, PollWfError>> {
-        let (external_wft_allow_handle, poller_wfts) = stream_when_allowed(external_wfts);
-        let new_wft_rx = stream::select(
-            poller_wfts
-                .map(ExternalPollerInputs::NewWft)
-                .chain(stream::once(async { ExternalPollerInputs::PollerDead })),
-            UnboundedReceiverStream::new(wfts_from_complete).map(ExternalPollerInputs::NewWft),
+        let wft_semaphore = MeteredSemaphore::new(
+            basics.max_outstanding_wfts,
+            basics.metrics.with_new_attrs([workflow_worker_type()]),
+            MetricsContext::available_task_slots,
         );
+        let wft_sem_clone = wft_semaphore.clone();
+        let proceeder = move || {
+            let wft_sem_clone = wft_sem_clone.clone();
+            async move { wft_sem_clone.acquire_owned().await.unwrap() }
+        };
+        let (external_wft_allow_handle, poller_wfts) =
+            stream_when_allowed(external_wfts, proceeder);
         let (run_update_tx, run_update_rx) = unbounded_channel();
         let local_rx = stream::select(
             local_rx.map(Into::into),
@@ -136,7 +136,11 @@ impl WFStream {
         );
         let all_inputs = stream::select_with_strategy(
             local_rx,
-            new_wft_rx.map(Into::into).boxed(),
+            poller_wfts
+                .map(|(wft, permit)| ExternalPollerInputs::NewWft(PermittedWFT { wft, permit }))
+                .chain(stream::once(async { ExternalPollerInputs::PollerDead }))
+                .map(Into::into)
+                .boxed(),
             // Priority always goes to the local stream
             |_: &mut ()| PollNext::Left,
         );
@@ -150,12 +154,7 @@ impl WFStream {
                 basics.metrics.clone(),
             ),
             client,
-            wft_semaphore: MeteredSemaphore::new(
-                basics.max_outstanding_wfts,
-                basics.metrics.with_new_attrs([workflow_worker_type()]),
-                MetricsContext::available_task_slots,
-            ),
-            saw_last_allowed_wft: false,
+            wft_semaphore,
             shutdown_token: basics.shutdown_token,
             metrics: basics.metrics,
         };
@@ -165,10 +164,9 @@ impl WFStream {
                 let _span_g = span.enter();
 
                 let maybe_activation = match action {
-                    WFStreamInput::NewWft(wft) => {
-                        debug!(run_id=%wft.workflow_execution.run_id, "New WFT");
-                        state.instantiate_or_update(wft);
-                        state.saw_last_allowed_wft = true;
+                    WFStreamInput::NewWft(pwft) => {
+                        debug!(run_id=%pwft.wft.workflow_execution.run_id, "New WFT");
+                        state.instantiate_or_update(pwft);
                         None
                     }
                     WFStreamInput::Local(local_input) => {
@@ -219,7 +217,6 @@ impl WFStream {
                 }
                 state.reconcile_buffered();
                 if state.should_allow_poll() {
-                    state.saw_last_allowed_wft = false;
                     external_wft_allow_handle.allow_one();
                 }
                 if state.shutdown_done() {
@@ -369,10 +366,11 @@ impl WFStream {
         }
     }
 
-    #[instrument(level = "debug", skip(self, work), fields(run_id=%work.workflow_execution.run_id))]
-    fn instantiate_or_update(&mut self, work: ValidPollWFTQResponse) {
-        let mut work = if let Some(w) = self.buffer_resp_if_outstanding_work(work) {
-            w
+    #[instrument(level = "debug", skip(self, pwft), 
+                 fields(run_id=%pwft.wft.workflow_execution.run_id))]
+    fn instantiate_or_update(&mut self, pwft: PermittedWFT) {
+        let (mut work, permit) = if let Some(w) = self.buffer_resp_if_outstanding_work(pwft) {
+            (w.wft, w.permit)
         } else {
             return;
         };
@@ -381,7 +379,7 @@ impl WFStream {
         // If our cache is full and this WFT is for an unseen run we must first evict a run before
         // we can deal with this task. So, buffer the task in that case.
         if !self.runs.has_run(&run_id) && self.runs.is_full() {
-            self.buffer_resp_on_full_cache(work);
+            self.buffer_resp_on_full_cache(PermittedWFT { wft: work, permit });
             return;
         }
 
@@ -459,16 +457,12 @@ impl WFStream {
             history_update,
             start_time,
         );
-        let _permit = self.wft_semaphore.try_acquire_owned().ok();
-        if _permit.is_none() {
-            dbg_panic!("Permits should always be available when processing a new WFT");
-        }
         run_handle.wft = Some(OutstandingTask {
             info: wft_info,
             hit_cache: !did_miss_cache,
             pending_queries,
             start_time,
-            _permit,
+            permit,
         })
     }
 
@@ -628,6 +622,9 @@ impl WFStream {
     fn process_post_activation(&mut self, report: PostActivationMsg) {
         let run_id = &report.run_id;
 
+        // If we reported to server, we always want to mark it complete.
+        let maybe_t = self.complete_wft(run_id, report.reported_wft_to_server);
+
         if self
             .get_activation(run_id)
             .map(|a| a.has_eviction())
@@ -636,8 +633,16 @@ impl WFStream {
             self.evict_run(run_id);
         };
 
-        // If we reported to server, we always want to mark it complete.
-        self.complete_wft(run_id, report.reported_wft_to_server);
+        if let Some(wft) = report.wft_from_complete {
+            debug!(run_id=%wft.workflow_execution.run_id, "New WFT from completion");
+            if let Some(t) = maybe_t {
+                self.instantiate_or_update(PermittedWFT {
+                    wft,
+                    permit: t.permit,
+                })
+            }
+        }
+
         if let Some(rh) = self.runs.get_mut(run_id) {
             // Delete the activation
             rh.activation.take();
@@ -765,11 +770,8 @@ impl WFStream {
 
     /// Stores some work if there is any outstanding WFT or activation for the run. If there was
     /// not, returns the work back out inside the option.
-    fn buffer_resp_if_outstanding_work(
-        &mut self,
-        work: ValidPollWFTQResponse,
-    ) -> Option<ValidPollWFTQResponse> {
-        let run_id = &work.workflow_execution.run_id;
+    fn buffer_resp_if_outstanding_work(&mut self, work: PermittedWFT) -> Option<PermittedWFT> {
+        let run_id = &work.wft.workflow_execution.run_id;
         if let Some(mut run) = self.runs.get_mut(run_id) {
             let about_to_issue_evict = run.trying_to_evict.is_some() && !run.last_action_acked;
             let has_wft = run.wft.is_some();
@@ -781,7 +783,7 @@ impl WFStream {
                 || !run.last_action_acked
             {
                 debug!(run_id = %run_id, run = ?run,
-                       "Got new WFT for a run with outstanding work");
+                       "Got new WFT for a run with outstanding work, buffering it");
                 run.buffered_resp = Some(work);
                 None
             } else {
@@ -792,13 +794,13 @@ impl WFStream {
         }
     }
 
-    fn buffer_resp_on_full_cache(&mut self, work: ValidPollWFTQResponse) {
-        debug!(run_id=%work.workflow_execution.run_id, "Buffering WFT because cache is full");
+    fn buffer_resp_on_full_cache(&mut self, work: PermittedWFT) {
+        debug!(run_id=%work.wft.workflow_execution.run_id, "Buffering WFT because cache is full");
         // If there's already a buffered poll for the run, replace it.
         if let Some(rh) = self
             .buffered_polls_need_cache_slot
             .iter_mut()
-            .find(|w| w.workflow_execution.run_id == work.workflow_execution.run_id)
+            .find(|w| w.wft.workflow_execution.run_id == work.wft.workflow_execution.run_id)
         {
             *rh = work;
         } else {
@@ -903,10 +905,7 @@ impl WFStream {
     }
 
     fn should_allow_poll(&self) -> bool {
-        self.saw_last_allowed_wft
-            && self.runs.can_accept_new()
-            && self.wft_semaphore.available_permits() > 0
-            && self.buffered_polls_need_cache_slot.is_empty()
+        self.runs.can_accept_new() && self.buffered_polls_need_cache_slot.is_empty()
     }
 
     // Useful when debugging


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed possible race in logic around whether poller should poll or not.
Also make this no longer panic in production code. Temporarily exceeding WFT capacity is better than crashing.

## Why?
Bug

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
