### PR TITLE
implement SignalWithStartWorkflow for client + tests

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -711,7 +711,7 @@ impl WorkflowClientTrait for Client {
                 }),
                 task_queue: Some(TaskQueue {
                     name: task_queue,
-                    kind: 0,
+                    kind: TaskQueueKind::Unspecified as i32,
                 }),
                 request_id,
                 workflow_task_timeout: options.task_timeout.map(Into::into),
@@ -963,9 +963,7 @@ impl WorkflowClientTrait for Client {
                 }),
                 task_queue: Some(TaskQueue {
                     name: task_queue,
-                    // #FIXME the go sdk gets this from a proto enum.  Not sure where
-                    // this is available in the rust prost generated stuff is at the moment.
-                    kind: 1,
+                    kind: TaskQueueKind::Normal as i32,
                 }),
                 request_id,
                 input,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -609,6 +609,20 @@ pub trait WorkflowClientTrait {
         payloads: Option<Payloads>,
     ) -> Result<SignalWorkflowExecutionResponse>;
 
+    /// Send signal and start workflow transcationally
+    //#TODO maybe lift the Signal type from sdk::workflow_context::options
+    #[allow(clippy::too_many_arguments)]
+    async fn signal_with_start_workflow_execution(
+        &self,
+        input: Option<Payloads>,
+        task_queue: String,
+        workflow_id: String,
+        workflow_type: String,
+        options: WorkflowOptions,
+        signal_name: String,
+        signal_input: Option<Payloads>,
+    ) -> Result<SignalWithStartWorkflowExecutionResponse>;
+
     /// Request a query of a certain workflow instance
     async fn query_workflow_execution(
         &self,
@@ -922,6 +936,44 @@ impl WorkflowClientTrait for Client {
                 signal_name,
                 input: payloads,
                 identity: self.inner.options.identity.clone(),
+                ..Default::default()
+            })
+            .await?
+            .into_inner())
+    }
+
+    async fn signal_with_start_workflow_execution(
+        &self,
+        input: Option<Payloads>,
+        task_queue: String,
+        workflow_id: String,
+        workflow_type: String,
+        options: WorkflowOptions,
+        signal_name: String,
+        signal_input: Option<Payloads>,
+    ) -> Result<SignalWithStartWorkflowExecutionResponse> {
+        let request_id = Uuid::new_v4().to_string();
+        Ok(self
+            .wf_svc()
+            .signal_with_start_workflow_execution(SignalWithStartWorkflowExecutionRequest {
+                namespace: self.namespace.clone(),
+                workflow_id,
+                workflow_type: Some(WorkflowType {
+                    name: workflow_type,
+                }),
+                task_queue: Some(TaskQueue {
+                    name: task_queue,
+                    // #FIXME the go sdk gets this from a proto enum.  Not sure where
+                    // this is available in the rust prost generated stuff is at the moment.
+                    kind: 1,
+                }),
+                request_id,
+                input,
+                signal_name,
+                signal_input,
+                identity: self.inner.options.identity.clone(),
+                workflow_task_timeout: options.task_timeout.map(Into::into),
+                search_attributes: options.search_attributes.map(Into::into),
                 ..Default::default()
             })
             .await?

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -346,6 +346,29 @@ where
         )
     }
 
+    async fn signal_with_start_workflow_execution(
+        &self,
+        input: Option<Payloads>,
+        task_queue: String,
+        workflow_id: String,
+        workflow_type: String,
+        options: WorkflowOptions,
+        signal_name: String,
+        signal_input: Option<Payloads>,
+    ) -> Result<SignalWithStartWorkflowExecutionResponse> {
+        retry_call!(
+            self,
+            signal_with_start_workflow_execution,
+            input.clone(),
+            task_queue.clone(),
+            workflow_id.clone(),
+            workflow_type.clone(),
+            options.clone(),
+            signal_name.clone(),
+            signal_input.clone()
+        )
+    }
+
     async fn query_workflow_execution(
         &self,
         workflow_id: String,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -488,7 +488,9 @@ impl ActivityHalf {
                         Ok(res) => ActivityExecutionResult::ok(res),
                         Err(err) => match err.downcast::<ActivityCancelledError>() {
                             Ok(ce) => ActivityExecutionResult::cancel_from_details(ce.details),
-                            Err(other_err) if other_err.is::<u64>() => ActivityExecutionResult::will_complete_async(),
+                            Err(other_err) if other_err.is::<ActivityResultPendingError>() => {
+                                ActivityExecutionResult::will_complete_async()
+                            }
                             Err(other_err) => ActivityExecutionResult::fail(other_err.into()),
                         },
                     };
@@ -726,7 +728,7 @@ pub struct ActivityFunction {
     act_func: BoxActFn,
 }
 
-/// Return this error to indicate your activity completes asynchronously 
+/// Return this error to indicate your activity completes asynchronously
 #[derive(Debug, Default)]
 pub struct ActivityResultPendingError;
 impl std::error::Error for ActivityResultPendingError {}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -290,10 +290,10 @@ impl TestWorker {
         self.inner.register_wf(workflow_type, wf_function)
     }
 
-    pub fn register_activity<A, R>(
+    pub fn register_activity<A, R, O>(
         &mut self,
         activity_type: impl Into<String>,
-        act_function: impl IntoActivityFunc<A, R>,
+        act_function: impl IntoActivityFunc<A, R, O>,
     ) {
         self.inner.register_activity(activity_type, act_function)
     }

--- a/tests/integ_tests/workflow_tests/signals.rs
+++ b/tests/integ_tests/workflow_tests/signals.rs
@@ -107,16 +107,13 @@ async fn sends_signal_with_create_wf() {
             vec![b"tada".into()].into_payloads(),
         )
         .await
-        .unwrap();
+        .expect("request succeeds.qed");
 
     worker.started_workflows.lock().push(WorkflowExecutionInfo {
         namespace: client.namespace().to_string(),
         workflow_id: "sends_signal_with_create_wf".to_owned(),
         run_id: Some(res.run_id.clone()),
     });
-    println!("RESULTS: {:?}", res);
-
-    // tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
 
     worker.run_until_done().await.unwrap();
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
```WorkflowClientTrait``` has a new ```signal_with_start_workflow_execution``` method.  ```RetryClient``` and ```Client``` implements this new method.  Added ```ActivityResultPendingError``` to support asynchronous activity completions.


## Why?
Nice to get closer to parity with other lang sdks.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/359

2. How was this tested:
Integration tests added for this feature in ```tests/integ_tests/workflow_tests/signals.rs```

3. Any docs updates needed?
Not that I am aware of.
