### PR TITLE
Auto-start of temporalite & testsrv for integ tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,6 +46,8 @@ steps:
     agents:
       queue: "default"
       docker: "*"
+    env:
+      INTEG_SERVER_TYPE: docker
     command: "cargo test --test integ_tests"
     timeout_in_minutes: 15
     plugins:

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
-integ-test = ["test", "--test", "integ_tests"]
+integ-test = ["run", "--package", "temporal-sdk-core", "--example", "integ_runner"]
 lint = ["clippy", "--all", "--test", "integ_tests", "--test", "load_tests"]

--- a/bridge-ffi/src/lib.rs
+++ b/bridge-ffi/src/lib.rs
@@ -99,7 +99,7 @@ pub extern "C" fn tmprl_bytes_free(worker: *mut tmprl_worker_t, bytes: *const tm
         worker.return_buf(vec);
     }
     unsafe {
-        Box::from_raw(bytes);
+        let _ = Box::from_raw(bytes);
     }
 }
 
@@ -174,7 +174,7 @@ pub extern "C" fn tmprl_runtime_new() -> *mut tmprl_runtime_t {
 pub extern "C" fn tmprl_runtime_free(runtime: *mut tmprl_runtime_t) {
     if !runtime.is_null() {
         unsafe {
-            Box::from_raw(runtime);
+            let _ = Box::from_raw(runtime);
         }
     }
 }

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -891,7 +891,7 @@ mod tests {
             .filter(|l| l.starts_with("rpc"))
             .map(|l| {
                 let stripped = l.strip_prefix("rpc ").unwrap();
-                (&stripped[..stripped.find('(').unwrap()]).trim()
+                (stripped[..stripped.find('(').unwrap()]).trim()
             })
             .collect();
         let no_underscores: HashSet<_> = impl_list.iter().map(|x| x.replace('_', "")).collect();

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -108,3 +108,9 @@ test = false
 [[bench]]
 name = "workflow_replay"
 harness = false
+
+# This is maybe a bit hacky, but we call the runner an "example" because that gets it compiling with
+# the dev-dependencies, which we want.
+[[example]]
+name = "integ_runner"
+path = "../tests/runner.rs"

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -229,11 +229,11 @@ impl EphemeralServer {
         // WARNING: This is based on empirical evidence starting a Python test
         // run on Linux with Python 3.7 (does not happen on Python 3.10 nor does
         // it happen on Temporalite nor does it happen in Rust integration
-        // tests). Do not consider this fixed without running that scenario.
+        // tests). Don't alter without running that scenario. EX: SIGINT works but not SIGKILL
         if let Some(pid) = self.child.id() {
             let nix_pid = nix::unistd::Pid::from_raw(pid as i32);
             Ok(spawn_blocking(move || {
-                nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGKILL)?;
+                nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGINT)?;
                 nix::sys::wait::waitpid(Some(nix_pid), None)
             })
             .await?

--- a/core/src/pollers/mod.rs
+++ b/core/src/pollers/mod.rs
@@ -19,6 +19,7 @@ pub type Result<T, E = tonic::Status> = std::result::Result<T, E>;
 /// A trait for things that poll the server. Hides complexity of concurrent polling or polling
 /// on sticky/nonsticky queues simultaneously.
 #[cfg_attr(test, mockall::automock)]
+#[cfg_attr(test, allow(unused))]
 #[async_trait::async_trait]
 pub trait Poller<PollResult>
 where
@@ -37,6 +38,7 @@ pub type BoxedActPoller = BoxedPoller<PollActivityTaskQueueResponse>;
 #[cfg(test)]
 mockall::mock! {
     pub ManualPoller<T: Send + Sync + 'static> {}
+    #[allow(unused)]
     impl<T: Send + Sync + 'static> Poller<T> for ManualPoller<T> {
         fn poll<'a, 'b>(&self)
           -> impl Future<Output = Option<Result<T>>> + Send + 'b

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -229,7 +229,7 @@ pub fn telemetry_init(opts: &TelemetryOptions) -> Result<&'static GlobalTelemDat
                                 .pretty()
                                 .with_source_location(false);
                             let reg = tracing_subscriber::registry()
-                                .with((&opts).try_get_env_filter()?)
+                                .with((opts).try_get_env_filter()?)
                                 .with(
                                     tracing_subscriber::fmt::layer()
                                         .with_target(false)

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -17,6 +17,7 @@ pub(crate) fn mock_manual_workflow_client() -> MockManualWorkerClient {
 // https://github.com/asomers/mockall/issues/189 to be fixed for it to go away.
 mockall::mock! {
     pub ManualWorkerClient {}
+    #[allow(unused)]
     impl WorkerClient for ManualWorkerClient {
         fn poll_workflow_task<'a, 'b>(&'a self, task_queue: String, is_sticky: bool)
             -> impl Future<Output = Result<PollWorkflowTaskQueueResponse>> + Send + 'b

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -133,6 +133,7 @@ async fn can_paginate_long_history() {
     worker.run_until_done().await.unwrap();
 }
 
+// TODO: Takes ages now, fix somehow
 #[tokio::test]
 async fn poll_of_nonexistent_namespace_is_fatal() {
     let mut starter = CoreWfStarter::new("whatever_yo");

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -105,7 +105,7 @@ async fn simple_query_legacy() {
     assert_eq!(&q_resp.unwrap()[0].data, query_resp);
 }
 
-#[rstest::rstest]
+#[rstest]
 #[case::no_eviction(false)]
 #[case::with_eviction(true)]
 #[tokio::test]

--- a/tests/integ_tests/workflow_tests/replay.rs
+++ b/tests/integ_tests/workflow_tests/replay.rs
@@ -11,8 +11,7 @@ use temporal_sdk_core_protos::{
     DEFAULT_WORKFLOW_TYPE,
 };
 use temporal_sdk_core_test_utils::{
-    canned_histories, history_from_proto_binary,
-    init_core_replay_preloaded, WorkerTestHelpers,
+    canned_histories, history_from_proto_binary, init_core_replay_preloaded, WorkerTestHelpers,
 };
 use tokio::join;
 

--- a/tests/integ_tests/workflow_tests/replay.rs
+++ b/tests/integ_tests/workflow_tests/replay.rs
@@ -1,7 +1,6 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
 use temporal_sdk::{WfContext, Worker, WorkflowFunction};
-use temporal_sdk_core::telemetry_init;
 use temporal_sdk_core_api::errors::{PollActivityError, PollWfError};
 use temporal_sdk_core_protos::{
     coresdk::{
@@ -12,7 +11,7 @@ use temporal_sdk_core_protos::{
     DEFAULT_WORKFLOW_TYPE,
 };
 use temporal_sdk_core_test_utils::{
-    canned_histories, get_integ_telem_options, history_from_proto_binary,
+    canned_histories, history_from_proto_binary,
     init_core_replay_preloaded, WorkerTestHelpers,
 };
 use tokio::join;
@@ -101,7 +100,6 @@ async fn workflow_nondeterministic_replay() {
 
 #[tokio::test]
 async fn replay_using_wf_function() {
-    telemetry_init(&get_integ_telem_options()).unwrap();
     let num_timers = 10;
     let t = canned_histories::long_sequential_timers(num_timers as usize);
     let func = timers_wf(num_timers);
@@ -118,7 +116,6 @@ async fn replay_ok_ending_with_terminated_or_timed_out() {
     t1.add_workflow_execution_terminated();
     let mut t2 = canned_histories::single_timer("1");
     t2.add_workflow_execution_timed_out();
-    telemetry_init(&get_integ_telem_options()).unwrap();
     for t in [t1, t2] {
         let func = timers_wf(1);
         let (worker, _) = init_core_replay_preloaded(

--- a/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
+++ b/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
@@ -1,8 +1,9 @@
-use std::collections::HashMap;
+use log::warn;
+use std::{collections::HashMap, env};
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{WfContext, WorkflowResult};
 use temporal_sdk_core_protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
-use temporal_sdk_core_test_utils::CoreWfStarter;
+use temporal_sdk_core_test_utils::{CoreWfStarter, INTEG_TEMPORALITE_USED_ENV_VAR};
 use uuid::Uuid;
 
 // These are initialized on the server as part of the autosetup container which we
@@ -24,6 +25,11 @@ async fn sends_upsert() {
     let wf_id = Uuid::new_v4();
     let mut starter = CoreWfStarter::new(wf_name);
     let mut worker = starter.worker().await;
+    if env::var(INTEG_TEMPORALITE_USED_ENV_VAR).is_ok() {
+        warn!("skipping sends_upsert -- does not work on temporalite");
+        return;
+    }
+
     worker.register_wf(wf_name, search_attr_updater);
     let run_id = worker
         .submit_wf(

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,4 +1,11 @@
 //! Integration tests
+//!
+//! Note that integ tests which want to use the server (nearly all of them) *need* to use the
+//! `#[rstest]` macro and accept the TODO fixture to support auto setup & teardown of ephemeral
+//! local servers.
+
+#[macro_use]
+extern crate rstest;
 
 #[cfg(test)]
 mod integ_tests {

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -1,0 +1,93 @@
+use anyhow::{anyhow, bail};
+use std::{
+    env,
+    env::args,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+use temporal_sdk_core::ephemeral_server::{TemporaliteConfigBuilder, TestServerConfigBuilder};
+use temporal_sdk_core_test_utils::{
+    default_cached_download, INTEG_SERVER_TARGET_ENV_VAR, INTEG_TEMPORALITE_USED_ENV_VAR,
+    INTEG_TEST_SERVER_USED_ENV_VAR,
+};
+use tokio::{self, process::Command};
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let server_type = env::var("INTEG_SERVER_TYPE")
+        .unwrap_or_else(|_| "temporalite".to_string())
+        .to_lowercase();
+    // Try building first, so that we error early on build failures & don't start server
+    let status = Command::new(&cargo)
+        .args(["test", "--test", "integ_tests", "--no-run"])
+        .status()
+        .await?;
+    if !status.success() {
+        bail!("Building integration tests failed!");
+    }
+
+    // Move to clap if we start doing any more complicated input
+    let (server, envs) = if server_type == "test-server" {
+        let config = TestServerConfigBuilder::default()
+            .exe(default_cached_download())
+            .build()?;
+        println!("Using java test server");
+        (
+            Some(config.start_server_with_output(Stdio::null()).await?),
+            vec![(INTEG_TEST_SERVER_USED_ENV_VAR, "true")],
+        )
+    } else if server_type == "temporalite" {
+        let config = TemporaliteConfigBuilder::default()
+            .exe(default_cached_download())
+            .build()?;
+        println!("Using temporalite");
+        (
+            Some(config.start_server_with_output(Stdio::null()).await?),
+            vec![(INTEG_TEMPORALITE_USED_ENV_VAR, "true")],
+        )
+    } else {
+        println!("Not starting up a server. One should be running already.");
+        (None, vec![])
+    };
+
+    // Run the integ tests, passing through arguments
+    let mut args = args();
+    // Shift off binary name
+    args.next();
+    let mut cmd = Command::new(&cargo);
+    if let Some(srv) = server.as_ref() {
+        cmd.env(
+            INTEG_SERVER_TARGET_ENV_VAR,
+            format!("http://{}", &srv.target),
+        );
+    }
+    let status = cmd
+        .envs(envs)
+        .current_dir(project_root())
+        .args(
+            ["test", "--test", "integ_tests"]
+                .into_iter()
+                .map(ToString::to_string)
+                .chain(args),
+        )
+        .status()
+        .await?;
+
+    if let Some(mut srv) = server {
+        srv.shutdown().await?;
+    }
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("Integ tests failed!"))
+    }
+}
+
+fn project_root() -> PathBuf {
+    Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .unwrap()
+        .to_path_buf()
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Temporalite is now used by default when running integ tests. CI still uses docker (for now, I will add temporalite additionally shortly). Java Test server is supported, but breaks many tests.

## Why?
No more docker or manually setting things up / stopping them when running integ tests, yay!

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
