### PR TITLE
Move worker build id to worker options, allow client id override there

### DIFF
--- a/bridge-ffi/src/wrappers.rs
+++ b/bridge-ffi/src/wrappers.rs
@@ -105,9 +105,6 @@ impl TryFrom<ClientOptions> for temporal_sdk_core::ClientOptions {
         if !req.identity.is_empty() {
             client_opts.identity(req.identity);
         }
-        if !req.worker_binary_id.is_empty() {
-            client_opts.worker_binary_id(req.worker_binary_id);
-        }
         if let Some(req_tls_config) = req.tls_config {
             let mut tls_config = temporal_sdk_core::TlsConfig::default();
             if !req_tls_config.server_root_ca_cert.is_empty() {

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -10,6 +10,14 @@ pub struct WorkerConfig {
     /// What task queue will this worker poll from? This task queue name will be used for both
     /// workflow and activity polling.
     pub task_queue: String,
+    /// A string that should be unique to the set of code this worker uses. IE: All the workflow,
+    /// activity, interceptor, and data converter code.
+    pub worker_build_id: String,
+    /// A human-readable string that can identify this worker. Using something like sdk version
+    /// and host name is a good default. If set, overrides the identity set (if any) on the client
+    /// used by this worker.
+    #[builder(default)]
+    pub client_identity_override: Option<String>,
     /// If set nonzero, workflows will be cached and sticky task queues will be used, meaning that
     /// history updates are applied incrementally to suspended instances of workflow execution.
     /// Workflows are evicted according to a least-recently-used policy one the cache maximum is

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -601,6 +601,7 @@ async fn max_tq_acts_set_passed_to_poll_properly() {
         .namespace("enchi")
         .task_queue("cat")
         .max_concurrent_at_polls(1_usize)
+        .worker_build_id("test_bin_id")
         .max_task_queue_activities_per_second(rate)
         .build()
         .unwrap();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -68,11 +68,14 @@ where
     CT: Into<AnyClient>,
 {
     let as_enum = client.into();
-    // TODO: Assert namespaces match
     let client = match as_enum {
         AnyClient::HighLevel(ac) => ac,
         AnyClient::LowLevel(ll) => {
-            let client = Client::new(*ll, worker_config.namespace.clone());
+            let mut client = Client::new(*ll, worker_config.namespace.clone());
+            client.set_worker_build_id(worker_config.worker_build_id.clone());
+            if let Some(ref id_override) = worker_config.client_identity_override {
+                client.options_mut().identity = id_override.clone();
+            }
             let retry_client = RetryClient::new(client, RetryConfig::default());
             Arc::new(retry_client)
         }

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -56,6 +56,7 @@ pub fn test_worker_cfg() -> WorkerConfigBuilder {
     let mut wcb = WorkerConfigBuilder::default();
     wcb.namespace("default")
         .task_queue(TEST_Q)
+        .worker_build_id("test_bin_id")
         // Serial polling since it makes mocking much easier.
         .max_concurrent_wft_polls(1_usize);
     wcb

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -546,6 +546,7 @@ mod tests {
         let cfg = wcb
             .namespace("default")
             .task_queue("whatever")
+            .worker_build_id("test_bin_id")
             .max_concurrent_wft_polls(5_usize)
             .build()
             .unwrap();

--- a/protos/local/temporal/sdk/core/bridge/bridge.proto
+++ b/protos/local/temporal/sdk/core/bridge/bridge.proto
@@ -56,7 +56,6 @@ message CreateClientRequest {
   string client_name = 3;
   string client_version = 4;
   string identity = 6;
-  string worker_binary_id = 7;
   TlsConfig tls_config = 8;
   RetryConfig retry_config = 9;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -64,6 +64,7 @@ pub fn init_core_replay_preloaded(
     let worker_cfg = WorkerConfigBuilder::default()
         .namespace(NAMESPACE)
         .task_queue(test_name)
+        .worker_build_id("test_bin_id")
         .build()
         .expect("Configuration options construct properly");
     let worker = init_replay_worker(worker_cfg, history).expect("Replay worker must init properly");

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -108,6 +108,7 @@ impl CoreWfStarter {
             worker_config: WorkerConfigBuilder::default()
                 .namespace(NAMESPACE)
                 .task_queue(task_queue)
+                .worker_build_id("test_build_id")
                 .max_cached_workflows(1000_usize)
                 .build()
                 .unwrap(),
@@ -435,7 +436,6 @@ pub fn get_integ_server_options() -> ClientOptions {
     let url = Url::try_from(&*temporal_server_address).unwrap();
     ClientOptionsBuilder::default()
         .identity("integ_tester".to_string())
-        .worker_binary_id("fakebinaryid".to_string())
         .target_url(url)
         .client_name("temporal-core".to_string())
         .client_version("0.1.0".to_string())

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -73,7 +73,6 @@ mod integ_tests {
         .unwrap();
         let sgo = ClientOptionsBuilder::default()
             .target_url(Url::from_str("https://localhost:7233").unwrap())
-            .worker_binary_id("binident".to_string())
             .tls_cfg(TlsConfig {
                 server_root_ca_cert: Some(root),
                 domain: Some("tls-sample".to_string()),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Moved (and renamed) worker build id to be on worker options, fairly obvious there.
Add ability to override client id from worker options too.

## Why?
Support https://github.com/temporalio/sdk-typescript/issues/697

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
