### PR TITLE
Add support for metrics over UDS

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -62,6 +62,7 @@ tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "
 tokio-util = { version = "0.7", features = ["io", "io-util"] }
 tokio-stream = "0.1"
 tonic = { version = "0.8", features = ["tls", "tls-roots"] }
+tower = { version="0.4.13" }
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.18"

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -254,7 +254,7 @@ pub fn telemetry_init(opts: TelemetryOptions) -> Result<TelemetryInstance, anyho
                                 UnixStream::connect(path.to_owned())
                             }))
                             .await?;
-                        exporter.with_channel(channel.to_owned())
+                        exporter.with_channel(channel)
                     } else {
                         exporter.with_endpoint(url.to_string())
                     };

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -240,9 +240,10 @@ pub fn telemetry_init(opts: TelemetryOptions) -> Result<TelemetryInstance, anyho
                     metric_periodicity,
                 }) => runtime.block_on(async {
                     let exporter = if url.scheme() == "unix" {
-                        let channel = Endpoint::try_from(url.as_str().to_owned())?
-                            .connect_with_connector(tower::service_fn(|url: Uri| {
-                                UnixStream::connect(url.path().to_owned())
+                        let path = url.path().to_owned();
+                        let channel = Endpoint::try_from("http://[::]:50051")?
+                            .connect_with_connector(tower::service_fn(move |_: Uri| {
+                                UnixStream::connect(path.to_owned())
                             }))
                             .await?;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->
Disclaimer:
I'm not a Rust developer and this draft is more of a proposal to check for two things:
1. Would this be valuable for the sdk-core? We are trying to use sockets in our organization and already do it for DogStatsd. Using TCP would require doing so at an org level.
2. Whether this is a sound implementation. It looks fairly reliable logic-wise but it does add one more code branch. Maybe there's a better way to do this more easily.

I also only focused on metrics because that's what we care about.

## What was changed
Handle 'unix' schema for metrics

## Why?
Currently, sdk-core only supports grpc over tcp while some collectors allow UDS usage.
Sadly `tonic` does not support connecting to `unix` schema natively.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

4. How was this tested:
Testing in progress (no longer getting invalid schema but have to verify metrics still reach destination)

5. Any docs updates needed?
No
