### PR TITLE
Avoid possible panic on autocompleting WFTs due to failure, and stop checking SA values for determinism

### DIFF
--- a/core/src/internal_flags.rs
+++ b/core/src/internal_flags.rs
@@ -47,20 +47,6 @@ impl InternalFlags {
         }
     }
 
-    #[cfg(test)]
-    pub fn all_core_enabled() -> Self {
-        Self {
-            enabled: true,
-            core: BTreeSet::from([
-                CoreInternalFlags::IdAndTypeDeterminismChecks,
-                CoreInternalFlags::UpsertSearchAttributeOnPatch,
-            ]),
-            lang: Default::default(),
-            core_since_last_complete: Default::default(),
-            lang_since_last_complete: Default::default(),
-        }
-    }
-
     pub fn add_from_complete(&mut self, e: &WorkflowTaskCompletedEventAttributes) {
         if !self.enabled {
             return;

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -538,6 +538,7 @@ impl Worker {
         self.workflows
             .activation_completed(
                 completion,
+                false,
                 self.post_activate_hook
                     .as_ref()
                     .map(|h| |data: PostActivateHookData| h(self, data)),

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -924,10 +924,7 @@ impl WorkflowMachines {
                     }
                     ProtoCmdAttrs::UpsertWorkflowSearchAttributesCommandAttributes(attrs) => {
                         self.add_cmd_to_wf_task(
-                            upsert_search_attrs_internal(
-                                attrs,
-                                self.observed_internal_flags.clone(),
-                            ),
+                            upsert_search_attrs_internal(attrs),
                             CommandIdKind::NeverResolves,
                         );
                     }

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -550,8 +550,15 @@ impl ManagedRun {
 
     /// Delete the currently tracked workflow activation and return it, if any. Should be called
     /// after the processing of the activation completion, and WFT reporting.
-    pub(super) fn delete_activation(&mut self) -> Option<OutstandingActivation> {
-        self.activation.take()
+    pub(super) fn delete_activation(
+        &mut self,
+        pred: impl FnOnce(&OutstandingActivation) -> bool,
+    ) -> Option<OutstandingActivation> {
+        if self.activation().map(pred).unwrap_or_default() {
+            self.activation.take()
+        } else {
+            None
+        }
     }
 
     /// Called when local activities resolve

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -929,6 +929,7 @@ impl ManagedRun {
     }
 
     fn insert_outstanding_activation(&mut self, act: &ActivationOrAuto) {
+        warn!("Inserting {:?}", act);
         let act_type = match &act {
             ActivationOrAuto::LangActivation(act) | ActivationOrAuto::ReadyForQueries(act) => {
                 if act.is_legacy_query() {

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -294,6 +294,7 @@ impl Workflows {
                                 workflow_completion::Success::from_variants(vec![]).into(),
                             ),
                         },
+                        true,
                         // We need to say a type, but the type is irrelevant, so imagine some
                         // boxed function we'll never call.
                         Option::<Box<dyn Fn(PostActivateHookData) + Send>>::None,
@@ -309,6 +310,7 @@ impl Workflows {
                             run_id,
                             status: Some(auto_fail_to_complete_status(machines_err)),
                         },
+                        true,
                         Option::<Box<dyn Fn(PostActivateHookData) + Send>>::None,
                     )
                     .await?;
@@ -324,6 +326,7 @@ impl Workflows {
     pub(super) async fn activation_completed(
         &self,
         completion: WorkflowActivationCompletion,
+        is_autocomplete: bool,
         post_activate_hook: Option<impl Fn(PostActivateHookData)>,
     ) -> Result<(), CompleteWfError> {
         let is_empty_completion = completion.is_empty();
@@ -469,6 +472,7 @@ impl Workflows {
             run_id,
             wft_report_status,
             wft_from_complete: maybe_pwft,
+            is_autocomplete,
         });
 
         Ok(())
@@ -941,6 +945,7 @@ struct PostActivationMsg {
     run_id: String,
     wft_report_status: WFTReportStatus,
     wft_from_complete: Option<(PreparedWFT, HistoryPaginator)>,
+    is_autocomplete: bool,
 }
 #[derive(Debug, Clone)]
 #[cfg_attr(

--- a/tests/integ_tests/workflow_tests/determinism.rs
+++ b/tests/integ_tests/workflow_tests/determinism.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use temporal_sdk::{ActivityOptions, WfContext, WorkflowResult};
-use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
 static RUN_CT: AtomicUsize = AtomicUsize::new(1);
@@ -41,42 +40,6 @@ async fn test_determinism_error_then_recovers() {
     let mut worker = starter.worker().await;
 
     worker.register_wf(wf_name.to_owned(), timer_wf_nondeterministic);
-    starter.start_with_worker(wf_name, &mut worker).await;
-    worker.run_until_done().await.unwrap();
-    // 4 because we still add on the 3rd and final attempt
-    assert_eq!(RUN_CT.load(Ordering::Relaxed), 4);
-}
-
-static RUN_CT_2: AtomicUsize = AtomicUsize::new(1);
-pub async fn sa_wf_nondeterministic(ctx: WfContext) -> WorkflowResult<()> {
-    let run_ct = RUN_CT_2.fetch_add(1, Ordering::Relaxed);
-
-    match run_ct {
-        1 | 3 | 4 => {
-            ctx.upsert_search_attributes([("thing".to_string(), "hey".as_json_payload().unwrap())]);
-            if run_ct == 1 {
-                // on first attempt we need to blow up after the timer fires so we will replay
-                panic!("dying on purpose");
-            }
-        }
-        2 => {
-            // On the second attempt we should cause a nondeterminism error
-            ctx.upsert_search_attributes([("thing".to_string(), "aey".as_json_payload().unwrap())]);
-        }
-        _ => panic!("Ran too many times"),
-    }
-    ctx.timer(Duration::from_secs(1)).await;
-    Ok(().into())
-}
-
-#[tokio::test]
-async fn test_determinism_sa_error_then_recovers() {
-    let wf_name = "test_sa_determinism_error_then_recovers";
-    let mut starter = CoreWfStarter::new(wf_name);
-    starter.no_remote_activities();
-    let mut worker = starter.worker().await;
-
-    worker.register_wf(wf_name.to_owned(), sa_wf_nondeterministic);
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
     // 4 because we still add on the 3rd and final attempt


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
1. Avoid a possible panic where if core was autocompleting some WFT because it encountered an error internally (ex: nondeterminism) while there was also an outstanding eviction, that autocomplete would trigger the eviction to finish even though lang hadn't replied to the eviction activation. Later, when we got that reply from lang, we freaked out because the workflow was no longer in cache.
2. Checking determinism for SA values is silly and overkill so we stopped

## Why?
Bug bad, SA determinism check too persnickety for little payoff.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/526

3. How was this tested:
Added UT that triggered the panic.

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
