### PR TITLE
Fix incorrect string names for polling methods (oops)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/protos/*.rs
 /tarpaulin-report.html
 /machine_coverage/
 /bindings/
+/core/machine_coverage/

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -95,7 +95,6 @@ where
         F: Send + Sync + Unpin + 'static,
     {
         let rtc = self.get_retry_config(call_name);
-        let req = req_cloner(&req);
         let fact = || {
             let req_clone = req_cloner(&req);
             callfn(self, req_clone)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Polling wasn't retrying forever properly because of a stupid string naming mistake. Fixed.

Unfortunately there wasn't really any reasonable way to UT this specific thing without either feeling performative (string == string I just wrote, which are both constants) or hilariously overkill (in memory fake grpc server, which currently isn't compiled).

So, strings are lifted into constants and doc'd better.

## Why?
Bug

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing uts

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
