### PR TITLE
Allow overriding origin for core connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/protos/*.rs
 /machine_coverage/
 /bindings/
 /core/machine_coverage/
+/.cloud_certs/

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -16,7 +16,6 @@ mod integ_tests {
     mod visibility_tests;
     mod workflow_tests;
 
-    use http::Uri;
     use std::str::FromStr;
     use temporal_client::WorkflowService;
     use temporal_sdk_core::{
@@ -72,10 +71,6 @@ mod integ_tests {
             .target_url(Url::from_str("https://spencer.temporal-dev.tmprl.cloud:7233").unwrap())
             .client_name("tls_tester")
             .client_version("clientver")
-            // Not necessary, but illustrates functionality for people using proxies, etc.
-            .override_origin(Some(Uri::from_static(
-                "https://spencer.temporal-dev.tmprl.cloud",
-            )))
             .tls_cfg(TlsConfig {
                 server_root_ca_cert: Some(root),
                 // Not necessary, but illustrates functionality for people using proxies, etc.
@@ -91,8 +86,9 @@ mod integ_tests {
             .connect("spencer.temporal-dev".to_string(), None, None)
             .await
             .unwrap();
-        con.list_workflow_executions(100, vec![], "".to_string())
+        dbg!(con
+            .list_workflow_executions(100, vec![], "".to_string())
             .await
-            .unwrap();
+            .unwrap());
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Allow overriding origin for connections

## Why?
When connecting via a proxy to cloud, just changing the domain for TLS verification is only part of the puzzle. Additionally, our stuff expects to see the right `:authority` and/or `host` headers set. Setting the origin value for the connection handles that.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
