### PR TITLE
add SignalWithStartOptions and builder

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,7 +12,7 @@ mod raw;
 mod retry;
 mod workflow_handle;
 
-pub use tonic::Status;
+pub use tonic::Status as TonicStatus;
 pub use crate::retry::{CallType, RetryClient, RETRYABLE_ERROR_CODES};
 pub use raw::{HealthService, OperatorService, TestService, WorkflowService};
 pub use temporal_sdk_core_protos::temporal::api::{

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,7 +12,7 @@ mod raw;
 mod retry;
 mod workflow_handle;
 
-pub use tonic::Status as TonicStatus;
+pub use tonic;
 pub use crate::retry::{CallType, RetryClient, RETRYABLE_ERROR_CODES};
 pub use raw::{HealthService, OperatorService, TestService, WorkflowService};
 pub use temporal_sdk_core_protos::temporal::api::{

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -675,7 +675,8 @@ impl Into<RegisterNamespaceRequest> for RegisterNamespaceOptions {
 
 impl RegisterNamespaceOptionsBuilder {
     /// Custum builder function for convenience
-    pub fn clusters(&mut self, clusters: Vec<String>) {
+    /// Warning: setting cluster_names could blow away any previously set cluster configs
+    pub fn cluster_names(&mut self, clusters: Vec<String>) {
         self.clusters = Some(
             clusters
                 .into_iter()
@@ -688,22 +689,22 @@ impl RegisterNamespaceOptionsBuilder {
 /// Helper struct for `signal_with_start_workflow_execution`.
 #[derive(Clone, derive_builder::Builder)]
 pub struct SignalWithStartOptions {
-    /// Input payload for the workflow run/signal
+    /// Input payload for the workflow run
     #[builder(setter(strip_option), default)]
     pub input: Option<Payloads>,
     /// Task Queue to target (required)
     #[builder(setter(into))]
     pub task_queue: String,
-    /// Workflow id of the run/signal (required)
+    /// Workflow id for the workflow run
     #[builder(setter(into))]
     pub workflow_id: String,
-    /// Workflow type of the run/signal (required)
+    /// Workflow type for the workflow run
     #[builder(setter(into))]
     pub workflow_type: String,
     #[builder(setter(strip_option), default)]
     /// Request id for idempotency/deduplication
     pub request_id: Option<String>,
-    /// The signal name to send (requierd)
+    /// The signal name to send (required)
     #[builder(setter(into))]
     pub signal_name: String,
     /// Payloads for the signal

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -609,7 +609,7 @@ pub struct RegisterNamespaceOptions {
     #[builder(setter(into))]
     pub description: String,
     /// Owner's email
-    #[builder(default)]
+    #[builder(setter(into), default)]
     pub owner_email: String,
     /// Workflow execution retention period
     #[builder(default = "DEFAULT_WORKFLOW_EXECUTION_RETENTION_PERIOD")]
@@ -624,7 +624,7 @@ pub struct RegisterNamespaceOptions {
     #[builder(default)]
     pub data: HashMap<String, String>,
     /// Security Token
-    #[builder(default)]
+    #[builder(setter(into), default)]
     pub security_token: String,
     /// Global namespace
     #[builder(default)]
@@ -633,13 +633,13 @@ pub struct RegisterNamespaceOptions {
     #[builder(setter(into), default = "ArchivalState::Unspecified")]
     pub history_archival_state: ArchivalState,
     /// History Archival uri
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into), default)]
     pub history_archival_uri: String,
     /// Visibility Archival setting
     #[builder(setter(into), default = "ArchivalState::Unspecified")]
     pub visibility_archival_state: ArchivalState,
     /// Visibility Archival uri
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into), default)]
     pub visibility_archival_uri: String,
 }
 
@@ -650,25 +650,25 @@ impl RegisterNamespaceOptions {
     }
 }
 
-impl Into<RegisterNamespaceRequest> for RegisterNamespaceOptions {
-    fn into(self) -> RegisterNamespaceRequest {
+impl From<RegisterNamespaceOptions> for RegisterNamespaceRequest {
+    fn from(val: RegisterNamespaceOptions) -> Self {
         RegisterNamespaceRequest {
-            namespace: self.namespace,
-            description: self.description,
-            owner_email: self.owner_email,
-            workflow_execution_retention_period: self
+            namespace: val.namespace,
+            description: val.description,
+            owner_email: val.owner_email,
+            workflow_execution_retention_period: val
                 .workflow_execution_retention_period
                 .try_into()
                 .ok(),
-            clusters: self.clusters,
-            active_cluster_name: self.active_cluster_name,
-            data: self.data,
-            security_token: self.security_token,
-            is_global_namespace: self.is_global_namespace,
-            history_archival_state: self.history_archival_state as i32,
-            history_archival_uri: self.history_archival_uri,
-            visibility_archival_state: self.visibility_archival_state as i32,
-            visibility_archival_uri: self.visibility_archival_uri,
+            clusters: val.clusters,
+            active_cluster_name: val.active_cluster_name,
+            data: val.data,
+            security_token: val.security_token,
+            is_global_namespace: val.is_global_namespace,
+            history_archival_state: val.history_archival_state as i32,
+            history_archival_uri: val.history_archival_uri,
+            visibility_archival_state: val.visibility_archival_state as i32,
+            visibility_archival_uri: val.visibility_archival_uri,
         }
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,6 +12,7 @@ mod raw;
 mod retry;
 mod workflow_handle;
 
+pub use tonic::Status;
 pub use crate::retry::{CallType, RetryClient, RETRYABLE_ERROR_CODES};
 pub use raw::{HealthService, OperatorService, TestService, WorkflowService};
 pub use temporal_sdk_core_protos::temporal::api::{

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,7 +12,6 @@ mod raw;
 mod retry;
 mod workflow_handle;
 
-pub use tonic;
 pub use crate::retry::{CallType, RetryClient, RETRYABLE_ERROR_CODES};
 pub use raw::{HealthService, OperatorService, TestService, WorkflowService};
 pub use temporal_sdk_core_protos::temporal::api::{
@@ -23,6 +22,7 @@ pub use temporal_sdk_core_protos::temporal::api::{
         list_open_workflow_executions_request::Filters as ListOpenFilters,
     },
 };
+pub use tonic;
 pub use workflow_handle::{WorkflowExecutionInfo, WorkflowExecutionResult};
 
 use crate::{
@@ -902,6 +902,9 @@ pub trait WorkflowClientTrait {
         query: String,
     ) -> Result<ListArchivedWorkflowExecutionsResponse>;
 
+    /// Get Cluster Search Attributes
+    async fn get_search_attributes(&self) -> Result<GetSearchAttributesResponse>;
+
     /// Returns options that were used to initialize the client
     fn get_options(&self) -> &ClientOptions;
 
@@ -1373,6 +1376,14 @@ impl WorkflowClientTrait for Client {
                 next_page_token,
                 query,
             })
+            .await?
+            .into_inner())
+    }
+
+    async fn get_search_attributes(&self) -> Result<GetSearchAttributesResponse> {
+        Ok(self
+            .wf_svc()
+            .get_search_attributes(GetSearchAttributesRequest {})
             .await?
             .into_inner())
     }

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -1,6 +1,6 @@
 use crate::{
     ClientOptions, ListClosedFilters, ListOpenFilters, Namespace, Result, RetryConfig,
-    StartTimeFilter, WorkflowClientTrait, WorkflowOptions,
+    SignalWithStartOptions, StartTimeFilter, WorkflowClientTrait, WorkflowOptions,
 };
 use backoff::{backoff::Backoff, exponential::ExponentialBackoff, Clock, SystemClock};
 use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
@@ -8,7 +8,7 @@ use std::{fmt::Debug, future::Future, sync::Arc, time::Duration};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::QueryResult,
     temporal::api::{
-        common::v1::{Header, Payload, Payloads},
+        common::v1::{Payload, Payloads},
         enums::v1::WorkflowTaskFailedCause,
         failure::v1::Failure,
         query::v1::WorkflowQuery,
@@ -362,28 +362,14 @@ where
 
     async fn signal_with_start_workflow_execution(
         &self,
-        input: Option<Payloads>,
-        task_queue: String,
-        workflow_id: String,
-        workflow_type: String,
-        request_id: Option<String>,
-        options: WorkflowOptions,
-        signal_name: String,
-        signal_input: Option<Payloads>,
-        signal_header: Option<Header>,
+        options: SignalWithStartOptions,
+        workflow_options: WorkflowOptions,
     ) -> Result<SignalWithStartWorkflowExecutionResponse> {
         retry_call!(
             self,
             signal_with_start_workflow_execution,
-            input.clone(),
-            task_queue.clone(),
-            workflow_id.clone(),
-            workflow_type.clone(),
-            request_id.clone(),
             options.clone(),
-            signal_name.clone(),
-            signal_input.clone(),
-            signal_header.clone()
+            workflow_options.clone()
         )
     }
 
@@ -524,6 +510,21 @@ where
         retry_call!(
             self,
             list_workflow_executions,
+            page_size,
+            next_page_token.clone(),
+            query.clone()
+        )
+    }
+
+    async fn list_archived_workflow_executions(
+        &self,
+        page_size: i32,
+        next_page_token: Vec<u8>,
+        query: String,
+    ) -> Result<ListArchivedWorkflowExecutionsResponse> {
+        retry_call!(
+            self,
+            list_archived_workflow_executions,
             page_size,
             next_page_token.clone(),
             query.clone()

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -538,6 +538,10 @@ where
         )
     }
 
+    async fn get_search_attributes(&self) -> Result<GetSearchAttributesResponse> {
+        retry_call!(self, get_search_attributes)
+    }
+
     fn get_options(&self) -> &ClientOptions {
         self.client.get_options()
     }

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ClientOptions, ListClosedFilters, ListOpenFilters, Namespace, Result, RetryConfig,
-    SignalWithStartOptions, StartTimeFilter, WorkflowClientTrait, WorkflowOptions,
+    ClientOptions, ListClosedFilters, ListOpenFilters, Namespace, RegisterNamespaceOptions, Result,
+    RetryConfig, SignalWithStartOptions, StartTimeFilter, WorkflowClientTrait, WorkflowOptions,
 };
 use backoff::{backoff::Backoff, exponential::ExponentialBackoff, Clock, SystemClock};
 use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
@@ -457,6 +457,13 @@ where
             workflow_id.clone(),
             run_id.clone()
         )
+    }
+
+    async fn register_namespace(
+        &self,
+        options: RegisterNamespaceOptions,
+    ) -> Result<RegisterNamespaceResponse> {
+        retry_call!(self, register_namespace, options.clone())
     }
 
     async fn list_namespaces(&self) -> Result<ListNamespacesResponse> {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -63,8 +63,7 @@ tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["parking_lot", "env-filter", "registry"] }
 url = "2.2"
 uuid = { version = "1.1", features = ["v4"] }
-# zip = "0.6"
-zip = { git = "https://github.com/zip-rs/zip", rev = "bb230ef56adc13436d1fcdfaa489249d119c498f"  }
+zip = "0.6.3"
 
 # 1st party local deps
 [dependencies.temporal-sdk-core-api]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -63,7 +63,8 @@ tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["parking_lot", "env-filter", "registry"] }
 url = "2.2"
 uuid = { version = "1.1", features = ["v4"] }
-zip = "0.6"
+# zip = "0.6"
+zip = { git = "https://github.com/zip-rs/zip", rev = "bb230ef56adc13436d1fcdfaa489249d119c498f"  }
 
 # 1st party local deps
 [dependencies.temporal-sdk-core-api]

--- a/tests/integ_tests/workflow_tests/signals.rs
+++ b/tests/integ_tests/workflow_tests/signals.rs
@@ -116,10 +116,7 @@ async fn sends_signal_with_create_wf() {
         .build()
         .unwrap();
     let res = client
-        .signal_with_start_workflow_execution(
-            options,
-            WorkflowOptions::default(),
-        )
+        .signal_with_start_workflow_execution(options, WorkflowOptions::default())
         .await
         .expect("request succeeds.qed");
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Added helper struct `SignalWithStartOptions` that also derives a builder
- Added client calls for `list_archived_workflow_executions`

## Why?
<!-- Tell your future self why have you made these changes -->
The parameter list for `client.signal_with_start_workflow_execution` was growing out of control.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
integration tests using this call was updated to use the builder.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
no