### PR TITLE
Make sure workers do not propagate retryable errors as fatal

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -138,8 +138,6 @@ pub struct RetryConfig {
     pub max_elapsed_time: Option<Duration>,
     /// maximum number of retry attempts.
     pub max_retries: usize,
-    /// If true, retry deadline exceeded errors
-    pub retry_deadlines: bool,
 }
 
 impl Default for RetryConfig {
@@ -151,7 +149,6 @@ impl Default for RetryConfig {
             max_interval: Duration::from_secs(5), // until it reaches 5 seconds.
             max_elapsed_time: Some(Duration::from_secs(10)), // 10 seconds total allocated time for all retries.
             max_retries: 10,
-            retry_deadlines: false,
         }
     }
 }
@@ -165,7 +162,6 @@ impl RetryConfig {
             max_interval: Duration::from_secs(10),
             max_elapsed_time: None,
             max_retries: 0,
-            retry_deadlines: true,
         }
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,7 +12,7 @@ mod raw;
 mod retry;
 mod workflow_handle;
 
-pub use crate::retry::{CallType, RetryClient};
+pub use crate::retry::{CallType, RetryClient, RETRYABLE_ERROR_CODES};
 pub use raw::WorkflowService;
 pub use workflow_handle::{WorkflowExecutionInfo, WorkflowExecutionResult};
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -138,6 +138,8 @@ pub struct RetryConfig {
     pub max_elapsed_time: Option<Duration>,
     /// maximum number of retry attempts.
     pub max_retries: usize,
+    /// If true, retry deadline exceeded errors
+    pub retry_deadlines: bool,
 }
 
 impl Default for RetryConfig {
@@ -149,6 +151,7 @@ impl Default for RetryConfig {
             max_interval: Duration::from_secs(5), // until it reaches 5 seconds.
             max_elapsed_time: Some(Duration::from_secs(10)), // 10 seconds total allocated time for all retries.
             max_retries: 10,
+            retry_deadlines: false,
         }
     }
 }
@@ -162,6 +165,7 @@ impl RetryConfig {
             max_interval: Duration::from_secs(10),
             max_elapsed_time: None,
             max_retries: 0,
+            retry_deadlines: true,
         }
     }
 }

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -633,8 +633,10 @@ mod tests {
             .expect_complete_workflow_task()
             .returning(move |_| Ok(Default::default()))
             .times(1);
-        let mut rc_allow_deadline = RetryConfig::default();
-        rc_allow_deadline.retry_deadlines = true;
+        let rc_allow_deadline = RetryConfig {
+            retry_deadlines: true,
+            ..Default::default()
+        };
         let retry_client = RetryClient::new(mock_client, rc_allow_deadline);
         let result = retry_client
             .complete_workflow_task(WorkflowTaskCompletion {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,7 @@ pub use worker::{Worker, WorkerConfig, WorkerConfigBuilder};
 use crate::{
     replay::mock_client_from_history,
     telemetry::metrics::{MetricsContext, METRIC_METER},
-    worker::client::{worker_retry_config, WorkerClientBag},
+    worker::client::WorkerClientBag,
 };
 use std::sync::Arc;
 use temporal_client::AnyClient;
@@ -86,7 +86,7 @@ where
             if let Some(ref id_override) = worker_config.client_identity_override {
                 client.options_mut().identity = id_override.clone();
             }
-            let retry_client = RetryClient::new(client, worker_retry_config());
+            let retry_client = RetryClient::new(client, Default::default());
             Arc::new(retry_client)
         }
     };

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,7 @@ pub use worker::{Worker, WorkerConfig, WorkerConfigBuilder};
 use crate::{
     replay::mock_client_from_history,
     telemetry::metrics::{MetricsContext, METRIC_METER},
-    worker::client::WorkerClientBag,
+    worker::client::{worker_retry_config, WorkerClientBag},
 };
 use std::sync::Arc;
 use temporal_client::AnyClient;
@@ -62,7 +62,17 @@ lazy_static::lazy_static! {
     };
 }
 
-/// Initialize a worker bound to a task queue
+/// Initialize a worker bound to a task queue.
+///
+/// Lang implementations should pass in a a [temporal_client::ConfiguredClient] directly (or a
+/// [RetryClient] wrapping one). When they do so, this function will always overwrite the client
+/// retry configuration, force the client to use the namespace defined in the worker config, and set
+/// the client identity appropriately. IE: Use [ClientOptions::connect_no_namespace], not
+/// [ClientOptions::connect].
+///
+/// It is also possible to pass in a [WorkflowClientTrait] implementor, but this largely exists to
+/// support testing and mocking. Lang impls should not operate that way, as it may result in
+/// improper retry behavior for a worker.
 pub fn init_worker<CT>(worker_config: WorkerConfig, client: CT) -> Worker
 where
     CT: Into<AnyClient>,
