### PR TITLE
Implement multiple histories support for replaying

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -362,6 +362,7 @@ impl ClientOptions {
     }
 }
 
+// TODO: Move to worker client
 /// A version of [RespondWorkflowTaskCompletedRequest] that will finish being filled out by the
 /// server client
 #[derive(Debug, Clone, PartialEq)]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -46,13 +46,12 @@ use temporal_sdk_core_protos::{
     coresdk::{workflow_commands::QueryResult, IntoPayloadsExt},
     grpc::health::v1::health_client::HealthClient,
     temporal::api::{
-        command::v1::Command,
         common::v1::{Header, Payload, Payloads, WorkflowExecution, WorkflowType},
         enums::v1::{TaskQueueKind, WorkflowIdReusePolicy, WorkflowTaskFailedCause},
         failure::v1::Failure,
         operatorservice::v1::operator_service_client::OperatorServiceClient,
         query::v1::WorkflowQuery,
-        taskqueue::v1::{StickyExecutionAttributes, TaskQueue},
+        taskqueue::v1::TaskQueue,
         testservice::v1::test_service_client::TestServiceClient,
         workflowservice::v1::{workflow_service_client::WorkflowServiceClient, *},
     },
@@ -360,25 +359,6 @@ impl ClientOptions {
         }
         Ok(channel)
     }
