### PR TITLE
Fix forgetting correct value for previous WFT started ID

### DIFF
--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -211,7 +211,7 @@ impl WorkflowMachines {
         driven_wf: DrivenWorkflow,
         metrics: MetricsContext,
     ) -> Self {
-        let replaying = history.previous_started_event_id > 0;
+        let replaying = history.previous_wft_started_id > 0;
         Self {
             last_history_from_server: history,
             namespace,
@@ -256,7 +256,7 @@ impl WorkflowMachines {
 
     pub(crate) fn new_history_from_server(&mut self, update: HistoryUpdate) -> Result<()> {
         self.last_history_from_server = update;
-        self.replaying = self.last_history_from_server.previous_started_event_id > 0;
+        self.replaying = self.last_history_from_server.previous_wft_started_id > 0;
         self.apply_next_wft_from_history()?;
         Ok(())
     }
@@ -530,7 +530,7 @@ impl WorkflowMachines {
         }
         if self.replaying
             && self.current_started_event_id
-                >= self.last_history_from_server.previous_started_event_id
+                >= self.last_history_from_server.previous_wft_started_id
             && event.event_type() != EventType::WorkflowTaskCompleted
         {
             // Replay is finished

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -587,7 +587,7 @@ impl Workflows {
 /// replay a run
 #[derive(Debug, derive_more::Display)]
 #[display(
-    fmt = "HistoryFetchReq(run_id: {})",
+    fmt = "CacheMissFetchReq(run_id: {})",
     "original_wft.work.execution.run_id"
 )]
 #[must_use]

--- a/tests/fuzzy_workflow.rs
+++ b/tests/fuzzy_workflow.rs
@@ -78,11 +78,8 @@ async fn fuzzy_workflow() {
     let num_workflows = 200;
     let wf_name = "fuzzy_wf";
     let mut starter = CoreWfStarter::new("fuzzy_workflow");
-    starter
-        .max_wft(25)
-        .max_cached_workflows(25)
-        .max_at(25)
-        .enable_wf_state_input_recording();
+    starter.max_wft(25).max_cached_workflows(25).max_at(25);
+    // .enable_wf_state_input_recording();
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), fuzzy_wf_def);
     worker.register_activity("echo_activity", echo);
@@ -103,13 +100,11 @@ async fn fuzzy_workflow() {
         workflow_handles.push(client.get_untyped_workflow_handle(wfid, rid));
     }
 
-    // 1234: Triggers - Local activity cannot be created as pre-resolved while not replaying
-    let rng = SmallRng::seed_from_u64(1234);
+    let rng = SmallRng::seed_from_u64(523189);
     let mut actions: Vec<FuzzyWfAction> = rng.sample_iter(FuzzyWfActionSampler).take(15).collect();
     actions.push(FuzzyWfAction::Shutdown);
 
     let sig_sender = async {
-        // loop {
         for action in actions {
             let sends: FuturesUnordered<_> = (0..num_workflows)
                 .map(|i| {


### PR DESCRIPTION
This fixes a bug I discovered and was able to make reproducible with the work in https://github.com/temporalio/sdk-core/pull/469
(and also needs that PR to be merged first, draft until it is)

The problem was introduced in https://github.com/temporalio/sdk-core/pull/463 which refactored history updates / pagination. 

The concept of the last started WFT id must be preserved as it was told to us according to server when we started the *current* workflow task. However, I intermixed the concept of the last processed ID as according to state machines with that value, because they're typically used for the same purpose - except in one important spot, determining when replay is finished.

It was possible when missing the cache to reset the last started WFT id to zero, because that is where we should begin processing from - but, out last started WFT was *not* zero, and hence we'd think we were not replaying even though we were.