### PR TITLE
Expose workflow start time

### DIFF
--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -1,13 +1,14 @@
 use super::TELEM_SERVICE_NAME;
 use crate::telemetry::GLOBAL_TELEM_DAT;
-use opentelemetry::sdk::metrics::aggregators::Aggregator;
-use opentelemetry::sdk::metrics::sdk_api::{Descriptor, InstrumentKind};
 use opentelemetry::{
     global,
     metrics::{Counter, Histogram, Meter},
     sdk::{
         export::metrics::AggregatorSelector,
-        metrics::aggregators::{histogram, last_value, sum},
+        metrics::{
+            aggregators::{histogram, last_value, sum, Aggregator},
+            sdk_api::{Descriptor, InstrumentKind},
+        },
     },
     Context, KeyValue,
 };
@@ -335,7 +336,8 @@ static WF_TASK_MS_BUCKETS: &[f64] = &[1., 10., 20., 50., 100., 200., 500., 1000.
 static ACT_EXE_MS_BUCKETS: &[f64] = &[50., 100., 500., 1000., 5000., 10_000., 60_000.];
 
 /// Schedule-to-start latency buckets for both WFT and AT
-static TASK_SCHED_TO_START_MS_BUCKETS: &[f64] = &[100., 500., 1000., 5000., 10_000.];
+static TASK_SCHED_TO_START_MS_BUCKETS: &[f64] =
+    &[100., 500., 1000., 5000., 10_000., 100_000., 1_000_000.];
 
 /// Default buckets. Should never really be used as they will be meaningless for many things, but
 /// broadly it's trying to represent latencies in millis.

--- a/core/src/worker/workflow/driven_workflow.rs
+++ b/core/src/worker/workflow/driven_workflow.rs
@@ -1,4 +1,5 @@
 use crate::worker::workflow::{WFCommand, WorkflowStartedInfo};
+use prost_types::Timestamp;
 use temporal_sdk_core_protos::{
     coresdk::workflow_activation::{
         start_workflow_from_attribs, workflow_activation_job, CancelWorkflow, SignalWorkflow,
@@ -36,6 +37,7 @@ impl DrivenWorkflow {
         &mut self,
         workflow_id: String,
         randomness_seed: u64,
+        start_time: Timestamp,
         attribs: WorkflowExecutionStartedEventAttributes,
     ) {
         debug!(run_id = %attribs.original_execution_run_id, "Driven WF start");
@@ -49,7 +51,9 @@ impl DrivenWorkflow {
             search_attrs: attribs.search_attributes.clone(),
             retry_policy: attribs.retry_policy.clone(),
         };
-        self.send_job(start_workflow_from_attribs(attribs, workflow_id, randomness_seed).into());
+        self.send_job(
+            start_workflow_from_attribs(attribs, workflow_id, randomness_seed, start_time).into(),
+        );
         self.started_attrs = Some(started_info);
     }
 

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -504,7 +504,7 @@ impl WorkflowMachines {
                     attrs,
                 )) = event.attributes
                 {
-                    if let Some(st) = event.event_time {
+                    if let Some(st) = event.event_time.clone() {
                         let as_systime: SystemTime = st.try_into()?;
                         self.workflow_start_time = Some(as_systime);
                         // Set the workflow time to be the event time of the first event, so that
@@ -516,6 +516,7 @@ impl WorkflowMachines {
                     self.drive_me.start(
                         self.workflow_id.clone(),
                         str_to_randomness_seed(&attrs.original_execution_run_id),
+                        event.event_time.unwrap_or_default(),
                         attrs,
                     );
                 } else {

--- a/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -119,6 +119,8 @@ message StartWorkflow {
     temporal.api.common.v1.Memo memo = 21;
     // Search attributes created/updated when this workflow was started
     temporal.api.common.v1.SearchAttributes search_attributes = 22;
+    // When the workflow execution started event was first written
+    google.protobuf.Timestamp start_time = 23;
 }
 
 /// Notify a workflow that a timer has fired

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -404,6 +404,7 @@ pub mod coresdk {
                 query::v1::WorkflowQuery,
             },
         };
+        use prost_types::Timestamp;
         use std::{
             collections::HashMap,
             fmt::{Display, Formatter},
@@ -599,6 +600,7 @@ pub mod coresdk {
             attrs: WorkflowExecutionStartedEventAttributes,
             workflow_id: String,
             randomness_seed: u64,
+            start_time: Timestamp,
         ) -> StartWorkflow {
             StartWorkflow {
                 workflow_type: attrs.workflow_type.map(|wt| wt.name).unwrap_or_default(),
@@ -632,6 +634,7 @@ pub mod coresdk {
                 cron_schedule_to_schedule_interval: attrs.first_workflow_task_backoff,
                 memo: attrs.memo,
                 search_attributes: attrs.search_attributes,
+                start_time: Some(start_time),
             }
         }
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose workflow start time in start workflow activation job

## Why?
Useful for some interceptor-based scenarios, etc. Should be exposed under unsafe area.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
