### PR TITLE
Ignore cancels of StartFailed state in child workflows

### DIFF
--- a/core/src/worker/workflow/machines/child_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/child_workflow_state_machine.rs
@@ -71,6 +71,7 @@ fsm! {
     // Ignore any spurious cancellations after resolution
     Cancelled --(Cancel) --> Cancelled;
     Failed --(Cancel) --> Failed;
+    StartFailed --(Cancel) --> StartFailed;
     TimedOut --(Cancel) --> TimedOut;
     Completed --(Cancel) --> Completed;
 }
@@ -845,6 +846,7 @@ mod test {
         for state in [
             ChildWorkflowMachineState::Cancelled(Cancelled {}),
             Failed {}.into(),
+            StartFailed {}.into(),
             TimedOut {}.into(),
             Completed {}.into(),
         ] {


### PR DESCRIPTION
User ran into `Invalid transition while attempting to cancel ChildWorkflowMachine in StartFailed` -- there's no reason to blow up in this case.