### PR TITLE
Fix bug where LA resolutions could trigger activations with no associated WFT

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -1,20 +1,38 @@
 use crate::{
     replay::{default_wes_attribs, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE},
-    test_help::{mock_sdk, mock_sdk_cfg, MockPollCfg, ResponseType},
+    test_help::{
+        hist_to_poll_resp, mock_sdk, mock_sdk_cfg, mock_worker, single_hist_mock_sg, MockPollCfg,
+        ResponseType, TEST_Q,
+    },
     worker::client::mocks::mock_workflow_client,
 };
 use anyhow::anyhow;
-use futures::future::join_all;
+use futures::{future::join_all, FutureExt};
 use std::{
-    sync::atomic::{AtomicUsize, Ordering},
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{ActContext, LocalActivityOptions, WfContext, WorkflowResult};
+use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::{
-    coresdk::AsJsonPayloadExt,
-    temporal::api::{common::v1::RetryPolicy, enums::v1::EventType, failure::v1::Failure},
+    coresdk::{
+        activity_result::ActivityExecutionResult,
+        workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        workflow_commands::{ActivityCancellationType, QueryResult, QuerySuccess},
+        workflow_completion::WorkflowActivationCompletion,
+        ActivityTaskCompletion, AsJsonPayloadExt,
+    },
+    temporal::api::{
+        common::v1::RetryPolicy, enums::v1::EventType, failure::v1::Failure,
+        query::v1::WorkflowQuery,
+    },
 };
+use temporal_sdk_core_test_utils::{schedule_local_activity_cmd, start_timer_cmd};
 use tokio::sync::Barrier;
 
 async fn echo(_ctx: ActContext, e: String) -> anyhow::Result<String> {
@@ -377,4 +395,125 @@ async fn local_act_null_result() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
+}
+
+#[tokio::test]
+async fn query_during_wft_heartbeat_doesnt_accidentally_fail_to_continue_heartbeat() {
+    crate::telemetry::test_telem_console();
+    let wfid = "fake_wf_id";
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    t.add_full_wf_task();
+    // get query here
+    t.add_local_activity_marker(1, "1", None, None, None);
+    t.add_workflow_execution_completed();
+
+    let query_with_hist_task = {
+        let mut pr = hist_to_poll_resp(&t, wfid, ResponseType::ToTaskNum(2), TEST_Q);
+        pr.queries = HashMap::new();
+        pr.queries.insert(
+            "the-query".to_string(),
+            WorkflowQuery {
+                query_type: "query-type".to_string(),
+                query_args: Some(b"hi".into()),
+                header: None,
+            },
+        );
+        pr
+    };
+    let after_la_resolve_activation_compl = Arc::new(Barrier::new(2));
+    let poll_barr = after_la_resolve_activation_compl.clone();
+    let tasks = [
+        hist_to_poll_resp(&t, wfid, ResponseType::ToTaskNum(1), TEST_Q),
+        query_with_hist_task,
+        hist_to_poll_resp(
+            &t,
+            wfid,
+            ResponseType::UntilResolved(
+                async move {
+                    poll_barr.wait().await;
+                }
+                .boxed(),
+                3,
+            ),
+            TEST_Q,
+        ),
+    ];
+    let mock = mock_workflow_client();
+    let mut mock = single_hist_mock_sg(wfid, t, tasks, mock, true);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 10);
+    let core = mock_worker(mock);
+
+    let barrier = Barrier::new(2);
+
+    let wf_fut = async {
+        let task = core.poll_workflow_activation().await.unwrap();
+        core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+            task.run_id,
+            schedule_local_activity_cmd(
+                1,
+                "act-id",
+                ActivityCancellationType::TryCancel,
+                Duration::from_secs(60),
+            ),
+        ))
+        .await
+        .unwrap();
+        dbg!("Done complete");
+        let task = core.poll_workflow_activation().await.unwrap();
+        // Get query, and complete it
+        let query = assert_matches!(
+            task.jobs.as_slice(),
+            [WorkflowActivationJob {
+                variant: Some(workflow_activation_job::Variant::QueryWorkflow(q)),
+            }] => q
+        );
+        core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+            task.run_id,
+            QueryResult {
+                query_id: query.query_id.clone(),
+                variant: Some(
+                    QuerySuccess {
+                        response: Some("whatever".into()),
+                    }
+                    .into(),
+                ),
+            }
+            .into(),
+        ))
+        .await
+        .unwrap();
+        // Now complete the LA
+        barrier.wait().await;
+        // Activation with it resolving:
+        let task = core.poll_workflow_activation().await.unwrap();
+        assert_matches!(
+            task.jobs.as_slice(),
+            [WorkflowActivationJob {
+                variant: Some(workflow_activation_job::Variant::ResolveActivity(_)),
+            }]
+        );
+        core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+            task.run_id,
+            start_timer_cmd(1, Duration::from_secs(1)),
+        ))
+        .await
+        .unwrap();
+        dbg!("double done");
+        after_la_resolve_activation_compl.wait().await;
+    };
+    let act_fut = async {
+        let act_task = core.poll_activity_task().await.unwrap();
+        barrier.wait().await;
+        core.complete_activity_task(ActivityTaskCompletion {
+            task_token: act_task.task_token,
+            result: Some(ActivityExecutionResult::ok(vec![1].into())),
+        })
+        .await
+        .unwrap();
+        dbg!("Act task completed");
+    };
+
+    tokio::join!(wf_fut, act_fut);
 }

--- a/core/src/worker/workflow/driven_workflow.rs
+++ b/core/src/worker/workflow/driven_workflow.rs
@@ -1,5 +1,4 @@
 use crate::worker::workflow::{WFCommand, WorkflowStartedInfo};