-}
-
-// TODO: Move to worker client
-/// A version of [RespondWorkflowTaskCompletedRequest] that will finish being filled out by the
-/// server client
-#[derive(Debug, Clone, PartialEq)]
-pub struct WorkflowTaskCompletion {
-    /// The task token that would've been received from polling for a workflow activation
-    pub task_token: TaskToken,
-    /// A list of new commands to send to the server, such as starting a timer.
-    pub commands: Vec<Command>,
-    /// If set, indicate that next task should be queued on sticky queue with given attributes.
-    pub sticky_attributes: Option<StickyExecutionAttributes>,
-    /// Responses to queries in the `queries` field of the workflow task.
-    pub query_responses: Vec<QueryResult>,
-    /// Indicate that the task completion should return a new WFT if one is available
-    pub return_new_workflow_task: bool,
-    /// Force a new WFT to be created after this completion
-    pub force_create_new_workflow_task: bool,
 }
 
 /// Interceptor which attaches common metadata (like "client-name") to every outgoing call

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -95,6 +95,12 @@ pub struct WorkerConfig {
     /// todo: link to feature docs
     #[builder(default = "false")]
     pub use_worker_versioning: bool,
+
+    /// If set true, shutdown will not finish until all pending evictions have been issued and
+    /// replied to. If not set (the default) shutdown will be considered complete when the only
+    /// remaining work is pending evictions.
+    #[builder(default = "false")]
+    pub issue_evicts_before_shutdown: bool,
 }
 
 impl WorkerConfig {

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -96,11 +96,15 @@ pub struct WorkerConfig {
     #[builder(default = "false")]
     pub use_worker_versioning: bool,
 
-    /// If set true, shutdown will not finish until all pending evictions have been issued and
-    /// replied to. If not set (the default) shutdown will be considered complete when the only
+    /// If set false (default), shutdown will not finish until all pending evictions have been
+    /// issued and replied to. If set true shutdown will be considered complete when the only
     /// remaining work is pending evictions.
+    ///
+    /// This flag is useful during tests to avoid needing to deal with lots of uninteresting
+    /// evictions during shutdown. Alternatively, if a lang implementation finds it easy to clean
+    /// up during shutdown, setting this true saves some back-and-forth.
     #[builder(default = "false")]
-    pub issue_evicts_before_shutdown: bool,
+    pub ignore_evicts_on_shutdown: bool,
 }
 
 impl WorkerConfig {

--- a/core/benches/workflow_replay.rs
+++ b/core/benches/workflow_replay.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use futures::StreamExt;
 use std::time::Duration;
 use temporal_sdk::{WfContext, Worker, WorkflowFunction};
-use temporal_sdk_core::{telemetry_init, TelemetryOptionsBuilder};
+use temporal_sdk_core::{replay::HistoryForReplay, telemetry_init, TelemetryOptionsBuilder};
 use temporal_sdk_core_protos::DEFAULT_WORKFLOW_TYPE;
 use temporal_sdk_core_test_utils::{canned_histories, init_core_replay_preloaded};
 
@@ -16,13 +16,16 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let num_timers = 10;
     let t = canned_histories::long_sequential_timers(num_timers as usize);
-    let hist = t.get_full_history_info().unwrap().into();
+    let hist = HistoryForReplay::new(
+        t.get_full_history_info().unwrap().into(),
+        "whatever".to_string(),
+    );
 
     c.bench_function("Small history replay", |b| {
         b.iter(|| {
             tokio_runtime.block_on(async {
                 let func = timers_wf(num_timers);
-                let (worker, _) = init_core_replay_preloaded("replay_bench", &hist);
+                let (worker, _) = init_core_replay_preloaded("replay_bench", [hist.clone()]);
                 let mut worker = Worker::new_from_core(worker, "replay_bench".to_string());
                 worker.register_wf(DEFAULT_WORKFLOW_TYPE, func);
                 worker.run().await.unwrap();
@@ -32,13 +35,16 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let num_tasks = 50;
     let t = canned_histories::lots_of_big_signals(num_tasks);
-    let hist = t.get_full_history_info().unwrap().into();
+    let hist = HistoryForReplay::new(
+        t.get_full_history_info().unwrap().into(),
+        "whatever".to_string(),
+    );
 
     c.bench_function("Large payloads history replay", |b| {
         b.iter(|| {
             tokio_runtime.block_on(async {
                 let func = big_signals_wf(num_tasks);
-                let (worker, _) = init_core_replay_preloaded("large_hist_bench", &hist);
+                let (worker, _) = init_core_replay_preloaded("large_hist_bench", [hist.clone()]);
                 let mut worker = Worker::new_from_core(worker, "large_hist_bench".to_string());
                 worker.register_wf(DEFAULT_WORKFLOW_TYPE, func);
                 worker.run().await.unwrap();

--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -81,9 +81,13 @@ impl Debug for OwnedMeteredSemPermit {
     }
 }
 
+// TODO: Convert to use stream rather than proceeder fn?
 /// From the input stream, create a new stream which only pulls from the input stream when allowed.
 /// When allowed is determined by the passed in `proceeder` which must return a future every time
 /// it's called. The input stream is only pulled from when that future resolves.
+///
+/// This is *almost* identical to `zip`, but does not terminate early if the input stream closes.
+/// The proceeder must allow the poll before the returned stream closes.
 pub(crate) fn stream_when_allowed<S, F, FF>(
     input: S,
     proceeder: FF,

--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -4,10 +4,9 @@ use crate::MetricsContext;
 use futures::{stream, Stream, StreamExt};
 use std::{
     fmt::{Debug, Formatter},
-    future::Future,
     sync::Arc,
 };
-use tokio::sync::{AcquireError, Notify, OwnedSemaphorePermit, Semaphore, TryAcquireError};
+use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
 /// Wraps a [Semaphore] with a function call that is fed the available permits any time a permit is
 /// acquired or restored through the provided methods
@@ -81,29 +80,30 @@ impl Debug for OwnedMeteredSemPermit {
     }
 }
 
-// TODO: Convert to use stream rather than proceeder fn?
 /// From the input stream, create a new stream which only pulls from the input stream when allowed.
-/// When allowed is determined by the passed in `proceeder` which must return a future every time
-/// it's called. The input stream is only pulled from when that future resolves.
+/// When allowed is determined by the passed in `proceeder` emitting an item. The input stream is
+/// only pulled from when that future resolves.
 ///
 /// This is *almost* identical to `zip`, but does not terminate early if the input stream closes.
-/// The proceeder must allow the poll before the returned stream closes.
-pub(crate) fn stream_when_allowed<S, F, FF>(
+/// The proceeder must allow the poll before the returned stream closes. If the proceeder terminates
+/// the overall stream will terminate.
+pub(crate) fn stream_when_allowed<S, AS>(
     input: S,
-    proceeder: FF,
-) -> impl Stream<Item = (S::Item, F::Output)>
+    proceeder: AS,
+) -> impl Stream<Item = (S::Item, AS::Item)>
 where
     S: Stream + Send + 'static,
-    F: Future,
-    FF: FnMut() -> F,
+    AS: Stream + Send + 'static,
 {
-    let acceptable_notify = Arc::new(Notify::new());
-    acceptable_notify.notify_one();
     let stream = stream::unfold(
-        (proceeder, input.boxed()),
+        (proceeder.boxed(), input.boxed()),
         |(mut proceeder, mut input)| async {
-            let v = proceeder().await;
-            input.next().await.map(|i| ((i, v), (proceeder, input)))
+            let v = proceeder.next().await;
+            if let Some(v) = v {
+                input.next().await.map(|i| ((i, v), (proceeder, input)))
+            } else {
+                None
+            }
         },
     );
     stream
@@ -121,19 +121,15 @@ pub(crate) use dbg_panic;
 mod tests {
     use super::*;
     use futures::pin_mut;
-    use std::{cell::RefCell, task::Poll};
+    use std::task::Poll;
     use tokio::sync::mpsc::unbounded_channel;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
 
-    // This is fine. Test only / guaranteed to happen serially.
-    #[allow(clippy::await_holding_refcell_ref)]
     #[test]
     fn stream_when_allowed_works() {
         let inputs = stream::iter([1, 2, 3]);
         let (allow_tx, allow_rx) = unbounded_channel();
-        let allow_rx = RefCell::new(allow_rx);
-        let when_allowed = stream_when_allowed(inputs, || async {
-            allow_rx.borrow_mut().recv().await.unwrap()
-        });
+        let when_allowed = stream_when_allowed(inputs, UnboundedReceiverStream::new(allow_rx));
 
         let waker = futures::task::noop_waker_ref();
         let mut cx = std::task::Context::from_waker(waker);

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -3,7 +3,7 @@ use crate::{
     replay::{default_wes_attribs, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE},
     test_help::{
         hist_to_poll_resp, mock_sdk, mock_sdk_cfg, mock_worker, single_hist_mock_sg, MockPollCfg,
-        ResponseType, TEST_Q,
+        ResponseType,
     },
     worker::client::mocks::mock_workflow_client,
 };
@@ -415,7 +415,7 @@ async fn query_during_wft_heartbeat_doesnt_accidentally_fail_to_continue_heartbe
     t.add_workflow_execution_completed();
 
     let query_with_hist_task = {
-        let mut pr = hist_to_poll_resp(&t, wfid, ResponseType::ToTaskNum(1), TEST_Q);
+        let mut pr = hist_to_poll_resp(&t, wfid, ResponseType::ToTaskNum(1));
         pr.queries = HashMap::new();
         pr.queries.insert(
             "the-query".to_string(),
@@ -441,7 +441,6 @@ async fn query_during_wft_heartbeat_doesnt_accidentally_fail_to_continue_heartbe
                 .boxed(),
                 3,
             ),
-            TEST_Q,
         ),
     ];
     let mock = mock_workflow_client();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -118,7 +118,6 @@ where
     config.max_cached_workflows = 1;
     config.max_concurrent_wft_polls = 1;
     config.no_remote_activities = true;
-    config.issue_evicts_before_shutdown = true;
     let historator = Historator::new(histories);
     let post_activate = historator.get_post_activate_hook();
     let shutdown_tok = historator.get_shutdown_setter();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -44,7 +44,7 @@ pub use url::Url;
 pub use worker::{Worker, WorkerConfig, WorkerConfigBuilder};
 
 use crate::{
-    replay::{mock_client_from_histories, Historator},
+    replay::{mock_client_from_histories, Historator, HistoryForReplay},
     telemetry::metrics::{MetricsContext, METRIC_METER},
     worker::client::WorkerClientBag,
 };
@@ -55,7 +55,7 @@ use temporal_sdk_core_api::{
     errors::{CompleteActivityError, PollActivityError, PollWfError},
     CoreLog, Worker as WorkerTrait,
 };
-use temporal_sdk_core_protos::{coresdk::ActivityHeartbeat, temporal::api::history::v1::History};
+use temporal_sdk_core_protos::coresdk::ActivityHeartbeat;
 
 lazy_static::lazy_static! {
     /// A process-wide unique string, which will be different on every startup
@@ -109,7 +109,7 @@ pub fn init_replay_worker<I>(
     histories: I,
 ) -> Result<Worker, anyhow::Error>
 where
-    I: Stream<Item = History> + Send + 'static,
+    I: Stream<Item = HistoryForReplay> + Send + 'static,
 {
     info!(
         task_queue = config.task_queue.as_str(),

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -6,17 +6,21 @@ use crate::{
     worker::client::{mocks::mock_manual_workflow_client, WorkerClient},
     Worker,
 };
-use futures::FutureExt;
+use futures::{FutureExt, Stream, StreamExt};
+use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use std::{
-    collections::{HashMap, HashSet},
-    iter,
-    sync::Arc,
-    time::Duration,
+    collections::HashMap,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
 };
-use temporal_sdk_core_api::Worker as WorkerTrait;
 use temporal_sdk_core_protos::temporal::api::{
     common::v1::WorkflowExecution,
+    enums::v1::WorkflowTaskFailedCause,
     history::v1::History,
     workflowservice::v1::{
         RespondWorkflowTaskCompletedResponse, RespondWorkflowTaskFailedResponse,
@@ -25,61 +29,60 @@ use temporal_sdk_core_protos::temporal::api::{
 pub use temporal_sdk_core_protos::{
     default_wes_attribs, HistoryInfo, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE,
 };
-use tokio::sync::Notify;
+use tokio::sync::{mpsc, mpsc::UnboundedSender, Mutex as TokioMutex};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::sync::CancellationToken;
 
 /// Create a mock client which can be used by a replay worker to serve up canned histories. It will
 /// return the entire history in one workflow task. If a workflow task failure is sent to the mock,
 /// it will send the complete response again.
 ///
 /// Once it runs out of histories to return, it will serve up default responses after a 10s delay
-pub(crate) fn mock_client_from_histories(
-    mut historator: Historator<impl Iterator<Item = History> + Send + 'static>,
-) -> impl WorkerClient {
+pub(crate) fn mock_client_from_histories(historator: Historator) -> impl WorkerClient {
     let mut mg = mock_manual_workflow_client();
 
-    let hook = historator.replay_complete_hook.clone();
-    let current_hist = Arc::new(Mutex::new(historator.next()));
-    let needs_dispatch = Arc::new(Mutex::new(true));
-    let chi_clone = current_hist.clone();
-    let nd_clone = needs_dispatch.clone();
-    let nd_fail_clone = needs_dispatch.clone();
-    let notifier = Arc::new(Notify::new());
-    let noti_clone = notifier.clone();
-    *hook.lock() = Box::new(move |_| {
-        if let Some(h) = historator.next() {
-            chi_clone.lock().replace(h);
-            *nd_clone.lock() = true;
-        }
-        noti_clone.notify_waiters();
-    });
+    let current_hist = Arc::new(TokioMutex::new(None));
+    let needs_redispatch = Arc::new(AtomicBool::new(false));
+    let hist_allow_tx = historator.replay_done_tx.clone();
+    let historator = Arc::new(TokioMutex::new(historator));
+    let nd_fail_clone = needs_redispatch.clone();
+
     mg.expect_poll_workflow_task().returning(move |_, _| {
-        let cur_hist_info = current_hist.lock();
-        let needs_disp_bool = *needs_dispatch.lock();
-        let history = match (cur_hist_info.as_ref(), needs_disp_bool) {
-            (Some(h), true) => {
-                *needs_dispatch.lock() = false;
-                h
-            }
-            _ => {
-                let noti = notifier.clone();
-                return async move {
-                    tokio::select! {
-                        _ = noti.notified() => {}
-                        _ = tokio::time::sleep(Duration::from_secs(10)) => {}
-                    }
-                    Ok(Default::default())
-                }
-                .boxed();
-            }
-        };
-        let hist_info = HistoryInfo::new_from_history(history, None).unwrap();
+        let current_hist = current_hist.clone();
+        let needs_redispatch = needs_redispatch.clone();
+        let historator = historator.clone();
+        info!("Polled");
         async move {
-            let mut resp = hist_info.as_poll_wft_response();
-            resp.workflow_execution = Some(WorkflowExecution {
-                workflow_id: "fake_wf_id".to_string(),
-                run_id: hist_info.orig_run_id().to_string(),
-            });
-            Ok(resp)
+            let mut hlock = historator.lock().await;
+            info!("Got historator lock");
+            // Always wait for permission before dispatching the next task
+            let last_run = hlock.allow_stream.next().await;
+            info!("Allowing next, last run: {:?}", last_run);
+
+            let mut cur_hist_info = current_hist.lock().await;
+            info!("Got cur hist lock");
+            let history = if needs_redispatch.swap(false, Ordering::AcqRel) {
+                info!("Re-dispatching");
+                &*cur_hist_info
+            } else {
+                let hist_rid = hlock.next().await;
+                *cur_hist_info = hist_rid;
+                &*cur_hist_info
+            };
+            if let Some(history) = history {
+                info!("Dispatching history");
+                let hist_info = HistoryInfo::new_from_history(history, None).unwrap();
+                let mut resp = hist_info.as_poll_wft_response();
+                resp.workflow_execution = Some(WorkflowExecution {
+                    workflow_id: "fake_wf_id".to_string(),
+                    run_id: hist_info.orig_run_id().to_string(),
+                });
+                Ok(resp)
+            } else {
+                warn!("Out of history yo");
+                hlock.worker_closer.get().map(|wc| wc.cancel());
+                Ok(Default::default())
+            }
         }
         .boxed()
     });
@@ -87,43 +90,54 @@ pub(crate) fn mock_client_from_histories(
     mg.expect_complete_workflow_task().returning(move |_| {
         async move { Ok(RespondWorkflowTaskCompletedResponse::default()) }.boxed()
     });
-    mg.expect_fail_workflow_task().returning(move |_, _, _| {
-        *nd_fail_clone.lock() = true;
-        async move { Ok(RespondWorkflowTaskFailedResponse::default()) }.boxed()
-    });
+    mg.expect_fail_workflow_task()
+        .returning(move |_, cause, _| {
+            warn!("Should fail wft and re-dispatch");
+            if matches!(cause, WorkflowTaskFailedCause::NonDeterministicError) {
+                // TODO: Record all failures for final output
+                warn!("Nondeterminism reported!");
+            } else {
+                nd_fail_clone.store(true, Ordering::Release);
+            }
+            // TODO: can get rid of bool and use channel instead??
+            hist_allow_tx.send("Failed".to_string()).unwrap();
+            async move { Ok(RespondWorkflowTaskFailedResponse::default()) }.boxed()
+        });
 
     mg
 }
 
-pub(crate) struct Historator<I> {
-    iter: iter::Fuse<I>,
+pub(crate) struct Historator {
+    iter: Pin<Box<dyn Stream<Item = History> + Send>>,
+    allow_stream: UnboundedReceiverStream<String>,
+    worker_closer: Arc<OnceCell<CancellationToken>>,
     dat: Arc<Mutex<HistoratorDat>>,
-    #[allow(clippy::type_complexity)] // Pshh clippy c'mon this is only a fraction of my power
-    replay_complete_hook: Arc<Mutex<Box<dyn FnMut(&str) + Send>>>,
+    replay_done_tx: UnboundedSender<String>,
 }
-impl<I> Historator<I>
-where
-    I: Iterator<Item = History> + Send + 'static,
-{
-    pub(crate) fn new<II: IntoIterator<IntoIter = I> + 'static>(
+impl Historator {
+    pub(crate) fn new(
         // TODO: history + wfid to avoid making them up?
-        histories: II,
+        histories: impl Stream<Item = History> + Send + 'static,
     ) -> Self {
+        let dat = Arc::new(Mutex::new(HistoratorDat::default()));
+        let (replay_done_tx, replay_done_rx) = mpsc::unbounded_channel();
+        // Need to allow the first history item
+        replay_done_tx.send("fake".to_string()).unwrap();
         Self {
-            iter: histories.into_iter().fuse(),
-            dat: Arc::new(Mutex::new(HistoratorDat::default())),
-            replay_complete_hook: Arc::new(Mutex::new(Box::new(|_| {}))),
+            iter: Box::pin(histories.fuse()),
+            allow_stream: UnboundedReceiverStream::new(replay_done_rx),
+            worker_closer: Arc::new(OnceCell::new()),
+            dat,
+            replay_done_tx,
         }
     }
-}
-impl<I> Historator<I> {
-    /// Builds and returns a callback that can be used as the post-activation hook for a worker
-    /// to trigger shutdown once all histories have completed replay
-    pub(crate) fn make_post_activate_hook(&self) -> impl Fn(&Worker, &str, usize) + Send + Sync {
+
+    /// Returns a callback that can be used as the post-activation hook for a worker to indicate
+    /// we're ready to replay the next history, or whatever else.
+    pub(crate) fn get_post_activate_hook(&self) -> impl Fn(&Worker, &str, usize) + Send + Sync {
         let dat = self.dat.clone();
-        let hook = self.replay_complete_hook.clone();
-        let completed_ids = Mutex::new(HashSet::new());
-        move |worker, activated_run_id, last_processed_event| {
+        let done_tx = self.replay_done_tx.clone();
+        move |_worker, activated_run_id, last_processed_event| {
             // We can't hold the lock while evaluating the hook, or we'd deadlock.
             let last_event_in_hist = dat
                 .lock()
@@ -132,45 +146,46 @@ impl<I> Historator<I> {
                 .cloned();
             if let Some(le) = last_event_in_hist {
                 if last_processed_event >= le {
-                    completed_ids.lock().insert(activated_run_id.to_string());
-                    (hook.lock())(activated_run_id);
+                    done_tx.send(activated_run_id.to_string()).unwrap();
                 }
-            }
-            let datlock = dat.lock();
-            if datlock.all_dispatched
-                && completed_ids.lock().len() >= datlock.run_id_to_last_event_num.len()
-            {
-                info!("All histories have concluded replay, triggering worker shutdown");
-                worker.initiate_shutdown();
             }
         }
     }
+
+    pub(crate) fn get_shutdown_setter(&self) -> impl FnOnce(CancellationToken) + 'static {
+        let wc = self.worker_closer.clone();
+        move |ct| {
+            wc.set(ct).expect("Shutdown token must only be set once");
+        }
+    }
 }
-impl<I> Iterator for Historator<I>
-where
-    I: Iterator<Item = History>,
-{
+
+impl Stream for Historator {
     type Item = History;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let next = self.iter.next();
-        if let Some(ref history) = next {
-            let run_id = history
-                .extract_run_id_from_start()
-                .expect(
-                    "Histories provided for replay must contain run ids in their workflow \
-                     execution started events",
-                )
-                .to_string();
-            let last_event = history.last_event_id();
-            self.dat
-                .lock()
-                .run_id_to_last_event_num
-                .insert(run_id, last_event as usize);
-        } else {
-            self.dat.lock().all_dispatched = true;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.iter.poll_next_unpin(cx) {
+            Poll::Ready(Some(history)) => {
+                let run_id = history
+                    .extract_run_id_from_start()
+                    .expect(
+                        "Histories provided for replay must contain run ids in their workflow \
+                                 execution started events",
+                    )
+                    .to_string();
+                let last_event = history.last_event_id();
+                self.dat
+                    .lock()
+                    .run_id_to_last_event_num
+                    .insert(run_id, last_event as usize);
+                Poll::Ready(Some(history))
+            }
+            Poll::Ready(None) => {
+                self.dat.lock().all_dispatched = true;
+                Poll::Ready(None)
+            }
+            o => o,
         }
-        next
     }
 }
 

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -95,7 +95,7 @@ pub(crate) fn mock_client_from_histories(historator: Historator) -> impl WorkerC
                 let hist_info = HistoryInfo::new_from_history(&history.hist, None).unwrap();
                 let mut resp = hist_info.as_poll_wft_response();
                 resp.workflow_execution = Some(WorkflowExecution {
-                    workflow_id: history.workflow_id.clone(),
+                    workflow_id: history.workflow_id,
                     run_id: hist_info.orig_run_id().to_string(),
                 });
                 Ok(resp)

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -2,15 +2,19 @@
 //! to replay canned histories. It should be used by Lang SDKs to provide replay capabilities to
 //! users during testing.
 
-use crate::worker::client::{mocks::mock_manual_workflow_client, WorkerClient};
+use crate::{
+    worker::client::{mocks::mock_manual_workflow_client, WorkerClient},
+    Worker,
+};
 use futures::FutureExt;
+use parking_lot::Mutex;
 use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+    collections::{HashMap, HashSet},
+    iter,
+    sync::Arc,
     time::Duration,
 };
+use temporal_sdk_core_api::Worker as WorkerTrait;
 use temporal_sdk_core_protos::temporal::api::{
     common::v1::WorkflowExecution,
     history::v1::History,
@@ -21,51 +25,157 @@ use temporal_sdk_core_protos::temporal::api::{
 pub use temporal_sdk_core_protos::{
     default_wes_attribs, HistoryInfo, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE,
 };
+use tokio::sync::Notify;
 
-/// Create a mock client which can be used by a replay worker to serve up canned history.
-/// It will return the entire history in one workflow task, after that it will return default
-/// responses (with a 10s wait). If a workflow task failure is sent to the mock, it will send
-/// the complete response again.
-pub(crate) fn mock_client_from_history(
-    history: &History,
-    task_queue: impl Into<String>,
+/// Create a mock client which can be used by a replay worker to serve up canned histories. It will
+/// return the entire history in one workflow task. If a workflow task failure is sent to the mock,
+/// it will send the complete response again.
+///
+/// Once it runs out of histories to return, it will serve up default responses after a 10s delay
+pub(crate) fn mock_client_from_histories(
+    mut historator: Historator<impl Iterator<Item = History> + Send + 'static>,
 ) -> impl WorkerClient {
     let mut mg = mock_manual_workflow_client();
 
-    let hist_info = HistoryInfo::new_from_history(history, None).unwrap();
-    let wf = WorkflowExecution {
-        workflow_id: "fake_wf_id".to_string(),
-        run_id: hist_info.orig_run_id().to_string(),
-    };
-
-    let did_send = Arc::new(AtomicBool::new(false));
-    let did_send_clone = did_send.clone();
-    let tq = task_queue.into();
+    let hook = historator.replay_complete_hook.clone();
+    let current_hist = Arc::new(Mutex::new(historator.next()));
+    let needs_dispatch = Arc::new(Mutex::new(true));
+    let chi_clone = current_hist.clone();
+    let nd_clone = needs_dispatch.clone();
+    let nd_fail_clone = needs_dispatch.clone();
+    let notifier = Arc::new(Notify::new());
+    let noti_clone = notifier.clone();
+    *hook.lock() = Box::new(move |_| {
+        if let Some(h) = historator.next() {
+            chi_clone.lock().replace(h);
+            *nd_clone.lock() = true;
+        }
+        noti_clone.notify_waiters();
+    });
     mg.expect_poll_workflow_task().returning(move |_, _| {
-        let hist_info = hist_info.clone();
-        let wf = wf.clone();
-        let did_send_clone = did_send_clone.clone();
-        let tq = tq.clone();
-        async move {
-            if !did_send_clone.swap(true, Ordering::AcqRel) {
-                let mut resp = hist_info.as_poll_wft_response(tq);
-                resp.workflow_execution = Some(wf.clone());
-                Ok(resp)
-            } else {
-                tokio::time::sleep(Duration::from_secs(10)).await;
-                Ok(Default::default())
+        let cur_hist_info = current_hist.lock();
+        let needs_disp_bool = *needs_dispatch.lock();
+        let history = match (cur_hist_info.as_ref(), needs_disp_bool) {
+            (Some(h), true) => {
+                *needs_dispatch.lock() = false;
+                h
             }
+            _ => {
+                let noti = notifier.clone();
+                return async move {
+                    tokio::select! {
+                        _ = noti.notified() => {}
+                        _ = tokio::time::sleep(Duration::from_secs(10)) => {}
+                    }
+                    Ok(Default::default())
+                }
+                .boxed();
+            }
+        };
+        let hist_info = HistoryInfo::new_from_history(history, None).unwrap();
+        async move {
+            let mut resp = hist_info.as_poll_wft_response();
+            resp.workflow_execution = Some(WorkflowExecution {
+                workflow_id: "fake_wf_id".to_string(),
+                run_id: hist_info.orig_run_id().to_string(),
+            });
+            Ok(resp)
         }
         .boxed()
     });
 
-    mg.expect_complete_workflow_task()
-        .returning(|_| async move { Ok(RespondWorkflowTaskCompletedResponse::default()) }.boxed());
+    mg.expect_complete_workflow_task().returning(move |_| {
+        async move { Ok(RespondWorkflowTaskCompletedResponse::default()) }.boxed()
+    });
     mg.expect_fail_workflow_task().returning(move |_, _, _| {
-        // We'll need to re-send the history if WFT fails
-        did_send.store(false, Ordering::Release);
-        async move { Ok(RespondWorkflowTaskFailedResponse {}) }.boxed()
+        *nd_fail_clone.lock() = true;
+        async move { Ok(RespondWorkflowTaskFailedResponse::default()) }.boxed()
     });
 
     mg
+}
+
+pub(crate) struct Historator<I> {
+    iter: iter::Fuse<I>,
+    dat: Arc<Mutex<HistoratorDat>>,
+    #[allow(clippy::type_complexity)] // Pshh clippy c'mon this is only a fraction of my power
+    replay_complete_hook: Arc<Mutex<Box<dyn FnMut(&str) + Send>>>,
+}
+impl<I> Historator<I>
+where
+    I: Iterator<Item = History> + Send + 'static,
+{
+    pub(crate) fn new<II: IntoIterator<IntoIter = I> + 'static>(
+        // TODO: history + wfid to avoid making them up?
+        histories: II,
+    ) -> Self {
+        Self {
+            iter: histories.into_iter().fuse(),
+            dat: Arc::new(Mutex::new(HistoratorDat::default())),
+            replay_complete_hook: Arc::new(Mutex::new(Box::new(|_| {}))),
+        }
+    }
+}
+impl<I> Historator<I> {
+    /// Builds and returns a callback that can be used as the post-activation hook for a worker
+    /// to trigger shutdown once all histories have completed replay
+    pub(crate) fn make_post_activate_hook(&self) -> impl Fn(&Worker, &str, usize) + Send + Sync {
+        let dat = self.dat.clone();
+        let hook = self.replay_complete_hook.clone();
+        let completed_ids = Mutex::new(HashSet::new());
+        move |worker, activated_run_id, last_processed_event| {
+            // We can't hold the lock while evaluating the hook, or we'd deadlock.
+            let last_event_in_hist = dat
+                .lock()
+                .run_id_to_last_event_num
+                .get(activated_run_id)
+                .cloned();
+            if let Some(le) = last_event_in_hist {
+                if last_processed_event >= le {
+                    completed_ids.lock().insert(activated_run_id.to_string());
+                    (hook.lock())(activated_run_id);
+                }
+            }
+            let datlock = dat.lock();
+            if datlock.all_dispatched
+                && completed_ids.lock().len() >= datlock.run_id_to_last_event_num.len()
+            {
+                info!("All histories have concluded replay, triggering worker shutdown");
+                worker.initiate_shutdown();
+            }
+        }
+    }
+}
+impl<I> Iterator for Historator<I>
+where
+    I: Iterator<Item = History>,
+{
+    type Item = History;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.iter.next();
+        if let Some(ref history) = next {
+            let run_id = history
+                .extract_run_id_from_start()
+                .expect(
+                    "Histories provided for replay must contain run ids in their workflow \
+                     execution started events",
+                )
+                .to_string();
+            let last_event = history.last_event_id();
+            self.dat
+                .lock()
+                .run_id_to_last_event_num
+                .insert(run_id, last_event as usize);
+        } else {
+            self.dat.lock().all_dispatched = true;
+        }
+        next
+    }
+}
+
+#[derive(Default)]
+struct HistoratorDat {
+    run_id_to_last_event_num: HashMap<String, usize>,
+    all_dispatched: bool,
 }

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -33,6 +33,22 @@ use tokio::sync::{mpsc, mpsc::UnboundedSender, Mutex as TokioMutex};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 
+/// Allows lang to feed histories into the replayer at whatever cadence it prefers
+pub struct HistoryFeeder {}
+pub struct HistoryFeederStream {}
+
+impl HistoryFeeder {
+    pub async fn feed(history: History) {}
+}
+
+impl Stream for HistoryFeederStream {
+    type Item = History;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        todo!()
+    }
+}
+
 /// Create a mock client which can be used by a replay worker to serve up canned histories. It will
 /// return the entire history in one workflow task. If a workflow task failure is sent to the mock,
 /// it will send the complete response again.

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -498,7 +498,7 @@ pub(crate) fn build_mock_pollers(mut cfg: MockPollCfg) -> MocksHolder {
             .into_iter()
             .map(|response| {
                 let cur_attempt = attempts_at_task_num.entry(response.hashable()).or_insert(1);
-                let mut r = hist_to_poll_resp(&hist.hist, hist.wf_id.clone(), response, TEST_Q);
+                let mut r = hist_to_poll_resp(&hist.hist, hist.wf_id.clone(), response);
                 r.attempt = *cur_attempt;
                 *cur_attempt += 1;
                 r
@@ -649,7 +649,6 @@ pub fn hist_to_poll_resp(
     t: &TestHistoryBuilder,
     wf_id: impl Into<String>,
     response_type: ResponseType,
-    task_queue: impl Into<String>,
 ) -> QueueResponse<PollWorkflowTaskQueueResponse> {
     let run_id = t.get_orig_run_id();
     let wf = WorkflowExecution {
@@ -678,7 +677,7 @@ pub fn hist_to_poll_resp(
             }
         }
     };
-    let mut resp = hist_info.as_poll_wft_response(task_queue);
+    let mut resp = hist_info.as_poll_wft_response();
     resp.workflow_execution = Some(wf);
     QueueResponse { resp, delay_until }
 }

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -58,6 +58,7 @@ pub fn test_worker_cfg() -> WorkerConfigBuilder {
     wcb.namespace("default")
         .task_queue(TEST_Q)
         .worker_build_id("test_bin_id")
+        .ignore_evicts_on_shutdown(true)
         // Serial polling since it makes mocking much easier.
         .max_concurrent_wft_polls(1_usize);
     wcb

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -6,7 +6,9 @@ use crate::{
     replay::TestHistoryBuilder,
     sticky_q_name_for_worker,
     worker::{
-        client::{mocks::mock_workflow_client, MockWorkerClient, WorkerClient},
+        client::{
+            mocks::mock_workflow_client, MockWorkerClient, WorkerClient, WorkflowTaskCompletion,
+        },
         new_wft_poller,
     },
     TaskToken, Worker, WorkerConfig, WorkerConfigBuilder,
@@ -26,7 +28,6 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use temporal_client::WorkflowTaskCompletion;
 use temporal_sdk_core_api::Worker as WorkerTrait;
 use temporal_sdk_core_protos::{
     coresdk::{

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -16,7 +16,7 @@ pub(crate) fn mock_manual_workflow_client() -> MockManualWorkerClient {
 // results. This is really annoying b/c of the async trait stuff. Need
 // https://github.com/asomers/mockall/issues/189 to be fixed for it to go away.
 mockall::mock! {
-    pub ManualWorkerClient {}
+    pub(crate) ManualWorkerClient {}
     #[allow(unused)]
     impl WorkerClient for ManualWorkerClient {
         fn poll_workflow_task<'a, 'b>(&'a self, task_queue: String, is_sticky: bool)

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -470,16 +470,6 @@ impl Worker {
         self.post_activate_hook = Some(Box::new(callback))
     }
 
-    /// Used for replay workers - causes the worker to shutdown when the given run reaches the
-    /// given event number
-    pub(crate) fn set_shutdown_on_run_reaches_event(&mut self, run_id: String, last_event: i64) {
-        self.set_post_activate_hook(move |worker, activated_run_id, last_processed_event| {
-            if activated_run_id == run_id && last_processed_event >= last_event as usize {
-                worker.initiate_shutdown();
-            }
-        });
-    }
-
     fn complete_local_act(
         &self,
         la_res: LocalActivityExecutionResult,

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -264,7 +264,7 @@ impl Worker {
                     metrics,
                     namespace: config.namespace.clone(),
                     task_queue: config.task_queue.clone(),
-                    issue_evicts_before_shutdown: config.issue_evicts_before_shutdown,
+                    ignore_evicts_on_shutdown: config.ignore_evicts_on_shutdown,
                 },
                 sticky_queue_name.map(|sq| StickyExecutionAttributes {
                     worker_task_queue: Some(TaskQueue {

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -264,6 +264,7 @@ impl Worker {
                     metrics,
                     namespace: config.namespace.clone(),
                     task_queue: config.task_queue.clone(),
+                    issue_evicts_before_shutdown: config.issue_evicts_before_shutdown,
                 },
                 sticky_queue_name.map(|sq| StickyExecutionAttributes {
                     worker_task_queue: Some(TaskQueue {
@@ -315,6 +316,10 @@ impl Worker {
         if let Some(b) = self.at_task_mgr {
             b.shutdown().await;
         }
+    }
+
+    pub(crate) fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown_token.clone()
     }
 
     /// Returns number of currently cached workflows

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -107,7 +107,7 @@ pub(super) struct WorkflowBasics {
     pub metrics: MetricsContext,
     pub namespace: String,
     pub task_queue: String,
-    pub issue_evicts_before_shutdown: bool,
+    pub ignore_evicts_on_shutdown: bool,
 }
 
 impl Workflows {

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     telemetry::VecDisplayer,
     worker::{
         activities::{ActivitiesFromWFTsHandle, PermittedTqResp},
-        client::WorkerClient,
+        client::{WorkerClient, WorkflowTaskCompletion},
         workflow::{
             managed_run::{ManagedRun, WorkflowManager},
             wft_poller::validate_wft,
@@ -43,7 +43,6 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use temporal_client::WorkflowTaskCompletion;
 use temporal_sdk_core_api::errors::{CompleteWfError, PollWfError};
 use temporal_sdk_core_protos::{
     coresdk::{

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -107,6 +107,7 @@ pub(super) struct WorkflowBasics {
     pub metrics: MetricsContext,
     pub namespace: String,
     pub task_queue: String,
+    pub issue_evicts_before_shutdown: bool,
 }
 
 impl Workflows {

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -41,7 +41,7 @@ pub(crate) struct WFStream {
     /// Ensures we stay at or below this worker's maximum concurrent workflow task limit
     wft_semaphore: MeteredSemaphore,
     shutdown_token: CancellationToken,
-    issue_evicts_before_shutdown: bool,
+    ignore_evicts_on_shutdown: bool,
 
     metrics: MetricsContext,
 }
@@ -165,7 +165,7 @@ impl WFStream {
             client,
             wft_semaphore,
             shutdown_token: basics.shutdown_token,
-            issue_evicts_before_shutdown: basics.issue_evicts_before_shutdown,
+            ignore_evicts_on_shutdown: basics.ignore_evicts_on_shutdown,
             metrics: basics.metrics,
         };
         all_inputs
@@ -876,7 +876,7 @@ impl WFStream {
         let all_runs_ready = self
             .runs
             .handles()
-            .all(|r| !r.has_any_pending_work(!self.issue_evicts_before_shutdown, false));
+            .all(|r| !r.has_any_pending_work(self.ignore_evicts_on_shutdown, false));
         if self.shutdown_token.is_cancelled() && all_runs_ready {
             info!("Workflow shutdown is done");
             true

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -41,6 +41,7 @@ pub(crate) struct WFStream {
     /// Ensures we stay at or below this worker's maximum concurrent workflow task limit
     wft_semaphore: MeteredSemaphore,
     shutdown_token: CancellationToken,
+    issue_evicts_before_shutdown: bool,
 
     metrics: MetricsContext,
 }
@@ -165,6 +166,7 @@ impl WFStream {
             client,
             wft_semaphore,
             shutdown_token: basics.shutdown_token,
+            issue_evicts_before_shutdown: basics.issue_evicts_before_shutdown,
             metrics: basics.metrics,
         };
         all_inputs
@@ -875,7 +877,7 @@ impl WFStream {
         let all_runs_ready = self
             .runs
             .handles()
-            .all(|r| !r.has_any_pending_work(true, false));
+            .all(|r| !r.has_any_pending_work(!self.issue_evicts_before_shutdown, false));
         if self.shutdown_token.is_cancelled() && all_runs_ready {
             info!("Workflow shutdown is done");
             true

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -10,9 +10,10 @@ use crate::{
     },
     temporal::api::{
         common::v1::{Payload, Payloads, WorkflowExecution, WorkflowType},
-        enums::v1::{EventType, WorkflowTaskFailedCause},
+        enums::v1::{EventType, TaskQueueKind, WorkflowTaskFailedCause},
         failure::v1::{failure, CanceledFailureInfo, Failure},
         history::v1::{history_event::Attributes, *},
+        taskqueue::v1::TaskQueue,
     },
     HistoryInfo,
 };
@@ -450,6 +451,17 @@ impl TestHistoryBuilder {
             .unwrap()
     }
 
+    /// Alter the workflow type of the history
+    pub fn set_wf_type(&mut self, name: &str) {
+        if let Some(Attributes::WorkflowExecutionStartedEventAttributes(wes)) =
+            self.events.get_mut(0).and_then(|e| e.attributes.as_mut())
+        {
+            wes.workflow_type = Some(WorkflowType {
+                name: name.to_string(),
+            })
+        }
+    }
+
     fn build_and_push_event(&mut self, event_type: EventType, attribs: Attributes) {
         self.current_event_id += 1;
         let evt = HistoryEvent {
@@ -492,6 +504,10 @@ pub fn default_wes_attribs() -> WorkflowExecutionStartedEventAttributes {
                 .try_into()
                 .expect("5 secs is a valid duration"),
         ),
+        task_queue: Some(TaskQueue {
+            name: "q".to_string(),
+            kind: TaskQueueKind::Normal as i32,
+        }),
         ..Default::default()
     }
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -75,8 +75,8 @@ where
         .worker_build_id("test_bin_id")
         .build()
         .expect("Configuration options construct properly");
-    let worker =
-        init_replay_worker(worker_cfg, histories).expect("Replay worker must init properly");
+    let worker = init_replay_worker(worker_cfg, stream::iter(histories))
+        .expect("Replay worker must init properly");
     (Arc::new(worker), test_name.to_string())
 }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -191,7 +191,6 @@ impl CoreWfStarter {
         &mut self,
         wf_id: impl Into<String>,
         run_id: impl Into<String>,
-        // TODO: Need not be passed in
         worker: &mut Worker,
     ) -> Result<(), anyhow::Error> {
         let wf_id = wf_id.into();

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -6,7 +6,7 @@ extern crate tracing;
 
 pub mod canned_histories;
 
-use crate::stream::TryStreamExt;
+use crate::stream::{Stream, TryStreamExt};
 use futures::{future, stream, stream::FuturesUnordered, StreamExt};
 use parking_lot::Mutex;
 use prost::Message;
@@ -21,9 +21,11 @@ use temporal_client::{
 use temporal_sdk::{interceptors::WorkerInterceptor, IntoActivityFunc, Worker, WorkflowFunction};
 use temporal_sdk_core::{
     ephemeral_server::{EphemeralExe, EphemeralExeVersion},
-    init_replay_worker, init_worker, telemetry_init, ClientOptions, ClientOptionsBuilder, Logger,
-    MetricsExporter, OtelCollectorOptions, TelemetryOptions, TelemetryOptionsBuilder,
-    TraceExporter, WorkerConfig, WorkerConfigBuilder,
+    init_replay_worker, init_worker,
+    replay::HistoryForReplay,
+    telemetry_init, ClientOptions, ClientOptionsBuilder, Logger, MetricsExporter,
+    OtelCollectorOptions, TelemetryOptions, TelemetryOptionsBuilder, TraceExporter, WorkerConfig,
+    WorkerConfigBuilder,
 };
 use temporal_sdk_core_api::Worker as CoreWorker;
 use temporal_sdk_core_protos::{
@@ -62,11 +64,17 @@ pub async fn init_core_and_create_wf(test_name: &str) -> CoreWfStarter {
 }
 
 /// Create a worker replay instance preloaded with provided histories. Returns the worker impl
-/// and the task queue name as in [init_core_and_create_wf].
+/// and the task queue name.
 pub fn init_core_replay_preloaded<I>(test_name: &str, histories: I) -> (Arc<dyn CoreWorker>, String)
 where
-    I: IntoIterator<Item = History> + 'static,
+    I: IntoIterator<Item = HistoryForReplay> + 'static,
     <I as IntoIterator>::IntoIter: Send,
+{
+    init_core_replay_stream(test_name, stream::iter(histories))
+}
+pub fn init_core_replay_stream<I>(test_name: &str, histories: I) -> (Arc<dyn CoreWorker>, String)
+where
+    I: Stream<Item = HistoryForReplay> + Send + 'static,
 {
     telemetry_init(&get_integ_telem_options()).expect("Telemetry inits cleanly");
     let worker_cfg = WorkerConfigBuilder::default()
@@ -75,8 +83,8 @@ where
         .worker_build_id("test_bin_id")
         .build()
         .expect("Configuration options construct properly");
-    let worker = init_replay_worker(worker_cfg, stream::iter(histories))
-        .expect("Replay worker must init properly");
+    let worker =
+        init_replay_worker(worker_cfg, histories).expect("Replay worker must init properly");
     (Arc::new(worker), test_name.to_string())
 }
 
@@ -186,15 +194,17 @@ impl CoreWfStarter {
         // TODO: Need not be passed in
         worker: &mut Worker,
     ) -> Result<(), anyhow::Error> {
+        let wf_id = wf_id.into();
         // Fetch history and replay it
         let history = self
             .get_client()
             .await
-            .get_workflow_execution_history(wf_id.into(), Some(run_id.into()), vec![])
+            .get_workflow_execution_history(wf_id.clone(), Some(run_id.into()), vec![])
             .await?
             .history
             .expect("history field must be populated");
-        let (replay_worker, _) = init_core_replay_preloaded(worker.task_queue(), [history]);
+        let with_id = HistoryForReplay::new(history, wf_id);
+        let (replay_worker, _) = init_core_replay_preloaded(worker.task_queue(), [with_id]);
         worker.with_new_core_worker(replay_worker);
         worker.run().await.unwrap();
         Ok(())

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -3,7 +3,6 @@ use futures::future::join_all;
 use std::time::Duration;
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{WfContext, WorkflowResult};
-use temporal_sdk_core_api::errors::PollWfError;
 use temporal_sdk_core_protos::coresdk::{
     activity_task::activity_task as act_task,
     workflow_activation::{workflow_activation_job, FireTimer, WorkflowActivationJob},
@@ -131,16 +130,4 @@ async fn can_paginate_long_history() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-}
-
-// TODO: Takes ages now, fix somehow
-#[tokio::test]
-async fn poll_of_nonexistent_namespace_is_fatal() {
-    let mut starter = CoreWfStarter::new("whatever_yo");
-    starter.worker_config.namespace = "I do not exist".to_string();
-    let worker = starter.get_worker().await;
-    assert_matches!(
-        worker.poll_workflow_activation().await,
-        Err(PollWfError::TonicError(_))
-    );
 }

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -180,15 +180,14 @@ async fn shutdown_aborts_actively_blocked_poll() {
 #[tokio::test]
 async fn fail_wf_task(#[values(true, false)] replay: bool) {
     let core = if replay {
-        let (core, _) = init_core_replay_preloaded(
-            "fail_wf_task",
-            [HistoryForReplay::new(
-                history_from_proto_binary("histories/fail_wf_task.bin")
-                    .await
-                    .unwrap(),
-                "fake".to_string(),
-            )],
+        let hist = HistoryForReplay::new(
+            history_from_proto_binary("histories/fail_wf_task.bin")
+                .await
+                .unwrap(),
+            "fake".to_string(),
         );
+        // We need to send the history twice, since we fail it the first time.
+        let (core, _) = init_core_replay_preloaded("fail_wf_task", [hist.clone(), hist]);
         core
     } else {
         let mut starter = init_core_and_create_wf("fail_wf_task").await;

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -181,9 +181,9 @@ async fn fail_wf_task(#[values(true, false)] replay: bool) {
     let core = if replay {
         let (core, _) = init_core_replay_preloaded(
             "fail_wf_task",
-            &history_from_proto_binary("histories/fail_wf_task.bin")
+            [history_from_proto_binary("histories/fail_wf_task.bin")
                 .await
-                .unwrap(),
+                .unwrap()],
         );
         core
     } else {

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -28,6 +28,7 @@ use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{
     interceptors::WorkerInterceptor, ActContext, ActivityOptions, WfContext, WorkflowResult,
 };
+use temporal_sdk_core::replay::HistoryForReplay;
 use temporal_sdk_core_api::{errors::PollWfError, Worker};
 use temporal_sdk_core_protos::{
     coresdk::{
@@ -181,9 +182,12 @@ async fn fail_wf_task(#[values(true, false)] replay: bool) {
     let core = if replay {
         let (core, _) = init_core_replay_preloaded(
             "fail_wf_task",
-            [history_from_proto_binary("histories/fail_wf_task.bin")
-                .await
-                .unwrap()],
+            [HistoryForReplay::new(
+                history_from_proto_binary("histories/fail_wf_task.bin")
+                    .await
+                    .unwrap(),
+                "fake".to_string(),
+            )],
         );
         core
     } else {

--- a/tests/integ_tests/workflow_tests/replay.rs
+++ b/tests/integ_tests/workflow_tests/replay.rs
@@ -161,3 +161,6 @@ fn timers_wf(num_timers: u32) -> WorkflowFunction {
         Ok(().into())
     })
 }
+
+// TODO: Add test to either ensure we can collect nondeterministic failures (and not loop forever
+//   replaying the same wf). Or that we end early on one.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Implemented ability to provide multiple histories when constructing a replay worker

## Why?
More efficient and easier to use than creating many workers lang side

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing / new tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
