### PR TITLE
Add retry policy to continue-as-new, and carry over current WF values

### DIFF
--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2011,7 +2011,7 @@ async fn continue_as_new_preserves_some_values() {
     let memo = HashMap::<String, Payload>::from([("enchi".to_string(), b"cat".into())]).into();
     let search = HashMap::<String, Payload>::from([("noisy".to_string(), b"kitty".into())]).into();
     let retry_policy = RetryPolicy {
-        backoff_coefficient: 3.14,
+        backoff_coefficient: 13.37,
         ..Default::default()
     };
     let mut wes_attrs = default_wes_attribs();

--- a/core/src/worker/workflow/driven_workflow.rs
+++ b/core/src/worker/workflow/driven_workflow.rs
@@ -45,6 +45,9 @@ impl DrivenWorkflow {
                 .workflow_execution_timeout
                 .clone()
                 .try_into_or_none(),
+            memo: attribs.memo.clone(),
+            search_attrs: attribs.search_attributes.clone(),
+            retry_policy: attribs.retry_policy.clone(),
         };
         self.send_job(start_workflow_from_attribs(attribs, workflow_id, randomness_seed).into());
         self.started_attrs = Some(started_info);

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1091,8 +1091,8 @@ impl WorkflowMachines {
         if let Some(started_info) = self.drive_me.get_started_info() {
             if attrs.memo.is_empty() {
                 attrs.memo = started_info
-                    .clone()
                     .memo
+                    .clone()
                     .map(Into::into)
                     .unwrap_or_default();
             }

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -58,6 +58,7 @@ use temporal_sdk_core_protos::{
     },
     temporal::api::{
         command::v1::{command::Attributes, Command as ProtoCommand, Command},
+        common::v1::{Memo, RetryPolicy, SearchAttributes},
         enums::v1::WorkflowTaskFailedCause,
         taskqueue::v1::StickyExecutionAttributes,
         workflowservice::v1::PollActivityTaskQueueResponse,
@@ -1141,6 +1142,9 @@ enum CommandID {
 pub struct WorkflowStartedInfo {
     workflow_task_timeout: Option<Duration>,
     workflow_execution_timeout: Option<Duration>,
+    memo: Option<Memo>,
+    search_attrs: Option<SearchAttributes>,
+    retry_policy: Option<RetryPolicy>,
 }
 
 type LocalActivityRequestSink =

--- a/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -173,27 +173,30 @@ message FailWorkflowExecution {
     temporal.api.failure.v1.Failure failure = 1;
 }
 
-// TODO: Maybe combine all execution resolves into one message
-/// Continue the workflow as a new execution. Unless noted otherwise, unset or default field values
-/// will re-use the issuing workflow's values.
+// Continue the workflow as a new execution
 message ContinueAsNewWorkflowExecution {
-    /// The identifier the lang-specific sdk uses to execute workflow code
+    // The identifier the lang-specific sdk uses to execute workflow code
     string workflow_type = 1;
-    /// Task queue for the new workflow execution
+    // Task queue for the new workflow execution
     string task_queue = 2;
-    /// Inputs to the workflow code. Should be specified. Will not re-use old arguments, as that
-    /// typically wouldn't make any sense.
+    // Inputs to the workflow code. Should be specified. Will not re-use old arguments, as that
+    // typically wouldn't make any sense.
     repeated temporal.api.common.v1.Payload arguments = 3;
-    /// Timeout for a single run of the new workflow.
+    // Timeout for a single run of the new workflow. Will not re-use current workflow's value.
     google.protobuf.Duration workflow_run_timeout = 4;
-    /// Timeout of a single workflow task.
+    // Timeout of a single workflow task. Will not re-use current workflow's value.
     google.protobuf.Duration workflow_task_timeout = 5;
-    /// Memo fields
+    // If set, the new workflow will have this memo. If unset, re-uses the current workflow's memo
     map<string, temporal.api.common.v1.Payload> memo = 6;
-    /// Header fields
+    // If set, the new workflow will have these headers. Will *not* re-use current workflow's
+    // headers otherwise.
     map<string, temporal.api.common.v1.Payload> headers = 7;
-    /// Search attributes
+    // If set, the new workflow will have these search attributes. If unset, re-uses the current
+    // workflow's search attributes.
     map<string, temporal.api.common.v1.Payload> search_attributes = 8;
+    // If set, the new workflow will have this retry policy. If unset, re-uses the current
+    // workflow's retry policy.
+    temporal.api.common.v1.RetryPolicy retry_policy = 9;
 }
 
 /// Indicate a workflow has completed as cancelled. Generally sent as a response to an activation

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1499,9 +1499,22 @@ pub mod temporal {
                                 input: c.arguments.into_payloads(),
                                 workflow_run_timeout: c.workflow_run_timeout,
                                 workflow_task_timeout: c.workflow_task_timeout,
-                                memo: Some(c.memo.into()),
-                                header: Some(c.headers.into()),
+                                memo: if c.memo.is_empty() {
+                                    None
+                                } else {
+                                    Some(c.memo.into())
+                                },
+                                header: if c.headers.is_empty() {
+                                    None
+                                } else {
+                                    Some(c.headers.into())
+                                },
                                 retry_policy: c.retry_policy,
+                                search_attributes: if c.search_attributes.is_empty() {
+                                    None
+                                } else {
+                                    Some(c.search_attributes.into())
+                                },
                                 ..Default::default()
                             },
                         )

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1501,7 +1501,7 @@ pub mod temporal {
                                 workflow_task_timeout: c.workflow_task_timeout,
                                 memo: Some(c.memo.into()),
                                 header: Some(c.headers.into()),
-                                search_attributes: Some(c.search_attributes.into()),
+                                retry_policy: c.retry_policy,
                                 ..Default::default()
                             },
                         )
@@ -1578,6 +1578,21 @@ pub mod temporal {
                 impl From<Header> for HashMap<String, Payload> {
                     fn from(h: Header) -> Self {
                         h.fields.into_iter().map(|(k, v)| (k, v.into())).collect()
+                    }
+                }
+
+                impl From<Memo> for HashMap<String, Payload> {
+                    fn from(h: Memo) -> Self {
+                        h.fields.into_iter().map(|(k, v)| (k, v.into())).collect()
+                    }
+                }
+
+                impl From<SearchAttributes> for HashMap<String, Payload> {
+                    fn from(h: SearchAttributes) -> Self {
+                        h.indexed_fields
+                            .into_iter()
+                            .map(|(k, v)| (k, v.into()))
+                            .collect()
                     }
                 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added retry policy field to CAN command.
Carry over memo, search attrs, and retry policy if not specified. (technically :boom: breaking). 

B/c of the maps being at the top level for memo/search attrs, there is not a simple way to just totally wipe the existing value. You'd have to set some pointless "a->a" mapping or something to force the override. Maybe we want to change that.

## Why?
Retry policy is needed
Carrying over the fields mentioned just generally makes sense.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/372

2. How was this tested:
Added UT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