-use std::collections::VecDeque;
 use temporal_sdk_core_protos::{
     coresdk::workflow_activation::{
         start_workflow_from_attribs, workflow_activation_job, CancelWorkflow, SignalWorkflow,
@@ -15,7 +14,7 @@ pub struct DrivenWorkflow {
     started_attrs: Option<WorkflowStartedInfo>,
     fetcher: Box<dyn WorkflowFetcher>,
     /// Outgoing activation jobs that need to be sent to the lang sdk
-    outgoing_wf_activation_jobs: VecDeque<workflow_activation_job::Variant>,
+    outgoing_wf_activation_jobs: Vec<workflow_activation_job::Variant>,
 }
 
 impl<WF> From<Box<WF>> for DrivenWorkflow
@@ -58,12 +57,12 @@ impl DrivenWorkflow {
 
     /// Enqueue a new job to be sent to the driven workflow
     pub fn send_job(&mut self, job: workflow_activation_job::Variant) {
-        self.outgoing_wf_activation_jobs.push_back(job);
+        self.outgoing_wf_activation_jobs.push(job);
     }
 
-    /// Check if there are pending jobs
-    pub fn has_pending_jobs(&self) -> bool {
-        !self.outgoing_wf_activation_jobs.is_empty()
+    /// Observe pending jobs
+    pub fn peek_pending_jobs(&self) -> &[workflow_activation_job::Variant] {
+        self.outgoing_wf_activation_jobs.as_slice()
     }
 
     /// Drain all pending jobs, so that they may be sent to the driven workflow

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -584,7 +584,7 @@ impl WorkflowMachines {
     }
 
     pub(crate) fn has_pending_jobs(&self) -> bool {
-        self.drive_me.has_pending_jobs()
+        !self.drive_me.peek_pending_jobs().is_empty()
     }
 
     fn set_current_time(&mut self, time: SystemTime) -> SystemTime {

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -235,7 +235,7 @@ impl Workflows {
                     let reserved_act_permits =
                         self.reserve_activity_slots_for_outgoing_commands(commands.as_mut_slice());
                     debug!(commands=%commands.display(), query_responses=%query_responses.display(),
-                           "Sending responses to server");
+                           force_new_wft, "Sending responses to server");
                     let mut completion = WorkflowTaskCompletion {
                         task_token,
                         commands,

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -578,6 +578,7 @@ impl ManagedRunHandle {
                     .as_ref()
                     .map(|wft| !wft.pending_queries.is_empty())
                     .unwrap_or_default(),
+                has_wft: self.wft.is_some(),
             });
         }
     }
@@ -935,6 +936,7 @@ enum RunActions {
     CheckMoreWork {
         want_to_evict: Option<RequestEvictMsg>,
         has_pending_queries: bool,
+        has_wft: bool,
     },
     LocalResolution(LocalResolution),
     HeartbeatTimeout,

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -45,7 +45,7 @@ pub(crate) struct WFStream {
     metrics: MetricsContext,
 }
 /// All possible inputs to the [WFStream]
-#[derive(derive_more::From)]
+#[derive(derive_more::From, Debug)]
 enum WFStreamInput {
     NewWft(PermittedWFT),
     Local(LocalInput),
@@ -64,6 +64,7 @@ impl From<RunUpdateResponse> for WFStreamInput {
     }
 }
 /// A non-poller-received input to the [WFStream]
+#[derive(Debug)]
 pub(super) struct LocalInput {
     pub input: LocalInputs,
     pub span: Span,
@@ -167,7 +168,8 @@ impl WFStream {
         };
         all_inputs
             .map(move |action| {
-                let span = span!(Level::DEBUG, "new_stream_input");
+                // TODO: readable version of action
+                let span = span!(Level::DEBUG, "new_stream_input", action=?action);
                 let _span_g = span.enter();
 
                 let maybe_activation = match action {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -29,7 +29,7 @@ use temporal_sdk_core_protos::{
     coresdk::{
         workflow_commands::{
             workflow_command, ActivityCancellationType, CompleteWorkflowExecution,
-            ScheduleActivity, StartTimer,
+            ScheduleActivity, ScheduleLocalActivity, StartTimer,
         },
         workflow_completion::WorkflowActivationCompletion,
     },
@@ -487,6 +487,25 @@ pub fn schedule_activity_cmd(
         start_to_close_timeout: Some(activity_timeout.into()),
         schedule_to_close_timeout: Some(activity_timeout.into()),
         heartbeat_timeout: Some(heartbeat_timeout.into()),
+        cancellation_type: cancellation_type as i32,
+        ..Default::default()
+    }
+    .into()
+}
+
+pub fn schedule_local_activity_cmd(
+    seq: u32,
+    activity_id: &str,
+    cancellation_type: ActivityCancellationType,
+    activity_timeout: Duration,
+) -> workflow_command::Variant {
+    ScheduleLocalActivity {
+        seq,
+        activity_id: activity_id.to_string(),
+        activity_type: "test_activity".to_string(),
+        schedule_to_start_timeout: Some(activity_timeout.into()),
+        start_to_close_timeout: Some(activity_timeout.into()),
+        schedule_to_close_timeout: Some(activity_timeout.into()),
         cancellation_type: cancellation_type as i32,
         ..Default::default()
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This fixes two related problems:
* It does not make sense to activate lang with a local activity resolution if there is no associated WFT with the run at the moment
* Replying to that activation would then cause things to break, because there is nowhere to send the commands

This is fixed in general terms by just not doing work until we have the next WFT

## Why?
It doesn't make sense to activate lang with LA resolutions if there is a missing WFT because, when we _do_ get a WFT, there might be information in there we need to send in the same activation (ex: signal). If that information changes the commands we should send in response, then we've done something wrong.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
