### PR TITLE
Make activity type / id mismatches a nondeterministic change

### DIFF
--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -8,6 +8,7 @@ on: # rebuild any PRs and main branch changes
 
 jobs:
   build-and-test:
+    timeout-minutes: 20
     runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v2

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -42,6 +42,9 @@ use temporal_sdk_core_protos::{
     temporal::api::{
         command::v1::{command::Attributes, ScheduleActivityTaskCommandAttributes},
         enums::v1::EventType,
+        history::v1::{
+            history_event::Attributes as EventAttributes, ActivityTaskScheduledEventAttributes,
+        },
         workflowservice::v1::{
             PollActivityTaskQueueResponse, RecordActivityTaskHeartbeatResponse,
             RespondActivityTaskCanceledResponse, RespondActivityTaskCompletedResponse,
@@ -828,11 +831,23 @@ async fn activity_tasks_from_completion_reserve_slots() {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let schedid = t.add_activity_task_scheduled("1");
+    let schedid = t.add(EventAttributes::ActivityTaskScheduledEventAttributes(
+        ActivityTaskScheduledEventAttributes {
+            activity_id: "1".to_string(),
+            activity_type: Some("act1".into()),
+            ..Default::default()
+        },
+    ));
     let startid = t.add_activity_task_started(schedid);
     t.add_activity_task_completed(schedid, startid, b"hi".into());
     t.add_full_wf_task();
-    let schedid = t.add_activity_task_scheduled("2");
+    let schedid = t.add(EventAttributes::ActivityTaskScheduledEventAttributes(
+        ActivityTaskScheduledEventAttributes {
+            activity_id: "2".to_string(),
+            activity_type: Some("act2".into()),
+            ..Default::default()
+        },
+    ));
     let startid = t.add_activity_task_started(schedid);
     t.add_activity_task_completed(schedid, startid, b"hi".into());
     t.add_full_wf_task();

--- a/core/src/core_tests/determinism.rs
+++ b/core/src/core_tests/determinism.rs
@@ -9,7 +9,10 @@ use std::{
 };
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{ActivityOptions, WfContext, WorkflowResult};
-use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowTaskFailedCause;
+use temporal_sdk_core_protos::{
+    temporal::api::{enums::v1::WorkflowTaskFailedCause, failure::v1::Failure},
+    DEFAULT_ACTIVITY_TYPE,
+};
 
 static DID_FAIL: AtomicBool = AtomicBool::new(false);
 pub async fn timer_wf_fails_once(ctx: WfContext) -> WorkflowResult<()> {
@@ -113,7 +116,7 @@ async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] use_cache:
 async fn test_activity_type_change_is_nondeterministic(#[case] use_cache: bool) {
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
-    let t = canned_histories::single_timer_wf_completes("1");
+    let t = canned_histories::single_activity("1");
     let mock = mock_workflow_client();
     let mut mh = MockPollCfg::from_resp_batches(
         wf_id,
@@ -124,8 +127,13 @@ async fn test_activity_type_change_is_nondeterministic(#[case] use_cache: bool) 
     );
     // We should see one wft failure which has nondeterminism cause
     mh.num_expected_fails = 1;
-    mh.expect_fail_wft_matcher =
-        Box::new(|_, cause, _| matches!(cause, WorkflowTaskFailedCause::NonDeterministicError));
+    mh.expect_fail_wft_matcher = Box::new(|_, cause, f| {
+        matches!(cause, WorkflowTaskFailedCause::NonDeterministicError)
+            && matches!(f, Some(Failure {
+                message,
+                ..
+            }) if message.contains("does not match activity type"))
+    });
     let mut worker = mock_sdk_cfg(mh, |cfg| {
         if use_cache {
             cfg.max_cached_workflows = 2;
@@ -135,6 +143,59 @@ async fn test_activity_type_change_is_nondeterministic(#[case] use_cache: bool) 
     worker.register_wf(wf_type.to_owned(), move |ctx: WfContext| async move {
         ctx.activity(ActivityOptions {
             activity_type: "not the default act type".to_string(),
+            ..Default::default()
+        })
+        .await;
+        Ok(().into())
+    });
+
+    worker
+        .submit_wf(
+            wf_id.to_owned(),
+            wf_type.to_owned(),
+            vec![],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+#[rstest::rstest]
+#[case::with_cache(true)]
+#[case::without_cache(false)]
+#[tokio::test]
+async fn test_activity_id_change_is_nondeterministic(#[case] use_cache: bool) {
+    let wf_id = "fakeid";
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let t = canned_histories::single_activity("1");
+    let mock = mock_workflow_client();
+    let mut mh = MockPollCfg::from_resp_batches(
+        wf_id,
+        t,
+        // Two polls are needed, since the first will fail
+        [ResponseType::AllHistory, ResponseType::AllHistory],
+        mock,
+    );
+    // We should see one wft failure which has nondeterminism cause
+    mh.num_expected_fails = 1;
+    mh.expect_fail_wft_matcher = Box::new(|_, cause, f| {
+        matches!(cause, WorkflowTaskFailedCause::NonDeterministicError)
+            && matches!(f, Some(Failure {
+                message,
+                ..
+            }) if message.contains("does not match activity id"))
+    });
+    let mut worker = mock_sdk_cfg(mh, |cfg| {
+        if use_cache {
+            cfg.max_cached_workflows = 2;
+        }
+    });
+
+    worker.register_wf(wf_type.to_owned(), move |ctx: WfContext| async move {
+        ctx.activity(ActivityOptions {
+            activity_id: Some("I'm bad and wrong!".to_string()),
+            activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
             ..Default::default()
         })
         .await;

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -566,10 +566,7 @@ async fn la_resolve_during_legacy_query_does_not_combine(#[case] impossible_quer
     let wfid = "fake_wf_id";
     let mut t = TestHistoryBuilder::default();
     let wes_short_wft_timeout = default_wes_attribs();
-    t.add(
-        EventType::WorkflowExecutionStarted,
-        wes_short_wft_timeout.into(),
-    );
+    t.add(wes_short_wft_timeout.into());
     // Since we don't send queries with start workflow, need one workflow task of something else
     // b/c we want to get an activation with a job and a nonlegacy query
     t.add_full_wf_task();

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -60,7 +60,7 @@ async fn local_act_two_wfts_before_marker(#[case] replay: bool, #[case] cached: 
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_full_wf_task();
     t.add_local_activity_result_marker(1, "1", b"echo".into());
     t.add_timer_fired(timer_started_event_id, "1".to_string());
@@ -130,7 +130,7 @@ async fn local_act_many_concurrent() {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_full_wf_task();
     for i in 1..=50 {
         t.add_local_activity_result_marker(i, &i.to_string(), b"echo".into());
@@ -302,7 +302,7 @@ async fn local_act_retry_long_backoff_uses_timer() {
         "1",
         Failure::application_failure("la failed".to_string(), false),
     );
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, "1".to_string());
     t.add_full_wf_task();
     t.add_local_activity_fail_marker(
@@ -310,7 +310,7 @@ async fn local_act_retry_long_backoff_uses_timer() {
         "2",
         Failure::application_failure("la failed".to_string(), false),
     );
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, "2".to_string());
     t.add_full_wf_task();
     t.add_workflow_execution_completed();
@@ -411,7 +411,7 @@ async fn local_act_command_immediately_follows_la_marker() {
     t.add_full_wf_task();
     t.add_full_wf_task();
     t.add_local_activity_result_marker(1, "1", "done".into());
-    t.add_get_event_id(EventType::TimerStarted, None);
+    t.add_by_type(EventType::TimerStarted);
     t.add_full_wf_task();
 
     let wf_id = "fakeid";
@@ -565,12 +565,11 @@ async fn la_resolve_during_legacy_query_does_not_combine(#[case] impossible_quer
     // never happen, but there was an issue where an LA resolving could trigger that.
     let wfid = "fake_wf_id";
     let mut t = TestHistoryBuilder::default();
-    let wes_short_wft_timeout = default_wes_attribs();
-    t.add(wes_short_wft_timeout.into());
+    t.add(default_wes_attribs());
     // Since we don't send queries with start workflow, need one workflow task of something else
     // b/c we want to get an activation with a job and a nonlegacy query
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, "1".to_string());
 
     // nonlegacy query got here & LA started here
@@ -802,7 +801,7 @@ async fn test_schedule_to_start_timeout_not_based_on_original_time(
             deets.backoff = Some(prost_dur!(from_secs(100)));
         },
     );
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, "1".to_string());
     t.add_workflow_task_scheduled_and_started();
 
@@ -868,7 +867,7 @@ async fn wft_failure_cancels_running_las() {
     let mut t = TestHistoryBuilder::default();
     t.add_wfe_started_with_wft_timeout(Duration::from_millis(200));
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, "1".to_string());
     t.add_workflow_task_scheduled_and_started();
 

--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -773,7 +773,6 @@ async fn legacy_query_combined_with_timer_fire_repro() {
     t.add_timer_fired(timer_started_event_id, "1".to_string());
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCancelRequested,
         history_event::Attributes::ActivityTaskCancelRequestedEventAttributes(
             ActivityTaskCancelRequestedEventAttributes {
                 scheduled_event_id,

--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -769,7 +769,7 @@ async fn legacy_query_combined_with_timer_fire_repro() {
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     let scheduled_event_id = t.add_activity_task_scheduled("1");
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, "1".to_string());
     t.add_full_wf_task();
     t.add(

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -988,12 +988,11 @@ async fn activity_not_canceled_when_also_completed_repro(hist_batches: &'static 
         &core,
         NonSticky,
         &[
-            // TODO: Act id mismatch. Should also check? Actually semi-debatable, but probably.
             gen_assert_and_reply(
                 &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_id,
-                    activity_id: activity_id.to_string(),
+                    activity_id: "act-1".to_string(),
                     cancellation_type: ActivityCancellationType::TryCancel as i32,
                     ..default_act_sched()
                 }

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -725,12 +725,12 @@ pub mod tests {
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_full_wf_task();
         t.add_full_wf_task(); // wft started 6
-        t.add_get_event_id(EventType::TimerStarted, None);
+        t.add_by_type(EventType::TimerStarted);
         t.add_full_wf_task(); // wft started 10
         t.add_full_wf_task();
         t.add_full_wf_task();
         t.add_full_wf_task(); // wft started 19
-        t.add_get_event_id(EventType::TimerStarted, None);
+        t.add_by_type(EventType::TimerStarted);
         t.add_full_wf_task(); // wft started 23
         t.add_we_signaled("whee", vec![]);
         t.add_full_wf_task();
@@ -866,9 +866,9 @@ pub mod tests {
         // Start with two complete normal WFTs
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_full_wf_task(); // wft start - 3
-        t.add_get_event_id(EventType::TimerStarted, None);
+        t.add_by_type(EventType::TimerStarted);
         t.add_full_wf_task(); // wft start - 7
-        t.add_get_event_id(EventType::TimerStarted, None);
+        t.add_by_type(EventType::TimerStarted);
         t.add_full_wf_task(); // wft start - 11
         for _ in 1..50 {
             // Add a bunch of heartbeats with no commands, which count as one task

--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -37,7 +37,7 @@ fsm! {
     Created --(Schedule, on_schedule)--> ScheduleCommandCreated;
 
     ScheduleCommandCreated --(CommandScheduleActivityTask) --> ScheduleCommandCreated;
-    ScheduleCommandCreated --(ActivityTaskScheduled(i64),
+    ScheduleCommandCreated --(ActivityTaskScheduled(ActTaskScheduledData),
         shared on_activity_task_scheduled) --> ScheduledEventRecorded;
     ScheduleCommandCreated --(Cancel, shared on_canceled) --> Canceled;
 
@@ -92,6 +92,11 @@ pub(super) enum ActivityMachineCommand {
     Cancel(Option<Payloads>),
     #[display(fmt = "RequestCancellation")]
     RequestCancellation(Command),
+}
+
+pub(super) struct ActTaskScheduledData {
+    event_id: i64,
+    act_type: String,
 }
 
 /// Creates a new activity state machine and a command to schedule it on the server.
@@ -174,7 +179,21 @@ impl TryFrom<HistoryEvent> for ActivityMachineEvents {
 
     fn try_from(e: HistoryEvent) -> Result<Self, Self::Error> {
         Ok(match e.event_type() {
-            EventType::ActivityTaskScheduled => Self::ActivityTaskScheduled(e.event_id),
+            EventType::ActivityTaskScheduled => {
+                if let Some(history_event::Attributes::ActivityTaskScheduledEventAttributes(
+                    attrs,
+                )) = e.attributes
+                {
+                    Self::ActivityTaskScheduled(ActTaskScheduledData {
+                        event_id: e.event_id,
+                        act_type: attrs.activity_type.unwrap_or_default().name,
+                    })
+                } else {
+                    return Err(WFMachinesError::Fatal(format!(
+                        "Activity scheduled attributes were unset: {e}"
+                    )));
+                }
+            }
             EventType::ActivityTaskStarted => Self::ActivityTaskStarted(e.event_id),
             EventType::ActivityTaskCompleted => {
                 if let Some(history_event::Attributes::ActivityTaskCompletedEventAttributes(
@@ -371,17 +390,25 @@ impl ScheduleCommandCreated {
     pub(super) fn on_activity_task_scheduled(
         self,
         dat: SharedState,
-        scheduled_event_id: i64,
+        sched_dat: ActTaskScheduledData,
     ) -> ActivityMachineTransition<ScheduledEventRecorded> {
+        if sched_dat.act_type != dat.attrs.activity_type {
+            return TransitionResult::Err(WFMachinesError::Nondeterminism(format!(
+                "Activity type of scheduled event '{}' does not \
+                 match activity type of activity command '{}'",
+                sched_dat.act_type, dat.attrs.activity_type
+            )));
+        }
         ActivityMachineTransition::ok_shared(
             vec![],
             ScheduledEventRecorded::default(),
             SharedState {
-                scheduled_event_id,
+                scheduled_event_id: sched_dat.event_id,
                 ..dat
             },
         )
     }
+
     pub(super) fn on_canceled(self, dat: SharedState) -> ActivityMachineTransition<Canceled> {
         let canceled_state = SharedState {
             cancelled_before_sent: true,
@@ -778,8 +805,9 @@ mod test {
     use temporal_sdk::{
         ActivityOptions, CancellableFuture, WfContext, WorkflowFunction, WorkflowResult,
     };
-    use temporal_sdk_core_protos::coresdk::workflow_activation::{
-        workflow_activation_job, WorkflowActivationJob,
+    use temporal_sdk_core_protos::{
+        coresdk::workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        DEFAULT_ACTIVITY_TYPE,
     };
 
     #[fixture]
@@ -799,7 +827,12 @@ mod test {
     }
 
     async fn activity_wf(command_sink: WfContext) -> WorkflowResult<()> {
-        command_sink.activity(ActivityOptions::default()).await;
+        command_sink
+            .activity(ActivityOptions {
+                activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
+                ..Default::default()
+            })
+            .await;
         Ok(().into())
     }
 

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -1373,14 +1373,14 @@ mod tests {
         let mut t = TestHistoryBuilder::default();
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_full_wf_task();
-        let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+        let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
         t.add_timer_fired(timer_started_event_id, "1".to_string());
         t.add_full_wf_task();
         if cancel_type != ActivityCancellationType::WaitCancellationCompleted {
             // With non-wait cancels, the cancel is immediate
             t.add_local_activity_cancel_marker(1, "1");
         }
-        let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+        let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
         if cancel_type == ActivityCancellationType::WaitCancellationCompleted {
             // With wait cancels, the cancel marker is not recorded until activity reports.
             t.add_local_activity_cancel_marker(1, "1");

--- a/core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/core/src/worker/workflow/machines/patch_state_machine.rs
@@ -302,7 +302,6 @@ mod tests {
             ),
         );
         t.add(
-            EventType::ActivityTaskCompleted,
             history_event::Attributes::ActivityTaskCompletedEventAttributes(
                 ActivityTaskCompletedEventAttributes {
                     scheduled_event_id,
@@ -590,7 +589,6 @@ mod tests {
                 ),
             );
             t.add(
-                EventType::ActivityTaskCompleted,
                 history_event::Attributes::ActivityTaskCompletedEventAttributes(
                     ActivityTaskCompletedEventAttributes {
                         scheduled_event_id,
@@ -602,31 +600,28 @@ mod tests {
             );
             t.add_full_wf_task();
             let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-            t.add(
-                EventType::TimerFired,
-                history_event::Attributes::TimerFiredEventAttributes(TimerFiredEventAttributes {
+            t.add(history_event::Attributes::TimerFiredEventAttributes(
+                TimerFiredEventAttributes {
                     started_event_id: timer_started_event_id,
                     timer_id: "1".to_owned(),
-                }),
-            );
+                },
+            ));
         } else {
             let started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-            t.add(
-                EventType::TimerFired,
-                history_event::Attributes::TimerFiredEventAttributes(TimerFiredEventAttributes {
+            t.add(history_event::Attributes::TimerFiredEventAttributes(
+                TimerFiredEventAttributes {
                     started_event_id,
                     timer_id: "1".to_owned(),
-                }),
-            );
+                },
+            ));
             t.add_full_wf_task();
             let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-            t.add(
-                EventType::TimerFired,
-                history_event::Attributes::TimerFiredEventAttributes(TimerFiredEventAttributes {
+            t.add(history_event::Attributes::TimerFiredEventAttributes(
+                TimerFiredEventAttributes {
                     started_event_id: timer_started_event_id,
                     timer_id: "2".to_owned(),
-                }),
-            );
+                },
+            ));
         }
         t.add_full_wf_task();
 
@@ -657,7 +652,6 @@ mod tests {
                 ),
             );
             t.add(
-                EventType::ActivityTaskCompleted,
                 history_event::Attributes::ActivityTaskCompletedEventAttributes(
                     ActivityTaskCompletedEventAttributes {
                         scheduled_event_id,
@@ -669,13 +663,12 @@ mod tests {
             );
         } else {
             let started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-            t.add(
-                EventType::TimerFired,
-                history_event::Attributes::TimerFiredEventAttributes(TimerFiredEventAttributes {
+            t.add(history_event::Attributes::TimerFiredEventAttributes(
+                TimerFiredEventAttributes {
                     started_event_id,
                     timer_id: "3".to_owned(),
-                }),
-            );
+                },
+            ));
         }
         t.add_full_wf_task();
         t.add_workflow_execution_completed();

--- a/core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/core/src/worker/workflow/machines/patch_state_machine.rs
@@ -237,9 +237,8 @@ mod tests {
             common::v1::ActivityType,
             enums::v1::{CommandType, EventType},
             history::v1::{
-                history_event, ActivityTaskCompletedEventAttributes,
-                ActivityTaskScheduledEventAttributes, ActivityTaskStartedEventAttributes,
-                TimerFiredEventAttributes,
+                ActivityTaskCompletedEventAttributes, ActivityTaskScheduledEventAttributes,
+                ActivityTaskStartedEventAttributes, TimerFiredEventAttributes,
             },
         },
     };
@@ -276,40 +275,22 @@ mod tests {
             MarkerType::NoMarker => {}
         };
 
-        let scheduled_event_id = t.add_get_event_id(
-            EventType::ActivityTaskScheduled,
-            Some(
-                history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                    ActivityTaskScheduledEventAttributes {
-                        activity_id: "0".to_string(),
-                        activity_type: Some(ActivityType {
-                            name: "".to_string(),
-                        }),
-                        ..Default::default()
-                    },
-                ),
-            ),
-        );
-        let started_event_id = t.add_get_event_id(
-            EventType::ActivityTaskStarted,
-            Some(
-                history_event::Attributes::ActivityTaskStartedEventAttributes(
-                    ActivityTaskStartedEventAttributes {
-                        scheduled_event_id,
-                        ..Default::default()
-                    },
-                ),
-            ),
-        );
-        t.add(
-            history_event::Attributes::ActivityTaskCompletedEventAttributes(
-                ActivityTaskCompletedEventAttributes {
-                    scheduled_event_id,
-                    started_event_id,
-                    ..Default::default()
-                },
-            ),
-        );
+        let scheduled_event_id = t.add(ActivityTaskScheduledEventAttributes {
+            activity_id: "0".to_string(),
+            activity_type: Some(ActivityType {
+                name: "".to_string(),
+            }),
+            ..Default::default()
+        });
+        let started_event_id = t.add(ActivityTaskStartedEventAttributes {
+            scheduled_event_id,
+            ..Default::default()
+        });
+        t.add(ActivityTaskCompletedEventAttributes {
+            scheduled_event_id,
+            started_event_id,
+            ..Default::default()
+        });
         t.add_full_wf_task();
         t.add_workflow_execution_completed();
         t
@@ -563,112 +544,66 @@ mod tests {
         t.add_full_wf_task();
         if have_marker_in_hist {
             t.add_has_change_marker(MY_PATCH_ID, false);
-            let scheduled_event_id = t.add_get_event_id(
-                EventType::ActivityTaskScheduled,
-                Some(
-                    history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                        ActivityTaskScheduledEventAttributes {
-                            activity_id: "1".to_owned(),
-                            activity_type: Some(ActivityType {
-                                name: "".to_string(),
-                            }),
-                            ..Default::default()
-                        },
-                    ),
-                ),
-            );
-            let started_event_id = t.add_get_event_id(
-                EventType::ActivityTaskStarted,
-                Some(
-                    history_event::Attributes::ActivityTaskStartedEventAttributes(
-                        ActivityTaskStartedEventAttributes {
-                            scheduled_event_id,
-                            ..Default::default()
-                        },
-                    ),
-                ),
-            );
-            t.add(
-                history_event::Attributes::ActivityTaskCompletedEventAttributes(
-                    ActivityTaskCompletedEventAttributes {
-                        scheduled_event_id,
-                        started_event_id,
-                        // TODO result: Some(Payloads { payloads: vec![Payload{ metadata: Default::default(), data: vec![] }] }),
-                        ..Default::default()
-                    },
-                ),
-            );
+            let scheduled_event_id = t.add(ActivityTaskScheduledEventAttributes {
+                activity_id: "1".to_owned(),
+                activity_type: Some(ActivityType {
+                    name: "".to_string(),
+                }),
+                ..Default::default()
+            });
+            let started_event_id = t.add(ActivityTaskStartedEventAttributes {
+                scheduled_event_id,
+                ..Default::default()
+            });
+            t.add(ActivityTaskCompletedEventAttributes {
+                scheduled_event_id,
+                started_event_id,
+                ..Default::default()
+            });
             t.add_full_wf_task();
-            let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-            t.add(history_event::Attributes::TimerFiredEventAttributes(
-                TimerFiredEventAttributes {
-                    started_event_id: timer_started_event_id,
-                    timer_id: "1".to_owned(),
-                },
-            ));
+            let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
+            t.add(TimerFiredEventAttributes {
+                started_event_id: timer_started_event_id,
+                timer_id: "1".to_owned(),
+            });
         } else {
-            let started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-            t.add(history_event::Attributes::TimerFiredEventAttributes(
-                TimerFiredEventAttributes {
-                    started_event_id,
-                    timer_id: "1".to_owned(),
-                },
-            ));
+            let started_event_id = t.add_by_type(EventType::TimerStarted);
+            t.add(TimerFiredEventAttributes {
+                started_event_id,
+                timer_id: "1".to_owned(),
+            });
             t.add_full_wf_task();
-            let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-            t.add(history_event::Attributes::TimerFiredEventAttributes(
-                TimerFiredEventAttributes {
-                    started_event_id: timer_started_event_id,
-                    timer_id: "2".to_owned(),
-                },
-            ));
+            let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
+            t.add(TimerFiredEventAttributes {
+                started_event_id: timer_started_event_id,
+                timer_id: "2".to_owned(),
+            });
         }
         t.add_full_wf_task();
 
         if have_marker_in_hist {
-            let scheduled_event_id = t.add_get_event_id(
-                EventType::ActivityTaskScheduled,
-                Some(
-                    history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                        ActivityTaskScheduledEventAttributes {
-                            activity_id: "2".to_string(),
-                            activity_type: Some(ActivityType {
-                                name: "".to_string(),
-                            }),
-                            ..Default::default()
-                        },
-                    ),
-                ),
-            );
-            let started_event_id = t.add_get_event_id(
-                EventType::ActivityTaskStarted,
-                Some(
-                    history_event::Attributes::ActivityTaskStartedEventAttributes(
-                        ActivityTaskStartedEventAttributes {
-                            scheduled_event_id,
-                            ..Default::default()
-                        },
-                    ),
-                ),
-            );
-            t.add(
-                history_event::Attributes::ActivityTaskCompletedEventAttributes(
-                    ActivityTaskCompletedEventAttributes {
-                        scheduled_event_id,
-                        started_event_id,
-                        // TODO result: Some(Payloads { payloads: vec![Payload{ metadata: Default::default(), data: vec![] }] }),
-                        ..Default::default()
-                    },
-                ),
-            );
+            let scheduled_event_id = t.add(ActivityTaskScheduledEventAttributes {
+                activity_id: "2".to_string(),
+                activity_type: Some(ActivityType {
+                    name: "".to_string(),
+                }),
+                ..Default::default()
+            });
+            let started_event_id = t.add(ActivityTaskStartedEventAttributes {
+                scheduled_event_id,
+                ..Default::default()
+            });
+            t.add(ActivityTaskCompletedEventAttributes {
+                scheduled_event_id,
+                started_event_id,
+                ..Default::default()
+            });
         } else {
-            let started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-            t.add(history_event::Attributes::TimerFiredEventAttributes(
-                TimerFiredEventAttributes {
-                    started_event_id,
-                    timer_id: "3".to_owned(),
-                },
-            ));
+            let started_event_id = t.add_by_type(EventType::TimerStarted);
+            t.add(TimerFiredEventAttributes {
+                started_event_id,
+                timer_id: "3".to_owned(),
+            });
         }
         t.add_full_wf_task();
         t.add_workflow_execution_completed();

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -63,27 +63,19 @@ impl TestHistoryBuilder {
     }
 
     /// Add an event by type with attributes. Bundles both into a [HistoryEvent] with an id that is
-    /// incremented on each call to add.
-    pub fn add(&mut self, attribs: Attributes) -> i64 {
+    /// incremented on each call to add. Returns the id of the new event.
+    pub fn add(&mut self, attribs: impl Into<Attributes>) -> i64 {
+        let attribs: Attributes = attribs.into();
         self.build_and_push_event(attribs.event_type(), attribs);
         self.current_event_id
     }
 
-    /// Adds an event to the history by type, with default attributes.
-    pub fn add_by_type(&mut self, event_type: EventType) {
+    /// Adds an event to the history by type, with default attributes. Returns the id of the new
+    /// event.
+    pub fn add_by_type(&mut self, event_type: EventType) -> i64 {
         let attribs =
             default_attribs(event_type).expect("Couldn't make default attributes in test builder");
-        self.build_and_push_event(event_type, attribs);
-    }
-
-    /// Adds an event, returning the ID that was assigned to it
-    pub fn add_get_event_id(&mut self, event_type: EventType, attrs: Option<Attributes>) -> i64 {
-        if let Some(a) = attrs {
-            self.build_and_push_event(event_type, a);
-        } else {
-            self.add_by_type(event_type);
-        }
-        self.current_event_id
+        self.add(attribs)
     }
 
     /// Adds the following events:
@@ -103,25 +95,21 @@ impl TestHistoryBuilder {
     }
 
     pub fn add_workflow_task_scheduled(&mut self) {
-        self.workflow_task_scheduled_event_id =
-            self.add_get_event_id(EventType::WorkflowTaskScheduled, None);
+        self.workflow_task_scheduled_event_id = self.add_by_type(EventType::WorkflowTaskScheduled);
     }
 
     pub fn add_workflow_task_started(&mut self) {
-        let attrs = WorkflowTaskStartedEventAttributes {
+        self.final_workflow_task_started_event_id = self.add(WorkflowTaskStartedEventAttributes {
             scheduled_event_id: self.workflow_task_scheduled_event_id,
             ..Default::default()
-        };
-        self.final_workflow_task_started_event_id =
-            self.add_get_event_id(EventType::WorkflowTaskStarted, Some(attrs.into()));
+        });
     }
 
     pub fn add_workflow_task_completed(&mut self) {
-        let attrs = WorkflowTaskCompletedEventAttributes {
+        let id = self.add(WorkflowTaskCompletedEventAttributes {
             scheduled_event_id: self.workflow_task_scheduled_event_id,
             ..Default::default()
-        };
-        let id = self.add_get_event_id(EventType::WorkflowTaskCompleted, Some(attrs.into()));
+        });
         self.previous_task_completed_id = id;
     }
 
@@ -179,30 +167,22 @@ impl TestHistoryBuilder {
     }
 
     pub fn add_activity_task_scheduled(&mut self, activity_id: impl Into<String>) -> i64 {
-        self.add_get_event_id(
-            EventType::ActivityTaskScheduled,
-            Some(Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.into(),
-                    activity_type: Some(ActivityType {
-                        name: DEFAULT_ACTIVITY_TYPE.to_string(),
-                    }),
-                    ..Default::default()
-                },
-            )),
-        )
+        self.add(ActivityTaskScheduledEventAttributes {
+            activity_id: activity_id.into(),
+            activity_type: Some(ActivityType {
+                name: DEFAULT_ACTIVITY_TYPE.to_string(),
+            }),
+            ..Default::default()
+        })
     }
 
     pub fn add_activity_task_started(&mut self, scheduled_event_id: i64) -> i64 {
-        self.add_get_event_id(
-            EventType::ActivityTaskStarted,
-            Some(Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            )),
-        )
+        self.add(Attributes::ActivityTaskStartedEventAttributes(
+            ActivityTaskStartedEventAttributes {
+                scheduled_event_id,
+                ..Default::default()
+            },
+        ))
     }
 
     pub fn add_activity_task_completed(
@@ -211,14 +191,12 @@ impl TestHistoryBuilder {
         started_event_id: i64,
         payload: Payload,
     ) {
-        self.add(Attributes::ActivityTaskCompletedEventAttributes(
-            ActivityTaskCompletedEventAttributes {
-                scheduled_event_id,
-                started_event_id,
-                result: vec![payload].into_payloads(),
-                ..Default::default()
-            },
-        ));
+        self.add(ActivityTaskCompletedEventAttributes {
+            scheduled_event_id,
+            started_event_id,
+            result: vec![payload].into_payloads(),
+            ..Default::default()
+        });
     }
 
     pub fn add_activity_task_cancel_requested(&mut self, scheduled_event_id: i64) {
@@ -258,12 +236,10 @@ impl TestHistoryBuilder {
     }
 
     pub fn add_timer_fired(&mut self, timer_started_evt_id: i64, timer_id: String) {
-        self.add(history_event::Attributes::TimerFiredEventAttributes(
-            TimerFiredEventAttributes {
-                started_event_id: timer_started_evt_id,
-                timer_id,
-            },
-        ));
+        self.add(TimerFiredEventAttributes {
+            started_event_id: timer_started_evt_id,
+            timer_id,
+        });
     }
 
     pub fn add_we_signaled(&mut self, signal_name: &str, payloads: Vec<Payload>) {
@@ -368,7 +344,7 @@ impl TestHistoryBuilder {
         workflow_id: impl Into<String>,
         run_id: impl Into<String>,
     ) -> i64 {
-        let attrs = SignalExternalWorkflowExecutionInitiatedEventAttributes {
+        self.add(SignalExternalWorkflowExecutionInitiatedEventAttributes {
             workflow_task_completed_event_id: self.previous_task_completed_id,
             workflow_execution: Some(WorkflowExecution {
                 workflow_id: workflow_id.into(),
@@ -377,11 +353,7 @@ impl TestHistoryBuilder {
             signal_name: signal_name.into(),
             control: "".to_string(),
             ..Default::default()
-        };
-        self.add_get_event_id(
-            EventType::SignalExternalWorkflowExecutionInitiated,
-            Some(attrs.into()),
-        )
+        })
     }
 
     pub fn add_external_signal_completed(&mut self, initiated_id: i64) {
@@ -404,18 +376,16 @@ impl TestHistoryBuilder {
     }
 
     pub fn add_cancel_external_wf(&mut self, execution: NamespacedWorkflowExecution) -> i64 {
-        let attrs = RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
-            workflow_task_completed_event_id: self.previous_task_completed_id,
-            namespace: execution.namespace,
-            workflow_execution: Some(WorkflowExecution {
-                workflow_id: execution.workflow_id,
-                run_id: execution.run_id,
-            }),
-            ..Default::default()
-        };
-        self.add_get_event_id(
-            EventType::RequestCancelExternalWorkflowExecutionInitiated,
-            Some(attrs.into()),
+        self.add(
+            RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
+                workflow_task_completed_event_id: self.previous_task_completed_id,
+                namespace: execution.namespace,
+                workflow_execution: Some(WorkflowExecution {
+                    workflow_id: execution.workflow_id,
+                    run_id: execution.run_id,
+                }),
+                ..Default::default()
+            },
         )
     }
 
@@ -444,7 +414,7 @@ impl TestHistoryBuilder {
     pub fn add_wfe_started_with_wft_timeout(&mut self, dur: Duration) {
         let mut wesattrs = default_wes_attribs();
         wesattrs.workflow_task_timeout = Some(dur.try_into().unwrap());
-        self.add(wesattrs.into());
+        self.add(wesattrs);
     }
 
     pub fn get_orig_run_id(&self) -> &str {

--- a/sdk-core-protos/src/history_info.rs
+++ b/sdk-core-protos/src/history_info.rs
@@ -208,7 +208,7 @@ mod tests {
         let mut t = TestHistoryBuilder::default();
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_full_wf_task();
-        let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+        let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
         t.add_timer_fired(timer_started_event_id, timer_id.to_string());
         t.add_workflow_task_scheduled_and_started();
         t

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -12,7 +12,10 @@ mod history_info;
 mod task_token;
 
 #[cfg(feature = "history_builders")]
-pub use history_builder::{default_wes_attribs, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE};
+pub use history_builder::{
+    default_act_sched, default_wes_attribs, TestHistoryBuilder, DEFAULT_ACTIVITY_TYPE,
+    DEFAULT_WORKFLOW_TYPE,
+};
 #[cfg(feature = "history_builders")]
 pub use history_info::HistoryInfo;
 pub use task_token::TaskToken;
@@ -26,7 +29,7 @@ pub mod coresdk {
     tonic::include_proto!("coresdk");
 
     use crate::temporal::api::{
-        common::v1::{ActivityType, Payload, Payloads, WorkflowExecution},
+        common::v1::{Payload, Payloads, WorkflowExecution},
         failure::v1::{failure::FailureInfo, ApplicationFailureInfo, Failure},
         workflowservice::v1::PollActivityTaskQueueResponse,
     };
@@ -1094,18 +1097,6 @@ pub mod coresdk {
         }
     }
 
-    impl From<String> for ActivityType {
-        fn from(name: String) -> Self {
-            Self { name }
-        }
-    }
-
-    impl From<ActivityType> for String {
-        fn from(at: ActivityType) -> Self {
-            at.name
-        }
-    }
-
     impl Failure {
         pub fn is_timeout(&self) -> Option<crate::temporal::api::enums::v1::TimeoutType> {
             match &self.failure_info {
@@ -1658,6 +1649,26 @@ pub mod temporal {
                         }
                     }
                 }
+
+                impl From<String> for ActivityType {
+                    fn from(name: String) -> Self {
+                        Self { name }
+                    }
+                }
+
+                impl From<&str> for ActivityType {
+                    fn from(name: &str) -> Self {
+                        Self {
+                            name: name.to_string(),
+                        }
+                    }
+                }
+
+                impl From<ActivityType> for String {
+                    fn from(at: ActivityType) -> Self {
+                        at.name
+                    }
+                }
             }
         }
         pub mod enums {
@@ -1791,6 +1802,60 @@ pub mod temporal {
                             self.event_id,
                             EventType::from_i32(self.event_type)
                         )
+                    }
+                }
+
+                impl Attributes {
+                    pub fn event_type(&self) -> EventType {
+                        // I just absolutely _love_ this
+                        match self {
+                            Attributes::WorkflowExecutionStartedEventAttributes(_) => {EventType::WorkflowExecutionStarted}
+                            Attributes::WorkflowExecutionCompletedEventAttributes(_) => {EventType::WorkflowExecutionCompleted}
+                            Attributes::WorkflowExecutionFailedEventAttributes(_) => {EventType::WorkflowExecutionFailed}
+                            Attributes::WorkflowExecutionTimedOutEventAttributes(_) => {EventType::WorkflowExecutionTimedOut}
+                            Attributes::WorkflowTaskScheduledEventAttributes(_) => {EventType::WorkflowTaskScheduled}
+                            Attributes::WorkflowTaskStartedEventAttributes(_) => {EventType::WorkflowTaskStarted}
+                            Attributes::WorkflowTaskCompletedEventAttributes(_) => {EventType::WorkflowTaskCompleted}
+                            Attributes::WorkflowTaskTimedOutEventAttributes(_) => {EventType::WorkflowTaskTimedOut}
+                            Attributes::WorkflowTaskFailedEventAttributes(_) => {EventType::WorkflowTaskFailed}
+                            Attributes::ActivityTaskScheduledEventAttributes(_) => {EventType::ActivityTaskScheduled}
+                            Attributes::ActivityTaskStartedEventAttributes(_) => {EventType::ActivityTaskStarted}
+                            Attributes::ActivityTaskCompletedEventAttributes(_) => {EventType::ActivityTaskCompleted}
+                            Attributes::ActivityTaskFailedEventAttributes(_) => {EventType::ActivityTaskFailed}
+                            Attributes::ActivityTaskTimedOutEventAttributes(_) => {EventType::ActivityTaskTimedOut}
+                            Attributes::TimerStartedEventAttributes(_) => {EventType::TimerStarted}
+                            Attributes::TimerFiredEventAttributes(_) => {EventType::TimerFired}
+                            Attributes::ActivityTaskCancelRequestedEventAttributes(_) => {EventType::ActivityTaskCancelRequested}
+                            Attributes::ActivityTaskCanceledEventAttributes(_) => {EventType::ActivityTaskCanceled}
+                            Attributes::TimerCanceledEventAttributes(_) => {EventType::TimerCanceled}
+                            Attributes::MarkerRecordedEventAttributes(_) => {EventType::MarkerRecorded}
+                            Attributes::WorkflowExecutionSignaledEventAttributes(_) => {EventType::WorkflowExecutionSignaled}
+                            Attributes::WorkflowExecutionTerminatedEventAttributes(_) => {EventType::WorkflowExecutionTerminated}
+                            Attributes::WorkflowExecutionCancelRequestedEventAttributes(_) => {EventType::WorkflowExecutionCancelRequested}
+                            Attributes::WorkflowExecutionCanceledEventAttributes(_) => {EventType::WorkflowExecutionCanceled}
+                            Attributes::RequestCancelExternalWorkflowExecutionInitiatedEventAttributes(_) => {EventType::RequestCancelExternalWorkflowExecutionInitiated}
+                            Attributes::RequestCancelExternalWorkflowExecutionFailedEventAttributes(_) => {EventType::RequestCancelExternalWorkflowExecutionFailed}
+                            Attributes::ExternalWorkflowExecutionCancelRequestedEventAttributes(_) => {EventType::ExternalWorkflowExecutionCancelRequested}
+                            Attributes::WorkflowExecutionContinuedAsNewEventAttributes(_) => {EventType::WorkflowExecutionContinuedAsNew}
+                            Attributes::StartChildWorkflowExecutionInitiatedEventAttributes(_) => {EventType::StartChildWorkflowExecutionInitiated}
+                            Attributes::StartChildWorkflowExecutionFailedEventAttributes(_) => {EventType::StartChildWorkflowExecutionFailed}
+                            Attributes::ChildWorkflowExecutionStartedEventAttributes(_) => {EventType::ChildWorkflowExecutionStarted}
+                            Attributes::ChildWorkflowExecutionCompletedEventAttributes(_) => {EventType::ChildWorkflowExecutionCompleted}
+                            Attributes::ChildWorkflowExecutionFailedEventAttributes(_) => {EventType::ChildWorkflowExecutionFailed}
+                            Attributes::ChildWorkflowExecutionCanceledEventAttributes(_) => {EventType::ChildWorkflowExecutionCanceled}
+                            Attributes::ChildWorkflowExecutionTimedOutEventAttributes(_) => {EventType::ChildWorkflowExecutionTimedOut}
+                            Attributes::ChildWorkflowExecutionTerminatedEventAttributes(_) => {EventType::ChildWorkflowExecutionTerminated}
+                            Attributes::SignalExternalWorkflowExecutionInitiatedEventAttributes(_) => {EventType::SignalExternalWorkflowExecutionInitiated}
+                            Attributes::SignalExternalWorkflowExecutionFailedEventAttributes(_) => {EventType::SignalExternalWorkflowExecutionFailed}
+                            Attributes::ExternalWorkflowExecutionSignaledEventAttributes(_) => {EventType::ExternalWorkflowExecutionSignaled}
+                            Attributes::UpsertWorkflowSearchAttributesEventAttributes(_) => {EventType::UpsertWorkflowSearchAttributes}
+                            Attributes::WorkflowUpdateRejectedEventAttributes(_) => {EventType::WorkflowUpdateRejected}
+                            Attributes::WorkflowUpdateAcceptedEventAttributes(_) => {EventType::WorkflowUpdateAccepted}
+                            Attributes::WorkflowUpdateCompletedEventAttributes(_) => {EventType::WorkflowUpdateCompleted}
+                            Attributes::WorkflowPropertiesModifiedExternallyEventAttributes(_) => {EventType::WorkflowPropertiesModifiedExternally}
+                            Attributes::ActivityPropertiesModifiedExternallyEventAttributes(_) => {EventType::ActivityPropertiesModifiedExternally}
+                            Attributes::WorkflowPropertiesModifiedEventAttributes(_) => {EventType::WorkflowPropertiesModified}
+                        }
                     }
                 }
             }

--- a/test-utils/src/canned_histories.rs
+++ b/test-utils/src/canned_histories.rs
@@ -24,7 +24,7 @@ pub fn single_timer(timer_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, timer_id.to_string());
     t.add_workflow_task_scheduled_and_started();
     t
@@ -53,8 +53,8 @@ pub fn cancel_timer(wait_timer_id: &str, cancel_timer_id: &str) -> TestHistoryBu
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let cancel_timer_started_id = t.add_get_event_id(EventType::TimerStarted, None);
-    let wait_timer_started_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let cancel_timer_started_id = t.add_by_type(EventType::TimerStarted);
+    let wait_timer_started_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(wait_timer_started_id, wait_timer_id.to_string());
     // 8
     t.add_full_wf_task();
@@ -85,8 +85,8 @@ pub fn parallel_timer(timer1: &str, timer2: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-    let timer_2_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
+    let timer_2_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, timer1.to_string());
     t.add_timer_fired(timer_2_started_event_id, timer2.to_string());
     t.add_workflow_task_scheduled_and_started();
@@ -172,7 +172,7 @@ pub fn workflow_fails_with_failure_two_different_points(
         },
     );
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, timer_2.to_string());
     t.add_workflow_task_scheduled_and_started();
     t.add_workflow_task_failed_with_failure(
@@ -367,17 +367,10 @@ pub fn started_activity_timeout(activity_id: &str) -> TestHistoryBuilder {
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
-    let started_event_id = t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let started_event_id = t.add(ActivityTaskStartedEventAttributes {
+        scheduled_event_id,
+        ..Default::default()
+    });
     t.add(
         history_event::Attributes::ActivityTaskTimedOutEventAttributes(
             ActivityTaskTimedOutEventAttributes {
@@ -435,17 +428,10 @@ pub fn cancel_started_activity_abandon(activity_id: &str, signal_id: &str) -> Te
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
-    t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    t.add(ActivityTaskStartedEventAttributes {
+        scheduled_event_id,
+        ..Default::default()
+    });
     t.add_we_signaled(
         signal_id,
         vec![Payload {
@@ -550,17 +536,10 @@ pub fn cancel_started_activity_with_signal_and_activity_task_cancel(
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
-    t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    t.add(ActivityTaskStartedEventAttributes {
+        scheduled_event_id,
+        ..Default::default()
+    });
     t.add_we_signaled(
         signal_id,
         vec![Payload {
@@ -674,17 +653,10 @@ pub fn cancel_started_activity_with_activity_task_cancel(
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
-    t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    t.add(ActivityTaskStartedEventAttributes {
+        scheduled_event_id,
+        ..Default::default()
+    });
     t.add_we_signaled(
         signal_id,
         vec![Payload {
@@ -764,7 +736,7 @@ pub fn long_sequential_timers(num_tasks: usize) -> TestHistoryBuilder {
     t.add_full_wf_task();
 
     for i in 1..=num_tasks {
-        let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+        let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
         t.add_timer_fired(timer_started_event_id, i.to_string());
         t.add_full_wf_task();
     }
@@ -819,12 +791,12 @@ pub fn unsent_at_cancel_repro() -> TestHistoryBuilder {
     t.add_full_wf_task();
 
     let scheduled_event_id = t.add_activity_task_scheduled(1.to_string());
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, 1.to_string());
 
     t.add_full_wf_task();
     t.add_activity_task_cancel_requested(scheduled_event_id);
-    t.add_get_event_id(EventType::TimerStarted, None);
+    t.add_by_type(EventType::TimerStarted);
     t.add_workflow_task_scheduled_and_started();
 
     t
@@ -862,18 +834,11 @@ pub fn cancel_not_sent_when_also_complete_repro() -> TestHistoryBuilder {
     );
     t.add_full_wf_task();
     t.add_activity_task_cancel_requested(scheduled_event_id);
-    t.add_get_event_id(EventType::TimerStarted, None);
-    let started_event_id = t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    t.add_by_type(EventType::TimerStarted);
+    let started_event_id = t.add(ActivityTaskStartedEventAttributes {
+        scheduled_event_id,
+        ..Default::default()
+    });
     t.add(
         history_event::Attributes::ActivityTaskCompletedEventAttributes(
             ActivityTaskCompletedEventAttributes {
@@ -925,17 +890,10 @@ pub fn wft_timeout_repro() -> TestHistoryBuilder {
             data: b"hello ".to_vec(),
         }],
     );
-    let started_event_id = t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let started_event_id = t.add(ActivityTaskStartedEventAttributes {
+        scheduled_event_id,
+        ..Default::default()
+    });
     t.add(
         history_event::Attributes::ActivityTaskCompletedEventAttributes(
             ActivityTaskCompletedEventAttributes {
@@ -967,7 +925,7 @@ pub fn timer_then_continue_as_new(timer_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, timer_id.to_string());
     t.add_full_wf_task();
     t.add_continued_as_new();
@@ -1016,7 +974,7 @@ pub fn timer_wf_cancel_req_failed(timer_id: &str) -> TestHistoryBuilder {
 /// 16: EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED
 pub fn timer_wf_cancel_req_do_another_timer_then_cancelled() -> TestHistoryBuilder {
     timer_cancel_req_then("1", |t| {
-        let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+        let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
         t.add_timer_fired(timer_started_event_id, "2".to_string());
         t.add_full_wf_task();
         t.add_cancelled();
@@ -1041,7 +999,7 @@ fn timer_cancel_req_then(
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, timer_id.to_string());
     t.add_cancel_requested();
     t.add_full_wf_task();
@@ -1090,32 +1048,22 @@ pub fn activity_double_resolve_repro() -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let act_sched_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: "1".to_string(),
-                    ..Default::default()
-                },
-            ),
+    let act_sched_id = t.add(
+        history_event::Attributes::ActivityTaskScheduledEventAttributes(
+            ActivityTaskScheduledEventAttributes {
+                activity_id: "1".to_string(),
+                ..Default::default()
+            },
         ),
     );
     t.add_we_signaled("sig1", vec![]);
     t.add_full_wf_task();
     t.add_activity_task_cancel_requested(act_sched_id);
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
-    t.add_get_event_id(
-        EventType::ActivityTaskStarted,
-        Some(
-            history_event::Attributes::ActivityTaskStartedEventAttributes(
-                ActivityTaskStartedEventAttributes {
-                    scheduled_event_id: act_sched_id,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
+    t.add(ActivityTaskStartedEventAttributes {
+        scheduled_event_id: act_sched_id,
+        ..Default::default()
+    });
     t.add(
         history_event::Attributes::ActivityTaskTimedOutEventAttributes(
             ActivityTaskTimedOutEventAttributes {
@@ -1148,32 +1096,18 @@ fn start_child_wf_preamble(child_wf_id: &str) -> (TestHistoryBuilder, i64, i64) 
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let initiated_event_id = t.add_get_event_id(
-        EventType::StartChildWorkflowExecutionInitiated,
-        Some(
-            history_event::Attributes::StartChildWorkflowExecutionInitiatedEventAttributes(
-                StartChildWorkflowExecutionInitiatedEventAttributes {
-                    workflow_id: child_wf_id.to_owned(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
-    let started_event_id = t.add_get_event_id(
-        EventType::ChildWorkflowExecutionStarted,
-        Some(
-            history_event::Attributes::ChildWorkflowExecutionStartedEventAttributes(
-                ChildWorkflowExecutionStartedEventAttributes {
-                    initiated_event_id,
-                    workflow_execution: Some(WorkflowExecution {
-                        workflow_id: child_wf_id.to_owned(),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let initiated_event_id = t.add(StartChildWorkflowExecutionInitiatedEventAttributes {
+        workflow_id: child_wf_id.to_owned(),
+        ..Default::default()
+    });
+    let started_event_id = t.add(ChildWorkflowExecutionStartedEventAttributes {
+        initiated_event_id,
+        workflow_execution: Some(WorkflowExecution {
+            workflow_id: child_wf_id.to_owned(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
     t.add_full_wf_task();
     (t, initiated_event_id, started_event_id)
 }
@@ -1367,30 +1301,16 @@ pub fn single_child_workflow_start_fail(child_wf_id: &str) -> TestHistoryBuilder
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let initiated_event_id = t.add_get_event_id(
-        EventType::StartChildWorkflowExecutionInitiated,
-        Some(
-            history_event::Attributes::StartChildWorkflowExecutionInitiatedEventAttributes(
-                StartChildWorkflowExecutionInitiatedEventAttributes {
-                    workflow_id: child_wf_id.to_owned(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
-    t.add_get_event_id(
-        EventType::StartChildWorkflowExecutionFailed,
-        Some(
-            history_event::Attributes::StartChildWorkflowExecutionFailedEventAttributes(
-                StartChildWorkflowExecutionFailedEventAttributes {
-                    workflow_id: child_wf_id.to_owned(),
-                    initiated_event_id,
-                    cause: StartChildWorkflowExecutionFailedCause::WorkflowAlreadyExists as i32,
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let initiated_event_id = t.add(StartChildWorkflowExecutionInitiatedEventAttributes {
+        workflow_id: child_wf_id.to_owned(),
+        ..Default::default()
+    });
+    t.add(StartChildWorkflowExecutionFailedEventAttributes {
+        workflow_id: child_wf_id.to_owned(),
+        initiated_event_id,
+        cause: StartChildWorkflowExecutionFailedCause::WorkflowAlreadyExists as i32,
+        ..Default::default()
+    });
     t.add_full_wf_task();
     t.add_workflow_execution_completed();
     t
@@ -1435,7 +1355,7 @@ pub fn two_local_activities_separated_by_timer() -> TestHistoryBuilder {
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     t.add_local_activity_result_marker(1, "1", b"hi".into());
-    let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
     t.add_timer_fired(timer_started_event_id, "1".to_string());
     t.add_full_wf_task();
     t.add_local_activity_result_marker(2, "2", b"hi2".into());

--- a/test-utils/src/canned_histories.rs
+++ b/test-utils/src/canned_histories.rs
@@ -59,14 +59,13 @@ pub fn cancel_timer(wait_timer_id: &str, cancel_timer_id: &str) -> TestHistoryBu
     // 8
     t.add_full_wf_task();
     // 11
-    t.add(
-        EventType::TimerCanceled,
-        history_event::Attributes::TimerCanceledEventAttributes(TimerCanceledEventAttributes {
+    t.add(history_event::Attributes::TimerCanceledEventAttributes(
+        TimerCanceledEventAttributes {
             started_event_id: cancel_timer_started_id,
             timer_id: cancel_timer_id.to_string(),
             ..Default::default()
-        }),
-    );
+        },
+    ));
     // 12
     t.add_workflow_execution_completed();
     t
@@ -224,7 +223,6 @@ pub fn single_failed_activity(activity_id: &str) -> TestHistoryBuilder {
     let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     let started_event_id = t.add_activity_task_started(scheduled_event_id);
     t.add(
-        EventType::ActivityTaskFailed,
         history_event::Attributes::ActivityTaskFailedEventAttributes(
             ActivityTaskFailedEventAttributes {
                 scheduled_event_id,
@@ -262,7 +260,6 @@ pub fn cancel_scheduled_activity(activity_id: &str, signal_id: &str) -> TestHist
     );
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCancelRequested,
         history_event::Attributes::ActivityTaskCancelRequestedEventAttributes(
             ActivityTaskCancelRequestedEventAttributes {
                 scheduled_event_id,
@@ -290,7 +287,6 @@ pub fn scheduled_activity_timeout(activity_id: &str) -> TestHistoryBuilder {
     t.add_full_wf_task();
     let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add(
-        EventType::ActivityTaskTimedOut,
         history_event::Attributes::ActivityTaskTimedOutEventAttributes(
             ActivityTaskTimedOutEventAttributes {
                 scheduled_event_id,
@@ -335,7 +331,6 @@ pub fn scheduled_cancelled_activity_timeout(
     );
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCancelRequested,
         history_event::Attributes::ActivityTaskCancelRequestedEventAttributes(
             ActivityTaskCancelRequestedEventAttributes {
                 scheduled_event_id,
@@ -344,7 +339,6 @@ pub fn scheduled_cancelled_activity_timeout(
         ),
     );
     t.add(
-        EventType::ActivityTaskTimedOut,
         history_event::Attributes::ActivityTaskTimedOutEventAttributes(
             ActivityTaskTimedOutEventAttributes {
                 scheduled_event_id,
@@ -372,17 +366,7 @@ pub fn started_activity_timeout(activity_id: &str) -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     let started_event_id = t.add_get_event_id(
         EventType::ActivityTaskStarted,
         Some(
@@ -395,7 +379,6 @@ pub fn started_activity_timeout(activity_id: &str) -> TestHistoryBuilder {
         ),
     );
     t.add(
-        EventType::ActivityTaskTimedOut,
         history_event::Attributes::ActivityTaskTimedOutEventAttributes(
             ActivityTaskTimedOutEventAttributes {
                 scheduled_event_id,
@@ -423,17 +406,7 @@ pub fn cancel_scheduled_activity_abandon(activity_id: &str, signal_id: &str) -> 
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    t.add_activity_task_scheduled(activity_id);
     t.add_we_signaled(
         signal_id,
         vec![Payload {
@@ -461,17 +434,7 @@ pub fn cancel_started_activity_abandon(activity_id: &str, signal_id: &str) -> Te
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add_get_event_id(
         EventType::ActivityTaskStarted,
         Some(
@@ -521,17 +484,7 @@ pub fn cancel_scheduled_activity_with_signal_and_activity_task_cancel(
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add_we_signaled(
         signal_id,
         vec![Payload {
@@ -541,7 +494,6 @@ pub fn cancel_scheduled_activity_with_signal_and_activity_task_cancel(
     );
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCancelRequested,
         history_event::Attributes::ActivityTaskCancelRequestedEventAttributes(
             ActivityTaskCancelRequestedEventAttributes {
                 scheduled_event_id,
@@ -558,7 +510,6 @@ pub fn cancel_scheduled_activity_with_signal_and_activity_task_cancel(
     );
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCanceled,
         history_event::Attributes::ActivityTaskCanceledEventAttributes(
             ActivityTaskCanceledEventAttributes {
                 scheduled_event_id,
@@ -598,17 +549,7 @@ pub fn cancel_started_activity_with_signal_and_activity_task_cancel(
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add_get_event_id(
         EventType::ActivityTaskStarted,
         Some(
@@ -629,7 +570,6 @@ pub fn cancel_started_activity_with_signal_and_activity_task_cancel(
     );
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCancelRequested,
         history_event::Attributes::ActivityTaskCancelRequestedEventAttributes(
             ActivityTaskCancelRequestedEventAttributes {
                 scheduled_event_id,
@@ -646,7 +586,6 @@ pub fn cancel_started_activity_with_signal_and_activity_task_cancel(
     );
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCanceled,
         history_event::Attributes::ActivityTaskCanceledEventAttributes(
             ActivityTaskCanceledEventAttributes {
                 scheduled_event_id,
@@ -681,17 +620,7 @@ pub fn cancel_scheduled_activity_with_activity_task_cancel(
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add_we_signaled(
         signal_id,
         vec![Payload {
@@ -701,7 +630,6 @@ pub fn cancel_scheduled_activity_with_activity_task_cancel(
     );
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCancelRequested,
         history_event::Attributes::ActivityTaskCancelRequestedEventAttributes(
             ActivityTaskCancelRequestedEventAttributes {
                 scheduled_event_id,
@@ -710,7 +638,6 @@ pub fn cancel_scheduled_activity_with_activity_task_cancel(
         ),
     );
     t.add(
-        EventType::ActivityTaskCanceled,
         history_event::Attributes::ActivityTaskCanceledEventAttributes(
             ActivityTaskCanceledEventAttributes {
                 scheduled_event_id,
@@ -746,17 +673,7 @@ pub fn cancel_started_activity_with_activity_task_cancel(
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: activity_id.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(activity_id);
     t.add_get_event_id(
         EventType::ActivityTaskStarted,
         Some(
@@ -777,7 +694,6 @@ pub fn cancel_started_activity_with_activity_task_cancel(
     );
     t.add_full_wf_task();
     t.add(
-        EventType::ActivityTaskCancelRequested,
         history_event::Attributes::ActivityTaskCancelRequestedEventAttributes(
             ActivityTaskCancelRequestedEventAttributes {
                 scheduled_event_id,
@@ -786,7 +702,6 @@ pub fn cancel_started_activity_with_activity_task_cancel(
         ),
     );
     t.add(
-        EventType::ActivityTaskCanceled,
         history_event::Attributes::ActivityTaskCanceledEventAttributes(
             ActivityTaskCanceledEventAttributes {
                 scheduled_event_id,
@@ -903,17 +818,7 @@ pub fn unsent_at_cancel_repro() -> TestHistoryBuilder {
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
 
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: 1.to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled(1.to_string());
     let timer_started_event_id = t.add_get_event_id(EventType::TimerStarted, None);
     t.add_timer_fired(timer_started_event_id, 1.to_string());
 
@@ -947,17 +852,7 @@ pub fn cancel_not_sent_when_also_complete_repro() -> TestHistoryBuilder {
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
 
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: "act-1".to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled("act-1");
     t.add_we_signaled(
         "sig-1",
         vec![Payload {
@@ -980,7 +875,6 @@ pub fn cancel_not_sent_when_also_complete_repro() -> TestHistoryBuilder {
         ),
     );
     t.add(
-        EventType::ActivityTaskCompleted,
         history_event::Attributes::ActivityTaskCompletedEventAttributes(
             ActivityTaskCompletedEventAttributes {
                 scheduled_event_id,
@@ -1015,17 +909,7 @@ pub fn wft_timeout_repro() -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_get_event_id(
-        EventType::ActivityTaskScheduled,
-        Some(
-            history_event::Attributes::ActivityTaskScheduledEventAttributes(
-                ActivityTaskScheduledEventAttributes {
-                    activity_id: "act-1".to_string(),
-                    ..Default::default()
-                },
-            ),
-        ),
-    );
+    let scheduled_event_id = t.add_activity_task_scheduled("act-1");
     t.add_we_signaled(
         "at-started",
         vec![Payload {
@@ -1053,7 +937,6 @@ pub fn wft_timeout_repro() -> TestHistoryBuilder {
         ),
     );
     t.add(
-        EventType::ActivityTaskCompleted,
         history_event::Attributes::ActivityTaskCompletedEventAttributes(
             ActivityTaskCompletedEventAttributes {
                 scheduled_event_id,
@@ -1234,7 +1117,6 @@ pub fn activity_double_resolve_repro() -> TestHistoryBuilder {
         ),
     );
     t.add(
-        EventType::ActivityTaskTimedOut,
         history_event::Attributes::ActivityTaskTimedOutEventAttributes(
             ActivityTaskTimedOutEventAttributes {
                 scheduled_event_id: act_sched_id,
@@ -1313,7 +1195,6 @@ fn start_child_wf_preamble(child_wf_id: &str) -> (TestHistoryBuilder, i64, i64) 
 pub fn single_child_workflow(child_wf_id: &str) -> TestHistoryBuilder {
     let (mut t, initiated_event_id, started_event_id) = start_child_wf_preamble(child_wf_id);
     t.add(
-        EventType::ChildWorkflowExecutionCompleted,
         history_event::Attributes::ChildWorkflowExecutionCompletedEventAttributes(
             ChildWorkflowExecutionCompletedEventAttributes {
                 initiated_event_id,
@@ -1345,7 +1226,6 @@ pub fn single_child_workflow(child_wf_id: &str) -> TestHistoryBuilder {
 pub fn single_child_workflow_fail(child_wf_id: &str) -> TestHistoryBuilder {
     let (mut t, initiated_event_id, started_event_id) = start_child_wf_preamble(child_wf_id);
     t.add(
-        EventType::ChildWorkflowExecutionFailed,
         history_event::Attributes::ChildWorkflowExecutionFailedEventAttributes(
             ChildWorkflowExecutionFailedEventAttributes {
                 initiated_event_id,
@@ -1380,7 +1260,6 @@ pub fn single_child_workflow_signaled(child_wf_id: &str, signame: &str) -> TestH
     let id = t.add_signal_wf(signame, "fake_wid", "fake_rid");
     t.add_external_signal_completed(id);
     t.add(
-        EventType::ChildWorkflowExecutionCompleted,
         history_event::Attributes::ChildWorkflowExecutionCompletedEventAttributes(
             ChildWorkflowExecutionCompletedEventAttributes {
                 initiated_event_id,
@@ -1418,7 +1297,6 @@ pub fn single_child_workflow_cancelled(child_wf_id: &str) -> TestHistoryBuilder 
     });
     t.add_cancel_external_wf_completed(id);
     t.add(
-        EventType::ChildWorkflowExecutionCanceled,
         history_event::Attributes::ChildWorkflowExecutionCanceledEventAttributes(
             ChildWorkflowExecutionCanceledEventAttributes {
                 initiated_event_id,

--- a/test-utils/src/canned_histories.rs
+++ b/test-utils/src/canned_histories.rs
@@ -874,7 +874,7 @@ pub fn wft_timeout_repro() -> TestHistoryBuilder {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    let scheduled_event_id = t.add_activity_task_scheduled("act-1");
+    let scheduled_event_id = t.add_activity_task_scheduled("1");
     t.add_we_signaled(
         "at-started",
         vec![Payload {
@@ -894,15 +894,11 @@ pub fn wft_timeout_repro() -> TestHistoryBuilder {
         scheduled_event_id,
         ..Default::default()
     });
-    t.add(
-        history_event::Attributes::ActivityTaskCompletedEventAttributes(
-            ActivityTaskCompletedEventAttributes {
-                scheduled_event_id,
-                started_event_id,
-                ..Default::default()
-            },
-        ),
-    );
+    t.add(ActivityTaskCompletedEventAttributes {
+        scheduled_event_id,
+        started_event_id,
+        ..Default::default()
+    });
     t.add_workflow_task_started();
     t.add_workflow_task_timed_out();
     t.add_full_wf_task();

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -50,6 +50,7 @@ use temporal_sdk_core_protos::{
         workflow_completion::WorkflowActivationCompletion,
     },
     temporal::api::{common::v1::Payload, history::v1::History},
+    DEFAULT_ACTIVITY_TYPE,
 };
 use tokio::sync::{mpsc::unbounded_channel, OnceCell};
 use url::Url;
@@ -588,7 +589,7 @@ pub fn schedule_activity_cmd(
     ScheduleActivity {
         seq,
         activity_id: activity_id.to_string(),
-        activity_type: "test_activity".to_string(),
+        activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
         task_queue: task_q.to_owned(),
         schedule_to_start_timeout: Some(activity_timeout.try_into().expect("duration fits")),
         start_to_close_timeout: Some(activity_timeout.try_into().expect("duration fits")),

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -17,6 +17,7 @@ use temporal_sdk_core_protos::{
         common::v1::{Payload, RetryPolicy},
         enums::v1::TimeoutType,
     },
+    DEFAULT_ACTIVITY_TYPE,
 };
 use temporal_sdk_core_test_utils::{
     init_core_and_create_wf, schedule_activity_cmd, CoreWfStarter, WorkerTestHelpers,
@@ -49,7 +50,7 @@ async fn activity_heartbeat() {
     assert_matches!(
         task.variant,
         Some(activity_task::Variant::Start(start_activity)) => {
-            assert_eq!(start_activity.activity_type, "test_activity".to_string())
+            assert_eq!(start_activity.activity_type, DEFAULT_ACTIVITY_TYPE.to_string())
         }
     );
     // Heartbeat timeout is set to 1 second, this loop is going to send heartbeat every 100ms.

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -40,15 +40,10 @@ async fn out_of_order_completion_doesnt_hang() {
     )
     .await
     .unwrap();
-    // Poll activity and verify that it's been scheduled with correct parameters, we don't expect to
-    // complete it in this test as activity is try-cancelled.
+    // Poll activity and verify that it's been scheduled, we don't expect to complete it in this
+    // test as activity is try-cancelled.
     let activity_task = core.poll_activity_task().await.unwrap();
-    assert_matches!(
-        activity_task.variant,
-        Some(act_task::Variant::Start(start_activity)) => {
-            assert_eq!(start_activity.activity_type, "test_activity".to_string())
-        }
-    );
+    assert_matches!(activity_task.variant, Some(act_task::Variant::Start(_)));
     // Poll workflow task and verify that activity has failed.
     let task = core.poll_workflow_activation().await.unwrap();
     assert_matches!(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
If an activity scheduled command has a different type from the scheduled event in history matching that sequence number, we'll now fail w/ nondeterminism as we always should've.

Turns out, the check that their ids match is also missing, which is less surprising than it sounds since we already do sequence number checks and in almost all cases the ID == the sequence number, but that's been fixed as well.

Also did a bunch of semi-related mechanical cleanup to test construction. You can look at only the first & last commit diffs to see relevant changes.

## Why?
Previous behavior was wrong.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/443
2. How was this tested:
Added test, existing tests.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
