### PR TITLE
Stop cloning state machines on every transition

### DIFF
--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -723,7 +723,7 @@ fn notify_lang_activity_timed_out(
     attrs: ActivityTaskTimedOutEventAttributes,
 ) -> TransitionResult<ActivityMachine, TimedOut> {
     ActivityMachineTransition::commands(vec![ActivityMachineCommand::Fail(new_timeout_failure(
-        &dat, attrs,
+        dat, attrs,
     ))])
 }
 

--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -111,9 +111,9 @@ impl ActivityMachine {
         attrs: ScheduleActivity,
         internal_flags: InternalFlagsRef,
     ) -> NewMachineWithCommand {
-        let mut s = Self {
-            state: Created {}.into(),
-            shared_state: SharedState {
+        let mut s = Self::from_parts(
+            Created {}.into(),
+            SharedState {
                 cancellation_type: ActivityCancellationType::from_i32(attrs.cancellation_type)
                     .unwrap(),
                 attrs,
@@ -122,7 +122,7 @@ impl ActivityMachine {
                 started_event_id: 0,
                 cancelled_before_sent: false,
             },
-        };
+        );
         OnEventWrapper::on_event_mut(&mut s, ActivityMachineEvents::Schedule)
             .expect("Scheduling activities doesn't fail");
         let command = Command {

--- a/core/src/worker/workflow/machines/cancel_external_state_machine.rs
+++ b/core/src/worker/workflow/machines/cancel_external_state_machine.rs
@@ -3,7 +3,7 @@ use super::{
     OnEventWrapper, WFMachinesAdapter, WFMachinesError,
 };
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, TransitionResult};
+use rustfsm::{fsm, StateMachine, TransitionResult};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::{
@@ -61,10 +61,7 @@ pub(super) fn new_external_cancel(
     only_child: bool,
     reason: String,
 ) -> NewMachineWithCommand {
-    let mut s = CancelExternalMachine {
-        state: Created {}.into(),
-        shared_state: SharedState { seq },
-    };
+    let mut s = CancelExternalMachine::from_parts(Created {}.into(), SharedState { seq });
     OnEventWrapper::on_event_mut(&mut s, CancelExternalMachineEvents::Schedule)
         .expect("Scheduling cancel external wf command doesn't fail");
     let cmd_attrs = command::Attributes::RequestCancelExternalWorkflowExecutionCommandAttributes(

--- a/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
@@ -3,7 +3,7 @@ use super::{
     NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
 };
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, TransitionResult};
+use rustfsm::{fsm, StateMachine, TransitionResult};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::CancelWorkflowExecution,
@@ -34,10 +34,7 @@ pub(super) enum CancelWorkflowMachineError {}
 pub(super) enum CancelWorkflowCommand {}
 
 pub(super) fn cancel_workflow(attribs: CancelWorkflowExecution) -> NewMachineWithCommand {
-    let mut machine = CancelWorkflowMachine {
-        state: Created {}.into(),
-        shared_state: (),
-    };
+    let mut machine = CancelWorkflowMachine::from_parts(Created {}.into(), ());
     OnEventWrapper::on_event_mut(&mut machine, CancelWorkflowMachineEvents::Schedule)
         .expect("Scheduling continue as new machine doesn't fail");
     let command = Command {

--- a/core/src/worker/workflow/machines/child_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/child_workflow_state_machine.rs
@@ -175,7 +175,7 @@ impl StartCommandCreated {
                 )),
                 ..Default::default()
             })),
-            failure_info: failure_info_from_state(&state, RetryState::NonRetryableFailure),
+            failure_info: failure_info_from_state(state, RetryState::NonRetryableFailure),
             ..Default::default()
         })])
     }
@@ -231,7 +231,7 @@ impl Started {
         ChildWorkflowMachineTransition::ok(
             vec![ChildWorkflowCommand::Fail(Failure {
                 message: "Child Workflow execution failed".to_owned(),
-                failure_info: failure_info_from_state(&state, attrs.retry_state()),
+                failure_info: failure_info_from_state(state, attrs.retry_state()),
                 cause: attrs.failure.map(Box::new),
                 ..Default::default()
             })],
@@ -256,7 +256,7 @@ impl Started {
                     )),
                     ..Default::default()
                 })),
-                failure_info: failure_info_from_state(&state, retry_state),
+                failure_info: failure_info_from_state(state, retry_state),
                 ..Default::default()
             })],
             TimedOut::default(),
