### PR TITLE
Add Operator API machinery to client

### DIFF
--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59
+FROM rust:1.62
 
 RUN rustup component add rustfmt && \
 	rustup component add clippy

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,6 +19,7 @@ derive_more = "0.99"
 futures = "0.3"
 futures-retry = "0.6.0"
 http = "0.2"
+once_cell = "1.13"
 opentelemetry = { version = "0.17", features = ["metrics"] }
 parking_lot = "0.12"
 prost-types = "0.9"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -42,7 +42,7 @@ use temporal_sdk_core_protos::{
         common::v1::{Payload, Payloads, WorkflowExecution, WorkflowType},
         enums::v1::{TaskQueueKind, WorkflowTaskFailedCause},
         failure::v1::Failure,
-        operatorservice::v1::operator_service_client::OperatorServiceClient,
+        operatorservice::v1::{operator_service_client::OperatorServiceClient, *},
         query::v1::{WorkflowQuery, WorkflowQueryResult},
         taskqueue::v1::{StickyExecutionAttributes, TaskQueue, TaskQueueMetadata},
         workflowservice::v1::{workflow_service_client::WorkflowServiceClient, *},
@@ -466,18 +466,22 @@ where
             operator_svc_client: OnceCell::new(),
         }
     }
+    /// Get the underlying workflow service client
     pub fn workflow_svc(&self) -> &WorkflowServiceClient<T> {
         self.workflow_svc_client
             .get_or_init(|| WorkflowServiceClient::new(self.svc.clone()))
     }
+    /// Get the underlying operator service client
     pub fn operator_svc(&self) -> &OperatorServiceClient<T> {
         self.operator_svc_client
             .get_or_init(|| OperatorServiceClient::new(self.svc.clone()))
     }
+    /// Get the underlying workflow service client mutably
     pub fn workflow_svc_mut(&mut self) -> &mut WorkflowServiceClient<T> {
         let _ = self.workflow_svc();
         self.workflow_svc_client.get_mut().unwrap()
     }
+    /// Get the underlying operator service client mutably
     pub fn operator_svc_mut(&mut self) -> &mut OperatorServiceClient<T> {
         let _ = self.operator_svc();
         self.operator_svc_client.get_mut().unwrap()

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -146,8 +146,12 @@ impl AttachMetricLabels {
     }
     pub fn task_q(&mut self, tq: Option<TaskQueue>) -> &mut Self {
         if let Some(tq) = tq {
-            self.labels.push(task_queue_kv(tq.name));
+            self.task_q_str(tq.name);
         }
+        self
+    }
+    pub fn task_q_str(&mut self, tq: impl Into<String>) -> &mut Self {
+        self.labels.push(task_queue_kv(tq.into()));
         self
     }
 }
@@ -624,6 +628,35 @@ proxier! {
         list_schedules,
         ListSchedulesRequest,
         ListSchedulesResponse,
+        |r| {
+            let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
+            r.extensions_mut().insert(labels);
+        }
+    );
+    (
+        update_worker_build_id_ordering,
+        UpdateWorkerBuildIdOrderingRequest,
+        UpdateWorkerBuildIdOrderingResponse,
+        |r| {
+            let mut labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
+            labels.task_q_str(r.get_ref().task_queue.clone());
+            r.extensions_mut().insert(labels);
+        }
+    );
+    (
+        get_worker_build_id_ordering,
+        GetWorkerBuildIdOrderingRequest,
+        GetWorkerBuildIdOrderingResponse,
+        |r| {
+            let mut labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
+            labels.task_q_str(r.get_ref().task_queue.clone());
+            r.extensions_mut().insert(labels);
+        }
+    );
+    (
+        update_workflow,
+        UpdateWorkflowRequest,
+        UpdateWorkflowResponse,
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ClientOptions, RawClientLikeUser, Result, RetryConfig, WorkflowClientTrait, WorkflowOptions,
+    ClientOptions, Result, RetryConfig, WorkflowClientTrait, WorkflowOptions,
     WorkflowTaskCompletion,
 };
 use backoff::{backoff::Backoff, ExponentialBackoff};
@@ -466,16 +466,16 @@ where
     }
 }
 
-impl<C> RawClientLikeUser for RetryClient<C>
-where
-    C: RawClientLikeUser,
-{
-    type RawClientT = C::RawClientT;
-
-    fn wf_svc(&self) -> Self::RawClientT {
-        self.client.wf_svc()
-    }
-}
+// impl<C> RawClientLikeUser for RetryClient<C>
+// where
+//     C: RawClientLikeUser,
+// {
+//     type RawClientT = C::RawClientT;
+//
+//     fn wf_svc(&self) -> Self::RawClientT {
+//         self.client.wf_svc()
+//     }
+// }
 
 #[cfg(test)]
 mod tests {

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -466,17 +466,6 @@ where
     }
 }
 
