### PR TITLE
Protect worker from more network errors

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -179,6 +179,14 @@ impl RetryConfig {
             max_retries: 0,
         }
     }
+
+    /// Because proxies are sometimes garbage and return fatal errors when they should be returning
+    /// a "not ready" status, we permit otherwise "fatal" looking errors for a brief period.
+    pub(crate) const fn fatal_poll_retry_policy() -> Self {
+        let mut r = Self::poll_retry_policy();
+        r.max_elapsed_time = Some(Duration::from_secs(60));
+        r
+    }
 }
 
 impl From<RetryConfig> for ExponentialBackoff {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -179,14 +179,6 @@ impl RetryConfig {
             max_retries: 0,
         }
     }
-
-    /// Because proxies are sometimes garbage and return fatal errors when they should be returning
-    /// a "not ready" status, we permit otherwise "fatal" looking errors for a brief period.
-    pub(crate) const fn fatal_poll_retry_policy() -> Self {
-        let mut r = Self::poll_retry_policy();
-        r.max_elapsed_time = Some(Duration::from_secs(60));
-        r
-    }
 }
 
 impl From<RetryConfig> for ExponentialBackoff {

--- a/core-api/src/errors.rs
+++ b/core-api/src/errors.rs
@@ -50,10 +50,6 @@ pub enum CompleteWfError {
         /// The run associated with the completion
         run_id: String,
     },
-    /// Unhandled error when calling the temporal server. Core will attempt to retry any non-fatal
-    /// errors, so lang should consider this fatal.
-    #[error("Unhandled grpc error when completing workflow task: {0:?}")]
-    TonicError(#[from] tonic::Status),
 }
 
 /// Errors thrown by [crate::Worker::complete_activity_task]
@@ -67,10 +63,6 @@ pub enum CompleteActivityError {
         /// The completion, which may not be included to avoid unnecessary copies.
         completion: Option<ActivityExecutionResult>,
     },
-    /// Unhandled error when calling the temporal server. Core will attempt to retry any non-fatal
-    /// errors, so lang should consider this fatal.
-    #[error("Unhandled grpc error when completing activity: {0:?}")]
-    TonicError(#[from] tonic::Status),
 }
 
 /// Errors thrown inside of workflow machines

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -14,7 +14,7 @@ use crate::{
     worker::{
         activities::activity_heartbeat_manager::ActivityHeartbeatError, client::WorkerClient,
     },
-    CompleteActivityError, PollActivityError, TaskToken,
+    PollActivityError, TaskToken,
 };
 use activity_heartbeat_manager::ActivityHeartbeatManager;
 use dashmap::DashMap;
@@ -231,7 +231,7 @@ impl WorkerActivityTasks {
         task_token: TaskToken,
         status: aer::Status,
         client: &dyn WorkerClient,
-    ) -> Result<(), CompleteActivityError> {
+    ) {
         if let Some((_, act_info)) = self.outstanding_activity_tasks.remove(&task_token) {
             let act_metrics = self.metrics.with_new_attrs([
                 activity_type(act_info.base.activity_type.clone()),
@@ -284,7 +284,7 @@ impl WorkerActivityTasks {
                         completion. This may happen if the activity has already been cancelled but \
                         completed anyway.");
                     } else {
-                        return Err(e.into());
+                        warn!(error=?e, "Network error while completing activity");
                     };
                 };
             };
@@ -294,7 +294,6 @@ impl WorkerActivityTasks {
                 &task_token
             );
         }
-        Ok(())
     }
 
     /// Attempt to record an activity heartbeat

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -2,9 +2,7 @@
 
 pub(crate) mod mocks;
 
-use temporal_client::{
-    Client, RetryClient, WorkflowService, WorkflowTaskCompletion, RETRYABLE_ERROR_CODES,
-};
+use temporal_client::{Client, RetryClient, WorkflowService, WorkflowTaskCompletion};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::QueryResult,
     temporal::api::{
@@ -17,16 +15,8 @@ use temporal_sdk_core_protos::{
     },
     TaskToken,
 };
-use tonic::Code;
 
 type Result<T, E = tonic::Status> = std::result::Result<T, E>;
-
-/// Returns true if the network error should not be reported to lang. This can happen if we've
-/// exceeded the max number of retries, and we prefer to just warn rather than blowing up lang.
-pub(crate) fn should_swallow_net_error(err: &tonic::Status) -> bool {
-    RETRYABLE_ERROR_CODES.contains(&err.code())
-        || matches!(err.code(), Code::Cancelled | Code::DeadlineExceeded)
-}
 
 /// Contains everything a worker needs to interact with the server
 pub(crate) struct WorkerClientBag {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
No completion errors will ever crash the worker
Long poll permits "fatal" errors for up to a minute

## Why?
Sometimes infrastructure pieces return stupid error codes, and we shouldn't crash in that case, even if things are telling us the error is fatal. Those things are stupid and wrong, but, so be it.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing UTs

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
