### PR TITLE
Create a helper for setting the trace subscriber for the current thread

### DIFF
--- a/core/src/telemetry/log_export.rs
+++ b/core/src/telemetry/log_export.rs
@@ -146,7 +146,7 @@ impl<'a> tracing::field::Visit for JsonVisitor<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{construct_filter_string, telemetry_init};
+    use crate::{telemetry::construct_filter_string, telemetry_init};
     use temporal_sdk_core_api::telemetry::{CoreTelemetry, Logger, TelemetryOptionsBuilder};
     use tracing::Level;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
See title

## Why?
Makes it easier to set trace subscriber for, ex, multithreaded tokio runtimes.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
