### PR TITLE
Figured out a reasonable way to make dupe run-ids work during replay

### DIFF
--- a/tests/integ_tests/workflow_tests/replay.rs
+++ b/tests/integ_tests/workflow_tests/replay.rs
@@ -54,6 +54,14 @@ async fn timer_workflow_replay() {
         );
     };
     let poll_fut = async {
+        let evict_task = core
+            .poll_workflow_activation()
+            .await
+            .expect("Should be an eviction activation");
+        assert!(evict_task.eviction_reason().is_some());
+        core.complete_workflow_activation(WorkflowActivationCompletion::empty(evict_task.run_id))
+            .await
+            .unwrap();
         assert_matches!(
             core.poll_workflow_activation().await,
             Err(PollWfError::ShutDown)


### PR DESCRIPTION
* Just explicitly evict after every finished run

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Made it possible to supply multiple histories with the same run id to the replayer

## Why?
Better than having to silently skip or fail early

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
