### PR TITLE
Add Ruby package option to coresdk protos

### DIFF
--- a/protos/local/temporal/sdk/core/activity_result/activity_result.proto
+++ b/protos/local/temporal/sdk/core/activity_result/activity_result.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.activity_result;
-option ruby_package = "Coresdk::ActivityResult";
+option ruby_package = "Temporalio::Bridge::Api::ActivityResult";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/protos/local/temporal/sdk/core/activity_result/activity_result.proto
+++ b/protos/local/temporal/sdk/core/activity_result/activity_result.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package coresdk.activity_result;
+option ruby_package = "Coresdk::ActivityResult";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/protos/local/temporal/sdk/core/activity_task/activity_task.proto
+++ b/protos/local/temporal/sdk/core/activity_task/activity_task.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
  * Definitions of the different activity tasks returned from [crate::Core::poll_task].
  */
 package coresdk.activity_task;
+option ruby_package = "Coresdk::ActivityTask";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/protos/local/temporal/sdk/core/activity_task/activity_task.proto
+++ b/protos/local/temporal/sdk/core/activity_task/activity_task.proto
@@ -4,7 +4,7 @@ syntax = "proto3";
  * Definitions of the different activity tasks returned from [crate::Core::poll_task].
  */
 package coresdk.activity_task;
-option ruby_package = "Coresdk::ActivityTask";
+option ruby_package = "Temporalio::Bridge::Api::ActivityTask";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/protos/local/temporal/sdk/core/child_workflow/child_workflow.proto
+++ b/protos/local/temporal/sdk/core/child_workflow/child_workflow.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.child_workflow;
-option ruby_package = "Coresdk::ChildWorkflow";
+option ruby_package = "Temporalio::Bridge::Api::ChildWorkflow";
 
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";

--- a/protos/local/temporal/sdk/core/child_workflow/child_workflow.proto
+++ b/protos/local/temporal/sdk/core/child_workflow/child_workflow.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package coresdk.child_workflow;
+option ruby_package = "Coresdk::ChildWorkflow";
 
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";

--- a/protos/local/temporal/sdk/core/common/common.proto
+++ b/protos/local/temporal/sdk/core/common/common.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.common;
-option ruby_package = "Coresdk::Common";
+option ruby_package = "Temporalio::Bridge::Api::Common";
 
 import "google/protobuf/duration.proto";
 

--- a/protos/local/temporal/sdk/core/common/common.proto
+++ b/protos/local/temporal/sdk/core/common/common.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package coresdk.common;
+option ruby_package = "Coresdk::Common";
 
 import "google/protobuf/duration.proto";
 

--- a/protos/local/temporal/sdk/core/core_interface.proto
+++ b/protos/local/temporal/sdk/core/core_interface.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk;
-option ruby_package = "Coresdk::CoreInterface";
+option ruby_package = "Temporalio::Bridge::Api::CoreInterface";
 
 // Note: Intellij will think the Google imports don't work because of the slightly odd nature of
 // the include paths. You can make it work by going to the "Protobuf Support" settings section

--- a/protos/local/temporal/sdk/core/core_interface.proto
+++ b/protos/local/temporal/sdk/core/core_interface.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package coresdk;
+option ruby_package = "Coresdk::CoreInterface";
 
 // Note: Intellij will think the Google imports don't work because of the slightly odd nature of
 // the include paths. You can make it work by going to the "Protobuf Support" settings section

--- a/protos/local/temporal/sdk/core/external_data/external_data.proto
+++ b/protos/local/temporal/sdk/core/external_data/external_data.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.external_data;
-option ruby_package = "Coresdk::ExternalData";
+option ruby_package = "Temporalio::Bridge::Api::ExternalData";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/protos/local/temporal/sdk/core/external_data/external_data.proto
+++ b/protos/local/temporal/sdk/core/external_data/external_data.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package coresdk.external_data;
+option ruby_package = "Coresdk::ExternalData";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
  * lang SDK applies these activation jobs to drive workflows.
  */
 package coresdk.workflow_activation;
-option ruby_package = "Coresdk::WorkflowActivation";
+option ruby_package = "Temporalio::Bridge::Api::WorkflowActivation";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";

--- a/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
  * lang SDK applies these activation jobs to drive workflows.
  */
 package coresdk.workflow_activation;
+option ruby_package = "Coresdk::WorkflowActivation";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";

--- a/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
  * activation.
  */
 package coresdk.workflow_commands;
+option ruby_package = "Coresdk::WorkflowCommands";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
  * activation.
  */
 package coresdk.workflow_commands;
-option ruby_package = "Coresdk::WorkflowCommands";
+option ruby_package = "Temporalio::Bridge::Api::WorkflowCommands";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/protos/local/temporal/sdk/core/workflow_completion/workflow_completion.proto
+++ b/protos/local/temporal/sdk/core/workflow_completion/workflow_completion.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package coresdk.workflow_completion;
+option ruby_package = "Coresdk::WorkflowCompletion";
 
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/enums/v1/failed_cause.proto";

--- a/protos/local/temporal/sdk/core/workflow_completion/workflow_completion.proto
+++ b/protos/local/temporal/sdk/core/workflow_completion/workflow_completion.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.workflow_completion;
-option ruby_package = "Coresdk::WorkflowCompletion";
+option ruby_package = "Temporalio::Bridge::Api::WorkflowCompletion";
 
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/enums/v1/failed_cause.proto";


### PR DESCRIPTION
## What changed

- Add `option ruby_package` on all coresdk proto files


## Why

- Ruby convention for module name is camel case. This was previously fixed manually in sdk-ruby