### PR TITLE
Fix more pagination insanity

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "cargo lint"
+    command: "cargo lint && cargo test-lint"
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.0.0:

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,5 @@ wf-input-replay = ["run", "--package", "temporal-sdk-core", "--features", "save_
                    "--example", "wf_input_replay", "--"]
 lint = ["clippy", "--workspace", "--examples", "--all-features",
         "--test", "integ_tests", "--test", "heavy_tests", "--", "--D", "warnings"]
+test-lint = ["clippy", "--all", "--all-features", "--examples", "--workspace",
+             "--tests", "--", "--D", "warnings"]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Primary owners
 
-* @Sushisource @bergundy @cretz @Spikhalskiy
+* @temporalio/sdk

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -896,10 +896,7 @@ async fn workflow_failures_only_reported_once() {
 #[tokio::test]
 async fn max_wft_respected() {
     let total_wfs = 100;
-    let wf_ids: Vec<_> = (0..total_wfs)
-        .into_iter()
-        .map(|i| format!("fake-wf-{i}"))
-        .collect();
+    let wf_ids: Vec<_> = (0..total_wfs).map(|i| format!("fake-wf-{i}")).collect();
     let hists = wf_ids.iter().map(|wf_id| {
         let hist = canned_histories::single_timer("1");
         FakeWfResponses {
@@ -1027,7 +1024,7 @@ async fn activity_not_canceled_when_also_completed_repro(hist_batches: &'static 
 #[tokio::test]
 async fn lots_of_workflows() {
     let total_wfs = 500;
-    let hists = (0..total_wfs).into_iter().map(|i| {
+    let hists = (0..total_wfs).map(|i| {
         let wf_id = format!("fake-wf-{i}");
         let hist = canned_histories::single_timer("1");
         FakeWfResponses {
@@ -2391,7 +2388,6 @@ async fn core_internal_flags() {
                 .copied()
                 .collect::<HashSet<_>>(),
             CoreInternalFlags::all_except_too_high()
-                .into_iter()
                 .map(|f| f as u32)
                 .collect()
         );

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -752,7 +752,7 @@ fn find_end_index_of_next_wft_seq(
                         } else {
                             return NextWFTSeqEndIndex::Complete(ix);
                         }
-                    } else if !has_last_wft {
+                    } else if !has_last_wft && !saw_any_command_event {
                         // Don't have enough events to look ahead of the WorkflowTaskCompleted. Need
                         // to fetch more.
                         continue;

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -1031,9 +1031,6 @@ impl ManagedRun {
         new_local_acts: Vec<LocalActRequest>,
     ) -> Result<(), WFMachinesError> {
         let immediate_resolutions = self.local_activity_request_sink.sink_reqs(new_local_acts);
-        if !immediate_resolutions.is_empty() {
-            warn!("Immediate res: {:?}", &immediate_resolutions);
-        }
         for resolution in immediate_resolutions {
             self.wfm
                 .notify_of_local_result(LocalResolution::LocalActivity(resolution))?;

--- a/core/src/worker/workflow/managed_run/managed_wf_test.rs
+++ b/core/src/worker/workflow/managed_run/managed_wf_test.rs
@@ -95,7 +95,7 @@ impl ManagedWFFunc {
                 run_id: "runid".to_string(),
                 history: hist,
                 metrics: MetricsContext::no_op(),
-                capabilities: &DEFAULT_TEST_CAPABILITIES,
+                capabilities: DEFAULT_TEST_CAPABILITIES,
             },
             Box::new(driver).into(),
         );


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
More fixes for everyone's favorite spot of code. This time, we handle the fact that we could consider workflow task sequences as complete if we just happen to have history which ends on a WFT started event - but that's not sufficient. If we know there might be more events, we need to peek beyond the started event to see if the next event is a task failure, or a heartbeat, etc.

## Why?
Bugs!

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
