### PR TITLE
Add support for global metric and tracing tags

### DIFF
--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -41,6 +41,10 @@ pub struct TelemetryOptions {
     /// Specifies the aggregation temporality for metric export. Defaults to cumulative.
     #[builder(default = "MetricTemporality::Cumulative")]
     pub metric_temporality: MetricTemporality,
+
+    // A map of tags to be applied to all metrics
+    #[builder(default)]
+    pub global_tags: HashMap<String, String>
 }
 
 /// Options for exporting to an OpenTelemetry Collector

--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -44,7 +44,7 @@ pub struct TelemetryOptions {
 
     // A map of tags to be applied to all metrics
     #[builder(default)]
-    pub global_tags: HashMap<String, String>
+    pub global_tags: HashMap<String, String>,
 }
 
 /// Options for exporting to an OpenTelemetry Collector


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add support for passing a map of tags for metrics and traces

## Why?
<!-- Tell your future self why have you made these changes -->
Currently - core SDK uses a single `service.name` tag (that cannot be overriden)
Many users, however, may want to supply their own (for example, to identify service or host running a worker or making client requests)

## Checklist
<!--- add/delete as needed --->

1. Closes #467

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Tested with a local otel collector and temporal SDK python.
Note: I used an older commit because python does not seem to compile with latest SDK.
Ensured a custom tag set in Python gets propagated to the collector (along service.name tag)

Did not test prometheus as we don't use it but can upon request

3. Any docs updates needed?
Probably not


We don't use opentelemetry so maybe variables aren't most aptly named so open to feedback on that (in datadog these are just tags)

Also, I added the functionality to both traces and metrics. I don't see why not do both but let me know if we want to do this for metrics-only.