### PR TITLE
Fix bug where cmds cancelled after prepared but before sent, were sent

### DIFF
--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -122,11 +122,10 @@ impl WorkflowFuture {
             UnblockEvent::CancelExternal(seq, _) => CommandID::CancelExternal(seq),
         };
         let unblocker = self.command_status.remove(&cmd_id);
-        unblocker
+        let _ = unblocker
             .ok_or_else(|| anyhow!("Command {:?} not found to unblock!", cmd_id))?
             .unblocker
-            .send(event)
-            .expect("Receive half of unblock channel must exist");
+            .send(event);
         Ok(())
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Commands that were cancelled after they were "perpared" but *before* they were sent, would be considered cancelled before sent internally, but still got sent to the server. This fixes that.

## Why?
Fix for https://github.com/temporalio/sdk-typescript/issues/731

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
