### PR TITLE
Fix and add test for sending activation w/ legacy query + other job

### DIFF
--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.63
+FROM rust:1.65
 
 RUN rustup component add rustfmt && \
 	rustup component add clippy

--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -112,7 +112,7 @@ where
 macro_rules! dbg_panic {
   ($($arg:tt)*) => {
       error!($($arg)*);
-      debug_assert!(true, $($arg)*);
+      debug_assert!(false, $($arg)*);
   };
 }
 pub(crate) use dbg_panic;

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -438,7 +438,7 @@ async fn many_concurrent_heartbeat_cancels() {
 #[tokio::test]
 async fn activity_timeout_no_double_resolve() {
     let t = canned_histories::activity_double_resolve_repro();
-    let core = build_fake_worker("fake_wf_id", t, &[3]);
+    let core = build_fake_worker("fake_wf_id", t, [3]);
     let activity_id = 1;
 
     poll_and_reply(

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -521,7 +521,6 @@ async fn query_during_wft_heartbeat_doesnt_accidentally_fail_to_continue_heartbe
 #[case::real_history(false)]
 #[tokio::test]
 async fn la_resolve_during_legacy_query_does_not_combine(#[case] impossible_query_in_task: bool) {
-    crate::telemetry::test_telem_console();
     // Ensures we do not send an activation with a legacy query and any other work, which should
     // never happen, but there was an issue where an LA resolving could trigger that.
     let wfid = "fake_wf_id";

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -546,7 +546,6 @@ async fn la_resolve_during_legacy_query_does_not_combine() {
         hist_to_poll_resp(&t, wfid.to_owned(), ResponseType::ToTaskNum(1)),
         {
             let mut pr = hist_to_poll_resp(&t, wfid.to_owned(), ResponseType::OneTask(2));
-            dbg!(&pr.history);
             pr.queries = HashMap::new();
             pr.queries.insert(
                 "q1".to_string(),
@@ -583,13 +582,11 @@ async fn la_resolve_during_legacy_query_does_not_combine() {
     ];
     let mock = mock_workflow_client();
     let mut mock = single_hist_mock_sg(wfid, t, tasks, mock, true);
-    let tasksmap = mock.outstanding_task_map.clone().unwrap();
     mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
     let core = mock_worker(mock);
 
     let wf_fut = async {
         let task = core.poll_workflow_activation().await.unwrap();
-        let rid = task.run_id.clone();
         assert_matches!(
             task.jobs.as_slice(),
             &[WorkflowActivationJob {
@@ -614,7 +611,6 @@ async fn la_resolve_during_legacy_query_does_not_combine() {
                 }
             ]
         );
-        // tasksmap.release_run(&rid);
         core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
             task.run_id,
             vec![

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -29,7 +29,7 @@ use temporal_sdk_core_protos::{
         ActivityTaskCompletion, AsJsonPayloadExt,
     },
     temporal::api::{
-        common::v1::RetryPolicy, enums::v1::EventType, failure::v1::Failure,
+        common::v1::RetryPolicy, enums::v1::EventType, failure::v1::Failure, history::v1::History,
         query::v1::WorkflowQuery,
     },
 };
@@ -522,31 +522,64 @@ async fn la_resolve_during_legacy_query_does_not_combine() {
     // never happen, but there was an issue where an LA resolving could trigger that.
     let wfid = "fake_wf_id";
     let mut t = TestHistoryBuilder::default();
-    let mut wes_short_wft_timeout = default_wes_attribs();
-    wes_short_wft_timeout.workflow_task_timeout = Some(prost_dur!(from_millis(200)));
+    let wes_short_wft_timeout = default_wes_attribs();
     t.add(
         EventType::WorkflowExecutionStarted,
         wes_short_wft_timeout.into(),
     );
+    // Since we don't send queries with start workflow, need one workflow task of something else
+    // b/c we want to get an activation with a job and a nonlegacy query
     t.add_full_wf_task();
-    // LA started here
+    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    t.add_timer_fired(timer_started_event_id, "1".to_string());
+
+    // nonlegacy query got here & LA started here
     t.add_full_wf_task();
-    // Query got here, at the same time that the LA is resolved
+    // legacy query got here, at the same time that the LA is resolved
     t.add_local_activity_marker(1, "1", None, None, None);
     t.add_workflow_execution_completed();
 
-    let legacy_q_task = {
-        let mut pr = hist_to_poll_resp(&t, wfid.to_owned(), ResponseType::OneTask(2));
-        pr.query = Some(WorkflowQuery {
-            query_type: "query-type".to_string(),
-            query_args: Some(b"hi".into()),
-            header: None,
-        });
-        pr
-    };
+    let barr = Arc::new(Barrier::new(2));
+    let barr_c = barr.clone();
+
     let tasks = [
         hist_to_poll_resp(&t, wfid.to_owned(), ResponseType::ToTaskNum(1)),
-        legacy_q_task,
+        {
+            let mut pr = hist_to_poll_resp(&t, wfid.to_owned(), ResponseType::OneTask(2));
+            dbg!(&pr.history);
+            pr.queries = HashMap::new();
+            pr.queries.insert(
+                "q1".to_string(),
+                WorkflowQuery {
+                    query_type: "query-type".to_string(),
+                    query_args: Some(b"hi".into()),
+                    header: None,
+                },
+            );
+            pr
+        },
+        {
+            let mut pr = hist_to_poll_resp(
+                &t,
+                wfid.to_owned(),
+                ResponseType::UntilResolved(
+                    async move {
+                        barr_c.wait().await;
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                    .boxed(),
+                    2,
+                ),
+            );
+            // Strip history, we need to look like we hit the cache during the legacy query.
+            pr.history = Some(History { events: vec![] });
+            pr.query = Some(WorkflowQuery {
+                query_type: "query-type".to_string(),
+                query_args: Some(b"hi".into()),
+                header: None,
+            });
+            pr
+        },
     ];
     let mock = mock_workflow_client();
     let mut mock = single_hist_mock_sg(wfid, t, tasks, mock, true);
@@ -557,22 +590,55 @@ async fn la_resolve_during_legacy_query_does_not_combine() {
     let wf_fut = async {
         let task = core.poll_workflow_activation().await.unwrap();
         let rid = task.run_id.clone();
-        tasksmap.release_run(&rid);
-        // Weirdly, we have to let a WFT heartbeat expire here, so that we'll respond with a WFT
-        // completion after the task is responded to by lang, thus allowing the application of
-        // the next wft (with the query) before the LA resolves internally.
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert_matches!(
+            task.jobs.as_slice(),
+            &[WorkflowActivationJob {
+                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+            },]
+        );
         core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
             task.run_id,
-            schedule_local_activity_cmd(
-                1,
-                "act-id",
-                ActivityCancellationType::TryCancel,
-                Duration::from_secs(60),
-            ),
+            start_timer_cmd(1, Duration::from_secs(1)),
         ))
         .await
         .unwrap();
+        let task = core.poll_workflow_activation().await.unwrap();
+        assert_matches!(
+            task.jobs.as_slice(),
+            &[
+                WorkflowActivationJob {
+                    variant: Some(workflow_activation_job::Variant::FireTimer(_)),
+                },
+                WorkflowActivationJob {
+                    variant: Some(workflow_activation_job::Variant::QueryWorkflow(_)),
+                }
+            ]
+        );
+        // tasksmap.release_run(&rid);
+        core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+            task.run_id,
+            vec![
+                schedule_local_activity_cmd(
+                    1,
+                    "act-id",
+                    ActivityCancellationType::TryCancel,
+                    Duration::from_secs(60),
+                ),
+                QueryResult {
+                    query_id: "q1".to_string(),
+                    variant: Some(
+                        QuerySuccess {
+                            response: Some("whatev".into()),
+                        }
+                        .into(),
+                    ),
+                }
+                .into(),
+            ],
+        ))
+        .await
+        .unwrap();
+        barr.wait().await;
         let task = core.poll_workflow_activation().await.unwrap();
         // The next task needs to be resolve, since the LA is completed immediately
         assert_matches!(
@@ -581,15 +647,9 @@ async fn la_resolve_during_legacy_query_does_not_combine() {
                 variant: Some(workflow_activation_job::Variant::ResolveActivity(_)),
             }]
         );
-        // Complete with something else pointless
-        core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
-            task.run_id,
-            start_timer_cmd(1, Duration::from_secs(1)),
-        ))
-        .await
-        .unwrap();
-        // Now we should get the query. In real life, this query would now be invalid, since we
-        // already responded to the last WFT with the consequences of the LA resolution.
+        // Complete workflow
+        core.complete_execution(&task.run_id).await;
+
         let task = core.poll_workflow_activation().await.unwrap();
         assert_matches!(
             task.jobs.as_slice(),
@@ -600,7 +660,6 @@ async fn la_resolve_during_legacy_query_does_not_combine() {
     };
     let act_fut = async {
         let act_task = core.poll_activity_task().await.unwrap();
-        // barrier.wait().await;
         core.complete_activity_task(ActivityTaskCompletion {
             task_token: act_task.task_token,
             result: Some(ActivityExecutionResult::ok(vec![1].into())),

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -24,7 +24,7 @@ use tokio::sync::{watch, Barrier};
 #[tokio::test]
 async fn after_shutdown_of_worker_get_shutdown_err() {
     let t = canned_histories::single_timer("1");
-    let worker = build_fake_worker("fake_wf_id", t, &[1]);
+    let worker = build_fake_worker("fake_wf_id", t, [1]);
     let res = worker.poll_workflow_activation().await.unwrap();
     assert_eq!(res.jobs.len(), 1);
     let run_id = res.run_id;
@@ -53,7 +53,7 @@ async fn after_shutdown_of_worker_get_shutdown_err() {
 #[tokio::test]
 async fn shutdown_worker_can_complete_pending_activation() {
     let t = canned_histories::single_timer("1");
-    let worker = build_fake_worker("fake_wf_id", t, &[2]);
+    let worker = build_fake_worker("fake_wf_id", t, [2]);
     let res = worker.poll_workflow_activation().await.unwrap();
     assert_eq!(res.jobs.len(), 1);
     // Complete the timer, will queue PA

--- a/core/src/core_tests/workflow_cancels.rs
+++ b/core/src/core_tests/workflow_cancels.rs
@@ -107,7 +107,7 @@ async fn timer_then_cancel_req_then_timer_then_cancelled() {
 async fn immediate_cancel() {
     let wfid = "fake_wf_id";
     let t = canned_histories::immediate_wf_cancel();
-    let core = build_fake_worker(wfid, t, &[1]);
+    let core = build_fake_worker(wfid, t, [1]);
 
     poll_and_reply(
         &core,

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -651,7 +651,7 @@ async fn workflow_update_random_seed_on_workflow_reset() {
         timer_1_id.to_string().as_str(),
         new_run_id,
     );
-    let core = build_fake_worker(wfid, t, &[2]);
+    let core = build_fake_worker(wfid, t, [2]);
 
     poll_and_reply(
         &core,
@@ -705,7 +705,7 @@ async fn cancel_timer_before_sent_wf_bridge() {
     t.add_full_wf_task();
     t.add_workflow_execution_completed();
 
-    let core = build_fake_worker(wfid, t, &[1]);
+    let core = build_fake_worker(wfid, t, [1]);
 
     poll_and_reply(
         &core,
@@ -1120,7 +1120,7 @@ async fn complete_after_eviction() {
     let t = canned_histories::single_timer("1");
     let mut mock = mock_workflow_client();
     mock.expect_complete_workflow_task().times(0);
-    let mock = single_hist_mock_sg(wfid, t, &[2], mock, true);
+    let mock = single_hist_mock_sg(wfid, t, [2], mock, true);
     let core = mock_worker(mock);
 
     let activation = core.poll_workflow_activation().await.unwrap();
@@ -1162,7 +1162,7 @@ async fn sends_appropriate_sticky_task_queue_responses() {
         .times(1)
         .returning(|_| Ok(Default::default()));
     mock.expect_complete_workflow_task().times(0);
-    let mut mock = single_hist_mock_sg(wfid, t, &[1], mock, false);
+    let mut mock = single_hist_mock_sg(wfid, t, [1], mock, false);
     mock.worker_cfg(|wc| wc.max_cached_workflows = 10);
     let core = mock_worker(mock);
 
@@ -1180,7 +1180,7 @@ async fn sends_appropriate_sticky_task_queue_responses() {
 async fn new_server_work_while_eviction_outstanding_doesnt_overwrite_activation() {
     let wfid = "fake_wf_id";
     let t = canned_histories::single_timer("1");
-    let mock = single_hist_mock_sg(wfid, t, &[1, 2], mock_workflow_client(), false);
+    let mock = single_hist_mock_sg(wfid, t, [1, 2], mock_workflow_client(), false);
     let taskmap = mock.outstanding_task_map.clone().unwrap();
     let core = mock_worker(mock);
 
@@ -1443,7 +1443,7 @@ async fn tries_cancel_of_completed_activity() {
     t.add_workflow_task_scheduled_and_started();
 
     let mock = mock_workflow_client();
-    let mut mock = single_hist_mock_sg("fake_wf_id", t, &[1, 2], mock, true);
+    let mut mock = single_hist_mock_sg("fake_wf_id", t, [1, 2], mock, true);
     mock.worker_cfg(|cfg| cfg.max_cached_workflows = 1);
     let core = mock_worker(mock);
 
@@ -1822,7 +1822,7 @@ async fn eviction_waits_until_replay_finished() {
     let wfid = "fake_wf_id";
     let t = canned_histories::long_sequential_timers(3);
     let mock = mock_workflow_client();
-    let mock = single_hist_mock_sg(wfid, t, &[3], mock, true);
+    let mock = single_hist_mock_sg(wfid, t, [3], mock, true);
     let core = mock_worker(mock);
 
     let activation = core.poll_workflow_activation().await.unwrap();
@@ -1883,7 +1883,7 @@ async fn autocompletes_wft_no_work() {
     t.add_activity_task_completed(scheduled_event_id, started_event_id, Default::default());
     t.add_full_wf_task();
     let mock = mock_workflow_client();
-    let mut mock = single_hist_mock_sg(wfid, t, &[1, 2, 3, 4], mock, true);
+    let mut mock = single_hist_mock_sg(wfid, t, [1, 2, 3, 4], mock, true);
     mock.worker_cfg(|w| w.max_cached_workflows = 1);
     let core = mock_worker(mock);
 

--- a/core/src/telemetry/log_export.rs
+++ b/core/src/telemetry/log_export.rs
@@ -167,6 +167,8 @@ mod tests {
             })
             .build()
             .unwrap();
+        // TODO: this breaks if other tests init telemetry. Should just bite the bullet & make
+        //   it nonglobal
         telemetry_init(&opts).unwrap();
 
         let top_span = span!(Level::INFO, "yayspan", huh = "wat");

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -515,6 +515,7 @@ enum CancelOrTimeout {
     },
 }
 
+#[allow(clippy::large_enum_variant)]
 enum NewOrCancel {
     New(NewOrRetry, OwnedMeteredSemPermit),
     Cancel(CancelOrTimeout),

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -286,6 +286,7 @@ impl SharedState {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, derive_more::Display)]
 pub(super) enum LocalActivityCommand {
     RequestActivityExecution(ValidScheduleLA),
@@ -937,7 +938,7 @@ mod tests {
         let commands = wfm.get_server_commands().commands;
         assert_eq!(commands.len(), 0);
         let ready_to_execute_las = wfm.drain_queued_local_activities();
-        let num_queued = if !replay { 1 } else { 0 };
+        let num_queued = usize::from(!replay);
         assert_eq!(ready_to_execute_las.len(), num_queued);
 
         if !replay {
@@ -1113,7 +1114,7 @@ mod tests {
         let commands = wfm.get_server_commands().commands;
         assert_eq!(commands.len(), 0);
         let ready_to_execute_las = wfm.drain_queued_local_activities();
-        let num_queued = if !replay { 1 } else { 0 };
+        let num_queued = usize::from(!replay);
         assert_eq!(ready_to_execute_las.len(), num_queued);
 
         if !replay {
@@ -1155,7 +1156,7 @@ mod tests {
             }]
         );
         let ready_to_execute_las = wfm.drain_queued_local_activities();
-        let num_queued = if !replay { 1 } else { 0 };
+        let num_queued = usize::from(!replay);
         assert_eq!(ready_to_execute_las.len(), num_queued);
         if !replay {
             wfm.complete_local_activity(2, ActivityExecutionResult::ok(b"Resolved".into()))
@@ -1380,7 +1381,7 @@ mod tests {
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].command_type, CommandType::StartTimer as i32);
         let ready_to_execute_las = wfm.drain_queued_local_activities();
-        let num_queued = if !replay { 1 } else { 0 };
+        let num_queued = usize::from(!replay);
         assert_eq!(ready_to_execute_las.len(), num_queued);
 
         // Next activation timer fires and activity cancel will be requested

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     protosext::{CompleteLocalActivityData, HistoryEventExt, ValidScheduleLA},
-    worker::LocalActivityExecutionResult,
+    worker::{workflow::OutgoingJob, LocalActivityExecutionResult},
 };
 use rustfsm::{fsm, MachineError, StateMachine, TransitionResult};
 use std::{
@@ -643,13 +643,14 @@ impl WFMachinesAdapter for LocalActivityMachine {
                     result.into()
                 };
                 let mut responses = vec![
-                    MachineResponse::PushWFJob(
-                        ResolveActivity {
+                    MachineResponse::PushWFJob(OutgoingJob {
+                        variant: ResolveActivity {
                             seq: self.shared_state.attrs.seq,
                             result: Some(resolution),
                         }
                         .into(),
-                    ),
+                        is_la_resolution: true,
+                    }),
                     MachineResponse::UpdateWFTime(complete_time),
                 ];
 

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -288,6 +288,7 @@ impl ManagedRun {
         match outcome {
             Ok((None, data, me)) => Ok(Some(me.prepare_complete_resp(resp_chan, data, false))),
             Ok((Some((chan, start_t, wft_timeout)), data, me)) => {
+                warn!("Thinks waiting on las");
                 if let Some(wola) = me.waiting_on_la.as_mut() {
                     wola.heartbeat_timeout_task.abort();
                 }

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -288,7 +288,6 @@ impl ManagedRun {
         match outcome {
             Ok((None, data, me)) => Ok(Some(me.prepare_complete_resp(resp_chan, data, false))),
             Ok((Some((chan, start_t, wft_timeout)), data, me)) => {
-                warn!("Thinks waiting on las");
                 if let Some(wola) = me.waiting_on_la.as_mut() {
                     wola.heartbeat_timeout_task.abort();
                 }
@@ -358,6 +357,7 @@ impl ManagedRun {
         let query_responses = data.query_responses;
         let has_query_responses = !query_responses.is_empty();
         let is_query_playback = data.has_pending_query && !has_query_responses;
+        let mut force_new_wft = due_to_heartbeat_timeout;
 
         // We only actually want to send commands back to the server if there are no more
         // pending activations and we are caught up on replay. We don't want to complete a wft
@@ -367,19 +367,26 @@ impl ManagedRun {
         // either.
         let no_commands_and_evicting =
             outgoing_cmds.commands.is_empty() && data.activation_was_only_eviction;
+        let should_respond = !(self.wfm.machines.has_pending_jobs()
+            || outgoing_cmds.replaying
+            || is_query_playback
+            || no_commands_and_evicting);
+        // If there are pending LA resolutions, and we're responding to a query here,
+        // we want to make sure to force a new task, as otherwise once we tell lang about
+        // the LA resolution there wouldn't be any task to reply to with the result of iterating
+        // the workflow.
+        if has_query_responses && self.wfm.machines.has_pending_la_resolutions() {
+            force_new_wft = true;
+        }
         let to_be_sent = ServerCommandsWithWorkflowInfo {
             task_token: data.task_token,
             action: ActivationAction::WftComplete {
-                force_new_wft: due_to_heartbeat_timeout,
+                force_new_wft,
                 commands: outgoing_cmds.commands,
                 query_responses,
             },
         };
 
-        let should_respond = !(self.wfm.machines.has_pending_jobs()
-            || outgoing_cmds.replaying
-            || is_query_playback
-            || no_commands_and_evicting);
         let outcome = if should_respond || has_query_responses {
             ActivationCompleteOutcome::ReportWFTSuccess(to_be_sent)
         } else {

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -182,7 +182,7 @@ impl Workflows {
                 }
                 stream.next().await.unwrap_or(Err(PollWfError::ShutDown))?
             };
-            Span::current().record("run_id", &r.run_id());
+            Span::current().record("run_id", r.run_id());
             match r {
                 ActivationOrAuto::LangActivation(act) | ActivationOrAuto::ReadyForQueries(act) => {
                     debug!(activation=%act, "Sending activation to lang");

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -969,13 +969,13 @@ fn put_queries_in_act(act: &mut WorkflowActivation, wft: &mut OutstandingTask) {
         return;
     }
 
-    // TODO: Mark broken? Evict?
-    // let has_legacy = wft.has_pending_legacy_query();
-    // // Cannot dispatch legacy query if there are any other jobs - which can happen if, ex, a local
-    // // activity resolves while we've gotten a legacy query after heartbeating.
-    // if has_legacy && !act.jobs.is_empty() {
-    //     return;
-    // }
+    let has_legacy = wft.has_pending_legacy_query();
+    // Cannot dispatch legacy query if there are any other jobs - which can happen if, ex, a local
+    // activity resolves while we've gotten a legacy query after heartbeating.
+    if has_legacy && !act.jobs.is_empty() {
+        dbg_panic!("Should never try to attach legacy query to activation with other jobs");
+        return;
+    }
 
     debug!(queries=?wft.pending_queries, "Dispatching queries");
     let query_jobs = wft

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -314,6 +314,7 @@ impl WFStream {
                             // If there are in-poll queries, insert jobs for those queries into the
                             // activation, but only if we hit the cache. If we didn't, those queries
                             // will need to be dealt with once replay is over
+                            dbg!(wft.hit_cache);
                             if wft.hit_cache {
                                 put_queries_in_act(&mut activation, wft);
                             }
@@ -964,17 +965,18 @@ impl WFStream {
 
 /// Drains pending queries from the workflow task and appends them to the activation's jobs
 fn put_queries_in_act(act: &mut WorkflowActivation, wft: &mut OutstandingTask) {
+    dbg!("Queries in act?");
     // Nothing to do if there are no pending queries
     if wft.pending_queries.is_empty() {
         return;
     }
 
-    let has_legacy = wft.has_pending_legacy_query();
-    // Cannot dispatch legacy query if there are any other jobs - which can happen if, ex, a local
-    // activity resolves while we've gotten a legacy query after heartbeating.
-    if has_legacy && !act.jobs.is_empty() {
-        return;
-    }
+    // let has_legacy = wft.has_pending_legacy_query();
+    // // Cannot dispatch legacy query if there are any other jobs - which can happen if, ex, a local
+    // // activity resolves while we've gotten a legacy query after heartbeating.
+    // if has_legacy && !act.jobs.is_empty() {
+    //     return;
+    // }
 
     debug!(queries=?wft.pending_queries, "Dispatching queries");
     let query_jobs = wft

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -314,7 +314,7 @@ impl WFStream {
                             // If there are in-poll queries, insert jobs for those queries into the
                             // activation, but only if we hit the cache. If we didn't, those queries
                             // will need to be dealt with once replay is over
-                            if !wft.pending_queries.is_empty() && wft.hit_cache {
+                            if wft.hit_cache {
                                 put_queries_in_act(&mut activation, wft);
                             }
                         }
@@ -964,6 +964,18 @@ impl WFStream {
 
 /// Drains pending queries from the workflow task and appends them to the activation's jobs
 fn put_queries_in_act(act: &mut WorkflowActivation, wft: &mut OutstandingTask) {
+    // Nothing to do if there are no pending queries
+    if wft.pending_queries.is_empty() {
+        return;
+    }
+
+    let has_legacy = wft.has_pending_legacy_query();
+    // Cannot dispatch legacy query if there are any other jobs - which can happen if, ex, a local
+    // activity resolves while we've gotten a legacy query after heartbeating.
+    if has_legacy && !act.jobs.is_empty() {
+        return;
+    }
+
     debug!(queries=?wft.pending_queries, "Dispatching queries");
     let query_jobs = wft
         .pending_queries

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -314,7 +314,6 @@ impl WFStream {
                             // If there are in-poll queries, insert jobs for those queries into the
                             // activation, but only if we hit the cache. If we didn't, those queries
                             // will need to be dealt with once replay is over
-                            dbg!(wft.hit_cache);
                             if wft.hit_cache {
                                 put_queries_in_act(&mut activation, wft);
                             }
@@ -965,12 +964,12 @@ impl WFStream {
 
 /// Drains pending queries from the workflow task and appends them to the activation's jobs
 fn put_queries_in_act(act: &mut WorkflowActivation, wft: &mut OutstandingTask) {
-    dbg!("Queries in act?");
     // Nothing to do if there are no pending queries
     if wft.pending_queries.is_empty() {
         return;
     }
 
+    // TODO: Mark broken? Evict?
     // let has_legacy = wft.has_pending_legacy_query();
     // // Cannot dispatch legacy query if there are any other jobs - which can happen if, ex, a local
     // // activity resolves while we've gotten a legacy query after heartbeating.

--- a/fsm/rustfsm_procmacro/tests/trybuild/no_handle_conversions_require_into_fail.stderr
+++ b/fsm/rustfsm_procmacro/tests/trybuild/no_handle_conversions_require_into_fail.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `One: From<Two>` is not satisfied
 11  |     Two --(B)--> One;
     |                  ^^^ the trait `From<Two>` is not implemented for `One`
     |
-    = note: required because of the requirements on the impl of `Into<One>` for `Two`
+    = note: required for `Two` to implement `Into<One>`
 note: required by a bound in `TransitionResult::<Sm, Ds>::from`
    --> $WORKSPACE/fsm/rustfsm_trait/src/lib.rs
     |


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Never send a legacy query with other jobs

## Why?
It's illegal. Other jobs can trigger new commands, and a legacy query activation can never be responded to with other commands, and I promise I'll never do it (oops)

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/426

2. How was this tested:
New test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