-// impl<C> RawClientLikeUser for RetryClient<C>
-// where
-//     C: RawClientLikeUser,
-// {
-//     type RawClientT = C::RawClientT;
-//
-//     fn wf_svc(&self) -> Self::RawClientT {
-//         self.client.wf_svc()
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
-use std::{fmt::Debug, future::Future, time::Duration};
+use std::{fmt::Debug, future::Future, sync::Arc, time::Duration};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::QueryResult,
     temporal::api::{
@@ -34,15 +34,15 @@ pub const RETRYABLE_ERROR_CODES: [Code; 7] = [
 #[derive(Debug, Clone)]
 pub struct RetryClient<SG> {
     client: SG,
-    retry_config: RetryConfig,
+    retry_config: Arc<RetryConfig>,
 }
 
 impl<SG> RetryClient<SG> {
     /// Use the provided retry config with the provided client
-    pub const fn new(client: SG, retry_config: RetryConfig) -> Self {
+    pub fn new(client: SG, retry_config: RetryConfig) -> Self {
         Self {
             client,
-            retry_config,
+            retry_config: Arc::new(retry_config),
         }
     }
 }
@@ -83,7 +83,7 @@ impl<SG> RetryClient<SG> {
     pub(crate) fn get_retry_config(&self, call_name: &'static str) -> RetryConfig {
         let call_type = Self::determine_call_type(call_name);
         match call_type {
-            CallType::Normal => self.retry_config.clone(),
+            CallType::Normal => (*self.retry_config).clone(),
             CallType::LongPoll => RetryConfig::poll_retry_policy(),
         }
     }

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -399,7 +399,6 @@ async fn local_act_null_result() {
 
 #[tokio::test]
 async fn query_during_wft_heartbeat_doesnt_accidentally_fail_to_continue_heartbeat() {
-    crate::telemetry::test_telem_console();
     let wfid = "fake_wf_id";
     let mut t = TestHistoryBuilder::default();
     let mut wes_short_wft_timeout = default_wes_attribs();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -86,7 +86,7 @@ where
             if let Some(ref id_override) = worker_config.client_identity_override {
                 client.options_mut().identity = id_override.clone();
             }
-            let retry_client = RetryClient::new(client, Default::default());
+            let retry_client = RetryClient::new(client, RetryConfig::default());
             Arc::new(retry_client)
         }
     };

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -270,7 +270,7 @@ impl Workflows {
                     task_token,
                     action: ActivationAction::RespondLegacyQuery { result },
                 } => {
-                    self.respond_legacy_query(task_token, result).await?;
+                    self.respond_legacy_query(task_token, *result).await?;
                     true
                 }
             },
@@ -794,7 +794,7 @@ pub(crate) enum ActivationAction {
         force_new_wft: bool,
     },
     /// We should respond to a legacy query request
-    RespondLegacyQuery { result: QueryResult },
+    RespondLegacyQuery { result: Box<QueryResult> },
 }
 
 #[derive(Debug, Eq, PartialEq, Hash)]
@@ -847,6 +847,7 @@ struct ActivationCompleteResult {
 }
 /// What needs to be done after calling [Workflows::activation_completed]
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum ActivationCompleteOutcome {
     /// The WFT must be reported as successful to the server using the contained information.
     ReportWFTSuccess(ServerCommandsWithWorkflowInfo),
@@ -917,6 +918,7 @@ fn validate_completion(
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum ValidatedCompletion {
     Success {
         run_id: String,
@@ -944,6 +946,7 @@ struct RunAction {
     trace_span: Span,
 }
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum RunActions {
     NewIncomingWFT(NewIncomingWFT),
     ActivationCompletion(RunActivationCompletion),
@@ -984,6 +987,7 @@ struct RunUpdateResponse {
     span: Span,
 }
 #[derive(Debug, derive_more::Display)]
+#[allow(clippy::large_enum_variant)]
 enum RunUpdateResponseKind {
     Good(GoodRunUpdate),
     Fail(FailRunUpdate),

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -539,7 +539,9 @@ impl WFStream {
                 &run_id,
                 ActivationCompleteOutcome::ReportWFTSuccess(ServerCommandsWithWorkflowInfo {
                     task_token,
-                    action: ActivationAction::RespondLegacyQuery { result: qr },
+                    action: ActivationAction::RespondLegacyQuery {
+                        result: Box::new(qr),
+                    },
                 }),
                 resp_chan,
             );

--- a/protos/api_upstream/.buildkite/Dockerfile
+++ b/protos/api_upstream/.buildkite/Dockerfile
@@ -1,2 +1,2 @@
-FROM temporalio/base-ci-builder:1.0.0
+FROM temporalio/base-ci-builder:1.5.0
 WORKDIR /temporal

--- a/protos/api_upstream/.github/CODEOWNERS
+++ b/protos/api_upstream/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Syntax is here:
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*                @temporalio/core
+*                @temporalio/server @temporalio/sdk

--- a/protos/api_upstream/.github/PULL_REQUEST_TEMPLATE.md
+++ b/protos/api_upstream/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,10 +6,6 @@
 **Why?**
 
 
-<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
-**How did you test it?**
-
-
-<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
-**Potential risks**
+<!-- Are there any breaking changes on binary or code level? -->
+**Breaking changes**
 

--- a/protos/api_upstream/.github/workflows/trigger-api-go-update.yml
+++ b/protos/api_upstream/.github/workflows/trigger-api-go-update.yml
@@ -1,0 +1,29 @@
+name: 'Trigger api-go Update'
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  notify:
+    name: 'Trigger api-go update'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Dispatch api-go Github Action
+        env:
+          PAT: ${{ secrets.COMMANDER_DATA_TOKEN }}
+          PARENT_REPO: temporalio/api-go
+          PARENT_BRANCH: ${{ toJSON('master') }}
+          WORKFLOW_ID: update-proto.yml
+          COMMIT_AUTHOR: ${{ toJSON(github.event.head_commit.author.name) }}
+          COMMIT_AUTHOR_EMAIL: ${{ toJSON(github.event.head_commit.author.email) }}
+          COMMIT_MESSAGE: ${{ toJSON(github.event.head_commit.message) }}
+        run: |
+          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ env.PAT }}" https://api.github.com/repos/${{ env.PARENT_REPO }}/actions/workflows/${{ env.WORKFLOW_ID }}/dispatches -d '{"ref":'"$PARENT_BRANCH"', "inputs":{"commit_author":'"$COMMIT_AUTHOR"', "commit_author_email":'"$COMMIT_AUTHOR_EMAIL"', "commit_message":'"$COMMIT_MESSAGE"'}}'

--- a/protos/api_upstream/Makefile
+++ b/protos/api_upstream/Makefile
@@ -33,11 +33,11 @@ grpc: buf-lint api-linter buf-breaking gogo-grpc fix-path
 
 go-grpc: clean $(PROTO_OUT)
 	printf $(COLOR) "Compile for go-gRPC..."
-	$(foreach PROTO_DIR,$(PROTO_DIRS),protoc $(PROTO_IMPORTS) --go_out=plugins=grpc,paths=source_relative:$(PROTO_OUT) $(PROTO_DIR)*.proto;)
+	$(foreach PROTO_DIR,$(PROTO_DIRS),protoc --fatal_warnings $(PROTO_IMPORTS) --go_out=plugins=grpc,paths=source_relative:$(PROTO_OUT) $(PROTO_DIR)*.proto;)
 
 gogo-grpc: clean $(PROTO_OUT)
 	printf $(COLOR) "Compile for gogo-gRPC..."
-	$(foreach PROTO_DIR,$(PROTO_DIRS),protoc $(PROTO_IMPORTS) --gogoslick_out=Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:$(PROTO_OUT) $(PROTO_DIR)*.proto;)
+	$(foreach PROTO_DIR,$(PROTO_DIRS),protoc --fatal_warnings $(PROTO_IMPORTS) --gogoslick_out=Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:$(PROTO_OUT) $(PROTO_DIR)*.proto;)
 
 fix-path:
 	mv -f $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal

--- a/protos/api_upstream/buf.yaml
+++ b/protos/api_upstream/buf.yaml
@@ -2,6 +2,7 @@ version: v1
 breaking:
   ignore:
     - temporal/api/schedule/v1
+    - temporal/api/update/v1
   use:
     - PACKAGE
 lint:

--- a/protos/api_upstream/temporal/api/command/v1/message.proto
+++ b/protos/api_upstream/temporal/api/command/v1/message.proto
@@ -37,6 +37,7 @@ import "dependencies/gogoproto/gogo.proto";
 
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/enums/v1/command_type.proto";
+import "temporal/api/enums/v1/update.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
@@ -213,6 +214,29 @@ message StartChildWorkflowExecutionCommandAttributes {
     temporal.api.common.v1.SearchAttributes search_attributes = 16;
 }
 
+message AcceptWorkflowUpdateCommandAttributes {
+    // A unique identifier for an update within a given workflow context
+    string update_id = 1;
+}
+
+message CompleteWorkflowUpdateCommandAttributes {
+    // A unique identifier for an update within a given workflow context
+    string update_id = 1;
+
+    // Whether the server should attempt to bypass making this update rejection
+    // durable in history. This field is only consulted when the result field
+    // indicates failure. Leaving this field in its default state (i.e.
+    // UPDATE_WORKFLOW_REJECTION_DURABILITY_PREFERENCE_UNSPECIFIED) will result
+    // in making the rejection durable.
+    temporal.api.enums.v1.WorkflowUpdateDurabilityPreference durability_preference = 2;
+
+    // The success or failure output of the update
+    oneof result {
+        temporal.api.common.v1.Payloads success = 3;
+        temporal.api.failure.v1.Failure failure = 4;
+    }
+}
+
 message Command {
     temporal.api.enums.v1.CommandType command_type = 1;
     oneof attributes {
@@ -229,5 +253,7 @@ message Command {
         StartChildWorkflowExecutionCommandAttributes start_child_workflow_execution_command_attributes = 12;
         SignalExternalWorkflowExecutionCommandAttributes signal_external_workflow_execution_command_attributes = 13;
         UpsertWorkflowSearchAttributesCommandAttributes upsert_workflow_search_attributes_command_attributes = 14;
+        AcceptWorkflowUpdateCommandAttributes accept_workflow_update_command_attributes = 15;
+        CompleteWorkflowUpdateCommandAttributes complete_workflow_update_command_attributes = 16;
     }
 }

--- a/protos/api_upstream/temporal/api/enums/v1/event_type.proto
+++ b/protos/api_upstream/temporal/api/enums/v1/event_type.proto
@@ -151,4 +151,18 @@ enum EventType {
     EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED = 39;
     // Workflow search attributes should be updated and synchronized with the visibility store
     EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES = 40;
+    // Workflow update request has been received
+    EVENT_TYPE_WORKFLOW_UPDATE_REQUESTED = 41;
+    // Workflow update request has been accepted by user workflow code
+    EVENT_TYPE_WORKFLOW_UPDATE_ACCEPTED = 42;
+    // Workflow update has been completed
+    EVENT_TYPE_WORKFLOW_UPDATE_COMPLETED = 43;
+    // Some property or properties of the workflow as a whole have changed by non-workflow code.
+    // The distinction of external vs. command-based modification is important so the SDK can
+    // maintain determinism when using the command-based approach.
+    EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY = 44;
+    // Some property or properties of an already-scheduled activity have changed by non-workflow code.
+    // The distinction of external vs. command-based modification is important so the SDK can
+    // maintain determinism when using the command-based approach.
+    EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY = 45;
 }

--- a/protos/api_upstream/temporal/api/enums/v1/update.proto
+++ b/protos/api_upstream/temporal/api/enums/v1/update.proto
@@ -27,31 +27,25 @@ package temporal.api.enums.v1;
 option go_package = "go.temporal.io/api/enums/v1;enums";
 option java_package = "io.temporal.api.enums.v1";
 option java_multiple_files = true;
-option java_outer_classname = "CommandTypeProto";
+option java_outer_classname = "UpdateProto";
 option ruby_package = "Temporal::Api::Enums::V1";
 option csharp_namespace = "Temporal.Api.Enums.V1";
 
-// Whenever this list of command types is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering.
-enum CommandType {
-    COMMAND_TYPE_UNSPECIFIED = 0;
-    COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK = 1;
-    COMMAND_TYPE_REQUEST_CANCEL_ACTIVITY_TASK = 2;
-    COMMAND_TYPE_START_TIMER = 3;
-    COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION = 4;
-    COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION = 5;
-    COMMAND_TYPE_CANCEL_TIMER = 6;
-    COMMAND_TYPE_CANCEL_WORKFLOW_EXECUTION = 7;
-    COMMAND_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION = 8;
-    COMMAND_TYPE_RECORD_MARKER = 9;
-    COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION = 10;
-    COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION = 11;
-    COMMAND_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION = 12;
-    COMMAND_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES = 13;
+enum WorkflowUpdateResultAccessStyle {
+    WORKFLOW_UPDATE_RESULT_ACCESS_STYLE_UNSPECIFIED = 0;
 
-    // Indicates that an update has been accepted for processing workflow code
-    COMMAND_TYPE_ACCEPT_WORKFLOW_UPDATE = 14;
+    // Indicates that the update response _must_ be included as part of the gRPC
+    // response body
+    WORKFLOW_UPDATE_RESULT_ACCESS_STYLE_REQUIRE_INLINE = 1;
+}
 
-    // Indicates that an update has completed and carries either the success or
-    // failure outcome of said update.
-    COMMAND_TYPE_COMPLETE_WORKFLOW_UPDATE = 15;
+enum WorkflowUpdateDurabilityPreference {
+    // The workflow expresses no preference as to the durability of the
+    // the associated update.
+    WORKFLOW_UPDATE_DURABILITY_PREFERENCE_UNSPECIFIED = 0;
+
+    // Used by a workflow to indicate that no workflow state mutation occurred
+    // while processing the update and that it wishes that the update not be
+    // made durable (and thus not take up space in workflow history).
+    WORKFLOW_UPDATE_DURABILITY_PREFERENCE_BYPASS = 1;
 }

--- a/protos/api_upstream/temporal/api/failure/v1/message.proto
+++ b/protos/api_upstream/temporal/api/failure/v1/message.proto
@@ -80,8 +80,26 @@ message ChildWorkflowExecutionFailureInfo {
 
 message Failure {
     string message = 1;
+    // The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK
+    // In some SDKs this is used to rehydrate the stack trace into an exception object.
     string source = 2;
     string stack_trace = 3;
+    // Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of
+    // errors originating in user code which might contain sensitive information.
+    // The `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto
+    // message.
+    //
+    // SDK authors: 
+    // - The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:
+    //   - Uses a JSON object to represent `{ message, stack_trace }`.
+    //   - Overwrites the original message with "Encoded failure" to indicate that more information could be extracted.
+    //   - Overwrites the original stack_trace with an empty string.
+    //   - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed
+    //     by the user-provided PayloadCodec
+    //
+    // - If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes.
+    // (-- api-linter: core::0203::optional=disabled --)
+    temporal.api.common.v1.Payload encoded_attributes = 20;
     Failure cause = 4;
     oneof failure_info {
         ApplicationFailureInfo application_failure_info = 5;

--- a/protos/api_upstream/temporal/api/history/v1/message.proto
+++ b/protos/api_upstream/temporal/api/history/v1/message.proto
@@ -41,8 +41,9 @@ import "temporal/api/enums/v1/failed_cause.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
-import "temporal/api/workflow/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
+import "temporal/api/update/v1/message.proto";
+import "temporal/api/workflow/v1/message.proto";
 
 // Always the first event in workflow history
 message WorkflowExecutionStartedEventAttributes {
@@ -634,6 +635,51 @@ message ChildWorkflowExecutionTerminatedEventAttributes {
     int64 started_event_id = 5;
 }
 
+message WorkflowUpdateRequestedEventAttributes {
+    temporal.api.common.v1.Header header = 1;
+    string request_id = 2;
+    string update_id = 3;
+    temporal.api.update.v1.WorkflowUpdate update = 4;
+}
+
+message WorkflowUpdateAcceptedEventAttributes {
+    temporal.api.common.v1.Header header = 1;
+    string update_id = 2;
+}
+
+message WorkflowUpdateCompletedEventAttributes {
+    temporal.api.common.v1.Header system_header = 1;
+    string update_id = 3;
+    oneof result {
+        temporal.api.common.v1.Payloads success = 4;
+        temporal.api.failure.v1.Failure failure = 5;
+    }
+}
+
+message WorkflowPropertiesModifiedExternallyEventAttributes {
+    // If set to a nonempty string, future workflow tasks for this workflow shall be dispatched on
+    // the provided queue.
+    string new_task_queue = 1;
+    // If set, update the workflow task timeout to this value.
+    google.protobuf.Duration new_workflow_task_timeout = 2 [(gogoproto.stdduration) = true];
+    // If set, update the workflow run timeout to this value. May be set to 0 for no timeout.
+    google.protobuf.Duration new_workflow_run_timeout = 3 [(gogoproto.stdduration) = true];
+    // If set, update the workflow execution timeout to this value. May be set to 0 for no timeout.
+    google.protobuf.Duration new_workflow_execution_timeout = 4 [(gogoproto.stdduration) = true];
+    // If set, update the workflow memo with the provided values. The values will be merged with
+    // the existing memo. If the user wants to delete values, a default/empty Payload should be
+    // used as the value for the key being deleted.
+    temporal.api.common.v1.Memo upserted_memo = 5;
+}
+
+message ActivityPropertiesModifiedExternallyEventAttributes {
+    // The id of the `ACTIVITY_TASK_SCHEDULED` event this modification corresponds to.
+    int64 scheduled_event_id = 1;
+    // If set, update the retry policy of the activity, replacing it with the specified one.
+    // The number of attempts at the activity is preserved.
+    temporal.api.common.v1.RetryPolicy new_retry_policy = 2;
+}
+
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.
 // See the `EventType` enum for more info about what each event is for.
 message HistoryEvent {
@@ -645,6 +691,11 @@ message HistoryEvent {
     int64 version = 4;
     // TODO: What is this? Appears unused by SDKs
     int64 task_id = 5;
+    // Set to true when the SDK may ignore the event as it does not impact workflow state or
+    // information in any way that the SDK need be concerned with. If an SDK encounters an event
+    // type which it does not understand, it must error unless this is true. If it is true, it's
+    // acceptable for the event type and/or attributes to be uninterpretable.
+    bool worker_may_ignore = 300;
     // The event details. The type must match that in `event_type`.
     oneof attributes {
         WorkflowExecutionStartedEventAttributes workflow_execution_started_event_attributes = 6;
@@ -687,6 +738,11 @@ message HistoryEvent {
         SignalExternalWorkflowExecutionFailedEventAttributes signal_external_workflow_execution_failed_event_attributes = 43;
         ExternalWorkflowExecutionSignaledEventAttributes external_workflow_execution_signaled_event_attributes = 44;
         UpsertWorkflowSearchAttributesEventAttributes upsert_workflow_search_attributes_event_attributes = 45;
+        WorkflowUpdateRequestedEventAttributes workflow_update_requested_event_attributes = 46;
+        WorkflowUpdateAcceptedEventAttributes workflow_update_accepted_event_attributes = 47;
+        WorkflowUpdateCompletedEventAttributes workflow_update_completed_event_attributes = 48;
+        WorkflowPropertiesModifiedExternallyEventAttributes workflow_properties_modified_externally_event_attributes = 49;
+        ActivityPropertiesModifiedExternallyEventAttributes activity_properties_modified_externally_event_attributes = 50;
     }
 }
 

--- a/protos/api_upstream/temporal/api/operatorservice/v1/request_response.proto
+++ b/protos/api_upstream/temporal/api/operatorservice/v1/request_response.proto
@@ -84,18 +84,16 @@ message DeleteNamespaceResponse {
     string deleted_namespace = 1;
 }
 
-// This message is EXPERIMENTAL and may be changed or removed in a later release.
 // (-- api-linter: core::0135::request-unknown-fields=disabled
 //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
 // (-- api-linter: core::0135::request-name-required=disabled
 //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
 message DeleteWorkflowExecutionRequest {
     string namespace = 1;
-    // Workflow executions to delete. If run_id is not specified, last one is used.
+    // Workflow Execution to delete. If run_id is not specified, the latest one is used.
     temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
 }
 
-// This message is EXPERIMENTAL and may be changed or removed in a later release.
 message DeleteWorkflowExecutionResponse {
 }
 

--- a/protos/api_upstream/temporal/api/operatorservice/v1/service.proto
+++ b/protos/api_upstream/temporal/api/operatorservice/v1/service.proto
@@ -66,8 +66,10 @@ service OperatorService {
     rpc DeleteNamespace (DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
     }
 
-    // DeleteWorkflowExecution deletes a closed workflow execution asynchronously (workflow must be completed or terminated before).
-    // This method is EXPERIMENTAL and may be changed or removed in a later release.
+    // DeleteWorkflowExecution asynchronously deletes a specific Workflow Execution (when
+    // WorkflowExecution.run_id is provided) or the latest Workflow Execution (when
+    // WorkflowExecution.run_id is not provided). If the Workflow Execution is Running, it will be
+    // terminated before deletion.
     // (-- api-linter: core::0135::method-signature=disabled
     //     aip.dev/not-precedent: DeleteNamespace RPC doesn't follow Google API format. --)
     // (-- api-linter: core::0135::response-message-name=disabled

--- a/protos/api_upstream/temporal/api/taskqueue/v1/message.proto
+++ b/protos/api_upstream/temporal/api/taskqueue/v1/message.proto
@@ -83,3 +83,23 @@ message StickyExecutionAttributes {
     //     aip.dev/not-precedent: "to" is used to indicate interval. --)
     google.protobuf.Duration schedule_to_start_timeout = 2 [(gogoproto.stdduration) = true];
 }
+
+// Used by the worker versioning APIs, represents a node in the version graph for a particular
+// task queue
+message VersionIdNode {
+    VersionId version = 1;
+    // A pointer to the previous version this version is considered to be compatible with
+    VersionIdNode previous_compatible = 2;
+    // A pointer to the last incompatible version (previous major version)
+    VersionIdNode previous_incompatible = 3;
+}
+
+// Used by the worker versioning APIs, represents a specific version of something
+// Currently, that's just a whole-worker id. In the future, if we support 
+// WASM workflow bundle based versioning, for example, then the inside of this
+// message may become a oneof of different version types.
+message VersionId {
+    // An opaque whole-worker identifier
+    string worker_build_id = 1;
+}
+

--- a/protos/api_upstream/temporal/api/update/v1/message.proto
+++ b/protos/api_upstream/temporal/api/update/v1/message.proto
@@ -22,37 +22,25 @@
 
 syntax = "proto3";
 
-package temporal.api.replication.v1;
+package temporal.api.update.v1;
 
-option go_package = "go.temporal.io/api/replication/v1;replication";
-option java_package = "io.temporal.api.replication.v1";
+option go_package = "go.temporal.io/api/update/v1;update";
+option java_package = "io.temporal.api.update.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
-option ruby_package = "Temporal::Api::Replication::V1";
-option csharp_namespace = "Temporal.Api.Replication.V1";
+option ruby_package = "Temporal::Api::Update::V1";
+option csharp_namespace = "Temporal.Api.Update.V1";
 
-import "google/protobuf/timestamp.proto";
+import "temporal/api/common/v1/message.proto";
 
-import "dependencies/gogoproto/gogo.proto";
+message WorkflowUpdate {
+    // Headers that are passed with the update to the processing workflow.
+    // These can include things like auth or tracing tokens.
+    temporal.api.common.v1.Header header = 1;
 
-import "temporal/api/enums/v1/namespace.proto";
+    // The name of the update function to invoke on the target workflow.
+    string name = 2;
 
-message ClusterReplicationConfig {
-    string cluster_name = 1;
-}
-
-message NamespaceReplicationConfig {
-    string active_cluster_name = 1;
-    repeated ClusterReplicationConfig clusters = 2;
-    temporal.api.enums.v1.ReplicationState state = 3;
-    // Contains the historical state of failover_versions for the cluster, truncated to contain only the last N
-    // states to ensure that the list does not grow unbounded.
-    repeated FailoverStatus failover_history = 4;
-}
-
-// Represents a historical replication status of a Namespace
-message FailoverStatus {
-    // Timestamp when the Cluster switched to the following failover_version
-    google.protobuf.Timestamp failover_time = 1 [(gogoproto.stdtime) = true];
-    int64 failover_version = 2;
+    // The arguments to pass to the named update function.
+    temporal.api.common.v1.Payloads args = 3;
 }

--- a/protos/api_upstream/temporal/api/workflow/v1/message.proto
+++ b/protos/api_upstream/temporal/api/workflow/v1/message.proto
@@ -142,3 +142,4 @@ message NewWorkflowExecutionInfo {
     temporal.api.common.v1.SearchAttributes search_attributes = 12;
     temporal.api.common.v1.Header header = 13;
 }
+

--- a/protos/api_upstream/temporal/api/workflowservice/v1/request_response.proto
+++ b/protos/api_upstream/temporal/api/workflowservice/v1/request_response.proto
@@ -38,6 +38,7 @@ import "temporal/api/enums/v1/common.proto";
 import "temporal/api/enums/v1/query.proto";
 import "temporal/api/enums/v1/reset.proto";
 import "temporal/api/enums/v1/task_queue.proto";
+import "temporal/api/enums/v1/update.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/history/v1/message.proto";
 import "temporal/api/workflow/v1/message.proto";
@@ -49,6 +50,7 @@ import "temporal/api/query/v1/message.proto";
 import "temporal/api/replication/v1/message.proto";
 import "temporal/api/schedule/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
+import "temporal/api/update/v1/message.proto";
 import "temporal/api/version/v1/message.proto";
 
 import "google/protobuf/duration.proto";
@@ -800,6 +802,9 @@ message GetSystemInfoResponse {
 
         // Supports scheduled workflow features.
         bool supports_schedules = 4;
+
+        // True if server uses protos that include temporal.api.failure.v1.Failure.encoded_attributes
+        bool encoded_failure_attributes = 5;
     }
 }
 
@@ -949,4 +954,86 @@ message ListSchedulesRequest {
 message ListSchedulesResponse {
     repeated temporal.api.schedule.v1.ScheduleListEntry schedules = 1;
     bytes next_page_token = 2;
+}
+
+// (-- api-linter: core::0134::request-mask-required=disabled
+//     aip.dev/not-precedent: UpdateWorkerBuildIdOrderingRequest doesn't follow Google API format --)
+// (-- api-linter: core::0134::request-resource-required=disabled
+//     aip.dev/not-precedent: UpdateWorkerBuildIdOrderingRequest RPC doesn't follow Google API format. --)
+message UpdateWorkerBuildIdOrderingRequest {
+    string namespace = 1;
+    // Must be set, the task queue to apply changes to. Because all workers on
+    // a given task queue must have the same set of workflow & activity
+    // implementations, there is no reason to specify a task queue type here.
+    string task_queue = 2;
+    // The version id we are targeting.
+    temporal.api.taskqueue.v1.VersionId version_id = 3;
+    // When set, indicates that the `version_id` in this message is compatible
+    // with the one specified in this field. Because compatability should form
+    // a DAG, any build id can only be the "next compatible" version for one
+    // other ID of a certain type at a time, and any setting which would create a cycle is invalid.
+    temporal.api.taskqueue.v1.VersionId previous_compatible = 4;
+    // When set, establishes the specified `version_id` as the default of it's type
+    // for the queue. Workers matching it will begin processing new workflow executions.
+    // The existing default will be marked as a previous incompatible version
+    // to this one, assuming it is not also in `is_compatible_with`.
+    bool become_default = 5;
+}
+message UpdateWorkerBuildIdOrderingResponse {}
+
+// (-- api-linter: core::0134::request-resource-required=disabled
+//     aip.dev/not-precedent: GetWorkerBuildIdOrderingRequest RPC doesn't follow Google API format. --)
+message GetWorkerBuildIdOrderingRequest {
+    string namespace = 1;
+    // Must be set, the task queue to interrogate about worker id ordering
+    string task_queue = 2;
+    // Limits how deep the returned DAG will go. 1 will return only the
+    // default build id. A default/0 value will return the entire graph.
+    int32 max_depth = 3;
+}
+message GetWorkerBuildIdOrderingResponse {
+    // The currently established default version
+    temporal.api.taskqueue.v1.VersionIdNode current_default = 1;
+    // Other current latest-compatible versions who are not the overall default. These are the
+    // versions that will be used when generating new tasks by following the graph from the
+    // version of the last task out to a leaf.
+    repeated temporal.api.taskqueue.v1.VersionIdNode compatible_leaves = 2;
+}
+
+// (-- api-linter: core::0134=disabled
+//     aip.dev/not-precedent: Update RPCs don't follow Google API format. --)
+message UpdateWorkflowRequest {
+    // A unique ID for this logical request
+    string request_id = 1;
+
+    // The manner in which the update result will be accessed.
+    // This field requires a non-default value; the default value of the enum
+    // will result in an error.
+    temporal.api.enums.v1.WorkflowUpdateResultAccessStyle result_access_style = 2;
+
+    // The namespace name of the target workflow
+    string namespace = 3;
+    // The target workflow id and (optionally) a specific run thereof
+    // (-- api-linter: core::0203::optional=disabled
+    //     aip.dev/not-precedent: false positive triggered by the word "optional" --)
+    temporal.api.common.v1.WorkflowExecution workflow_execution = 4;
+    // If set, this call will error if the most recent (if no run id is set on
+    // `workflow_execution`), or specified (if it is) workflow execution is not
+    // part of the same execution chain as this id.
+    string first_execution_run_id = 5;
+
+    // The name under which the workflow update function is registered and the
+    // arguments to pass to said function.
+    temporal.api.update.v1.WorkflowUpdate update = 6;
+}
+
+message UpdateWorkflowResponse {
+    // An opaque token that can be used to retrieve the update result via
+    // polling if it is not returned as part of the gRPC response
+    bytes update_token = 1;
+    // The success or failure status of the update
+    oneof result {
+        temporal.api.common.v1.Payloads success = 2;
+        temporal.api.failure.v1.Failure failure = 3;
+    }
 }

--- a/protos/api_upstream/temporal/api/workflowservice/v1/service.proto
+++ b/protos/api_upstream/temporal/api/workflowservice/v1/service.proto
@@ -368,4 +368,18 @@ service WorkflowService {
     // List all schedules in a namespace.
     rpc ListSchedules (ListSchedulesRequest) returns (ListSchedulesResponse) {
     }
+
+    // (-- api-linter: core::0134::response-message-name=disabled
+    //     aip.dev/not-precedent: UpdateWorkerBuildIdOrdering RPC doesn't follow Google API format. --)
+    // (-- api-linter: core::0134::method-signature=disabled
+    //     aip.dev/not-precedent: UpdateWorkerBuildIdOrdering RPC doesn't follow Google API format. --)
+    rpc UpdateWorkerBuildIdOrdering (UpdateWorkerBuildIdOrderingRequest) returns (UpdateWorkerBuildIdOrderingResponse) {}
+    // This could / maybe should just be part of `DescribeTaskQueue`, but is broken out here to show easily.
+    rpc GetWorkerBuildIdOrdering (GetWorkerBuildIdOrderingRequest) returns (GetWorkerBuildIdOrderingResponse) {}
+
+    // Invokes the specified update function on user workflow code.
+    // (-- api-linter: core::0134=disabled
+    //     aip.dev/not-precedent: UpdateWorkflow doesn't follow Google API format --)
+    rpc UpdateWorkflow(UpdateWorkflowRequest) returns (UpdateWorkflowResponse) {
+    }
 }

--- a/sdk-core-protos/build.rs
+++ b/sdk-core-protos/build.rs
@@ -93,6 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "../protos/local/temporal/sdk/core/core_interface.proto",
                 "../protos/local/temporal/sdk/core/bridge/bridge.proto",
                 "../protos/api_upstream/temporal/api/workflowservice/v1/service.proto",
+                "../protos/api_upstream/temporal/api/operatorservice/v1/service.proto",
             ],
             &["../protos/api_upstream", "../protos/local"],
         )?;

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -334,6 +334,7 @@ impl TestHistoryBuilder {
                 failure_info: Some(failure::FailureInfo::CanceledFailureInfo(
                     CanceledFailureInfo { details: None },
                 )),
+                encoded_attributes: Default::default(),
             }),
             None,
         );

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1318,6 +1318,11 @@ pub mod coresdk {
 // This is disgusting, but unclear to me how to avoid it. TODO: Discuss w/ prost maintainer
 pub mod temporal {
     pub mod api {
+        pub mod cluster {
+            pub mod v1 {
+                tonic::include_proto!("temporal.api.cluster.v1");
+            }
+        }
         pub mod command {
             pub mod v1 {
                 tonic::include_proto!("temporal.api.command.v1");
@@ -1506,21 +1511,6 @@ pub mod temporal {
                 }
             }
         }
-        pub mod enums {
-            pub mod v1 {
-                tonic::include_proto!("temporal.api.enums.v1");
-            }
-        }
-        pub mod failure {
-            pub mod v1 {
-                tonic::include_proto!("temporal.api.failure.v1");
-            }
-        }
-        pub mod filter {
-            pub mod v1 {
-                tonic::include_proto!("temporal.api.filter.v1");
-            }
-        }
         pub mod common {
             pub mod v1 {
                 use std::{
@@ -1592,6 +1582,21 @@ pub mod temporal {
                         }
                     }
                 }
+            }
+        }
+        pub mod enums {
+            pub mod v1 {
+                tonic::include_proto!("temporal.api.enums.v1");
+            }
+        }
+        pub mod failure {
+            pub mod v1 {
+                tonic::include_proto!("temporal.api.failure.v1");
+            }
+        }
+        pub mod filter {
+            pub mod v1 {
+                tonic::include_proto!("temporal.api.filter.v1");
             }
         }
         pub mod history {
@@ -1709,31 +1714,31 @@ pub mod temporal {
                 }
             }
         }
-
         pub mod namespace {
             pub mod v1 {
                 tonic::include_proto!("temporal.api.namespace.v1");
             }
         }
-
+        pub mod operatorservice {
+            pub mod v1 {
+                tonic::include_proto!("temporal.api.operatorservice.v1");
+            }
+        }
         pub mod query {
             pub mod v1 {
                 tonic::include_proto!("temporal.api.query.v1");
             }
         }
-
         pub mod replication {
             pub mod v1 {
                 tonic::include_proto!("temporal.api.replication.v1");
             }
         }
-
         pub mod schedule {
             pub mod v1 {
                 tonic::include_proto!("temporal.api.schedule.v1");
             }
         }
-
         pub mod taskqueue {
             pub mod v1 {
                 use crate::temporal::api::enums::v1::TaskQueueKind;
@@ -1749,19 +1754,21 @@ pub mod temporal {
                 }
             }
         }
-
+        pub mod update {
+            pub mod v1 {
+                tonic::include_proto!("temporal.api.update.v1");
+            }
+        }
         pub mod version {
             pub mod v1 {
                 tonic::include_proto!("temporal.api.version.v1");
             }
         }
-
         pub mod workflow {
             pub mod v1 {
                 tonic::include_proto!("temporal.api.workflow.v1");
             }
         }
-
         pub mod workflowservice {
             pub mod v1 {
                 use std::{


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added operator API client capability
* New trait which existing client types implement
* New top-level client type `TemporalServiceClient` which wraps both sub-clients

## Why?
Expose operator service

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/346

2. How was this tested:
Existing tests, added coverage test for operator service APIs

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
