### PR TITLE
Auto-upsert versions SA on patched calls & nondeterminism check for upserts

### DIFF
--- a/.buildkite/docker/docker-compose.yaml
+++ b/.buildkite/docker/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
   #      - '9042:9042'
 
   temporal:
-    image: temporalio/auto-setup:1.18.3
+    image: temporalio/auto-setup:1.20.0
     ports:
       - "7233:7233"
       - "7234:7234"

--- a/core/src/internal_flags.rs
+++ b/core/src/internal_flags.rs
@@ -17,9 +17,11 @@ use temporal_sdk_core_protos::temporal::api::{
 #[repr(u32)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug)]
 pub(crate) enum CoreInternalFlags {
-    /// In this flag, additional checks were added to a number of state machines to ensure that
+    /// In this flag additional checks were added to a number of state machines to ensure that
     /// the ID and type of activities, local activities, and child workflows match during replay.
     IdAndTypeDeterminismChecks = 1,
+    /// Introduced automatically upserting search attributes for each patched call
+    UpsertSearchAttributeOnPatch = 2,
     /// We received a value higher than this code can understand.
     TooHigh = u32::MAX,
 }
@@ -73,7 +75,8 @@ impl InternalFlags {
     /// [Self::gather_for_wft_complete].
     pub fn try_use(&mut self, core_patch: CoreInternalFlags, should_record: bool) -> bool {
         if !self.enabled {
-            // If the server does not support the metadata field, we must assume
+            // If the server does not support the metadata field, we must assume we can never use
+            // any internal flags since they can't be recorded for future use
             return false;
         }
 
@@ -108,6 +111,7 @@ impl CoreInternalFlags {
     fn from_u32(v: u32) -> Self {
         match v {
             1 => Self::IdAndTypeDeterminismChecks,
+            2 => Self::UpsertSearchAttributeOnPatch,
             _ => Self::TooHigh,
         }
     }

--- a/core/src/internal_flags.rs
+++ b/core/src/internal_flags.rs
@@ -20,7 +20,8 @@ pub(crate) enum CoreInternalFlags {
     /// In this flag additional checks were added to a number of state machines to ensure that
     /// the ID and type of activities, local activities, and child workflows match during replay.
     IdAndTypeDeterminismChecks = 1,
-    /// Introduced automatically upserting search attributes for each patched call
+    /// Introduced automatically upserting search attributes for each patched call, and
+    /// nondeterminism checks for upserts.
     UpsertSearchAttributeOnPatch = 2,
     /// We received a value higher than this code can understand.
     TooHigh = u32::MAX,
@@ -40,6 +41,20 @@ impl InternalFlags {
         Self {
             enabled: server_capabilities.sdk_metadata,
             core: Default::default(),
+            lang: Default::default(),
+            core_since_last_complete: Default::default(),
+            lang_since_last_complete: Default::default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn all_core_enabled() -> Self {
+        Self {
+            enabled: true,
+            core: BTreeSet::from([
+                CoreInternalFlags::IdAndTypeDeterminismChecks,
+                CoreInternalFlags::UpsertSearchAttributeOnPatch,
+            ]),
             lang: Default::default(),
             core_since_last_complete: Default::default(),
             lang_since_last_complete: Default::default(),

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -30,8 +30,10 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use temporal_sdk_core_api::errors::{PollActivityError, PollWfError};
-use temporal_sdk_core_api::Worker as WorkerTrait;
+use temporal_sdk_core_api::{
+    errors::{PollActivityError, PollWfError},
+    Worker as WorkerTrait,
+};
 use temporal_sdk_core_protos::{
     coresdk::{
         workflow_activation::WorkflowActivation,

--- a/core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/core/src/worker/workflow/machines/patch_state_machine.rs
@@ -147,7 +147,6 @@ pub(super) fn has_change<'a>(
                  visibility records will not include the following patch: {}",
                 machine.shared_state.patch_id
             );
-            dbg!(serialized.data.len());
             vec![]
         } else {
             let indexed_fields = {

--- a/core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/core/src/worker/workflow/machines/patch_state_machine.rs
@@ -34,7 +34,7 @@ use crate::{
 use anyhow::Context;
 use rustfsm::{fsm, TransitionResult};
 use std::{
-    collections::{hash_map::RandomState, HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     convert::TryFrom,
 };
 use temporal_sdk_core_protos::{
@@ -134,7 +134,7 @@ pub(super) fn has_change<'a>(
         vec![]
     } else {
         // Produce an upsert SA command for this patch.
-        let mut all_ids = HashSet::<_, RandomState>::from_iter(existing_patch_ids);
+        let mut all_ids = BTreeSet::from_iter(existing_patch_ids);
         all_ids.insert(machine.shared_state.patch_id.as_str());
         let serialized = all_ids
             .as_json_payload()

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -7,7 +7,7 @@ use rustfsm::{fsm, TransitionResult};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::UpsertWorkflowSearchAttributes,
     temporal::api::{
-        command::v1::Command,
+        command::v1::{Command, UpsertWorkflowSearchAttributesCommandAttributes},
         enums::v1::{CommandType, EventType},
         history::v1::HistoryEvent,
     },
@@ -35,6 +35,20 @@ fsm! {
 /// to apply the provided search attribute update.
 pub(super) fn upsert_search_attrs(
     attribs: UpsertWorkflowSearchAttributes,
+) -> NewMachineWithCommand {
+    let sm = UpsertSearchAttributesMachine::new();
+    let cmd = Command {
+        command_type: CommandType::UpsertWorkflowSearchAttributes as i32,
+        attributes: Some(attribs.into()),
+    };
+    NewMachineWithCommand {
+        command: cmd,
+        machine: sm.into(),
+    }
+}
+
+pub(super) fn upsert_search_attrs_from_raw(
+    attribs: UpsertWorkflowSearchAttributesCommandAttributes,
 ) -> NewMachineWithCommand {
     let sm = UpsertSearchAttributesMachine::new();
     let cmd = Command {

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -1,18 +1,22 @@
 use super::{workflow_machines::MachineResponse, NewMachineWithCommand};
-use crate::worker::workflow::{
-    machines::{
-        patch_state_machine::VERSION_SEARCH_ATTR_KEY, Cancellable, EventInfo, HistEventData,
-        WFMachinesAdapter,
+use crate::{
+    internal_flags::CoreInternalFlags,
+    worker::workflow::{
+        machines::{
+            patch_state_machine::VERSION_SEARCH_ATTR_KEY, Cancellable, EventInfo, HistEventData,
+            WFMachinesAdapter,
+        },
+        InternalFlagsRef, WFMachinesError,
     },
-    WFMachinesError,
 };
 use rustfsm::{fsm, TransitionResult};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::UpsertWorkflowSearchAttributes,
     temporal::api::{
         command::v1::{command, Command, UpsertWorkflowSearchAttributesCommandAttributes},
+        common::v1::SearchAttributes,
         enums::v1::{CommandType, EventType},
-        history::v1::HistoryEvent,
+        history::v1::{history_event, HistoryEvent},
     },
 };
 
@@ -34,14 +38,15 @@ fsm! {
     // upon observing a history event indicating that the command has been recorded. Note that this
     // does not imply that the command has been _executed_, only that it _will be_ executed at some
     // point in the future.
-    CommandIssued --(CommandRecorded) --> Done;
+    CommandIssued --(CommandRecorded(CmdRecDat), shared on_command_recorded) --> Done;
 }
 
 /// Instantiates an UpsertSearchAttributesMachine and packs it together with an initial command
 /// to apply the provided search attribute update.
 pub(super) fn upsert_search_attrs(
     attribs: UpsertWorkflowSearchAttributes,
-) -> Result<NewMachineWithCommand, WFMachinesError> {
+    internal_flags: InternalFlagsRef,
+) -> NewMachineWithCommand {
     if attribs
         .search_attributes
         .contains_key(VERSION_SEARCH_ATTR_KEY)
@@ -51,24 +56,47 @@ pub(super) fn upsert_search_attrs(
              is not permitted and has no effect!"
         );
         // We must still create the command to preserve compatability with anyone previously doing
-        // this
-        return Ok(create_new(UpsertWorkflowSearchAttributes::default()));
+        // this.
+        create_new(Default::default(), true, internal_flags)
+    } else {
+        create_new(attribs.search_attributes.into(), false, internal_flags)
     }
-    Ok(create_new(attribs))
 }
 
 /// May be used by other state machines / internal needs which desire upserting search attributes.
 pub(super) fn upsert_search_attrs_internal(
     attribs: UpsertWorkflowSearchAttributesCommandAttributes,
+    internal_flags: InternalFlagsRef,
 ) -> NewMachineWithCommand {
-    create_new(attribs)
+    create_new(
+        attribs.search_attributes.unwrap_or_default(),
+        true,
+        internal_flags,
+    )
 }
 
-fn create_new(attribs: impl Into<command::Attributes>) -> NewMachineWithCommand {
-    let sm = UpsertSearchAttributesMachine::new();
+fn create_new(
+    sa_map: SearchAttributes,
+    should_skip_determinism: bool,
+    internal_flags: InternalFlagsRef,
+) -> NewMachineWithCommand {
+    let sm = UpsertSearchAttributesMachine {
+        state: Created {}.into(),
+        shared_state: SharedState {
+            sa_map: sa_map.clone(),
+            should_skip_determinism,
+            internal_flags,
+        },
+    };
     let cmd = Command {
         command_type: CommandType::UpsertWorkflowSearchAttributes as i32,
-        attributes: Some(attribs.into()),
+        attributes: Some(
+            command::Attributes::UpsertWorkflowSearchAttributesCommandAttributes(
+                UpsertWorkflowSearchAttributesCommandAttributes {
+                    search_attributes: Some(sa_map),
+                },
+            ),
+        ),
     };
     NewMachineWithCommand {
         command: cmd,
@@ -76,8 +104,12 @@ fn create_new(attribs: impl Into<command::Attributes>) -> NewMachineWithCommand 
     }
 }
 
-/// Unused but must exist
-type SharedState = ();
+#[derive(Clone)]
+pub(super) struct SharedState {
+    should_skip_determinism: bool,
+    sa_map: SearchAttributes,
+    internal_flags: InternalFlagsRef,
+}
 
 /// The state-machine-specific set of commands that are the results of state transition in the
 /// UpsertSearchAttributesMachine. There are none of these because this state machine emits the
@@ -94,20 +126,38 @@ pub(super) struct Created {}
 /// higher-level machinery, it transitions into this state.
 #[derive(Debug, Default, Clone, derive_more::Display)]
 pub(super) struct CommandIssued {}
+pub(super) struct CmdRecDat {
+    sa_map: Option<SearchAttributes>,
+    replaying: bool,
+}
+
+impl CommandIssued {
+    pub(super) fn on_command_recorded(
+        self,
+        shared: SharedState,
+        dat: CmdRecDat,
+    ) -> UpsertSearchAttributesMachineTransition<Done> {
+        if shared.internal_flags.borrow_mut().try_use(
+            CoreInternalFlags::UpsertSearchAttributeOnPatch,
+            !dat.replaying,
+        ) {
+            let sa = dat.sa_map.unwrap_or_default();
+            if !shared.should_skip_determinism && shared.sa_map != sa {
+                return TransitionResult::Err(WFMachinesError::Nondeterminism(format!(
+                    "Search attribute upsert calls must remain deterministic, but {:?} does not \
+                 match the attributes from history: {:?}",
+                    shared.sa_map, sa
+                )));
+            }
+        }
+        TransitionResult::default()
+    }
+}
 
 /// Once the server has recorded its receipt of the search attribute update, the
 /// UpsertSearchAttributesMachine transitions into this terminal state.
 #[derive(Debug, Default, Clone, derive_more::Display)]
 pub(super) struct Done {}
-
-impl UpsertSearchAttributesMachine {
-    fn new() -> Self {
-        Self {
-            state: Created {}.into(),
-            shared_state: (),
-        }
-    }
-}
 
 impl WFMachinesAdapter for UpsertSearchAttributesMachine {
     /// Transforms an UpsertSearchAttributesMachine-specific command (i.e. an instance of the type
@@ -142,11 +192,15 @@ impl TryFrom<HistEventData> for UpsertSearchAttributesMachineEvents {
     type Error = WFMachinesError;
 
     fn try_from(e: HistEventData) -> Result<Self, Self::Error> {
-        let e = e.event;
-        match e.event_type() {
-            EventType::UpsertWorkflowSearchAttributes => {
-                Ok(UpsertSearchAttributesMachineEvents::CommandRecorded)
-            }
+        match e.event.attributes {
+            Some(history_event::Attributes::UpsertWorkflowSearchAttributesEventAttributes(
+                attrs,
+            )) => Ok(UpsertSearchAttributesMachineEvents::CommandRecorded(
+                CmdRecDat {
+                    sa_map: attrs.search_attributes,
+                    replaying: e.replaying,
+                },
+            )),
             _ => Err(Self::Error::Nondeterminism(format!(
                 "UpsertWorkflowSearchAttributesMachine does not handle {e}"
             ))),
@@ -172,13 +226,6 @@ impl TryFrom<CommandType> for UpsertSearchAttributesMachineEvents {
 }
 
 // There is no Command/Response associated with this transition
-impl From<CommandIssued> for Done {
-    fn from(_: CommandIssued) -> Self {
-        Self {}
-    }
-}
-
-// There is no Command/Response associated with this transition
 impl From<Created> for CommandIssued {
     fn from(_: Created) -> Self {
         Self {}
@@ -189,6 +236,7 @@ impl From<Created> for CommandIssued {
 mod tests {
     use super::{super::OnEventWrapper, *};
     use crate::{
+        internal_flags::InternalFlags,
         replay::TestHistoryBuilder,
         test_help::{build_mock_pollers, mock_worker, MockPollCfg, ResponseType},
         worker::{
@@ -196,13 +244,16 @@ mod tests {
             workflow::{machines::patch_state_machine::VERSION_SEARCH_ATTR_KEY, ManagedWFFunc},
         },
     };
-    use rustfsm::StateMachine;
-    use std::collections::HashMap;
+    use rustfsm::{MachineError, StateMachine};
+    use std::{cell::RefCell, collections::HashMap, rc::Rc};
     use temporal_sdk::{WfContext, WorkflowFunction};
     use temporal_sdk_core_api::Worker;
     use temporal_sdk_core_protos::{
         coresdk::{workflow_completion::WorkflowActivationCompletion, AsJsonPayloadExt},
-        temporal::api::{command::v1::command::Attributes, common::v1::Payload},
+        temporal::api::{
+            command::v1::command::Attributes, common::v1::Payload,
+            history::v1::UpsertWorkflowSearchAttributesEventAttributes,
+        },
     };
 
     #[tokio::test]
@@ -256,16 +307,34 @@ mod tests {
         wfm.shutdown().await.unwrap();
     }
 
-    #[tokio::test]
-    async fn upsert_search_attrs_sm() {
-        let mut sm = UpsertSearchAttributesMachine::new();
-        assert_eq!(Created {}.to_string(), sm.state().to_string());
+    #[rstest::rstest]
+    fn upsert_search_attrs_sm(#[values(true, false)] nondetermistic: bool) {
+        let mut sm = UpsertSearchAttributesMachine {
+            state: Created {}.into(),
+            shared_state: SharedState {
+                sa_map: Default::default(),
+                should_skip_determinism: false,
+                internal_flags: Rc::new(RefCell::new(InternalFlags::all_core_enabled())),
+            },
+        };
 
-        let cmd_scheduled_sm_event = CommandType::UpsertWorkflowSearchAttributes
-            .try_into()
-            .unwrap();
+        let sa_attribs = if nondetermistic {
+            UpsertWorkflowSearchAttributesEventAttributes {
+                workflow_task_completed_event_id: 0,
+                search_attributes: Some(SearchAttributes {
+                    indexed_fields: HashMap::from([("Yo".to_string(), Payload::default())]),
+                }),
+            }
+        } else {
+            Default::default()
+        };
         let recorded_history_event = HistoryEvent {
             event_type: EventType::UpsertWorkflowSearchAttributes as i32,
+            attributes: Some(
+                history_event::Attributes::UpsertWorkflowSearchAttributesEventAttributes(
+                    sa_attribs,
+                ),
+            ),
             ..Default::default()
         };
         assert!(sm.matches_event(&recorded_history_event));
@@ -277,13 +346,25 @@ mod tests {
         .try_into()
         .unwrap();
 
-        OnEventWrapper::on_event_mut(&mut sm, cmd_scheduled_sm_event)
-            .expect("CommandScheduled should transition Created -> CommandIssued");
+        OnEventWrapper::on_event_mut(
+            &mut sm,
+            CommandType::UpsertWorkflowSearchAttributes
+                .try_into()
+                .unwrap(),
+        )
+        .expect("CommandScheduled should transition Created -> CommandIssued");
         assert_eq!(CommandIssued {}.to_string(), sm.state().to_string());
 
-        OnEventWrapper::on_event_mut(&mut sm, cmd_recorded_sm_event)
-            .expect("CommandRecorded should transition CommandIssued -> Done");
-        assert_eq!(Done {}.to_string(), sm.state().to_string());
+        let recorded_res = OnEventWrapper::on_event_mut(&mut sm, cmd_recorded_sm_event);
+        if nondetermistic {
+            assert_matches!(
+                recorded_res.unwrap_err(),
+                MachineError::Underlying(WFMachinesError::Nondeterminism(_))
+            );
+        } else {
+            recorded_res.expect("CommandRecorded should transition CommandIssued -> Done");
+            assert_eq!(Done {}.to_string(), sm.state().to_string());
+        }
     }
 
     #[tokio::test]

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -913,7 +913,10 @@ impl WorkflowMachines {
                     }
                     ProtoCmdAttrs::UpsertWorkflowSearchAttributesCommandAttributes(attrs) => {
                         self.add_cmd_to_wf_task(
-                            upsert_search_attrs_internal(attrs),
+                            upsert_search_attrs_internal(
+                                attrs,
+                                self.observed_internal_flags.clone(),
+                            ),
                             CommandIdKind::NeverResolves,
                         );
                     }
@@ -1023,7 +1026,7 @@ impl WorkflowMachines {
                 }
                 WFCommand::UpsertSearchAttributes(attrs) => {
                     self.add_cmd_to_wf_task(
-                        upsert_search_attrs(attrs)?,
+                        upsert_search_attrs(attrs, self.observed_internal_flags.clone()),
                         CommandIdKind::NeverResolves,
                     );
                 }

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1026,7 +1026,11 @@ impl WorkflowMachines {
                 }
                 WFCommand::UpsertSearchAttributes(attrs) => {
                     self.add_cmd_to_wf_task(
-                        upsert_search_attrs(attrs, self.observed_internal_flags.clone()),
+                        upsert_search_attrs(
+                            attrs,
+                            self.observed_internal_flags.clone(),
+                            self.replaying,
+                        ),
                         CommandIdKind::NeverResolves,
                     );
                 }

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -23,6 +23,8 @@ use crate::{
                 activity_state_machine::ActivityMachine,
                 child_workflow_state_machine::ChildWorkflowMachine,
                 modify_workflow_properties_state_machine::modify_workflow_properties,
+                patch_state_machine::VERSION_SEARCH_ATTR_KEY,
+                upsert_search_attributes_state_machine::upsert_search_attrs_from_raw,
                 HistEventData,
             },
             CommandID, DrivenWorkflow, HistoryUpdate, InternalFlagsRef, LocalResolution,
@@ -57,7 +59,7 @@ use temporal_sdk_core_protos::{
     temporal::api::{
         command::v1::{command::Attributes as ProtoCmdAttrs, Command as ProtoCommand},
         enums::v1::EventType,
-        history::v1::{history_event, HistoryEvent},
+        history::v1::{history_event, history_event::Attributes, HistoryEvent},
         sdk::v1::WorkflowTaskCompletedMetadata,
     },
 };
@@ -465,6 +467,7 @@ impl WorkflowMachines {
         }
 
         let mut saw_completed = false;
+        let mut do_handle_event = true;
         let mut history = events.into_iter().peekable();
         while let Some(event) = history.next() {
             if event.event_id != self.last_processed_event + 1 {
@@ -491,14 +494,26 @@ impl WorkflowMachines {
                 saw_completed = true;
             }
 
-            self.handle_event(
-                HistEventData {
-                    event,
-                    replaying: self.replaying,
-                    current_task_is_last_in_history: has_final_event,
-                },
-                next_event.is_some() || !has_final_event,
-            )?;
+            if do_handle_event {
+                let eho = self.handle_event(
+                    HistEventData {
+                        event,
+                        replaying: self.replaying,
+                        current_task_is_last_in_history: has_final_event,
+                    },
+                    next_event,
+                )?;
+                if matches!(
+                    eho,
+                    EventHandlingOutcome::SkipEvent {
+                        skip_next_upsert: true
+                    }
+                ) {
+                    do_handle_event = false;
+                }
+            } else {
+                do_handle_event = true;
+            }
             self.last_processed_event = eid;
         }
 
@@ -556,8 +571,7 @@ impl WorkflowMachines {
         Ok(num_events_to_process)
     }
 
-    /// Handle a single event from the workflow history. `has_next_event` should be false if `event`
-    /// is the last event in the history.
+    /// Handle a single event from the workflow history.
     ///
     /// This function will attempt to apply the event to the workflow state machines. If there is
     /// not a matching machine for the event, a nondeterminism error is returned. Otherwise, the
@@ -565,7 +579,11 @@ impl WorkflowMachines {
     /// does not match the expected type. A fatal error may be returned if the machine is in an
     /// invalid state.
     #[instrument(skip(self, event_dat), fields(event=%event_dat))]
-    fn handle_event(&mut self, event_dat: HistEventData, has_next_event: bool) -> Result<()> {
+    fn handle_event(
+        &mut self,
+        event_dat: HistEventData,
+        next_event: Option<&HistoryEvent>,
+    ) -> Result<EventHandlingOutcome> {
         let event = &event_dat.event;
         if event.is_final_wf_execution_event() {
             self.have_seen_terminal_event = true;
@@ -574,14 +592,16 @@ impl WorkflowMachines {
             event.event_type(),
             EventType::WorkflowExecutionTerminated | EventType::WorkflowExecutionTimedOut
         ) {
-            return if has_next_event {
+            let are_more_events =
+                next_event.is_some() || !event_dat.current_task_is_last_in_history;
+            return if are_more_events {
                 Err(WFMachinesError::Fatal(
                     "Machines were fed a history which has an event after workflow execution was \
                      terminated!"
                         .to_string(),
                 ))
             } else {
-                Ok(())
+                Ok(EventHandlingOutcome::Normal)
             };
         }
         if event.event_type() == EventType::Unspecified || event.attributes.is_none() {
@@ -591,13 +611,14 @@ impl WorkflowMachines {
                 )))
             } else {
                 debug!("Event is ignorable");
-                Ok(())
+                Ok(EventHandlingOutcome::SkipEvent {
+                    skip_next_upsert: false,
+                })
             };
         }
 
         if event.is_command_event() {
-            self.handle_command_event(event_dat)?;
-            return Ok(());
+            return self.handle_command_event(event_dat, next_event);
         }
 
         if let Some(initial_cmd_id) = event.get_initial_command_event_id() {
@@ -623,7 +644,7 @@ impl WorkflowMachines {
             self.handle_non_stateful_event(event_dat)?;
         }
 
-        Ok(())
+        Ok(EventHandlingOutcome::Normal)
     }
 
     /// A command event is an event which is generated from a command emitted as a result of
@@ -635,8 +656,13 @@ impl WorkflowMachines {
     /// The handling consists of verifying that the next command in the commands queue is associated
     /// with a state machine, which is then notified about the event and the command is removed from
     /// the commands queue.
-    fn handle_command_event(&mut self, event_dat: HistEventData) -> Result<()> {
+    fn handle_command_event(
+        &mut self,
+        event_dat: HistEventData,
+        next_event: Option<&HistoryEvent>,
+    ) -> Result<EventHandlingOutcome> {
         let event = &event_dat.event;
+
         if event.is_local_activity_marker() {
             let deets = event.extract_local_activity_marker_data().ok_or_else(|| {
                 WFMachinesError::Fatal(format!("Local activity marker was unparsable: {event:?}"))
@@ -646,7 +672,7 @@ impl WorkflowMachines {
             if let Machines::LocalActivityMachine(lam) = self.machine(mkey) {
                 if lam.marker_should_get_special_handling()? {
                     self.submachine_handle_event(mkey, event_dat)?;
-                    return Ok(());
+                    return Ok(EventHandlingOutcome::Normal);
                 }
             } else {
                 return Err(WFMachinesError::Fatal(format!(
@@ -661,13 +687,13 @@ impl WorkflowMachines {
         let consumed_cmd = loop {
             if let Some(peek_machine) = self.commands.front() {
                 let mach = self.machine(peek_machine.machine);
-                match change_marker_handling(event, mach)? {
-                    ChangeMarkerOutcome::SkipEvent => return Ok(()),
-                    ChangeMarkerOutcome::SkipCommand => {
+                match change_marker_handling(event, mach, next_event)? {
+                    EventHandlingOutcome::SkipCommand { skip_next_upsert } => {
                         self.commands.pop_front();
                         continue;
                     }
-                    ChangeMarkerOutcome::Normal => {}
+                    eho @ EventHandlingOutcome::SkipEvent { .. } => return Ok(eho),
+                    EventHandlingOutcome::Normal => {}
                 }
             }
 
@@ -696,7 +722,7 @@ impl WorkflowMachines {
                 .insert(event_id, consumed_cmd.machine);
         }
 
-        Ok(())
+        Ok(EventHandlingOutcome::Normal)
     }
 
     fn handle_non_stateful_event(&mut self, event_dat: HistEventData) -> Result<()> {
@@ -885,6 +911,12 @@ impl WorkflowMachines {
                             CommandIdKind::CoreInternal,
                         );
                     }
+                    ProtoCmdAttrs::UpsertWorkflowSearchAttributesCommandAttributes(attrs) => {
+                        self.add_cmd_to_wf_task(
+                            upsert_search_attrs_from_raw(attrs),
+                            CommandIdKind::NeverResolves,
+                        );
+                    }
                     c => {
                         return Err(WFMachinesError::Fatal(format!(
                         "A machine requested to create a new command of an unsupported type: {c:?}"
@@ -1056,13 +1088,20 @@ impl WorkflowMachines {
                 WFCommand::SetPatchMarker(attrs) => {
                     // Do not create commands for change IDs that we have already created commands
                     // for.
-                    if !matches!(self.encountered_change_markers.get(&attrs.patch_id),
+                    let encountered_entry = self.encountered_change_markers.get(&attrs.patch_id);
+                    if !matches!(encountered_entry,
                                  Some(ChangeInfo {created_command}) if *created_command)
                     {
-                        self.add_cmd_to_wf_task(
-                            has_change(attrs.patch_id.clone(), self.replaying, attrs.deprecated),
-                            CommandIdKind::NeverResolves,
+                        let (patch_machine, other_cmds) = has_change(
+                            attrs.patch_id.clone(),
+                            self.replaying,
+                            attrs.deprecated,
+                            encountered_entry.is_some(),
+                            self.observed_internal_flags.clone(),
                         );
+                        let mkey =
+                            self.add_cmd_to_wf_task(patch_machine, CommandIdKind::NeverResolves);
+                        self.process_machine_responses(mkey, other_cmds)?;
 
                         if let Some(ci) = self.encountered_change_markers.get_mut(&attrs.patch_id) {
                             ci.created_command = true;
@@ -1167,15 +1206,21 @@ impl WorkflowMachines {
     }
 
     /// Add a new command/machines for that command to the current workflow task
-    fn add_cmd_to_wf_task(&mut self, machine: NewMachineWithCommand, id: CommandIdKind) {
+    fn add_cmd_to_wf_task(
+        &mut self,
+        machine: NewMachineWithCommand,
+        id: CommandIdKind,
+    ) -> MachineKey {
         let mach = self.add_new_command_machine(machine);
+        let key = mach.machine;
         if let CommandIdKind::LangIssued(id) = id {
-            self.id_to_machine.insert(id, mach.machine);
+            self.id_to_machine.insert(id, key);
         }
         if matches!(id, CommandIdKind::CoreInternal) {
-            self.machine_is_core_created.insert(mach.machine, ());
+            self.machine_is_core_created.insert(key, ());
         }
         self.current_wf_task_commands.push_back(mach);
+        key
     }
 
     fn add_new_command_machine(&mut self, machine: NewMachineWithCommand) -> CommandAndMachine {
@@ -1235,15 +1280,20 @@ fn str_to_randomness_seed(run_id: &str) -> u64 {
     s.finish()
 }
 
-enum ChangeMarkerOutcome {
-    SkipEvent,
-    SkipCommand,
+#[must_use]
+enum EventHandlingOutcome {
+    SkipEvent { skip_next_upsert: bool },
+    SkipCommand { skip_next_upsert: bool },
     Normal,
 }
 
 /// Special handling for patch markers, when handling command events as in
 /// [WorkflowMachines::handle_command_event]
-fn change_marker_handling(event: &HistoryEvent, mach: &Machines) -> Result<ChangeMarkerOutcome> {
+fn change_marker_handling(
+    event: &HistoryEvent,
+    mach: &Machines,
+    next_event: Option<&HistoryEvent>,
+) -> Result<EventHandlingOutcome> {
     if !mach.matches_event(event) {
         // Version markers can be skipped in the event they are deprecated
         if let Some((patch_name, deprecated)) = event.get_patch_marker_details() {
@@ -1251,7 +1301,20 @@ fn change_marker_handling(event: &HistoryEvent, mach: &Machines) -> Result<Chang
             // markers are allowed without matching changed calls.
             if deprecated {
                 debug!("Deprecated patch marker tried against wrong machine, skipping.");
-                return Ok(ChangeMarkerOutcome::SkipEvent);
+
+                // Also ignore the subsequent upsert event if present
+                // TODO: But we still need to include data in currently known attrs??
+                let mut skip_next_upsert = false;
+                if let Some(Attributes::UpsertWorkflowSearchAttributesEventAttributes(atts)) =
+                    next_event.and_then(|ne| ne.attributes.as_ref())
+                {
+                    if let Some(ref sa) = atts.search_attributes {
+                        skip_next_upsert = sa.indexed_fields.contains_key(VERSION_SEARCH_ATTR_KEY);
+                        dbg!(skip_next_upsert);
+                    }
+                }
+
+                return Ok(EventHandlingOutcome::SkipEvent { skip_next_upsert });
             }
             return Err(WFMachinesError::Nondeterminism(format!(
                 "Non-deprecated patch marker encountered for change {patch_name}, \
@@ -1262,11 +1325,13 @@ fn change_marker_handling(event: &HistoryEvent, mach: &Machines) -> Result<Chang
         // calls take the old path, and deprecated calls assume history is produced by a new-code
         // worker.
         if matches!(mach, Machines::PatchMachine(_)) {
+            // TODO: Do we need this here at all? Is this covered?
+            let skip_next_upsert = false;
             debug!("Skipping non-matching event against patch machine");
-            return Ok(ChangeMarkerOutcome::SkipCommand);
+            return Ok(EventHandlingOutcome::SkipCommand { skip_next_upsert });
         }
     }
-    Ok(ChangeMarkerOutcome::Normal)
+    Ok(EventHandlingOutcome::Normal)
 }
 
 #[derive(derive_more::From)]

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1097,8 +1097,9 @@ impl WorkflowMachines {
                             self.replaying,
                             attrs.deprecated,
                             encountered_entry.is_some(),
+                            self.encountered_change_markers.keys().map(|s| s.as_str()),
                             self.observed_internal_flags.clone(),
-                        );
+                        )?;
                         let mkey =
                             self.add_cmd_to_wf_task(patch_machine, CommandIdKind::NeverResolves);
                         self.process_machine_responses(mkey, other_cmds)?;

--- a/core/src/worker/workflow/managed_run/managed_wf_test.rs
+++ b/core/src/worker/workflow/managed_run/managed_wf_test.rs
@@ -3,6 +3,7 @@ use crate::{
     replay::TestHistoryBuilder,
     test_help::TEST_Q,
     worker::{
+        client::mocks::DEFAULT_TEST_CAPABILITIES,
         workflow::{
             history_update::tests::TestHBExt, machines::WorkflowMachines, WFCommand,
             WorkflowFetcher,
@@ -94,7 +95,7 @@ impl ManagedWFFunc {
                 run_id: "runid".to_string(),
                 history: hist,
                 metrics: MetricsContext::no_op(),
-                capabilities: &Default::default(),
+                capabilities: &DEFAULT_TEST_CAPABILITIES,
             },
             Box::new(driver).into(),
         );

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -428,8 +428,10 @@ impl TestHistoryBuilder {
             "TemporalChangeVersion".to_string(),
             attribs.as_json_payload().unwrap(),
         );
-        let mut attrs = UpsertWorkflowSearchAttributesEventAttributes::default();
-        attrs.search_attributes = Some(SearchAttributes { indexed_fields });
+        let attrs = UpsertWorkflowSearchAttributesEventAttributes {
+            workflow_task_completed_event_id: self.previous_task_completed_id,
+            search_attributes: Some(SearchAttributes { indexed_fields }),
+        };
         self.build_and_push_event(EventType::UpsertWorkflowSearchAttributes, attrs.into())
     }
 

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -422,11 +422,11 @@ impl TestHistoryBuilder {
         self.add(wesattrs);
     }
 
-    pub fn add_upsert_search_attrs_for_patch(&mut self) {
+    pub fn add_upsert_search_attrs_for_patch(&mut self, attribs: &[String]) {
         let mut indexed_fields = HashMap::new();
         indexed_fields.insert(
             "TemporalChangeVersion".to_string(),
-            "yo".as_json_payload().unwrap(),
+            attribs.as_json_payload().unwrap(),
         );
         let mut attrs = UpsertWorkflowSearchAttributesEventAttributes::default();
         attrs.search_attributes = Some(SearchAttributes { indexed_fields });


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* Auto-create an upsert command for the `TemporalChangeVersion` SA upon patched calls
* Warn & don't do that if it would exceed SA size limit
* Nondeterminism checking for upsert calls

## Why?
Parity + Safety

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/492

2. How was this tested:
Added UTs / existing UTs & ITs

3. Any docs updates needed?
We will need lang release notes to mention the determinism changes & the fact that writing/reading the `TemporalChangeVersion` attribute from workflow code is a no-no.
