### PR TITLE
Ensure LA tasks can be delivered during shutdown

### DIFF
--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -830,7 +830,7 @@ async fn activity_tasks_from_completion_are_delivered() {
         .unwrap();
     }
 
-    core.drain_activity_poller_and_shutdown().await;
+    core.drain_pollers_and_shutdown().await;
 
     // Verify only a single eager activity was scheduled (the one on our worker's task queue)
     assert_eq!(num_eager_requested.load(Ordering::Relaxed), 3);

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -1051,7 +1051,7 @@ async fn local_act_records_nonfirst_attempts_ok() {
 }
 
 #[tokio::test]
-async fn las_can_be_delivered_during_shutdown() {
+async fn local_activities_can_be_delivered_during_shutdown() {
     let wfid = "fake_wf_id";
     let mut t = TestHistoryBuilder::default();
     t.add_wfe_started_with_wft_timeout(Duration::from_millis(200));

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -594,8 +594,8 @@ impl LocalActivityManager {
         }
     }
 
-    /// Try to close the activity stream as soon as worker shutdown is initiated.
-    /// This is required for activity-only workers where since workflows are not polled and the activity poller might
+    /// Try to close the activity stream as soon as worker shutdown is initiated. This is required
+    /// for activity-only workers where since workflows are not polled and the activity poller might
     /// get "stuck".
     pub(crate) fn shutdown_initiated(&self) {
         self.set_shutdown_complete_if_ready(&mut self.dat.lock());
@@ -613,7 +613,7 @@ impl LocalActivityManager {
 
     fn set_shutdown_complete_if_ready(&self, dlock: &mut MutexGuard<LAMData>) -> bool {
         let nothing_outstanding = dlock.outstanding_activity_tasks.is_empty();
-        if nothing_outstanding {
+        if nothing_outstanding && self.workflows_have_shut_down.is_cancelled() {
             self.shutdown_complete_tok.cancel();
         }
         nothing_outstanding


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix shutting down the LA manager a bit too early. Now we wait for workflows to shutdown first.

## Why?
If you completed a task with a new LA request, that would all just get dropped, now it doesn't.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
