### PR TITLE
Fix client metrics lacking the `temporal_` prefix

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -13,6 +13,7 @@ mod retry;
 mod workflow_handle;
 
 pub use crate::retry::{CallType, RetryClient, RETRYABLE_ERROR_CODES};
+pub use metrics::ClientMetricProvider;
 pub use raw::{HealthService, OperatorService, TestService, WorkflowService};
 pub use temporal_sdk_core_protos::temporal::api::{
     enums::v1::ArchivalState,
@@ -34,7 +35,6 @@ use crate::{
 use backoff::{exponential, ExponentialBackoff, SystemClock};
 use http::uri::InvalidUri;
 use once_cell::sync::OnceCell;
-use opentelemetry::metrics::Meter;
 use parking_lot::RwLock;
 use std::{
     collections::HashMap,
@@ -286,7 +286,7 @@ impl ClientOptions {
     pub async fn connect(
         &self,
         namespace: impl Into<String>,
-        metrics_meter: Option<&Meter>,
+        metrics_meter: Option<&dyn ClientMetricProvider>,
         headers: Option<Arc<RwLock<HashMap<String, String>>>>,
     ) -> Result<RetryClient<Client>, ClientInitError> {
         let client = self
@@ -304,7 +304,7 @@ impl ClientOptions {
     /// See [RetryClient] for more
     pub async fn connect_no_namespace(
         &self,
-        metrics_meter: Option<&Meter>,
+        metrics_meter: Option<&dyn ClientMetricProvider>,
         headers: Option<Arc<RwLock<HashMap<String, String>>>>,
     ) -> Result<RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>, ClientInitError>
     {

--- a/core-api/Cargo.toml
+++ b/core-api/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["development-tools"]
 [dependencies]
 async-trait = "0.1"
 derive_builder = "0.12"
-opentelemetry = "0.18"
 prost-types = "0.11"
 serde = { version = "1.0", default_features = false, features = ["derive"] }
 serde_json = "1.0"

--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -1,4 +1,3 @@
-use opentelemetry::metrics::Meter;
 use std::{
     collections::HashMap,
     net::SocketAddr,
@@ -18,11 +17,6 @@ pub trait CoreTelemetry {
     /// Returns the list of logs from oldest to newest. Returns an empty vec if the feature is not
     /// configured.
     fn fetch_buffered_logs(&self) -> Vec<CoreLog>;
-
-    /// If metrics gathering is enabled, returns the OTel meter for core telemetry, which can be
-    /// used to create metrics instruments, or passed to things that create/record metrics (ex:
-    /// clients).
-    fn get_metric_meter(&self) -> Option<&Meter>;
 }
 
 /// Telemetry configuration options. Construct with [TelemetryOptionsBuilder]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -44,8 +44,9 @@ pub use worker::{Worker, WorkerConfig, WorkerConfigBuilder};
 use crate::{
     replay::{mock_client_from_histories, Historator, HistoryForReplay},
     telemetry::{
-        metrics::MetricsContext, remove_trace_subscriber_for_current_thread,
-        set_trace_subscriber_for_current_thread, telemetry_init, TelemetryInstance,
+        metrics::{MetricsContext, TemporalMeter},
+        remove_trace_subscriber_for_current_thread, set_trace_subscriber_for_current_thread,
+        telemetry_init, TelemetryInstance,
     },
     worker::client::WorkerClientBag,
 };
@@ -54,7 +55,7 @@ use std::sync::Arc;
 use temporal_client::{ConfiguredClient, TemporalServiceClientWithMetrics};
 use temporal_sdk_core_api::{
     errors::{CompleteActivityError, PollActivityError, PollWfError},
-    telemetry::{CoreTelemetry, TelemetryOptions},
+    telemetry::TelemetryOptions,
     Worker as WorkerTrait,
 };
 use temporal_sdk_core_protos::coresdk::ActivityHeartbeat;
@@ -65,7 +66,7 @@ use temporal_sdk_core_protos::coresdk::ActivityHeartbeat;
 /// After the worker is initialized, you should use [CoreRuntime::tokio_handle] to run the worker's
 /// async functions.
 ///
-/// Lang implementations may pass in a [temporal_client::ConfiguredClient] directly (or a
+/// Lang implementations may pass in a [ConfiguredClient] directly (or a
 /// [RetryClient] wrapping one, or a handful of other variants of the same idea). When they do so,
 /// this function will always overwrite the client retry configuration, force the client to use the
 /// namespace defined in the worker config, and set the client identity appropriately. IE: Use
@@ -264,7 +265,7 @@ impl CoreRuntime {
     }
 
     /// Returns the metric meter used for recording metrics, if they were enabled.
-    pub fn metric_meter(&self) -> Option<&opentelemetry::metrics::Meter> {
+    pub fn metric_meter(&self) -> Option<TemporalMeter> {
         self.telemetry.get_metric_meter()
     }
 

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -98,6 +98,13 @@ impl TelemetryInstance {
     pub fn prom_port(&self) -> Option<SocketAddr> {
         self.prom_binding
     }
+
+    /// Returns our wrapper for OTel metric meters, can be used to, ex: initialize clients
+    pub fn get_metric_meter(&self) -> Option<TemporalMeter> {
+        self.metrics
+            .as_ref()
+            .map(|(_, m)| TemporalMeter::new(m, self.metric_prefix))
+    }
 }
 
 thread_local! {
@@ -137,10 +144,6 @@ impl CoreTelemetry for TelemetryInstance {
         } else {
             vec![]
         }
-    }
-
-    fn get_metric_meter(&self) -> Option<&Meter> {
-        self.metrics.as_ref().map(|(_, m)| m)
     }
 }
 
@@ -389,6 +392,7 @@ pub mod test_initters {
         .unwrap();
     }
 }
+use crate::telemetry::metrics::TemporalMeter;
 #[cfg(test)]
 pub use test_initters::*;
 

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -28,7 +28,7 @@ async fn prometheus_metrics_exported() {
     let addr = rt.telemetry().prom_port().unwrap();
     let opts = get_integ_server_options();
     let mut raw_client = opts
-        .connect_no_namespace(rt.metric_meter(), None)
+        .connect_no_namespace(rt.metric_meter().as_deref(), None)
         .await
         .unwrap();
     assert!(raw_client.get_client().capabilities().is_some());
@@ -40,10 +40,10 @@ async fn prometheus_metrics_exported() {
 
     let body = get_text(format!("http://{addr}/metrics")).await;
     assert!(body.contains(
-        "request_latency_count{operation=\"ListNamespaces\",service_name=\"temporal-core-sdk\"} 1"
+        "temporal_request_latency_count{operation=\"ListNamespaces\",service_name=\"temporal-core-sdk\"} 1"
     ));
     assert!(body.contains(
-        "request_latency_count{operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\"} 1"
+        "temporal_request_latency_count{operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\"} 1"
     ));
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -36,7 +36,7 @@ mod integ_tests {
         let opts = get_integ_server_options();
         let runtime = CoreRuntime::new_assume_tokio(get_integ_telem_options()).unwrap();
         let mut retrying_client = opts
-            .connect_no_namespace(runtime.metric_meter(), None)
+            .connect_no_namespace(runtime.metric_meter().as_deref(), None)
             .await
             .unwrap();
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Client metrics were emitted missing this prefix, by accident.

## Why?
Not what we say on the tin.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/483

2. How was this tested:
Existing test

3. Any docs updates needed?
Potentially a breaking change for users depending on the incorrect names. There is an existing flag to not use the prefix, but that'll apply to _all_ metrics, including ones that maybe they expected to find the prefix on. 

IMO, we should go with this and just call it out in release notes, as emitting multiple metrics is uggo - but if needed we can add _another_ flag for specifically this issue.