### PR TITLE
Fix possibly dropping final events in a WFT during cache miss

### DIFF
--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -288,6 +288,9 @@ impl HistoryPaginator {
                 // extract this update, but server isn't giving us any. We have no choice except to
                 // give up and evict.
                 error!(
+                    current_events=?current_events,
+                    no_next_page,
+                    seen_enough_events,
                     "We expected to be able to fetch more events but server says there are none"
                 );
                 return Err(EMPTY_FETCH_ERR.clone());
@@ -1360,7 +1363,7 @@ pub mod tests {
             let sig_ctr_clone = sig_ctr_clone.clone();
             async move {
                 let mut sigchan = ctx.make_signal_channel("hi");
-                while let Some(v) = sigchan.next().await {
+                while sigchan.next().await.is_some() {
                     if sig_ctr_clone.fetch_add(1, Ordering::AcqRel) == 1 {
                         break;
                     }

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -11,7 +11,7 @@ use crate::{
     SignalExternalWfResult, TimerResult, UnblockEvent, Unblockable,
 };
 use crossbeam::channel::{Receiver, Sender};
-use futures::{task::Context, FutureExt, Stream};
+use futures::{task::Context, FutureExt, Stream, StreamExt};
 use parking_lot::RwLock;
 use std::{
     collections::HashMap,
@@ -394,6 +394,14 @@ impl DrainableSignalStream {
         let mut receiver = self.0.into_inner();
         let mut signals = vec![];
         while let Ok(s) = receiver.try_recv() {
+            signals.push(s);
+        }
+        signals
+    }
+
+    pub fn drain_ready(&mut self) -> Vec<SignalData> {
+        let mut signals = vec![];
+        while let Some(s) = self.0.next().now_or_never().flatten() {
             signals.push(s);
         }
         signals

--- a/sdk/src/workflow_context/options.rs
+++ b/sdk/src/workflow_context/options.rs
@@ -272,7 +272,7 @@ impl Signal {
 }
 
 /// Data contained within a signal
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SignalData {
     /// The arguments the signal will receive
     pub input: Vec<Payload>,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
It was possible to drop events that were in a WFT but not in the history fetch request in the event that pagination ends up being required.

## Why?
Bug

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