@@ -279,7 +279,7 @@ impl Started {
                     )),
                     ..Default::default()
                 })),
-                failure_info: failure_info_from_state(&state, RetryState::NonRetryableFailure),
+                failure_info: failure_info_from_state(state, RetryState::NonRetryableFailure),
                 ..Default::default()
             })],
             Terminated::default(),

--- a/core/src/worker/workflow/machines/child_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/child_workflow_state_machine.rs
@@ -6,7 +6,7 @@ use crate::{
     internal_flags::CoreInternalFlags,
     worker::workflow::{machines::HistEventData, InternalFlagsRef},
 };
-use rustfsm::{fsm, MachineError, TransitionResult};
+use rustfsm::{fsm, MachineError, StateMachine, TransitionResult};
 use std::convert::{TryFrom, TryInto};
 use temporal_sdk_core_protos::{
     coresdk::{
@@ -134,7 +134,7 @@ pub(super) struct StartCommandCreated {}
 impl StartCommandCreated {
     pub(super) fn on_start_child_workflow_execution_initiated(
         self,
-        state: SharedState,
+        state: &mut SharedState,
         event_dat: ChildWorkflowInitiatedData,
     ) -> ChildWorkflowMachineTransition<StartEventRecorded> {
         if state.internal_flags.borrow_mut().try_use(
@@ -156,41 +156,28 @@ impl StartCommandCreated {
                 )));
             }
         }
-        ChildWorkflowMachineTransition::ok_shared(
-            vec![],
-            StartEventRecorded::default(),
-            SharedState {
-                initiated_event_id: event_dat.event_id,
-                ..state
-            },
-        )
+        state.initiated_event_id = event_dat.event_id;
+        ChildWorkflowMachineTransition::default()
     }
 
     pub(super) fn on_cancelled(
         self,
-        state: SharedState,
+        state: &mut SharedState,
     ) -> ChildWorkflowMachineTransition<Cancelled> {
-        let state = SharedState {
-            cancelled_before_sent: true,
-            ..state
-        };
-        ChildWorkflowMachineTransition::ok_shared(
-            vec![ChildWorkflowCommand::StartCancel(Failure {
-                message: "Child Workflow execution cancelled before scheduled".to_owned(),
-                cause: Some(Box::new(Failure {
-                    failure_info: Some(FailureInfo::CanceledFailureInfo(
-                        failure::CanceledFailureInfo {
-                            ..Default::default()
-                        },
-                    )),
-                    ..Default::default()
-                })),
-                failure_info: failure_info_from_state(&state, RetryState::NonRetryableFailure),
+        state.cancelled_before_sent = true;
+        ChildWorkflowMachineTransition::commands(vec![ChildWorkflowCommand::StartCancel(Failure {
+            message: "Child Workflow execution cancelled before scheduled".to_owned(),
+            cause: Some(Box::new(Failure {
+                failure_info: Some(FailureInfo::CanceledFailureInfo(
+                    failure::CanceledFailureInfo {
+                        ..Default::default()
+                    },
+                )),
                 ..Default::default()
-            })],
-            Cancelled::default(),
-            state,
-        )
+            })),
+            failure_info: failure_info_from_state(&state, RetryState::NonRetryableFailure),
+            ..Default::default()
+        })])
     }
 }
 