@@ -76,19 +86,18 @@ where
             if let Some(ref id_override) = worker_config.client_identity_override {
                 client.options_mut().identity = id_override.clone();
             }
-            let retry_client = RetryClient::new(client, RetryConfig::default());
+            let retry_client = RetryClient::new(client, worker_retry_config());
             Arc::new(retry_client)
         }
     };
-    let c_opts = client.get_options().clone();
     if client.namespace() != worker_config.namespace {
         panic!("Passed in client is not bound to the same namespace as the worker");
     }
+    let sticky_q = sticky_q_name_for_worker(&client.get_options().identity, &worker_config);
     let client_bag = Arc::new(WorkerClientBag::new(
         Box::new(client),
         worker_config.namespace.clone(),
     ));
-    let sticky_q = sticky_q_name_for_worker(&c_opts.identity, &worker_config);
     let metrics = MetricsContext::top_level(worker_config.namespace.clone())
         .with_task_q(worker_config.task_queue.clone());
     Worker::new(worker_config, sticky_q, client_bag, metrics)

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -131,7 +131,7 @@ impl ActivityHeartbeatManager {
     /// Initiates shutdown procedure by stopping lifecycle loop and awaiting for all in-flight
     /// heartbeat requests to be flushed to the server.
     pub(super) async fn shutdown(&self) {
-        let _ = self.shutdown_token.cancel();
+        self.shutdown_token.cancel();
         let mut handle = self.join_handle.lock().await;
         if let Some(h) = handle.take() {
             let handle_r = h.await;
@@ -282,7 +282,7 @@ impl HeartbeatStreamState {
     ) -> Option<HeartbeatExecutorAction> {
         if let Some(state) = self.tt_to_state.remove(&tt) {
             if let Some(cancel_tok) = state.throttled_cancellation_token {
-                let _ = cancel_tok.cancel();
+                cancel_tok.cancel();
             }
             if let Some(last_deets) = state.last_recorded_details {
                 self.tt_needs_flush.insert(tt.clone(), on_complete);

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -6,7 +6,7 @@ use std::{
     borrow::Borrow,
     ops::{Deref, DerefMut},
 };
-use temporal_client::{WorkflowClientTrait, WorkflowTaskCompletion};
+use temporal_client::{RetryConfig, WorkflowClientTrait, WorkflowTaskCompletion};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::QueryResult,
     temporal::api::{
@@ -17,6 +17,15 @@ use temporal_sdk_core_protos::{
 };
 
 type Result<T, E = tonic::Status> = std::result::Result<T, E>;
+
+/// Workers are willing to retry things forever
+pub(crate) fn worker_retry_config() -> RetryConfig {
+    let mut rc = RetryConfig::default();
+    rc.max_retries = 0;
+    rc.max_elapsed_time = None;
+    rc.retry_deadlines = true;
+    rc
+}
 
 /// Contains everything a worker needs to interact with the server
 pub(crate) struct WorkerClientBag {

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -20,11 +20,12 @@ type Result<T, E = tonic::Status> = std::result::Result<T, E>;
 
 /// Workers are willing to retry things forever
 pub(crate) fn worker_retry_config() -> RetryConfig {
-    let mut rc = RetryConfig::default();
-    rc.max_retries = 0;
-    rc.max_elapsed_time = None;
-    rc.retry_deadlines = true;
-    rc
+    RetryConfig {
+        max_retries: 0,
+        max_elapsed_time: None,
+        retry_deadlines: true,
+        ..Default::default()
+    }
 }
 
 /// Contains everything a worker needs to interact with the server

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -6,7 +6,9 @@ use std::{
     borrow::Borrow,
     ops::{Deref, DerefMut},
 };
-use temporal_client::{RetryConfig, WorkflowClientTrait, WorkflowTaskCompletion};
+use temporal_client::{
+    RetryConfig, WorkflowClientTrait, WorkflowTaskCompletion, RETRYABLE_ERROR_CODES,
+};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::QueryResult,
     temporal::api::{
@@ -15,6 +17,7 @@ use temporal_sdk_core_protos::{
     },
     TaskToken,
 };
+use tonic::Code;
 
 type Result<T, E = tonic::Status> = std::result::Result<T, E>;
 
@@ -26,6 +29,13 @@ pub(crate) fn worker_retry_config() -> RetryConfig {
         retry_deadlines: true,
         ..Default::default()
     }
+}
+
+/// Returns true if the network error should not be reported to lang. This can happen if we've
+/// exceeded the max number of retries, and we prefer to just warn rather than blowing up lang.
+pub(crate) fn should_swallow_net_error(err: &tonic::Status) -> bool {
+    RETRYABLE_ERROR_CODES.contains(&err.code())
+        || matches!(err.code(), Code::Cancelled | Code::DeadlineExceeded)
 }
 
 /// Contains everything a worker needs to interact with the server

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -6,9 +6,7 @@ use std::{
     borrow::Borrow,
     ops::{Deref, DerefMut},
 };
-use temporal_client::{
-    RetryConfig, WorkflowClientTrait, WorkflowTaskCompletion, RETRYABLE_ERROR_CODES,
-};
+use temporal_client::{WorkflowClientTrait, WorkflowTaskCompletion, RETRYABLE_ERROR_CODES};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::QueryResult,
     temporal::api::{
@@ -20,16 +18,6 @@ use temporal_sdk_core_protos::{
 use tonic::Code;
 
 type Result<T, E = tonic::Status> = std::result::Result<T, E>;
-
-/// Workers are willing to retry things forever
-pub(crate) fn worker_retry_config() -> RetryConfig {
-    RetryConfig {
-        max_retries: 0,
-        max_elapsed_time: None,
-        retry_deadlines: true,
-        ..Default::default()
-    }
-}
 
 /// Returns true if the network error should not be reported to lang. This can happen if we've
 /// exceeded the max number of retries, and we prefer to just warn rather than blowing up lang.

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -449,19 +449,11 @@ impl Worker {
         completion: WorkflowActivationCompletion,
     ) -> Result<(), CompleteWfError> {
         let run_id = completion.run_id.clone();
-        match self.workflows.activation_completed(completion).await {
-            Ok(most_recent_event) => {
-                if let Some(h) = &self.post_activate_hook {
-                    h(self, &run_id, most_recent_event);
-                }
-                Ok(())
-            }
-            Err(CompleteWfError::TonicError(e)) if should_swallow_net_error(&e) => {
-                warn!(error=?e, "Network error while completing workflow activation");
-                Ok(())
-            }
-            Err(e) => Err(e),
+        let most_recent_event = self.workflows.activation_completed(completion).await?;
+        if let Some(h) = &self.post_activate_hook {
+            h(self, &run_id, most_recent_event);
         }
+        Ok(())
     }
 
     /// Request a workflow eviction

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     worker::{
         activities::{DispatchOrTimeoutLA, LACompleteAction, LocalActivityManager},
-        client::WorkerClientBag,
+        client::{should_swallow_net_error, WorkerClientBag},
         workflow::{LocalResolution, Workflows},
     },
     ActivityHeartbeat, CompleteActivityError, PollActivityError, PollWfError, WorkerTrait,
@@ -408,7 +408,7 @@ impl Worker {
                     // no other situations where core generates "internal" commands so it is much
                     // simpler for lang to reply with the timer / next LA command than to do it
                     // internally. Plus, this backoff hack we'd like to eliminate eventually.
-                    self.complete_local_act(as_la_res, info, Some(backoff))
+                    self.complete_local_act(as_la_res, info, Some(backoff));
                 }
                 LACompleteAction::WillBeRetried => {
                     // Nothing to do here
@@ -421,7 +421,13 @@ impl Worker {
         }
 
         if let Some(atm) = &self.at_task_mgr {
-            atm.complete(task_token, status, &**self.wf_client).await
+            match atm.complete(task_token, status, &**self.wf_client).await {
+                Err(CompleteActivityError::TonicError(e)) if should_swallow_net_error(&e) => {
+                    warn!(error=?e, "Network error while completing activity");
+                    Ok(())
+                }
+                o => o,
+            }
         } else {
             error!(
                 "Tried to complete activity {} on a worker that does not have an activity manager",
@@ -443,11 +449,19 @@ impl Worker {
         completion: WorkflowActivationCompletion,
     ) -> Result<(), CompleteWfError> {
         let run_id = completion.run_id.clone();
-        let most_recent_event = self.workflows.activation_completed(completion).await?;
-        if let Some(h) = &self.post_activate_hook {
-            h(self, &run_id, most_recent_event);
+        match self.workflows.activation_completed(completion).await {
+            Ok(most_recent_event) => {
+                if let Some(h) = &self.post_activate_hook {
+                    h(self, &run_id, most_recent_event);
+                }
+                Ok(())
+            }
+            Err(CompleteWfError::TonicError(e)) if should_swallow_net_error(&e) => {
+                warn!(error=?e, "Network error while completing workflow activation");
+                Ok(())
+            }
+            Err(e) => Err(e),
         }
-        Ok(())
     }
 
     /// Request a workflow eviction


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Workers should not bubble up retryable errors as fatal, rather they should prefer to just drop the task and let it expire naturally.

## Why?
Robustness

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
New UT. Can't test specific scenario user reported b/c of Tonic internals, but it's not exactly complex.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
