### PR TITLE
Fix possible incorrect history length value

### DIFF
--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.68
 RUN rustup component add rustfmt && \
 	rustup component add clippy
 
-RUN cargo install cargo-tarpaulin
+# RUN cargo install cargo-tarpaulin
 RUN apt-get update && apt-get install -y protobuf-compiler
 
 WORKDIR /sdk-core

--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65
+FROM rust:1.68
 
 RUN rustup component add rustfmt && \
 	rustup component add clippy

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "cargo tarpaulin --out Html --workspace && cargo test -- --include-ignored"
+    command: "cargo tarpaulin --out Html --workspace --engine llvm && cargo test -- --include-ignored"
     artifact_paths:
       - "tarpaulin-report.html"
       - "machine_coverage/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "cargo tarpaulin --out Html --workspace --engine llvm && cargo test -- --include-ignored"
+    command: "cargo test -- --include-ignored"
     artifact_paths:
       - "tarpaulin-report.html"
       - "machine_coverage/*"

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -21,6 +21,7 @@ use std::{
     },
     time::Duration,
 };
+use temporal_client::WorkflowOptions;
 use temporal_sdk::{ActivityOptions, CancellableFuture, WfContext};
 use temporal_sdk_core_api::{errors::PollWfError, Worker as WorkerTrait};
 use temporal_sdk_core_protos::{
@@ -2536,4 +2537,59 @@ async fn jobs_are_in_appropriate_order() {
         act.jobs[2].variant.as_ref().unwrap(),
         workflow_activation_job::Variant::FireTimer(_)
     );
+}
+
+#[rstest]
+#[tokio::test]
+async fn history_length_with_fail_and_timeout(
+    #[values(true, false)] use_cache: bool,
+    #[values(vec![ResponseType::AllHistory],
+             vec![
+                 ResponseType::ToTaskNum(1),
+                 ResponseType::ToTaskNum(2),
+                 ResponseType::AllHistory,
+             ],
+    )]
+    history_responses: Vec<ResponseType>,
+) {
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
+    t.add_timer_fired(timer_started_event_id, "1".to_string());
+    t.add_workflow_task_scheduled_and_started();
+    t.add_workflow_task_failed_with_failure(WorkflowTaskFailedCause::Unspecified, "ahh".into());
+    t.add_workflow_task_scheduled_and_started();
+    t.add_workflow_task_timed_out();
+    t.add_full_wf_task();
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
+    t.add_timer_fired(timer_started_event_id, "2".to_string());
+    t.add_full_wf_task();
+    t.add_workflow_execution_completed();
+
+    let mh =
+        MockPollCfg::from_resp_batches("fake_wf_id", t, history_responses, mock_workflow_client());
+    let mut worker = mock_sdk_cfg(mh, |wc| {
+        if use_cache {
+            wc.max_cached_workflows = 1
+        }
+    });
+    worker.register_wf(DEFAULT_WORKFLOW_TYPE, |ctx: WfContext| async move {
+        assert_eq!(ctx.history_length(), 3);
+        ctx.timer(Duration::from_secs(1)).await;
+        assert_eq!(ctx.history_length(), 14);
+        ctx.timer(Duration::from_secs(1)).await;
+        assert_eq!(ctx.history_length(), 19);
+        Ok(().into())
+    });
+    worker
+        .submit_wf(
+            "fake_wf_id".to_owned(),
+            DEFAULT_WORKFLOW_TYPE.to_owned(),
+            vec![],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
 }

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2545,13 +2545,14 @@ async fn history_length_with_fail_and_timeout(
     #[values(true, false)] use_cache: bool,
     #[values(vec![ResponseType::AllHistory],
              vec![
-                 ResponseType::ToTaskNum(1),
-                 ResponseType::ToTaskNum(2),
-                 ResponseType::AllHistory,
+                ResponseType::ToTaskNum(1),
+                ResponseType::ToTaskNum(2),
+                ResponseType::AllHistory,
              ],
     )]
     history_responses: Vec<ResponseType>,
 ) {
+    let wfid = "fake_wf_id";
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
@@ -2567,8 +2568,7 @@ async fn history_length_with_fail_and_timeout(
     t.add_full_wf_task();
     t.add_workflow_execution_completed();
 
-    let mh =
-        MockPollCfg::from_resp_batches("fake_wf_id", t, history_responses, mock_workflow_client());
+    let mh = MockPollCfg::from_resp_batches(wfid, t, history_responses, mock_workflow_client());
     let mut worker = mock_sdk_cfg(mh, |wc| {
         if use_cache {
             wc.max_cached_workflows = 1
@@ -2584,7 +2584,74 @@ async fn history_length_with_fail_and_timeout(
     });
     worker
         .submit_wf(
-            "fake_wf_id".to_owned(),
+            wfid.to_owned(),
+            DEFAULT_WORKFLOW_TYPE.to_owned(),
+            vec![],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn history_length_with_empty_page_fail_and_timeout(#[values(true, false)] use_cache: bool) {
+    crate::telemetry::test_telem_console();
+    let wfid = "fake_wf_id";
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
+    t.add_timer_fired(timer_started_event_id, "1".to_string());
+    t.add_workflow_task_scheduled_and_started();
+    t.add_workflow_task_failed_with_failure(WorkflowTaskFailedCause::Unspecified, "ahh".into());
+    t.add_workflow_task_scheduled_and_started();
+    t.add_workflow_task_timed_out();
+    t.add_full_wf_task();
+    let timer_started_event_id = t.add_by_type(EventType::TimerStarted);
+    t.add_timer_fired(timer_started_event_id, "2".to_string());
+    t.add_full_wf_task();
+    t.add_workflow_execution_completed();
+
+    let mut mock_client = mock_workflow_client();
+    let mut needs_fetch = hist_to_poll_resp(&t, wfid, ResponseType::ToTaskNum(2)).resp;
+    needs_fetch.next_page_token = vec![1];
+    // Truncate the history a bit
+    needs_fetch.history.as_mut().unwrap().events.truncate(6);
+    let needs_fetch_resp = ResponseType::Raw(needs_fetch);
+    let mut empty_fetch_resp: GetWorkflowExecutionHistoryResponse =
+        t.get_history_info(1).unwrap().into();
+    empty_fetch_resp.history.as_mut().unwrap().events = vec![];
+    mock_client
+        .expect_get_workflow_execution_history()
+        .returning(move |_, _, _| Ok(empty_fetch_resp.clone()))
+        .times(1);
+    let history_responses = [
+        ResponseType::ToTaskNum(1),
+        needs_fetch_resp,
+        ResponseType::ToTaskNum(2),
+        ResponseType::AllHistory,
+    ];
+
+    let mut mh = MockPollCfg::from_resp_batches(wfid, t, history_responses, mock_client);
+    mh.num_expected_fails = 1;
+    let mut worker = mock_sdk_cfg(mh, |wc| {
+        if use_cache {
+            wc.max_cached_workflows = 1
+        }
+    });
+    worker.register_wf(DEFAULT_WORKFLOW_TYPE, |ctx: WfContext| async move {
+        assert_eq!(ctx.history_length(), 3);
+        ctx.timer(Duration::from_secs(1)).await;
+        assert_eq!(ctx.history_length(), 14);
+        ctx.timer(Duration::from_secs(1)).await;
+        assert_eq!(ctx.history_length(), 19);
+        Ok(().into())
+    });
+    worker
+        .submit_wf(
+            wfid.to_owned(),
             DEFAULT_WORKFLOW_TYPE.to_owned(),
             vec![],
             WorkflowOptions::default(),

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -25,9 +25,9 @@ use tracing::Instrument;
 
 lazy_static::lazy_static! {
     static ref EMPTY_FETCH_ERR: tonic::Status
-        = tonic::Status::data_loss("Fetched empty history page");
+        = tonic::Status::unknown("Fetched empty history page");
     static ref EMPTY_TASK_ERR: tonic::Status
-        = tonic::Status::data_loss("Received an empty workflow task with no queries or history");
+        = tonic::Status::unknown("Received an empty workflow task with no queries or history");
 }
 
 /// Represents one or more complete WFT sequences. History events are expected to be consumed from
@@ -1120,7 +1120,7 @@ pub mod tests {
             Arc::new(mock_client),
         );
         let err = paginator.extract_next_update().await.unwrap_err();
-        assert_matches!(err.code(), tonic::Code::DataLoss);
+        assert_matches!(err.code(), tonic::Code::Unknown);
     }
 
     #[tokio::test]

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -42,6 +42,9 @@ pub struct HistoryUpdate {
     /// extracted from. Hence, while processing multiple logical WFTs during replay which were part
     /// of one large history fetched from server, multiple updates may have the same value here.
     pub previous_wft_started_id: i64,
+    /// The `started_event_id` field from the WFT which this update is tied to. Multiple updates
+    /// may have the same value if they're associated with the same WFT.
+    pub wft_started_id: i64,
     /// True if this update contains the final WFT in history, and no more attempts to extract
     /// additional updates should be made.
     has_last_wft: bool,
@@ -80,6 +83,7 @@ pub struct HistoryPaginator {
     pub(crate) wf_id: String,
     pub(crate) run_id: String,
     pub(crate) previous_wft_started_id: i64,
+    pub(crate) wft_started_event_id: i64,
 
     #[cfg_attr(feature = "save_wf_inputs", serde(skip))]
     client: Arc<dyn WorkerClient>,
@@ -130,6 +134,7 @@ impl HistoryPaginator {
         let mut paginator = HistoryPaginator::new(
             wft.history,
             wft.previous_started_event_id,
+            wft.started_event_id,
             wft.workflow_execution.workflow_id.clone(),
             wft.workflow_execution.run_id.clone(),
             npt,
@@ -139,7 +144,13 @@ impl HistoryPaginator {
             return Err(EMPTY_TASK_ERR.clone());
         }
         let update = if empty_hist {
-            HistoryUpdate::from_events([], wft.previous_started_event_id, true).0
+            HistoryUpdate::from_events(
+                [],
+                wft.previous_started_event_id,
+                wft.started_event_id,
+                true,
+            )
+            .0
         } else {
             paginator.extract_next_update().await?
         };
@@ -163,6 +174,7 @@ impl HistoryPaginator {
             wf_id: req.original_wft.work.execution.workflow_id.clone(),
             run_id: req.original_wft.work.execution.run_id.clone(),
             previous_wft_started_id: req.original_wft.work.update.previous_wft_started_id,
+            wft_started_event_id: req.original_wft.work.update.wft_started_id,
             client,
             event_queue: Default::default(),
             next_page_token: NextPageToken::FetchFromStart,
@@ -177,6 +189,7 @@ impl HistoryPaginator {
     fn new(
         initial_history: History,
         previous_wft_started_id: i64,
+        wft_started_event_id: i64,
         wf_id: String,
         run_id: String,
         next_page_token: impl Into<NextPageToken>,
@@ -197,6 +210,7 @@ impl HistoryPaginator {
             next_page_token,
             final_events,
             previous_wft_started_id,
+            wft_started_event_id,
         }
     }
 
@@ -211,6 +225,7 @@ impl HistoryPaginator {
             next_page_token: NextPageToken::FetchFromStart,
             final_events: vec![],
             previous_wft_started_id: -2,
+            wft_started_event_id: -2,
         }
     }
 
@@ -225,7 +240,7 @@ impl HistoryPaginator {
     /// we have two, or until we are at the end of history.
     pub(crate) async fn extract_next_update(&mut self) -> Result<HistoryUpdate, tonic::Status> {
         loop {
-            self.get_next_page().await?;
+            let no_next_page = self.get_next_page().await?;
             let current_events = mem::take(&mut self.event_queue);
             if current_events.is_empty() {
                 // If next page fetching happened, and we still ended up with no events, something
@@ -238,18 +253,35 @@ impl HistoryPaginator {
                 return Err(EMPTY_FETCH_ERR.clone());
             }
             let first_event_id = current_events.front().unwrap().event_id;
-            // If there are some events at the end of the fetched events which represent only a
-            // portion of a complete WFT, retain them to be used in the next extraction.
-            let no_more = matches!(self.next_page_token, NextPageToken::Done);
-            let (update, extra) =
-                HistoryUpdate::from_events(current_events, self.previous_wft_started_id, no_more);
+            // We only *really* have the last WFT if the events go all the way up to at least the
+            // WFT started event id. Otherwise we somehow still have partial history.
+            let no_more = matches!(self.next_page_token, NextPageToken::Done)
+                && current_events
+                    .back()
+                    .map(|e| e.event_id)
+                    .unwrap_or_default()
+                    >= self.wft_started_event_id;
+            let (update, extra) = HistoryUpdate::from_events(
+                current_events,
+                self.previous_wft_started_id,
+                self.wft_started_event_id,
+                no_more,
+            );
             let extra_eid_same = extra
                 .first()
                 .map(|e| e.event_id == first_event_id)
                 .unwrap_or_default();
+            // If there are some events at the end of the fetched events which represent only a
+            // portion of a complete WFT, retain them to be used in the next extraction.
             self.event_queue = extra.into();
             if !no_more && extra_eid_same {
                 // There was not a meaningful WFT in the whole page. We must fetch more
+                if no_next_page {
+                    error!(
+                    "ahhhh expected to be able to fetch more events but server says there are none"
+                );
+                    return Err(EMPTY_FETCH_ERR.clone());
+                }
                 continue;
             }
             return Ok(update);
@@ -266,7 +298,7 @@ impl HistoryPaginator {
                 NextPageToken::FetchFromStart => vec![],
                 NextPageToken::Next(v) => v,
             };
-            debug!(run_id=%self.run_id, "Fetching new history page");
+            warn!(run_id=%self.run_id, "Fetching new history page");
             let fetch_res = self
                 .client
                 .get_workflow_execution_history(self.wf_id.clone(), Some(self.run_id.clone()), npt)
@@ -363,6 +395,7 @@ impl HistoryUpdate {
         Self {
             events: vec![],
             previous_wft_started_id: -1,
+            wft_started_id: -1,
             has_last_wft: false,
         }
     }
@@ -380,6 +413,7 @@ impl HistoryUpdate {
     pub fn from_events<I: IntoIterator<Item = HistoryEvent>>(
         events: I,
         previous_wft_started_id: i64,
+        wft_started_id: i64,
         has_last_wft: bool,
     ) -> (Self, Vec<HistoryEvent>)
     where
@@ -388,12 +422,14 @@ impl HistoryUpdate {
         let mut all_events: Vec<_> = events.into_iter().collect();
         let mut last_end =
             find_end_index_of_next_wft_seq(all_events.as_slice(), previous_wft_started_id);
+        dbg!(last_end, previous_wft_started_id, has_last_wft);
         if matches!(last_end, NextWFTSeqEndIndex::Incomplete(_)) {
             return if has_last_wft {
                 (
                     Self {
                         events: all_events,
                         previous_wft_started_id,
+                        wft_started_id,
                         has_last_wft,
                     },
                     vec![],
@@ -403,6 +439,7 @@ impl HistoryUpdate {
                     Self {
                         events: vec![],
                         previous_wft_started_id,
+                        wft_started_id,
                         has_last_wft,
                     },
                     all_events,
@@ -430,6 +467,7 @@ impl HistoryUpdate {
             Self {
                 events: all_events,
                 previous_wft_started_id,
+                wft_started_id,
                 has_last_wft,
             },
             remaining_events,
@@ -443,6 +481,7 @@ impl HistoryUpdate {
     pub fn new_from_events<I: IntoIterator<Item = HistoryEvent>>(
         events: I,
         previous_wft_started_id: i64,
+        wft_started_id: i64,
     ) -> Self
     where
         <I as IntoIterator>::IntoIter: Send + 'static,
@@ -450,6 +489,7 @@ impl HistoryUpdate {
         Self {
             events: events.into_iter().collect(),
             previous_wft_started_id,
+            wft_started_id,
             has_last_wft: true,
         }
     }
@@ -653,7 +693,11 @@ pub mod tests {
 
     impl From<HistoryInfo> for HistoryUpdate {
         fn from(v: HistoryInfo) -> Self {
-            Self::new_from_events(v.events().to_vec(), v.previous_started_event_id())
+            Self::new_from_events(
+                v.events().to_vec(),
+                v.previous_started_event_id(),
+                v.workflow_task_started_event_id(),
+            )
         }
     }
 
@@ -789,7 +833,9 @@ pub mod tests {
     }
 
     fn paginator_setup(history: TestHistoryBuilder, chunk_size: usize) -> HistoryPaginator {
-        let full_hist = history.get_full_history_info().unwrap().into_events();
+        let hinfo = history.get_full_history_info().unwrap();
+        let wft_started = hinfo.workflow_task_started_event_id();
+        let full_hist = hinfo.into_events();
         let initial_hist = full_hist.chunks(chunk_size).next().unwrap().to_vec();
         let mut mock_client = mock_workflow_client();
 
@@ -821,6 +867,7 @@ pub mod tests {
                 events: initial_hist,
             },
             0,
+            wft_started,
             "wfid".to_string(),
             "runid".to_string(),
             vec![1],
@@ -908,7 +955,14 @@ pub mod tests {
         // The update should contain the first two complete WFTs, ending on the 8th event which
         // is WFT started. The remaining events should be returned. False flags means the creator
         // knows there are more events, so we should return need fetch
-        let (mut update, remaining) = HistoryUpdate::from_events(ends_in_middle_of_seq, 0, false);
+        let (mut update, remaining) = HistoryUpdate::from_events(
+            ends_in_middle_of_seq,
+            0,
+            t.get_full_history_info()
+                .unwrap()
+                .workflow_task_started_event_id(),
+            false,
+        );
         assert_eq!(remaining[0].event_id, 8);
         assert_eq!(remaining.last().unwrap().event_id, 19);
         let seq = update.take_next_wft_sequence(0).unwrap_events();
@@ -927,7 +981,15 @@ pub mod tests {
         let t = three_wfts_then_heartbeats();
         let mut ends_in_middle_of_seq = t.as_history_update().events;
         ends_in_middle_of_seq.truncate(20);
-        let (mut update, remaining) = HistoryUpdate::from_events(ends_in_middle_of_seq, 0, false);
+        // TODO: dedupe
+        let (mut update, remaining) = HistoryUpdate::from_events(
+            ends_in_middle_of_seq,
+            0,
+            t.get_full_history_info()
+                .unwrap()
+                .workflow_task_started_event_id(),
+            false,
+        );
         assert!(remaining.is_empty());
         let seq = update.take_next_wft_sequence(0).unwrap_events();
         assert_eq!(seq.last().unwrap().event_id, 3);
@@ -986,6 +1048,7 @@ pub mod tests {
         let timer_hist = canned_histories::single_timer("t");
         let partial_task = timer_hist.get_one_wft(2).unwrap();
         let prev_started_wft_id = partial_task.previous_started_event_id();
+        let wft_started_id = partial_task.workflow_task_started_event_id();
         let mut history_from_get: GetWorkflowExecutionHistoryResponse =
             timer_hist.get_history_info(2).unwrap().into();
         // Chop off the last event, which is WFT started, which server doesn't return in get
@@ -999,6 +1062,7 @@ pub mod tests {
         let mut paginator = HistoryPaginator::new(
             partial_task.into(),
             prev_started_wft_id,
+            wft_started_id,
             "wfid".to_string(),
             "runid".to_string(),
             // A cache miss means we'll try to fetch from start
@@ -1047,6 +1111,7 @@ pub mod tests {
         let timer_hist = canned_histories::single_timer("t");
         let partial_task = timer_hist.get_one_wft(2).unwrap();
         let prev_started_wft_id = partial_task.previous_started_event_id();
+        let wft_started_id = partial_task.workflow_task_started_event_id();
         let mut mock_client = mock_workflow_client();
         mock_client
             .expect_get_workflow_execution_history()
@@ -1055,6 +1120,7 @@ pub mod tests {
         let mut paginator = HistoryPaginator::new(
             partial_task.into(),
             prev_started_wft_id,
+            wft_started_id,
             "wfid".to_string(),
             "runid".to_string(),
             // A cache miss means we'll try to fetch from start
@@ -1070,6 +1136,7 @@ pub mod tests {
         let timer_hist = canned_histories::single_timer("t");
         let partial_task = timer_hist.get_one_wft(2).unwrap();
         let prev_started_wft_id = partial_task.previous_started_event_id();
+        let wft_started_id = partial_task.workflow_task_started_event_id();
         let full_resp: GetWorkflowExecutionHistoryResponse =
             timer_hist.get_full_history_info().unwrap().into();
         let mut mock_client = mock_workflow_client();
@@ -1092,6 +1159,7 @@ pub mod tests {
         let mut paginator = HistoryPaginator::new(
             partial_task.into(),
             prev_started_wft_id,
+            wft_started_id,
             "wfid".to_string(),
             "runid".to_string(),
             // A cache miss means we'll try to fetch from start

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -483,6 +483,7 @@ impl Workflows {
             run_id: run_id.into(),
             message: message.into(),
             reason,
+            auto_reply_fail_tt: None,
         });
     }
 
@@ -936,6 +937,10 @@ struct RequestEvictMsg {
     run_id: String,
     message: String,
     reason: EvictionReason,
+    /// If set, we requested eviction because something went wrong processing a brand new poll task,
+    /// which means we won't have stored the WFT and we need to track the task token separately so
+    /// we can reply with a failure to server after the evict goes through.
+    auto_reply_fail_tt: Option<TaskToken>,
 }
 #[derive(Debug)]
 pub(crate) struct HeartbeatTimeoutMsg {

--- a/core/src/worker/workflow/wft_extraction.rs
+++ b/core/src/worker/workflow/wft_extraction.rs
@@ -64,7 +64,7 @@ impl WFTExtractor {
                     match wft {
                         Ok(wft) => {
                             let run_id = wft.workflow_execution.run_id.clone();
-                            let tt = wft.task_token.clone().into();
+                            let tt = wft.task_token.clone();
                             Ok(match HistoryPaginator::from_poll(wft, client).await {
                                 Ok((pag, prep)) => WFTExtractorOutput::NewWFT(PermittedWFT {
                                     work: prep,

--- a/core/src/worker/workflow/wft_extraction.rs
+++ b/core/src/worker/workflow/wft_extraction.rs
@@ -12,6 +12,7 @@ use crate::{
 use futures::Stream;
 use futures_util::{stream, stream::PollNext, FutureExt, StreamExt};
 use std::{future, sync::Arc};
+use temporal_sdk_core_protos::TaskToken;
 use tracing::Span;
 
 /// Transforms incoming validated WFTs and history fetching requests into [PermittedWFT]s ready
@@ -30,6 +31,7 @@ pub(super) enum WFTExtractorOutput {
     FailedFetch {
         run_id: String,
         err: tonic::Status,
+        auto_reply_fail_tt: Option<TaskToken>,
     },
     PollerDead,
 }
@@ -62,13 +64,18 @@ impl WFTExtractor {
                     match wft {
                         Ok(wft) => {
                             let run_id = wft.workflow_execution.run_id.clone();
+                            let tt = wft.task_token.clone().into();
                             Ok(match HistoryPaginator::from_poll(wft, client).await {
                                 Ok((pag, prep)) => WFTExtractorOutput::NewWFT(PermittedWFT {
                                     work: prep,
                                     permit: permit.into_used(),
                                     paginator: pag,
                                 }),
-                                Err(err) => WFTExtractorOutput::FailedFetch { run_id, err },
+                                Err(err) => WFTExtractorOutput::FailedFetch {
+                                    run_id,
+                                    err,
+                                    auto_reply_fail_tt: Some(tt),
+                                },
                             })
                         }
                         Err(e) => Err(e),
@@ -96,7 +103,11 @@ impl WFTExtractor {
                             let run_id = req.original_wft.work.execution.run_id.clone();
                             match HistoryPaginator::from_fetchreq(req, client).await {
                                 Ok(r) => WFTExtractorOutput::FetchResult(r, rc),
-                                Err(err) => WFTExtractorOutput::FailedFetch { run_id, err },
+                                Err(err) => WFTExtractorOutput::FailedFetch {
+                                    run_id,
+                                    err,
+                                    auto_reply_fail_tt: None,
+                                },
                             }
                         }
                         HistoryFetchReq::NextPage(mut req, rc) => {
@@ -110,6 +121,7 @@ impl WFTExtractor {
                                 Err(err) => WFTExtractorOutput::FailedFetch {
                                     run_id: req.paginator.run_id,
                                     err,
+                                    auto_reply_fail_tt: None,
                                 },
                             }
                         }

--- a/sdk-core-protos/src/history_info.rs
+++ b/sdk-core-protos/src/history_info.rs
@@ -183,6 +183,11 @@ impl HistoryInfo {
     pub fn previous_started_event_id(&self) -> i64 {
         self.previous_started_event_id
     }
+
+    /// Returns the current workflow task started event id
+    pub fn workflow_task_started_event_id(&self) -> i64 {
+        self.workflow_task_started_event_id
+    }
 }
 
 impl From<HistoryInfo> for History {

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1923,6 +1923,7 @@ pub mod temporal {
             }
         }
         pub mod schedule {
+            #[allow(rustdoc::invalid_html_tags)]
             pub mod v1 {
                 tonic::include_proto!("temporal.api.schedule.v1");
             }

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -98,6 +98,7 @@ pub struct WfContextSharedData {
     pub changes: HashMap<String, bool>,
     pub is_replaying: bool,
     pub wf_time: Option<SystemTime>,
+    pub history_length: u32,
 }
 
 // TODO: Dataconverter type interface to replace Payloads here. Possibly just use serde
@@ -146,6 +147,11 @@ impl WfContext {
     /// Return the current time according to the workflow (which is not wall-clock time).
     pub fn workflow_time(&self) -> Option<SystemTime> {
         self.shared.read().wf_time
+    }
+
+    /// Return the length of history so far at this point in the workflow
+    pub fn history_length(&self) -> u32 {
+        self.shared.read().history_length
     }
 
     pub(crate) fn get_shared_data(&self) -> Arc<RwLock<WfContextSharedData>> {

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -254,6 +254,7 @@ impl Future for WorkflowFuture {
                 let mut wlock = self.ctx_shared.write();
                 wlock.is_replaying = activation.is_replaying;
                 wlock.wf_time = activation.timestamp.try_into_or_none();
+                wlock.history_length = activation.history_length;
             }
 
             let mut die_of_eviction_when_done = false;


### PR DESCRIPTION
It was possible to hit a case where core would fail to realize it needed to fetch more events and instead apply partial history, with an incorrect length.

This fixes that.