@@ -200,20 +187,14 @@ pub(super) struct StartEventRecorded {}
 impl StartEventRecorded {
     pub(super) fn on_child_workflow_execution_started(
         self,
-        state: SharedState,
+        state: &mut SharedState,
         event: ChildWorkflowExecutionStartedEvent,
     ) -> ChildWorkflowMachineTransition<Started> {
-        ChildWorkflowMachineTransition::ok_shared(
-            vec![ChildWorkflowCommand::Start(
-                event.workflow_execution.clone(),
-            )],
-            Started::default(),
-            SharedState {
-                started_event_id: event.started_event_id,
-                run_id: event.workflow_execution.run_id,
-                ..state
-            },
-        )
+        state.started_event_id = event.started_event_id;
+        state.run_id = event.workflow_execution.run_id;
+        ChildWorkflowMachineTransition::commands(vec![ChildWorkflowCommand::Start(
+            event.workflow_execution.clone(),
+        )])
     }
     pub(super) fn on_start_child_workflow_execution_failed(
         self,
@@ -244,7 +225,7 @@ impl Started {
     }
     fn on_child_workflow_execution_failed(
         self,
-        state: SharedState,
+        state: &mut SharedState,
         attrs: ChildWorkflowExecutionFailedEventAttributes,
     ) -> ChildWorkflowMachineTransition<Failed> {
         ChildWorkflowMachineTransition::ok(
@@ -259,7 +240,7 @@ impl Started {
     }
     fn on_child_workflow_execution_timed_out(
         self,
-        state: SharedState,
+        state: &mut SharedState,
         retry_state: RetryState,
     ) -> ChildWorkflowMachineTransition<TimedOut> {
         ChildWorkflowMachineTransition::ok(
@@ -286,7 +267,7 @@ impl Started {
     }
     fn on_child_workflow_execution_terminated(
         self,
-        state: SharedState,
+        state: &mut SharedState,
     ) -> ChildWorkflowMachineTransition<Terminated> {
         ChildWorkflowMachineTransition::ok(
             vec![ChildWorkflowCommand::Fail(Failure {
@@ -306,7 +287,7 @@ impl Started {
     }
     fn on_cancelled(
         self,
-        state: SharedState,
+        state: &mut SharedState,
     ) -> ChildWorkflowMachineTransition<StartedOrCancelled> {
         let dest = match state.cancel_type {
             ChildWorkflowCancellationType::Abandon | ChildWorkflowCancellationType::TryCancel => {
@@ -349,9 +330,9 @@ impl ChildWorkflowMachine {
         attribs: StartChildWorkflowExecution,
         internal_flags: InternalFlagsRef,
     ) -> NewMachineWithCommand {
-        let mut s = Self {
-            state: Created {}.into(),
-            shared_state: SharedState {
+        let mut s = Self::from_parts(
+            Created {}.into(),
+            SharedState {
                 lang_sequence_number: attribs.seq,
                 workflow_id: attribs.workflow_id.clone(),
                 workflow_type: attribs.workflow_type.clone(),
@@ -363,7 +344,7 @@ impl ChildWorkflowMachine {
                 started_event_id: 0,
                 cancelled_before_sent: false,
             },
-        };
+        );
         OnEventWrapper::on_event_mut(&mut s, ChildWorkflowMachineEvents::Schedule)
             .expect("Scheduling child workflows doesn't fail");
         let cmd = Command {
@@ -897,7 +878,7 @@ mod test {
         ] {
             let mut s = ChildWorkflowMachine {
                 state: state.clone(),
-                shared_state: SharedState {
+                shared_state: &mut SharedState {
                     initiated_event_id: 0,
                     started_event_id: 0,
                     lang_sequence_number: 0,

--- a/core/src/worker/workflow/machines/child_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/child_workflow_state_machine.rs
@@ -191,9 +191,9 @@ impl StartEventRecorded {
         event: ChildWorkflowExecutionStartedEvent,
     ) -> ChildWorkflowMachineTransition<Started> {
         state.started_event_id = event.started_event_id;
-        state.run_id = event.workflow_execution.run_id;
+        state.run_id = event.workflow_execution.run_id.clone();
         ChildWorkflowMachineTransition::commands(vec![ChildWorkflowCommand::Start(
-            event.workflow_execution.clone(),
+            event.workflow_execution,
         )])
     }
     pub(super) fn on_start_child_workflow_execution_failed(
@@ -876,9 +876,9 @@ mod test {
             TimedOut {}.into(),
             Completed {}.into(),
         ] {
-            let mut s = ChildWorkflowMachine {
-                state: state.clone(),
-                shared_state: &mut SharedState {
+            let mut s = ChildWorkflowMachine::from_parts(
+                state.clone(),
+                SharedState {
                     initiated_event_id: 0,
                     started_event_id: 0,
                     lang_sequence_number: 0,
@@ -890,10 +890,10 @@ mod test {
                     cancel_type: Default::default(),
                     internal_flags: Rc::new(RefCell::new(InternalFlags::new(&Default::default()))),
                 },
-            };
+            );
             let cmds = s.cancel().unwrap();
             assert_eq!(cmds.len(), 0);
-            assert_eq!(discriminant(&state), discriminant(&s.state));
+            assert_eq!(discriminant(&state), discriminant(s.state()));
         }
     }
 }

--- a/core/src/worker/workflow/machines/continue_as_new_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/continue_as_new_workflow_state_machine.rs
@@ -3,7 +3,7 @@ use super::{
     WFMachinesAdapter, WFMachinesError,
 };
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, TransitionResult};
+use rustfsm::{fsm, StateMachine, TransitionResult};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::ContinueAsNewWorkflowExecution,
@@ -31,10 +31,7 @@ fsm! {
 pub(super) enum ContinueAsNewWorkflowCommand {}
 
 pub(super) fn continue_as_new(attribs: ContinueAsNewWorkflowExecution) -> NewMachineWithCommand {
-    let mut machine = ContinueAsNewWorkflowMachine {
-        state: Created {}.into(),
-        shared_state: (),
-    };
+    let mut machine = ContinueAsNewWorkflowMachine::from_parts(Created {}.into(), ());
     OnEventWrapper::on_event_mut(&mut machine, ContinueAsNewWorkflowMachineEvents::Schedule)
         .expect("Scheduling continue as new machine doesn't fail");
     let command = Command {

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -522,7 +522,7 @@ impl ResultNotified {
                 shared.attrs.seq
             )));
         }
-        verify_marker_dat!(&shared, &dat, TransitionResult::default())
+        verify_marker_dat!(shared, &dat, TransitionResult::default())
     }
 }
 
@@ -538,7 +538,7 @@ impl WaitingMarkerEvent {
         dat: CompleteLocalActivityData,
     ) -> LocalActivityMachineTransition<MarkerCommandRecorded> {
         verify_marker_dat!(
-            &shared,
+            shared,
             &dat,
             TransitionResult::commands(if self.already_resolved {
                 vec![]
@@ -593,7 +593,7 @@ impl WaitingMarkerEventPreResolved {
         shared: &mut SharedState,
         dat: CompleteLocalActivityData,
     ) -> LocalActivityMachineTransition<MarkerCommandRecorded> {
-        verify_marker_dat!(&shared, &dat, TransitionResult::default())
+        verify_marker_dat!(shared, &dat, TransitionResult::default())
     }
 }
 

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -167,15 +167,15 @@ pub(super) fn new_local_activity(
         .original_schedule_time
         .get_or_insert(SystemTime::now());
 
-    let mut machine = LocalActivityMachine {
-        state: initial_state,
-        shared_state: SharedState {
+    let mut machine = LocalActivityMachine::from_parts(
+        initial_state,
+        SharedState {
             attrs,
             replaying_when_invoked,
             wf_time_when_started: wf_time,
             internal_flags,
         },
-    };
+    );
 
     let mut res = OnEventWrapper::on_event_mut(&mut machine, LocalActivityMachineEvents::Schedule)
         .expect("Scheduling local activities doesn't fail");
@@ -199,13 +199,13 @@ impl LocalActivityMachine {
     ///
     /// Attempting the check in any other state likely means a bug in the SDK.
     pub(super) fn marker_should_get_special_handling(&self) -> Result<bool, WFMachinesError> {
-        match &self.state {
+        match self.state() {
             LocalActivityMachineState::ResultNotified(_) => Ok(false),
             LocalActivityMachineState::WaitingMarkerEvent(_) => Ok(true),
             LocalActivityMachineState::WaitingMarkerEventPreResolved(_) => Ok(true),
             _ => Err(WFMachinesError::Fatal(format!(
                 "Attempted to check for LA marker handling in invalid state {}",
-                self.state
+                self.state()
             ))),
         }
     }
@@ -213,7 +213,10 @@ impl LocalActivityMachine {
     /// Returns true if the machine will willingly accept data from a marker in its current state.
     /// IE: Calling [Self::try_resolve_with_dat] makes sense.
     pub(super) fn will_accept_resolve_marker(&self) -> bool {
-        matches!(self.state, LocalActivityMachineState::WaitingMarkerEvent(_))
+        matches!(
+            self.state(),
+            LocalActivityMachineState::WaitingMarkerEvent(_)
+        )
     }
 
     /// Must be called if the workflow encounters a non-replay workflow task
@@ -351,7 +354,7 @@ pub(super) struct Executing {}
 impl Executing {
     pub(super) fn on_schedule(
         self,
-        dat: SharedState,
+        dat: &mut SharedState,
     ) -> LocalActivityMachineTransition<RequestSent> {
         TransitionResult::commands([LocalActivityCommand::RequestActivityExecution(dat.attrs)])
     }
@@ -463,7 +466,7 @@ impl RequestSent {
 
     fn on_no_wait_cancel(
         self,
-        shared: SharedState,
+        shared: &mut SharedState,
         cancel_type: ActivityCancellationType,
     ) -> LocalActivityMachineTransition<MarkerCommandCreated> {
         let mut cmds = vec![];
@@ -502,7 +505,7 @@ pub(super) struct ResultNotified {
 impl ResultNotified {
     pub(super) fn on_marker_recorded(
         self,
-        shared: SharedState,
+        shared: &mut SharedState,
         dat: CompleteLocalActivityData,
     ) -> LocalActivityMachineTransition<MarkerCommandRecorded> {
         if self.result_type == ResultType::Completed && dat.result.is_err() {
@@ -529,7 +532,7 @@ pub(super) struct WaitingMarkerEvent {
 impl WaitingMarkerEvent {
     pub(super) fn on_marker_recorded(
         self,
-        shared: SharedState,
+        shared: &mut SharedState,
         dat: CompleteLocalActivityData,
     ) -> LocalActivityMachineTransition<MarkerCommandRecorded> {
         verify_marker_dat!(
@@ -555,17 +558,13 @@ impl WaitingMarkerEvent {
     }
     pub(super) fn on_started_non_replay_wft(
         self,
-        mut dat: SharedState,
+        dat: &mut SharedState,
     ) -> LocalActivityMachineTransition<RequestSent> {
         // We aren't really "replaying" anymore for our purposes, and want to record the marker.
         dat.replaying_when_invoked = false;
-        TransitionResult::ok_shared(
-            [LocalActivityCommand::RequestActivityExecution(
-                dat.attrs.clone(),
-            )],
-            RequestSent::default(),
-            dat,
-        )
+        TransitionResult::commands([LocalActivityCommand::RequestActivityExecution(
+            dat.attrs.clone(),
+        )])
     }
 
     fn on_cancel_requested(self) -> LocalActivityMachineTransition<WaitingMarkerEvent> {
@@ -589,7 +588,7 @@ pub(super) struct WaitingMarkerEventPreResolved {}
 impl WaitingMarkerEventPreResolved {
     pub(super) fn on_marker_recorded(
         self,
-        shared: SharedState,
+        shared: &mut SharedState,
         dat: CompleteLocalActivityData,
     ) -> LocalActivityMachineTransition<MarkerCommandRecorded> {
         verify_marker_dat!(&shared, &dat, TransitionResult::default())

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -356,7 +356,9 @@ impl Executing {
         self,
         dat: &mut SharedState,
     ) -> LocalActivityMachineTransition<RequestSent> {
-        TransitionResult::commands([LocalActivityCommand::RequestActivityExecution(dat.attrs)])
+        TransitionResult::commands([LocalActivityCommand::RequestActivityExecution(
+            dat.attrs.clone(),
+        )])
     }
 }
 

--- a/core/src/worker/workflow/machines/mod.rs
+++ b/core/src/worker/workflow/machines/mod.rs
@@ -278,7 +278,7 @@ trait Cancellable: StateMachine {
     }
 }
 
-/// We need to wrap calls to [StateMachine::on_event_mut] to track coverage, or anything else
+/// We need to wrap calls to [StateMachine::on_event] to track coverage, or anything else
 /// we'd like to do on every call.
 pub(crate) trait OnEventWrapper: StateMachine
 where
@@ -295,7 +295,7 @@ where
         #[cfg(test)]
         let converted_event_str = event.to_string();
 
-        let res = StateMachine::on_event_mut(self, event);
+        let res = StateMachine::on_event(self, event);
         if res.is_ok() {
             #[cfg(test)]
             add_coverage(

--- a/core/src/worker/workflow/machines/modify_workflow_properties_state_machine.rs
+++ b/core/src/worker/workflow/machines/modify_workflow_properties_state_machine.rs
@@ -3,7 +3,7 @@ use crate::worker::workflow::{
     machines::{Cancellable, EventInfo, HistEventData, WFMachinesAdapter},
     WFMachinesError,
 };
-use rustfsm::{fsm, TransitionResult};
+use rustfsm::{fsm, StateMachine, TransitionResult};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::ModifyWorkflowProperties,
     temporal::api::{
@@ -28,10 +28,7 @@ fsm! {
 pub(super) fn modify_workflow_properties(
     lang_cmd: ModifyWorkflowProperties,
 ) -> NewMachineWithCommand {
-    let sm = ModifyWorkflowPropertiesMachine {
-        state: Created {}.into(),
-        shared_state: (),
-    };
+    let sm = ModifyWorkflowPropertiesMachine::from_parts(Created {}.into(), ());
     let cmd = Command {
         command_type: CommandType::ModifyWorkflowProperties as i32,
         attributes: Some(lang_cmd.into()),

--- a/core/src/worker/workflow/machines/signal_external_state_machine.rs
+++ b/core/src/worker/workflow/machines/signal_external_state_machine.rs
@@ -425,13 +425,10 @@ mod tests {
             SignalExternalMachineState::Cancelled(Cancelled {}),
             Signaled {}.into(),
         ] {
-            let mut s = SignalExternalMachine {
-                state: state.clone(),
-                shared_state: Default::default(),
-            };
+            let mut s = SignalExternalMachine::from_parts(state.clone(), Default::default());
             let cmds = s.cancel().unwrap();
             assert_eq!(cmds.len(), 0);
-            assert_eq!(discriminant(&state), discriminant(&s.state));
+            assert_eq!(discriminant(&state), discriminant(s.state()));
         }
     }
 }

--- a/core/src/worker/workflow/machines/timer_state_machine.rs
+++ b/core/src/worker/workflow/machines/timer_state_machine.rs
@@ -417,13 +417,10 @@ mod test {
     #[test]
     fn cancels_ignored_terminal() {
         for state in [TimerMachineState::Canceled(Canceled {}), Fired {}.into()] {
-            let mut s = TimerMachine {
-                state: state.clone(),
-                shared_state: Default::default(),
-            };
+            let mut s = TimerMachine::from_parts(state.clone(), Default::default());
             let cmds = s.cancel().unwrap();
             assert_eq!(cmds.len(), 0);
-            assert_eq!(discriminant(&state), discriminant(&s.state));
+            assert_eq!(discriminant(&state), discriminant(s.state()));
         }
     }
 }

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -318,14 +318,14 @@ mod tests {
 
     #[rstest::rstest]
     fn upsert_search_attrs_sm(#[values(true, false)] nondetermistic: bool) {
-        let mut sm = UpsertSearchAttributesMachine {
-            state: Created {}.into(),
-            shared_state: &mut SharedState {
+        let mut sm = UpsertSearchAttributesMachine::from_parts(
+            Created {}.into(),
+            SharedState {
                 sa_map: Default::default(),
                 should_skip_determinism: false,
                 internal_flags: Rc::new(RefCell::new(InternalFlags::all_core_enabled())),
             },
-        };
+        );
 
         let sa_attribs = if nondetermistic {
             UpsertWorkflowSearchAttributesEventAttributes {

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -9,7 +9,7 @@ use crate::{
         InternalFlagsRef, WFMachinesError,
     },
 };
-use rustfsm::{fsm, TransitionResult};
+use rustfsm::{fsm, StateMachine, TransitionResult};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::UpsertWorkflowSearchAttributes,
     temporal::api::{
@@ -85,14 +85,14 @@ fn create_new(
     should_skip_determinism: bool,
     internal_flags: InternalFlagsRef,
 ) -> NewMachineWithCommand {
-    let sm = UpsertSearchAttributesMachine {
-        state: Created {}.into(),
-        shared_state: SharedState {
+    let sm = UpsertSearchAttributesMachine::from_parts(
+        Created {}.into(),
+        SharedState {
             sa_map: sa_map.clone(),
             should_skip_determinism,
             internal_flags,
         },
-    };
+    );
     let cmd = Command {
         command_type: CommandType::UpsertWorkflowSearchAttributes as i32,
         attributes: Some(
@@ -139,7 +139,7 @@ pub(super) struct CmdRecDat {
 impl CommandIssued {
     pub(super) fn on_command_recorded(
         self,
-        shared: SharedState,
+        shared: &mut SharedState,
         dat: CmdRecDat,
     ) -> UpsertSearchAttributesMachineTransition<Done> {
         if shared.internal_flags.borrow_mut().try_use(
@@ -320,7 +320,7 @@ mod tests {
     fn upsert_search_attrs_sm(#[values(true, false)] nondetermistic: bool) {
         let mut sm = UpsertSearchAttributesMachine {
             state: Created {}.into(),
-            shared_state: SharedState {
+            shared_state: &mut SharedState {
                 sa_map: Default::default(),
                 should_skip_determinism: false,
                 internal_flags: Rc::new(RefCell::new(InternalFlags::all_core_enabled())),

--- a/core/src/worker/workflow/machines/workflow_task_state_machine.rs
+++ b/core/src/worker/workflow/machines/workflow_task_state_machine.rs
@@ -4,7 +4,7 @@ use super::{
     workflow_machines::MachineResponse, Cancellable, EventInfo, WFMachinesAdapter, WFMachinesError,
 };
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, TransitionResult};
+use rustfsm::{fsm, StateMachine, TransitionResult};
 use std::{
     convert::{TryFrom, TryInto},
     time::SystemTime,
@@ -32,12 +32,12 @@ fsm! {
 
 impl WorkflowTaskMachine {
     pub(super) fn new(wf_task_started_event_id: i64) -> Self {
-        Self {
-            state: Created {}.into(),
-            shared_state: SharedState {
+        Self::from_parts(
+            Created {}.into(),
+            SharedState {
                 wf_task_started_event_id,
             },
-        }
+        )
     }
 }
 
@@ -201,7 +201,7 @@ pub(super) struct WFTFailedDat {
 impl Scheduled {
     pub(super) fn on_workflow_task_started(
         self,
-        shared: SharedState,
+        shared: &mut SharedState,
         WFTStartedDat {
             current_time_millis,
             started_event_id,

--- a/fsm/rustfsm_procmacro/src/lib.rs
+++ b/fsm/rustfsm_procmacro/src/lib.rs
@@ -471,7 +471,7 @@ impl StateMachineDefinition {
                             Fields::Unnamed(_) => {
                                 let arglist = if ts.mutates_shared {
                                     // TODO: should be &mut (or & and & mut) w/ keyword
-                                    quote! {self.shared_state, val}
+                                    quote! {&mut self.shared_state, val}
                                 } else {
                                     quote! {val}
                                 };
@@ -484,7 +484,7 @@ impl StateMachineDefinition {
                             }
                             Fields::Unit => {
                                 let arglist = if ts.mutates_shared {
-                                    quote! {self.shared_state}
+                                    quote! {&mut self.shared_state}
                                 } else {
                                     quote! {}
                                 };

--- a/fsm/rustfsm_trait/src/lib.rs
+++ b/fsm/rustfsm_trait/src/lib.rs
@@ -190,20 +190,15 @@ where
         }
     }
 
-    /// Updates the passed in state to be the new state, returning commands or error
-    pub fn into_cmd_result(
-        self,
-        write_state: &mut Sm::State,
-    ) -> Result<Vec<Sm::Command>, MachineError<Sm::Error>> {
+    /// Transforms the transition result into a machine-ready outcome with commands and new state,
+    /// or a [MachineError]
+    pub fn into_cmd_result(self) -> Result<(Vec<Sm::Command>, Sm::State), MachineError<Sm::Error>> {
         let general = self.into_general();
         match general {
             TransitionResult::Ok {
                 new_state,
                 commands,
-            } => {
-                *write_state = new_state;
-                Ok(commands)
-            }
+            } => Ok((commands, new_state)),
             TransitionResult::InvalidTransition => Err(MachineError::InvalidTransition),
             TransitionResult::Err(e) => Err(MachineError::Underlying(e)),
         }

--- a/fsm/rustfsm_trait/src/lib.rs
+++ b/fsm/rustfsm_trait/src/lib.rs
@@ -19,45 +19,12 @@ pub trait StateMachine: Sized {
     /// The type used to represent commands the machine issues upon transitions.
     type Command;
 
-    /// Handle an incoming event, returning a transition result which represents updates to apply
-    /// to the state machine.
-    fn on_event(self, event: Self::Event) -> TransitionResult<Self, Self::State>;
-
-    /// Handle an incoming event and mutate the state machine to update to the new state and apply
-    /// any changes to shared state.
-    ///
-    /// Returns the commands issued by the transition on success, otherwise a [MachineError]
-    fn on_event_mut(
+    /// Handle an incoming event, returning any new commands or an error. Implementations may
+    /// mutate current state, possibly moving to a new state.
+    fn on_event(
         &mut self,
         event: Self::Event,
-    ) -> Result<Vec<Self::Command>, MachineError<Self::Error>>
-    where
-        Self: Clone,
-    {
-        // TODO: Get rid of this clone. It's pointless.
-        // NOTE: This clone is actually nice in some sense, giving us a kind of transactionality.
-        //   However if there are really big things in state it could be an issue.
-        let res = self.clone().on_event(event);
-        match res {
-            TransitionResult::Ok {
-                commands,
-                new_state,
-                shared_state,
-            } => {
-                *self = Self::from_parts(shared_state, new_state);
-                Ok(commands)
-            }
-            TransitionResult::OkNoShare {
-                commands,
-                new_state,
-            } => {
-                self.set_state(new_state);
-                Ok(commands)
-            }
-            TransitionResult::InvalidTransition => Err(MachineError::InvalidTransition),
-            TransitionResult::Err(e) => Err(MachineError::Underlying(e)),
-        }
-    }
+    ) -> Result<Vec<Self::Command>, MachineError<Self::Error>>;
 
     fn name(&self) -> &str;
 
@@ -72,7 +39,7 @@ pub trait StateMachine: Sized {
     fn has_reached_final_state(&self) -> bool;
 
     /// Given the shared data and new state, create a new instance.
-    fn from_parts(shared: Self::SharedState, state: Self::State) -> Self;
+    fn from_parts(state: Self::State, shared: Self::SharedState) -> Self;
 
     /// Return a PlantUML definition of the fsm that can be used to visualize it
     fn visualizer() -> &'static str;
@@ -137,12 +104,6 @@ where
     Ok {
         commands: Vec<Machine::Command>,
         new_state: DestinationState,
-        shared_state: Machine::SharedState,
-    },
-    /// The transition was successful with no shared state change
-    OkNoShare {
-        commands: Vec<Machine::Command>,
-        new_state: DestinationState,
     },
     /// There was some error performing the transition
     Err(Machine::Error),
@@ -159,23 +120,9 @@ where
     where
         CI: IntoIterator<Item = Sm::Command>,
     {
-        Self::OkNoShare {
-            commands: commands.into_iter().collect(),
-            new_state,
-        }
-    }
-
-    /// Produce a transition with the provided commands to the provided state with shared state
-    /// changes
-    pub fn ok_shared<CI, SS>(commands: CI, new_state: Ds, new_shared: SS) -> Self
-    where
-        CI: IntoIterator<Item = Sm::Command>,
-        SS: Into<Sm::SharedState>,
-    {
         Self::Ok {
             commands: commands.into_iter().collect(),
             new_state,
-            shared_state: new_shared.into(),
         }
     }
 
@@ -186,7 +133,7 @@ where
         CurrentState: Into<Ds>,
     {
         let as_dest: Ds = current_state.into();
-        Self::OkNoShare {
+        Self::Ok {
             commands: vec![],
             new_state: as_dest,
         }
@@ -203,7 +150,7 @@ where
     where
         CI: IntoIterator<Item = Sm::Command>,
     {
-        Self::OkNoShare {
+        Self::Ok {
             commands: commands.into_iter().collect(),
             new_state: Ds::default(),
         }
@@ -216,7 +163,7 @@ where
     Ds: Into<Sm::State> + Default,
 {
     fn default() -> Self {
-        Self::OkNoShare {
+        Self::Ok {
             commands: vec![],
             new_state: Ds::default(),
         }
@@ -235,20 +182,30 @@ where
             TransitionResult::Ok {
                 commands,
                 new_state,
-                shared_state,
             } => TransitionResult::Ok {
-                commands,
-                new_state: new_state.into(),
-                shared_state,
-            },
-            TransitionResult::OkNoShare {
-                commands,
-                new_state,
-            } => TransitionResult::OkNoShare {
                 commands,
                 new_state: new_state.into(),
             },
             TransitionResult::Err(e) => TransitionResult::Err(e),
+        }
+    }
+
+    /// Updates the passed in state to be the new state, returning commands or error
+    pub fn into_cmd_result(
+        self,
+        write_state: &mut Sm::State,
+    ) -> Result<Vec<Sm::Command>, MachineError<Sm::Error>> {
+        let general = self.into_general();
+        match general {
+            TransitionResult::Ok {
+                new_state,
+                commands,
+            } => {
+                *write_state = new_state;
+                Ok(commands)
+            }
+            TransitionResult::InvalidTransition => Err(MachineError::InvalidTransition),
+            TransitionResult::Err(e) => Err(MachineError::Underlying(e)),
         }
     }
 }

--- a/fsm/rustfsm_trait/src/lib.rs
+++ b/fsm/rustfsm_trait/src/lib.rs
@@ -192,6 +192,7 @@ where
 
     /// Transforms the transition result into a machine-ready outcome with commands and new state,
     /// or a [MachineError]
+    #[allow(clippy::type_complexity)]
     pub fn into_cmd_result(self) -> Result<(Vec<Sm::Command>, Sm::State), MachineError<Sm::Error>> {
         let general = self.into_general();
         match general {


### PR DESCRIPTION
This had just been bugging me for a while. Needless copying going on. Will improve perf, probably not by much, but in some pathological cases it could make a real difference.

Side bonus, ended up with less code.