### PR TITLE
Fix failed fetch request not unblocking completion

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -35,7 +35,6 @@ use temporal_sdk_core_protos::{
         common::v1::RetryPolicy,
         enums::v1::{EventType, TimeoutType, WorkflowTaskFailedCause},
         failure::v1::Failure,
-        history::v1::History,
         query::v1::WorkflowQuery,
     },
 };
@@ -611,8 +610,12 @@ async fn la_resolve_during_legacy_query_does_not_combine(#[case] impossible_quer
                     2,
                 ),
             );
-            // Strip history, we need to look like we hit the cache
-            pr.history = Some(History { events: vec![] });
+            // Strip beginning of history so the only events are WFT sched/started, we need to look
+            // like we hit the cache
+            {
+                let h = pr.history.as_mut().unwrap();
+                h.events = h.events.split_off(6);
+            }
             // In the nonsense server response case, we attach a legacy query, otherwise this
             // response looks like a normal response to a forced WFT heartbeat.
             if impossible_query_in_task {

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -207,6 +207,7 @@ impl ManagedRun {
         if let Some(lq) = legacy_query_from_poll {
             pending_queries.push(lq);
         }
+
         self.paginator = Some(pwft.paginator);
         self.wft = Some(OutstandingTask {
             info: wft_info,
@@ -432,7 +433,6 @@ impl ManagedRun {
                     debug!("Need to fetch a history page before next WFT can be applied");
                     self.completion_waiting_on_page_fetch = Some(rac);
                     Err(NextPageReq {
-                        last_processed_id: self.most_recently_processed_event_number(),
                         paginator,
                         span: Span::current(),
                     })
@@ -516,6 +516,7 @@ impl ManagedRun {
             run_id: self.run_id().to_string(),
             message,
             reason,
+            because_fetch_failed: false,
         });
         let should_report = match &evict_req_outcome {
             EvictionRequestResult::EvictionRequested(Some(attempt), _)
@@ -754,6 +755,21 @@ impl ManagedRun {
 
     pub(super) fn request_eviction(&mut self, info: RequestEvictMsg) -> EvictionRequestResult {
         let attempts = self.wft.as_ref().map(|wt| wt.info.attempt);
+
+        // If we were waiting on a page fetch and we're getting evicted because fetching failed,
+        // then make sure we allow the completion to proceed, otherwise we're stuck waiting forever.
+        if self.completion_waiting_on_page_fetch.is_some() && info.because_fetch_failed {
+            // We just checked it is some, unwrap OK.
+            let c = self.completion_waiting_on_page_fetch.take().unwrap();
+            let run_upd = self.failed_completion(
+                WorkflowTaskFailedCause::Unspecified,
+                info.reason,
+                Failure::application_failure(info.message, false).into(),
+                c.resp_chan,
+            );
+            return EvictionRequestResult::EvictionRequested(attempts, run_upd);
+        }
+
         if !self.activation_has_eviction() && self.trying_to_evict.is_none() {
             debug!(run_id=%info.run_id, reason=%info.message, "Eviction requested");
             self.trying_to_evict = Some(info);
@@ -893,6 +909,7 @@ impl ManagedRun {
                         run_id: self.run_id().to_string(),
                         message: format!("Error while updating workflow: {:?}", fail.source),
                         reason: fail.source.evict_reason(),
+                        because_fetch_failed: false,
                     })
                     .into_run_update_resp()
                 };

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -398,7 +398,6 @@ impl Workflows {
             run_id: run_id.into(),
             message: message.into(),
             reason,
-            because_fetch_failed: false,
         });
     }
 
@@ -829,7 +828,6 @@ struct RequestEvictMsg {
     run_id: String,
     message: String,
     reason: EvictionReason,
-    because_fetch_failed: bool,
 }
 #[derive(Debug)]
 pub(crate) struct HeartbeatTimeoutMsg {

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -355,7 +355,7 @@ impl Workflows {
         };
 
         let maybe_pwft = if let Some(wft) = wft_from_complete {
-            match HistoryPaginator::from_poll(wft, self.client.clone(), 0).await {
+            match HistoryPaginator::from_poll(wft, self.client.clone()).await {
                 Ok((paginator, pwft)) => Some((pwft, paginator)),
                 Err(e) => {
                     self.request_eviction(
@@ -398,6 +398,7 @@ impl Workflows {
             run_id: run_id.into(),
             message: message.into(),
             reason,
+            because_fetch_failed: false,
         });
     }
 
@@ -599,7 +600,6 @@ struct CacheMissFetchReq {
 #[derive(Debug)]
 #[must_use]
 struct NextPageReq {
-    last_processed_id: i64,
     paginator: HistoryPaginator,
     span: Span,
 }
@@ -829,6 +829,7 @@ struct RequestEvictMsg {
     run_id: String,
     message: String,
     reason: EvictionReason,
+    because_fetch_failed: bool,
 }
 #[derive(Debug)]
 pub(crate) struct HeartbeatTimeoutMsg {

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -170,6 +170,7 @@ impl WFStream {
                             run_id,
                             message: format!("Fetching history failed: {err:?}"),
                             reason: EvictionReason::Fatal,
+                            because_fetch_failed: true,
                         })
                         .into_run_update_resp(),
                     WFStreamInput::PollerDead => {
@@ -425,6 +426,7 @@ impl WFStream {
                 run_id,
                 message: "Workflow cache full".to_string(),
                 reason: EvictionReason::CacheFull,
+                because_fetch_failed: false,
             })
         } else {
             // This branch shouldn't really be possible
@@ -513,6 +515,7 @@ impl WFStream {
                     run_id,
                     message: "Workflow cache full".to_string(),
                     reason: EvictionReason::CacheFull,
+                    because_fetch_failed: false,
                 })
                 .into_run_update_resp(),
             );

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -169,8 +169,7 @@ impl WFStream {
                         .request_eviction(RequestEvictMsg {
                             run_id,
                             message: format!("Fetching history failed: {err:?}"),
-                            reason: EvictionReason::Fatal,
-                            because_fetch_failed: true,
+                            reason: EvictionReason::PaginationOrHistoryFetch,
                         })
                         .into_run_update_resp(),
                     WFStreamInput::PollerDead => {
@@ -426,7 +425,6 @@ impl WFStream {
                 run_id,
                 message: "Workflow cache full".to_string(),
                 reason: EvictionReason::CacheFull,
-                because_fetch_failed: false,
             })
         } else {
             // This branch shouldn't really be possible
@@ -515,7 +513,6 @@ impl WFStream {
                     run_id,
                     message: "Workflow cache full".to_string(),
                     reason: EvictionReason::CacheFull,
-                    because_fetch_failed: false,
                 })
                 .into_run_update_resp(),
             );

--- a/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -258,6 +258,8 @@ message RemoveFromCache {
         // There was some fatal error processing the workflow, typically an internal error, but
         // can also happen if then network drops out while paginating. Check message string.
         FATAL = 8;
+        // Something went wrong attempting to fetch more history events.
+        PAGINATION_OR_HISTORY_FETCH = 9;
     }
     EvictionReason reason = 2;
 }

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let mut cmd = Command::new(&cargo);
     if let Some(srv) = server.as_ref() {
+        println!("Running on {}", srv.target);
         cmd.env(
             INTEG_SERVER_TARGET_ENV_VAR,
             format!("http://{}", &srv.target),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
If fetching pages failed while in the middle of an activation completion, that could leave the completion stuck because the eviction wouldn't unblock it. This fixes that.

## Why?
Bug

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
