### PR TITLE
Fix replaying same run id multiple times possibly hanging replay

### DIFF
--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -10,7 +10,7 @@ use futures::{FutureExt, Stream, StreamExt};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -126,6 +126,7 @@ pub(crate) struct Historator {
     worker_closer: Arc<OnceCell<CancellationToken>>,
     dat: Arc<Mutex<HistoratorDat>>,
     replay_done_tx: UnboundedSender<String>,
+    seen_run_ids: HashSet<String>,
 }
 impl Historator {
     pub(crate) fn new(histories: impl Stream<Item = HistoryForReplay> + Send + 'static) -> Self {
@@ -139,6 +140,7 @@ impl Historator {
             worker_closer: Arc::new(OnceCell::new()),
             dat,
             replay_done_tx,
+            seen_run_ids: Default::default(),
         }
     }
 
@@ -184,6 +186,15 @@ impl Stream for Historator {
                                  execution started events",
                     )
                     .to_string();
+                if self.seen_run_ids.contains(&run_id) {
+                    info!(
+                        "Already replayed workflow with run id {}, skipping",
+                        &run_id
+                    );
+                    return self.poll_next(cx);
+                } else {
+                    self.seen_run_ids.insert(run_id.clone());
+                }
                 let last_event = history.hist.last_event_id();
                 self.dat
                     .lock()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Because of the expectations we have around WF tasks it was possible during replay to feed the same history in multiple times and hang the worker, since it tried to apply it as a task instead of a brand new run.

## Why?
Make sure users accidentally feeding in dupe histories doesn't break replay

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added UT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
