### PR TITLE
Added the option to have the activity return a non-retryable error.

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools"]
 
 [dependencies]
 async-trait = "0.1"
+thiserror = "1.0"
 anyhow = "1.0"
 base64 = "0.20"
 crossbeam = "0.8"

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -1,6 +1,6 @@
+use anyhow::anyhow;
 use assert_matches::assert_matches;
 use std::time::Duration;
-use anyhow::anyhow;
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowExecutionResult, WorkflowOptions};
 use temporal_sdk::{
     ActContext, ActExitValue, ActivityOptions, CancellableFuture, WfContext, WorkflowResult,
@@ -223,10 +223,10 @@ async fn activity_non_retryable_failure_with_error() {
             Duration::from_secs(60),
             Duration::from_secs(60),
         )
-            .into_completion(task.run_id),
+        .into_completion(task.run_id),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     // Poll activity and verify that it's been scheduled with correct parameters
     let task = core.poll_activity_task().await.unwrap();
     assert_matches!(
@@ -241,8 +241,8 @@ async fn activity_non_retryable_failure_with_error() {
         task_token: task.task_token,
         result: Some(ActivityExecutionResult::fail(failure.clone())),
     })
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     // Poll workflow task and verify that activity has failed.
     let task = core.poll_workflow_activation().await.unwrap();
     assert_matches!(
@@ -277,7 +277,6 @@ async fn activity_non_retryable_failure_with_error() {
     );
     core.complete_execution(&task.run_id).await;
 }
-
 
 #[tokio::test]
 async fn activity_retry() {
@@ -353,7 +352,6 @@ async fn activity_retry() {
     );
     core.complete_execution(&task.run_id).await;
 }
-
 
 #[tokio::test]
 async fn activity_cancellation_try_cancel() {


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added a `NonRetryableActivityError` type so that an ActivityFunction can return this Error and the activity is not retried. Hence, the workflow will fail.

## Why?
<!-- Tell your future self why have you made these changes -->
To be able to accommodate for the use-case where you as the user *know* that the activity should not be retried.

## Checklist
<!--- add/delete as needed --->

1. Closes: https://github.com/temporalio/sdk-core/issues/454

2. How was this tested:
Test was added `activity_non_retryable_failure_with_error` that uses the new function: `Failure::application_failure_from_error`.
  Also, created a manual test locally: Where an activity was used that returns the **new** error type. Not sure if a test could be added to `local_activities` to properly test the error conversion code? Could use some pointers here if this is deemed necessary :) Thanks!

4. Any docs updates needed?
 Not sure, as there is no currently published Rust docs.
