### PR TITLE
Use tokio-rustls for reqwest

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,7 +45,7 @@ prometheus = "0.13"
 prost = "0.11"
 prost-types = "0.11"
 rand = "0.8.3"
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls", "tokio-rustls"], default-features = false }
 ringbuf = "0.2"
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Removes the dependency on system's libssl (usually openssl) which complicates cross compilation.