### PR TITLE
Remove setter(strip_option) for graceful_shutdown_period worker option

### DIFF
--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -121,7 +121,7 @@ pub struct WorkerConfig {
 
     /// If set, core will issue cancels for all outstanding activities after shutdown has been
     /// initiated and this amount of time has elapsed.
-    #[builder(setter(strip_option), default)]
+    #[builder(default)]
     pub graceful_shutdown_period: Option<Duration>,
 }
 


### PR DESCRIPTION
More convenient to use from lang since we don't need to conditionally set the option.