### PR TITLE
Fix flag lookahead in next workflow task completion

### DIFF
--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -426,7 +426,10 @@ impl WorkflowMachines {
         // Update observed patches with any that were used in the task
         if let Some(next_complete) = self
             .last_history_from_server
-            .peek_next_wft_completed(self.last_processed_event)
+            // Our last_processed event is always a WorkflowTaskStarted, we don't care about
+            // internal flags in the current workflow task since we already know about those.
+            // Peek past the WorkflowTaskCompleted event for the current workflow task.
+            .peek_next_wft_completed(self.last_processed_event + 2)
         {
             (*self.observed_internal_flags)
                 .borrow_mut()

--- a/tests/integ_tests/workflow_tests/patches.rs
+++ b/tests/integ_tests/workflow_tests/patches.rs
@@ -2,8 +2,13 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
+use temporal_client::WorkflowClientTrait;
+use tokio_util::sync::CancellationToken;
 
 use temporal_sdk::{WfContext, WorkflowResult};
+use temporal_sdk_core_protos::coresdk::workflow_commands::SetPatchMarker;
+use temporal_sdk_core_protos::coresdk::workflow_completion::WorkflowActivationCompletion;
+use temporal_sdk_core_protos::temporal::api::query::v1::WorkflowQuery;
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
 const MY_PATCH_ID: &str = "integ_test_change_name";
@@ -89,4 +94,67 @@ async fn replaying_with_patch_marker() {
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
+}
+
+#[tokio::test]
+async fn query_replay_with_patch_marker_is_deterministic() {
+    let mut starter = CoreWfStarter::new("patch_and_wait");
+    starter.max_cached_workflows(0).no_remote_activities();
+    let worker = starter.get_worker().await;
+    let client = starter.get_client().await;
+
+    let run_id = starter.start_wf().await;
+    let token = CancellationToken::new();
+    let token_clone = token.clone();
+
+    let query_future = async {
+        token.cancelled().await;
+        client
+            .query_workflow_execution(
+                starter.get_wf_id().to_owned(),
+                run_id,
+                WorkflowQuery {
+                    query_type: "irrelevant".to_owned(),
+                    query_args: None,
+                    header: None,
+                },
+            )
+            .await
+            .unwrap();
+    };
+
+    let poll_future = async {
+        // First task is replayed
+        for _ in 0..2 {
+            // 1st iteration: StartWorkflow
+            // 2nd iteration (replay): StartWorkflow, NotifyHasPatch
+            let activation = worker.poll_workflow_activation().await.unwrap();
+            println!("p1 {}", activation);
+            let response = vec![SetPatchMarker {
+                patch_id: "test".to_string(),
+                deprecated: false,
+            }
+            .into()];
+            worker
+                .complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+                    activation.run_id,
+                    response.clone(),
+                ))
+                .await
+                .unwrap();
+            // 1st iteration: RemoveFromCache
+            // 2nd iteration (replay): QueryWorkflow
+            let activation = worker.poll_workflow_activation().await.unwrap();
+            println!("p2 {}", activation);
+            worker
+                .complete_workflow_activation(WorkflowActivationCompletion::empty(
+                    activation.run_id,
+                ))
+                .await
+                .unwrap();
+            token_clone.cancel();
+        }
+    };
+
+    tokio::join!(query_future, poll_future);
 }


### PR DESCRIPTION
Found and fixed an NDE with patches during replay with latest server in the TS SDK integration tests.

https://github.com/temporalio/sdk-typescript/actions/runs/4349517127/jobs/7599273593#step:13:11327