### PR TITLE
Fix misnamed metric "workflow_task_execution_failed"

### DIFF
--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -277,7 +277,7 @@ impl Instruments {
             wf_e2e_latency: hst(WF_E2E_LATENCY_NAME),
             wf_task_queue_poll_empty_counter: ctr("workflow_task_queue_poll_empty"),
             wf_task_queue_poll_succeed_counter: ctr("workflow_task_queue_poll_succeed"),
-            wf_task_execution_failure_counter: ctr("workflow_task_queue_poll_failed"),
+            wf_task_execution_failure_counter: ctr("workflow_task_execution_failed"),
             wf_task_sched_to_start_latency: hst(WF_TASK_SCHED_TO_START_LATENCY_NAME),
             wf_task_replay_latency: hst(WF_TASK_REPLAY_LATENCY_NAME),
             wf_task_execution_latency: hst(WF_TASK_EXECUTION_LATENCY_NAME),


### PR DESCRIPTION
## What changed

- Renamed metric "workflow_task_queue_poll_failed" to "workflow_task_execution_failed"


## Why

- Because that's its correct name. (It used to be that.)[https://github.com/temporalio/sdk-core/commit/3773ad500c8123023af7500923fdd153e0454c8c#diff-246d533d84d5df8c1dc8eabc111db937ce1b749b75acff627cb0755bee313102L263-L267]