### PR TITLE
Fix activity scheduled_to_start_latency metric

### DIFF
--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1837,12 +1837,12 @@ pub mod temporal {
                 tonic::include_proto!("temporal.api.workflowservice.v1");
 
                 macro_rules! sched_to_start_impl {
-                    () => {
-                        /// Return the duration of the task schedule time to its start time if both
-                        /// are set and time went forward.
+                    ($sched_field:ident) => {
+                        /// Return the duration of the task schedule time (current attempt) to its
+                        /// start time if both are set and time went forward.
                         pub fn sched_to_start(&self) -> Option<Duration> {
                             if let Some((sch, st)) =
-                                self.scheduled_time.clone().zip(self.started_time.clone())
+                                self.$sched_field.clone().zip(self.started_time.clone())
                             {
                                 let sch: Result<SystemTime, _> = sch.try_into();
                                 let st: Result<SystemTime, _> = st.try_into();
@@ -1856,7 +1856,7 @@ pub mod temporal {
                 }
 
                 impl PollWorkflowTaskQueueResponse {
-                    sched_to_start_impl!();
+                    sched_to_start_impl!(scheduled_time);
                 }
 
                 impl Display for PollWorkflowTaskQueueResponse {
@@ -1898,7 +1898,7 @@ pub mod temporal {
                 }
 
                 impl PollActivityTaskQueueResponse {
-                    sched_to_start_impl!();
+                    sched_to_start_impl!(current_attempt_scheduled_time);
                 }
 
                 impl QueryWorkflowResponse {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This metric was using original attempt schedule time rather than current attempt.

## Why?
Align with other SDKs, enables resolving https://github.com/temporalio/sdk-typescript/issues/972

