### PR TITLE
Revert "Add support for metrics over UDS"

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -62,7 +62,6 @@ tokio = { version = "1.1", features = ["rt", "rt-multi-thread", "parking_lot", "
 tokio-util = { version = "0.7", features = ["io", "io-util"] }
 tokio-stream = "0.1"
 tonic = { version = "0.8", features = ["tls", "tls-roots"] }
-tower = { version="0.4.13" }
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.18"

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -41,11 +41,7 @@ use temporal_sdk_core_api::telemetry::{
     CoreLog, CoreTelemetry, Logger, MetricTemporality, MetricsExporter, OtelCollectorOptions,
     TelemetryOptions, TraceExporter,
 };
-use tokio::net::UnixStream;
-use tonic::{
-    metadata::MetadataMap,
-    transport::{Endpoint, Uri},
-};
+use tonic::metadata::MetadataMap;
 use tracing::{Level, Subscriber};
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
@@ -242,22 +238,6 @@ pub fn telemetry_init(opts: TelemetryOptions) -> Result<TelemetryInstance, anyho
                     headers,
                     metric_periodicity,
                 }) => runtime.block_on(async {
-                    let exporter = opentelemetry_otlp::new_exporter()
-                        .tonic()
-                        .with_metadata(MetadataMap::from_headers(headers.try_into()?));
-                    let exporter = if url.scheme() == "unix" {
-                        // Workaround the fact that tonic doesn't automatically work w/ UDS schemes
-                        let path = url.path().to_owned();
-                        // The endpoint URL is not used.
-                        let channel = Endpoint::try_from("http://[::]:0")?
-                            .connect_with_connector(tower::service_fn(move |_: Uri| {
-                                UnixStream::connect(path.to_owned())
-                            }))
-                            .await?;
-                        exporter.with_channel(channel)
-                    } else {
-                        exporter.with_endpoint(url.to_string())
-                    };
                     let metrics = opentelemetry_otlp::new_pipeline()
                         .metrics(
                             aggregator,
@@ -266,7 +246,12 @@ pub fn telemetry_init(opts: TelemetryOptions) -> Result<TelemetryInstance, anyho
                         )
                         .with_period(metric_periodicity.unwrap_or_else(|| Duration::from_secs(1)))
                         .with_resource(default_resource())
-                        .with_exporter(exporter)
+                        .with_exporter(
+                            opentelemetry_otlp::new_exporter()
+                                .tonic()
+                                .with_endpoint(url.to_string())
+                                .with_metadata(MetadataMap::from_headers(headers.try_into()?)),
+                        )
                         .build()?;
                     Ok::<_, anyhow::Error>(Some(
                         Box::new(metrics) as Box<dyn MeterProvider + Send + Sync>


### PR DESCRIPTION
Reverts temporalio/sdk-core#507

For context:
In additional testing I found that there is a bug in opentelemetry-otlp library.
It does not respect `with_channel` for _metrics_ as of now (and falls back to default endpoint)

I may try to fix it there if I have resources but I want to revert this for now to avoid the confusion I've gone through (I have a local bandaid but a proper fix needs much more polish).

To clarify: the traffic I saw in my initial testing turned out to be the connection opening with an immediate 'GOAWAY' frame (as the channel presumably gets immediately "collected").
I mistakenly thought that the traffic I saw initially contained metrics that we failed to ingest on _our_ end.

I will revisit this if\when opentelemetry-otlp has a fix for this.

Thank you again for a speedy response with the initial PR!

