### PR TITLE
Fix slot metrics appearing to be off-by-one because of reservation

### DIFF
--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -4,7 +4,10 @@ use crate::MetricsContext;
 use futures::{stream, Stream, StreamExt};
 use std::{
     fmt::{Debug, Formatter},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
@@ -13,6 +16,11 @@ use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore, TryAcquireError
 #[derive(Clone)]
 pub(crate) struct MeteredSemaphore {
     sem: Arc<Semaphore>,
+    /// The number of permit owners who have acquired a permit from the semaphore, but are not yet
+    /// meaningfully using that permit. This is useful for giving a more semantically accurate count
+    /// of used task slots, since we typically wait for a permit first before polling, but that slot
+    /// isn't used in the sense the user expects until we actually also get the corresponding task.
+    unused_claimants: Arc<AtomicUsize>,
     metrics_ctx: MetricsContext,
     record_fn: fn(&MetricsContext, usize),
 }
@@ -25,6 +33,7 @@ impl MeteredSemaphore {
     ) -> Self {
         Self {
             sem: Arc::new(Semaphore::new(inital_permits)),
+            unused_claimants: Arc::new(AtomicUsize::new(0)),
             metrics_ctx,
             record_fn,
         }
@@ -36,42 +45,62 @@ impl MeteredSemaphore {
 
     pub async fn acquire_owned(&self) -> Result<OwnedMeteredSemPermit, AcquireError> {
         let res = self.sem.clone().acquire_owned().await?;
-        self.record();
-        Ok(OwnedMeteredSemPermit {
-            inner: res,
-            record_fn: self.record_drop_owned(),
-        })
+        Ok(self.build_owned(res))
     }
 
     pub fn try_acquire_owned(&self) -> Result<OwnedMeteredSemPermit, TryAcquireError> {
         let res = self.sem.clone().try_acquire_owned()?;
+        Ok(self.build_owned(res))
+    }
+
+    fn build_owned(&self, res: OwnedSemaphorePermit) -> OwnedMeteredSemPermit {
+        self.unused_claimants.fetch_add(1, Ordering::Release);
         self.record();
-        Ok(OwnedMeteredSemPermit {
+        OwnedMeteredSemPermit {
             inner: res,
-            record_fn: self.record_drop_owned(),
-        })
+            unused_claimants: Some(self.unused_claimants.clone()),
+            record_fn: self.record_owned(),
+        }
     }
 
     fn record(&self) {
-        (self.record_fn)(&self.metrics_ctx, self.sem.available_permits());
+        (self.record_fn)(
+            &self.metrics_ctx,
+            self.sem.available_permits() + self.unused_claimants.load(Ordering::Acquire),
+        );
     }
 
-    fn record_drop_owned(&self) -> Box<dyn Fn() + Send + Sync> {
+    fn record_owned(&self) -> Box<dyn Fn(bool) + Send + Sync> {
         let rcf = self.record_fn;
         let mets = self.metrics_ctx.clone();
         let sem = self.sem.clone();
-        Box::new(move || rcf(&mets, sem.available_permits() + 1))
+        let uc = self.unused_claimants.clone();
+        // When being called from the drop impl, the semaphore permit isn't actually dropped yet,
+        // so account for that.
+        Box::new(move |add_one: bool| {
+            let extra = if add_one { 1 } else { 0 };
+            rcf(
+                &mets,
+                sem.available_permits() + uc.load(Ordering::Acquire) + extra,
+            )
+        })
     }
 }
 
 /// Wraps an [OwnedSemaphorePermit] to update metrics when it's dropped
 pub(crate) struct OwnedMeteredSemPermit {
     inner: OwnedSemaphorePermit,
-    record_fn: Box<dyn Fn() + Send + Sync>,
+    /// See [MeteredSemaphore::unused_claimants]. If present when dropping, used to decrement the
+    /// count.
+    unused_claimants: Option<Arc<AtomicUsize>>,
+    record_fn: Box<dyn Fn(bool) + Send + Sync>,
 }
 impl Drop for OwnedMeteredSemPermit {
     fn drop(&mut self) {
-        (self.record_fn)()
+        if let Some(uc) = self.unused_claimants.take() {
+            uc.fetch_sub(1, Ordering::Release);
+        }
+        (self.record_fn)(true)
     }
 }
 impl Debug for OwnedMeteredSemPermit {
@@ -79,15 +108,30 @@ impl Debug for OwnedMeteredSemPermit {
         self.inner.fmt(f)
     }
 }
-#[cfg(feature = "save_wf_inputs")]
 impl OwnedMeteredSemPermit {
+    /// Should be called once this permit is actually being "used" for the work it was meant to
+    /// permit.
+    pub(crate) fn into_used(mut self) -> UsedMeteredSemPermit {
+        if let Some(uc) = self.unused_claimants.take() {
+            uc.fetch_sub(1, Ordering::Release);
+            (self.record_fn)(false)
+        }
+        UsedMeteredSemPermit(self)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct UsedMeteredSemPermit(OwnedMeteredSemPermit);
+impl UsedMeteredSemPermit {
+    #[cfg(feature = "save_wf_inputs")]
     pub(crate) fn fake_deserialized() -> Self {
         let sem = Arc::new(Semaphore::new(1));
         let inner = sem.try_acquire_owned().unwrap();
-        Self {
+        Self(OwnedMeteredSemPermit {
             inner,
-            record_fn: Box::new(|| {}),
-        }
+            unused_claimants: None,
+            record_fn: Box::new(|_| {}),
+        })
     }
 }
 

--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -78,7 +78,7 @@ impl MeteredSemaphore {
         // When being called from the drop impl, the semaphore permit isn't actually dropped yet,
         // so account for that.
         Box::new(move |add_one: bool| {
-            let extra = if add_one { 1 } else { 0 };
+            let extra = usize::from(add_one);
             rcf(
                 &mets,
                 sem.available_permits() + uc.load(Ordering::Acquire) + extra,

--- a/core/src/telemetry/prometheus_server.rs
+++ b/core/src/telemetry/prometheus_server.rs
@@ -13,7 +13,7 @@ use opentelemetry::{
 };
 use opentelemetry_prometheus::{ExporterBuilder, PrometheusExporter};
 use prometheus::{Encoder, TextEncoder};
-use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 
 /// Exposes prometheus metrics for scraping
 pub(super) struct PromServer {
@@ -29,6 +29,8 @@ impl PromServer {
     ) -> Result<Self, MetricsError> {
         let controller =
             controllers::basic(processors::factory(aggregation, temporality).with_memory(true))
+                // Because Prom is pull-based, make this always refresh
+                .with_collect_period(Duration::from_secs(0))
                 .with_resource(default_resource())
                 .build();
         let exporter = ExporterBuilder::new(controller).try_init()?;

--- a/core/src/telemetry/prometheus_server.rs
+++ b/core/src/telemetry/prometheus_server.rs
@@ -1,15 +1,13 @@
 use crate::telemetry::default_resource;
 use hyper::{
     header::CONTENT_TYPE,
+    server::conn::AddrIncoming,
     service::{make_service_fn, service_fn},
     Body, Method, Request, Response, Server,
 };
-use opentelemetry::{
-    metrics::MetricsError,
-    sdk::{
-        export::metrics::{aggregation::TemporalitySelector, AggregatorSelector},
-        metrics::{controllers, processors},
-    },
+use opentelemetry::sdk::{
+    export::metrics::{aggregation::TemporalitySelector, AggregatorSelector},
+    metrics::{controllers, processors},
 };
 use opentelemetry_prometheus::{ExporterBuilder, PrometheusExporter};
 use prometheus::{Encoder, TextEncoder};
@@ -17,7 +15,7 @@ use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 
 /// Exposes prometheus metrics for scraping
 pub(super) struct PromServer {
-    addr: SocketAddr,
+    bound_addr: AddrIncoming,
     pub exporter: Arc<PrometheusExporter>,
 }
 
@@ -26,7 +24,7 @@ impl PromServer {
         addr: SocketAddr,
         aggregation: impl AggregatorSelector + Send + Sync + 'static,
         temporality: impl TemporalitySelector + Send + Sync + 'static,
-    ) -> Result<Self, MetricsError> {
+    ) -> Result<Self, anyhow::Error> {
         let controller =
             controllers::basic(processors::factory(aggregation, temporality).with_memory(true))
                 // Because Prom is pull-based, make this always refresh
@@ -34,13 +32,14 @@ impl PromServer {
                 .with_resource(default_resource())
                 .build();
         let exporter = ExporterBuilder::new(controller).try_init()?;
+        let bound_addr = AddrIncoming::bind(&addr)?;
         Ok(Self {
             exporter: Arc::new(exporter),
-            addr,
+            bound_addr,
         })
     }
 
-    pub async fn run(&self) -> hyper::Result<()> {
+    pub async fn run(self) -> hyper::Result<()> {
         // Spin up hyper server to serve metrics for scraping. We use hyper since we already depend
         // on it via Tonic.
         let expclone = self.exporter.clone();
@@ -48,8 +47,12 @@ impl PromServer {
             let expclone = expclone.clone();
             async move { Ok::<_, Infallible>(service_fn(move |req| metrics_req(req, expclone.clone()))) }
         });
-        let server = Server::bind(&self.addr).serve(svc);
+        let server = Server::builder(self.bound_addr).serve(svc);
         server.await
+    }
+
+    pub fn bound_addr(&self) -> SocketAddr {
+        self.bound_addr.local_addr()
     }
 }
 

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -1,5 +1,5 @@
 use crate::{
-    abstractions::{dbg_panic, MeteredSemaphore, OwnedMeteredSemPermit},
+    abstractions::{dbg_panic, MeteredSemaphore, OwnedMeteredSemPermit, UsedMeteredSemPermit},
     protosext::ValidScheduleLA,
     retry_logic::RetryPolicyExt,
     worker::workflow::HeartbeatTimeoutMsg,
@@ -51,7 +51,7 @@ pub(crate) struct LocalInFlightActInfo {
     pub la_info: NewLocalAct,
     pub dispatch_time: Instant,
     pub attempt: u32,
-    _permit: OwnedMeteredSemPermit,
+    _permit: UsedMeteredSemPermit,
 }
 
 #[derive(Debug, Clone)]
@@ -432,7 +432,7 @@ impl LocalActivityManager {
                 la_info: la_info_for_in_flight_map,
                 dispatch_time: Instant::now(),
                 attempt,
-                _permit: permit,
+                _permit: permit.into_used(),
             },
         );
 

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -22,7 +22,9 @@ pub(crate) use history_update::HistoryUpdate;
 pub(crate) use managed_run::ManagedWFFunc;
 
 use crate::{
-    abstractions::{stream_when_allowed, MeteredSemaphore, OwnedMeteredSemPermit},
+    abstractions::{
+        stream_when_allowed, MeteredSemaphore, OwnedMeteredSemPermit, UsedMeteredSemPermit,
+    },
     protosext::{legacy_query_failure, ValidPollWFTQResponse},
     telemetry::{metrics::workflow_worker_type, VecDisplayer},
     worker::{
@@ -641,9 +643,9 @@ pub(crate) struct PermittedWFT {
     work: PreparedWFT,
     #[cfg_attr(
         feature = "save_wf_inputs",
-        serde(skip, default = "OwnedMeteredSemPermit::fake_deserialized")
+        serde(skip, default = "UsedMeteredSemPermit::fake_deserialized")
     )]
-    permit: OwnedMeteredSemPermit,
+    permit: UsedMeteredSemPermit,
     #[cfg_attr(
         feature = "save_wf_inputs",
         serde(skip, default = "HistoryPaginator::fake_deserialized")
@@ -683,7 +685,7 @@ pub(crate) struct OutstandingTask {
     pub start_time: Instant,
     /// The WFT permit owned by this task, ensures we don't exceed max concurrent WFT, and makes
     /// sure the permit is automatically freed when we delete the task.
-    pub permit: OwnedMeteredSemPermit,
+    pub permit: UsedMeteredSemPermit,
 }
 
 impl OutstandingTask {

--- a/core/src/worker/workflow/wft_extraction.rs
+++ b/core/src/worker/workflow/wft_extraction.rs
@@ -65,7 +65,7 @@ impl WFTExtractor {
                             Ok(match HistoryPaginator::from_poll(wft, client).await {
                                 Ok((pag, prep)) => WFTExtractorOutput::NewWFT(PermittedWFT {
                                     work: prep,
-                                    permit,
+                                    permit: permit.into_used(),
                                     paginator: pag,
                                 }),
                                 Err(err) => WFTExtractorOutput::FailedFetch { run_id, err },

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -1,8 +1,22 @@
-use temporal_client::WorkflowService;
-use temporal_sdk_core::CoreRuntime;
-use temporal_sdk_core_api::telemetry::MetricsExporter;
-use temporal_sdk_core_protos::temporal::api::workflowservice::v1::ListNamespacesRequest;
-use temporal_sdk_core_test_utils::{get_integ_server_options, get_integ_telem_options};
+use std::{sync::Arc, time::Duration};
+use temporal_client::{WorkflowClientTrait, WorkflowOptions, WorkflowService};
+use temporal_sdk_core::{init_worker, CoreRuntime};
+use temporal_sdk_core_api::{telemetry::MetricsExporter, worker::WorkerConfigBuilder, Worker};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        activity_result::ActivityExecutionResult,
+        workflow_commands::{ScheduleActivity, ScheduleLocalActivity},
+        workflow_completion::WorkflowActivationCompletion,
+        ActivityTaskCompletion,
+    },
+    temporal::api::{enums::v1::WorkflowIdReusePolicy, workflowservice::v1::ListNamespacesRequest},
+};
+use temporal_sdk_core_test_utils::{get_integ_server_options, get_integ_telem_options, NAMESPACE};
+use tokio::sync::Barrier;
+
+async fn get_text(endpoint: String) -> String {
+    reqwest::get(endpoint).await.unwrap().text().await.unwrap()
+}
 
 #[tokio::test]
 async fn prometheus_metrics_exported() {
@@ -22,16 +36,203 @@ async fn prometheus_metrics_exported() {
         .await
         .unwrap();
 
-    let body = reqwest::get(format!("http://{addr}/metrics"))
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
+    let body = get_text(format!("http://{addr}/metrics")).await;
     assert!(body.contains(
         "request_latency_count{operation=\"ListNamespaces\",service_name=\"temporal-core-sdk\"} 1"
     ));
     assert!(body.contains(
         "request_latency_count{operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\"} 1"
     ));
+}
+
+#[tokio::test]
+async fn one_slot_worker_reports_available_slot() {
+    // TODO: Diff port
+    let mut telemopts = get_integ_telem_options();
+    let addr = "127.0.0.1:10919";
+    let tq = "one_slot_worker_tq";
+    telemopts.metrics = Some(MetricsExporter::Prometheus(addr.parse().unwrap()));
+    let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
+
+    let worker_cfg = WorkerConfigBuilder::default()
+        .namespace(NAMESPACE)
+        .task_queue(tq)
+        .worker_build_id("test_build_id")
+        .max_cached_workflows(1_usize)
+        .max_outstanding_activities(1_usize)
+        .max_outstanding_local_activities(1_usize)
+        .max_outstanding_workflow_tasks(1_usize)
+        .build()
+        .unwrap();
+
+    let client = Arc::new(
+        get_integ_server_options()
+            .connect(worker_cfg.namespace.clone(), None, None)
+            .await
+            .expect("Must connect"),
+    );
+    let worker = init_worker(&rt, worker_cfg, client.clone()).expect("Worker inits cleanly");
+    let wf_task_barr = Barrier::new(2);
+    let act_task_barr = Barrier::new(2);
+
+    let wf_polling = async {
+        let task = worker.poll_workflow_activation().await.unwrap();
+        wf_task_barr.wait().await;
+        wf_task_barr.wait().await;
+        worker
+            .complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+                task.run_id,
+                ScheduleActivity {
+                    seq: 1,
+                    activity_id: "1".to_string(),
+                    activity_type: "test_act".to_string(),
+                    task_queue: tq.to_string(),
+                    start_to_close_timeout: Some(prost_dur!(from_secs(30))),
+                    ..Default::default()
+                }
+                .into(),
+            ))
+            .await
+            .unwrap();
+        wf_task_barr.wait().await;
+
+        let task = worker.poll_workflow_activation().await.unwrap();
+        worker
+            .complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+                task.run_id,
+                ScheduleLocalActivity {
+                    seq: 2,
+                    activity_id: "2".to_string(),
+                    activity_type: "test_act".to_string(),
+                    start_to_close_timeout: Some(prost_dur!(from_secs(30))),
+                    ..Default::default()
+                }
+                .into(),
+            ))
+            .await
+            .unwrap();
+    };
+
+    let act_polling = async {
+        let task = worker.poll_activity_task().await.unwrap();
+        act_task_barr.wait().await;
+        worker
+            .complete_activity_task(ActivityTaskCompletion {
+                task_token: task.task_token,
+                result: Some(ActivityExecutionResult::ok(vec![1].into())),
+            })
+            .await
+            .unwrap();
+        act_task_barr.wait().await;
+
+        let task = worker.poll_activity_task().await.unwrap();
+        act_task_barr.wait().await;
+        act_task_barr.wait().await;
+        worker
+            .complete_activity_task(ActivityTaskCompletion {
+                task_token: task.task_token,
+                result: Some(ActivityExecutionResult::ok(vec![1].into())),
+            })
+            .await
+            .unwrap();
+        act_task_barr.wait().await;
+    };
+
+    let testing = async {
+        // Wait just a beat for the poller to initiate
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let body = get_text(format!("http://{addr}/metrics")).await;
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"WorkflowWorker\"}} 1"
+        )));
+
+        // Start a workflow so that a task will get delivered
+        client
+            .start_workflow(
+                vec![],
+                tq.to_owned(),
+                "one_slot_metric_test".to_owned(),
+                "whatever".to_string(),
+                None,
+                WorkflowOptions {
+                    id_reuse_policy: WorkflowIdReusePolicy::TerminateIfRunning,
+                    execution_timeout: Some(Duration::from_secs(5)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        wf_task_barr.wait().await;
+
+        // At this point the workflow task is outstanding, so there should be 0 slots, and
+        // the activities haven't started, so there should be 1 each.
+        let body = get_text(format!("http://{addr}/metrics")).await;
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"WorkflowWorker\"}} 0"
+        )));
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"ActivityWorker\"}} 1"
+        )));
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"LocalActivityWorker\"}} 1"
+        )));
+
+        // Now we allow the complete to proceed. Once it goes through, there should be 1 WFT slot
+        // open but 0 activity slots
+        wf_task_barr.wait().await;
+        wf_task_barr.wait().await;
+        // Sometimes the recording takes an extra bit. 🤷
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let body = get_text(format!("http://{addr}/metrics")).await;
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"WorkflowWorker\"}} 1"
+        )));
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"ActivityWorker\"}} 0"
+        )));
+
+        // Now complete the activity and watch it go up
+        act_task_barr.wait().await;
+        // Wait for completion to finish
+        act_task_barr.wait().await;
+        let body = get_text(format!("http://{addr}/metrics")).await;
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"ActivityWorker\"}} 1"
+        )));
+
+        // Proceed to local activity command
+        act_task_barr.wait().await;
+        // Ensure that, once we have the LA task, slots are 0
+        let body = get_text(format!("http://{addr}/metrics")).await;
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"LocalActivityWorker\"}} 0"
+        )));
+        // When completion is done, we have 1 again
+        act_task_barr.wait().await;
+        act_task_barr.wait().await;
+        let body = get_text(format!("http://{addr}/metrics")).await;
+        assert!(body.contains(&format!(
+            "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
+             service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
+             worker_type=\"LocalActivityWorker\"}} 1"
+        )));
+    };
+    tokio::join!(wf_polling, act_polling, testing);
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
See title

## Why?
Though in some sense correct, the fact that we pre-reserve slots is confusing to users looking at metrics.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/474
2. How was this tested:
Added integ test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
