### PR TITLE
WIP: Workflow defintions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can buld and test the project using cargo:
 Run integ tests with `cargo integ-test`. You will need to already be running the server:
 `docker-compose -f .buildkite/docker/docker-compose.yaml up`
 
+Run load tests with `cargo test --features=save_wf_inputs --test heavy_tests`.
+
 ## Formatting
 To format all code run:
 `cargo fmt --all`

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -95,6 +95,8 @@ bimap = "0.6.1"
 clap = { version = "4.0", features = ["derive"] }
 criterion = "0.4"
 rstest = "0.17"
+serde = "1.0"
+serde_json = "1.0"
 temporal-sdk-core-test-utils = { path = "../test-utils" }
 temporal-sdk = { path = "../sdk" }
 

--- a/core/benches/workflow_replay.rs
+++ b/core/benches/workflow_replay.rs
@@ -1,9 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::StreamExt;
 use std::time::Duration;
-use temporal_sdk::{WfContext, WorkflowFunction};
+use temporal_sdk::{WfContext, WfExitValue, WorkflowFunction};
 use temporal_sdk_core::replay::HistoryForReplay;
-use temporal_sdk_core_protos::DEFAULT_WORKFLOW_TYPE;
+use temporal_sdk_core_protos::{coresdk::AsJsonPayloadExt, DEFAULT_WORKFLOW_TYPE};
 use temporal_sdk_core_test_utils::{canned_histories, replay_sdk_worker};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -58,7 +58,9 @@ fn timers_wf(num_timers: u32) -> WorkflowFunction {
         for _ in 1..=num_timers {
             ctx.timer(Duration::from_secs(1)).await;
         }
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     })
 }
 
@@ -71,6 +73,8 @@ fn big_signals_wf(num_tasks: usize) -> WorkflowFunction {
             }
         }
 
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     })
 }

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -23,7 +23,7 @@ use std::{
     time::Duration,
 };
 use temporal_client::WorkflowOptions;
-use temporal_sdk::{ActivityOptions, WfContext};
+use temporal_sdk::{ActivityOptions, WfContext, WfExitValue};
 use temporal_sdk_core_api::{
     errors::{CompleteActivityError, PollActivityError},
     Worker as WorkerTrait,
@@ -41,7 +41,7 @@ use temporal_sdk_core_protos::{
             ScheduleActivity,
         },
         workflow_completion::WorkflowActivationCompletion,
-        ActivityTaskCompletion,
+        ActivityTaskCompletion, AsJsonPayloadExt,
     },
     temporal::api::{
         command::v1::{command::Attributes, ScheduleActivityTaskCommandAttributes},
@@ -945,7 +945,9 @@ async fn activity_tasks_from_completion_reserve_slots() {
             })
             .await;
             complete_token.cancel();
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         }
     });
 

--- a/core/src/core_tests/replay_flag.rs
+++ b/core/src/core_tests/replay_flag.rs
@@ -1,15 +1,16 @@
 use crate::{test_help::canned_histories, worker::ManagedWFFunc};
 use rstest::{fixture, rstest};
 use std::time::Duration;
-use temporal_sdk::{WfContext, WorkflowFunction};
-use temporal_sdk_core_protos::temporal::api::enums::v1::CommandType;
-
+use temporal_sdk::{WfContext, WfExitValue, WorkflowFunction};
+use temporal_sdk_core_protos::{coresdk::AsJsonPayloadExt, temporal::api::enums::v1::CommandType};
 fn timers_wf(num_timers: u32) -> WorkflowFunction {
     WorkflowFunction::new(move |command_sink: WfContext| async move {
         for _ in 1..=num_timers {
             command_sink.timer(Duration::from_secs(1)).await;
         }
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     })
 }
 

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -784,8 +784,9 @@ pub mod tests {
     use futures_util::TryStreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use temporal_client::WorkflowOptions;
-    use temporal_sdk::WfContext;
+    use temporal_sdk::{WfContext, WfExitValue};
     use temporal_sdk_core_protos::{
+        coresdk::AsJsonPayloadExt,
         temporal::api::{
             common::v1::WorkflowExecution, enums::v1::WorkflowTaskFailedCause,
             workflowservice::v1::GetWorkflowExecutionHistoryResponse,
@@ -1422,7 +1423,9 @@ pub mod tests {
                         break;
                     }
                 }
-                Ok(().into())
+                Ok(WfExitValue::Normal(
+                    "success".as_json_payload().expect("serializes fine"),
+                ))
             }
         });
 
@@ -1670,7 +1673,9 @@ pub mod tests {
                         break;
                     }
                 }
-                Ok(().into())
+                Ok(WfExitValue::Normal(
+                    "success".as_json_payload().expect("serializes fine"),
+                ))
             }
         });
 

--- a/core/src/worker/workflow/machines/cancel_external_state_machine.rs
+++ b/core/src/worker/workflow/machines/cancel_external_state_machine.rs
@@ -227,9 +227,10 @@ impl Cancellable for CancelExternalMachine {}
 mod tests {
     use super::*;
     use crate::{replay::TestHistoryBuilder, worker::workflow::ManagedWFFunc};
-    use temporal_sdk::{WfContext, WorkflowFunction, WorkflowResult};
+    use temporal_sdk::{WfContext, WfExitValue, WorkflowFunction, WorkflowResult};
+    use temporal_sdk_core_protos::{coresdk::AsJsonPayloadExt, temporal::api::common::v1::Payload};
 
-    async fn cancel_sender(ctx: WfContext) -> WorkflowResult<()> {
+    async fn cancel_sender(ctx: WfContext) -> WorkflowResult<Payload> {
         let res = ctx
             .cancel_external(NamespacedWorkflowExecution {
                 namespace: "some_namespace".to_string(),
@@ -240,7 +241,9 @@ mod tests {
         if res.is_err() {
             Err(anyhow::anyhow!("Cancel fail!"))
         } else {
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         }
     }
 

--- a/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
@@ -119,11 +119,12 @@ mod tests {
     use crate::{test_help::canned_histories, worker::workflow::ManagedWFFunc};
     use std::time::Duration;
     use temporal_sdk::{WfContext, WfExitValue, WorkflowFunction, WorkflowResult};
-    use temporal_sdk_core_protos::coresdk::workflow_activation::{
-        workflow_activation_job, WorkflowActivationJob,
+    use temporal_sdk_core_protos::{
+        coresdk::workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        temporal::api::common::v1::Payload,
     };
 
-    async fn wf_with_timer(ctx: WfContext) -> WorkflowResult<()> {
+    async fn wf_with_timer(ctx: WfContext) -> WorkflowResult<Payload> {
         ctx.timer(Duration::from_millis(500)).await;
         Ok(WfExitValue::Cancelled)
     }

--- a/core/src/worker/workflow/machines/continue_as_new_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/continue_as_new_workflow_state_machine.rs
@@ -118,8 +118,9 @@ mod tests {
     use crate::{test_help::canned_histories, worker::workflow::ManagedWFFunc};
     use std::time::Duration;
     use temporal_sdk::{WfContext, WfExitValue, WorkflowFunction, WorkflowResult};
+    use temporal_sdk_core_protos::temporal::api::common::v1::Payload;
 
-    async fn wf_with_timer(ctx: WfContext) -> WorkflowResult<()> {
+    async fn wf_with_timer(ctx: WfContext) -> WorkflowResult<Payload> {
         ctx.timer(Duration::from_millis(500)).await;
         Ok(WfExitValue::continue_as_new(
             ContinueAsNewWorkflowExecution {

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -884,26 +884,31 @@ mod tests {
     use rstest::rstest;
     use std::time::Duration;
     use temporal_sdk::{
-        CancellableFuture, LocalActivityOptions, WfContext, WorkflowFunction, WorkflowResult,
+        CancellableFuture, LocalActivityOptions, WfContext, WfExitValue, WorkflowFunction,
+        WorkflowResult,
     };
     use temporal_sdk_core_protos::{
         coresdk::{
             activity_result::ActivityExecutionResult,
             workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+            AsJsonPayloadExt,
         },
         temporal::api::{
-            command::v1::command, enums::v1::WorkflowTaskFailedCause, failure::v1::Failure,
+            command::v1::command, common::v1::Payload, enums::v1::WorkflowTaskFailedCause,
+            failure::v1::Failure,
         },
         DEFAULT_ACTIVITY_TYPE,
     };
 
-    async fn la_wf(ctx: WfContext) -> WorkflowResult<()> {
+    async fn la_wf(ctx: WfContext) -> WorkflowResult<Payload> {
         ctx.local_activity(LocalActivityOptions {
             activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
             ..Default::default()
         })
         .await;
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     }
 
     #[rstest]
@@ -1014,7 +1019,7 @@ mod tests {
         wfm.shutdown().await.unwrap();
     }
 
-    async fn two_la_wf(ctx: WfContext) -> WorkflowResult<()> {
+    async fn two_la_wf(ctx: WfContext) -> WorkflowResult<Payload> {
         ctx.local_activity(LocalActivityOptions {
             activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
             ..Default::default()
@@ -1025,7 +1030,9 @@ mod tests {
             ..Default::default()
         })
         .await;
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     }
 
     #[rstest]
@@ -1115,7 +1122,7 @@ mod tests {
         wfm.shutdown().await.unwrap();
     }
 
-    async fn two_la_wf_parallel(ctx: WfContext) -> WorkflowResult<()> {
+    async fn two_la_wf_parallel(ctx: WfContext) -> WorkflowResult<Payload> {
         tokio::join!(
             ctx.local_activity(LocalActivityOptions {
                 activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
@@ -1126,7 +1133,9 @@ mod tests {
                 ..Default::default()
             })
         );
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     }
 
     #[rstest]
@@ -1206,7 +1215,7 @@ mod tests {
         wfm.shutdown().await.unwrap();
     }
 
-    async fn la_timer_la(ctx: WfContext) -> WorkflowResult<()> {
+    async fn la_timer_la(ctx: WfContext) -> WorkflowResult<Payload> {
         ctx.local_activity(LocalActivityOptions {
             activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
             ..Default::default()
@@ -1218,7 +1227,9 @@ mod tests {
             ..Default::default()
         })
         .await;
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     }
 
     #[rstest]
@@ -1410,7 +1421,9 @@ mod tests {
             });
             la.cancel(&ctx);
             la.await;
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
         let mut t = TestHistoryBuilder::default();
         t.add_by_type(EventType::WorkflowExecutionStarted);
@@ -1477,7 +1490,9 @@ mod tests {
                 rfail.cause.unwrap().failure_info,
                 Some(FailureInfo::CanceledFailureInfo(_))
             );
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
 
         let mut t = TestHistoryBuilder::default();

--- a/core/src/worker/workflow/machines/modify_workflow_properties_state_machine.rs
+++ b/core/src/worker/workflow/machines/modify_workflow_properties_state_machine.rs
@@ -118,9 +118,10 @@ impl From<Created> for CommandIssued {
 mod tests {
     use super::*;
     use crate::{replay::TestHistoryBuilder, worker::workflow::ManagedWFFunc};
-    use temporal_sdk::{WfContext, WorkflowFunction};
-    use temporal_sdk_core_protos::temporal::api::{
-        command::v1::command::Attributes, common::v1::Payload,
+    use temporal_sdk::{WfContext, WfExitValue, WorkflowFunction};
+    use temporal_sdk_core_protos::{
+        coresdk::AsJsonPayloadExt,
+        temporal::api::{command::v1::command::Attributes, common::v1::Payload},
     };
 
     #[tokio::test]
@@ -149,7 +150,9 @@ mod tests {
                     },
                 ),
             ]);
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
         let mut wfm = ManagedWFFunc::new(t, wff, vec![]);
 

--- a/core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/core/src/worker/workflow/machines/patch_state_machine.rs
@@ -285,7 +285,7 @@ mod tests {
         collections::{hash_map::RandomState, HashSet, VecDeque},
         time::Duration,
     };
-    use temporal_sdk::{ActivityOptions, WfContext, WorkflowFunction};
+    use temporal_sdk::{ActivityOptions, WfContext, WfExitValue, WorkflowFunction};
     use temporal_sdk_core_protos::{
         constants::PATCH_MARKER_NAME,
         coresdk::{
@@ -458,7 +458,9 @@ mod tests {
                 }
                 _ => panic!("Invalid workflow version for test setup"),
             }
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
 
         let t = patch_marker_single_activity(marker_type, workflow_version, replaying);
@@ -648,7 +650,9 @@ mod tests {
             } else {
                 ctx.timer(ONE_SECOND).await;
             }
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
 
         let mut t = TestHistoryBuilder::default();
@@ -786,7 +790,9 @@ mod tests {
                     let _dontcare = ctx.patched(&format!("patch-{i}"));
                     ctx.timer(ONE_SECOND).await;
                 }
-                Ok(().into())
+                Ok(WfExitValue::Normal(
+                    "success".as_json_payload().expect("serializes fine"),
+                ))
             }),
             vec![],
         );

--- a/core/src/worker/workflow/machines/timer_state_machine.rs
+++ b/core/src/worker/workflow/machines/timer_state_machine.rs
@@ -268,8 +268,8 @@ mod test {
     };
     use rstest::{fixture, rstest};
     use std::{mem::discriminant, time::Duration};
-    use temporal_sdk::{CancellableFuture, WfContext, WorkflowFunction};
-
+    use temporal_sdk::{CancellableFuture, WfContext, WfExitValue, WorkflowFunction};
+    use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
     #[fixture]
     fn happy_wfm() -> ManagedWFFunc {
         /*
@@ -285,7 +285,9 @@ mod test {
         */
         let func = WorkflowFunction::new(|command_sink: WfContext| async move {
             command_sink.timer(Duration::from_secs(5)).await;
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
 
         let t = canned_histories::single_timer("1");
@@ -329,7 +331,9 @@ mod test {
     async fn mismatched_timer_ids_errors() {
         let func = WorkflowFunction::new(|command_sink: WfContext| async move {
             command_sink.timer(Duration::from_secs(5)).await;
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
 
         let t = canned_histories::single_timer("badid");
@@ -350,7 +354,9 @@ mod test {
             // Cancel the first timer after having waited on the second
             cancel_timer_fut.cancel(&ctx);
             cancel_timer_fut.await;
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
 
         let t = canned_histories::cancel_timer("2", "1");
@@ -399,7 +405,9 @@ mod test {
             // Immediately cancel the timer
             cancel_timer_fut.cancel(&ctx);
             cancel_timer_fut.await;
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
 
         let mut t = TestHistoryBuilder::default();

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -204,7 +204,7 @@ mod tests {
     };
     use rustfsm::StateMachine;
     use std::collections::HashMap;
-    use temporal_sdk::{WfContext, WorkflowFunction};
+    use temporal_sdk::{WfContext, WfExitValue, WorkflowFunction};
     use temporal_sdk_core_api::Worker;
     use temporal_sdk_core_protos::{
         coresdk::{
@@ -217,7 +217,6 @@ mod tests {
         },
     };
     use temporal_sdk_core_test_utils::WorkerTestHelpers;
-
     #[tokio::test]
     async fn upsert_search_attrs_from_workflow() {
         let mut t = TestHistoryBuilder::default();
@@ -244,7 +243,9 @@ mod tests {
                     },
                 ),
             ]);
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         });
         let mut wfm = ManagedWFFunc::new(t, wff, vec![]);
 

--- a/core/src/worker/workflow/managed_run/managed_wf_test.rs
+++ b/core/src/worker/workflow/managed_run/managed_wf_test.rs
@@ -61,7 +61,7 @@ pub struct ManagedWFFunc {
     activation_tx: UnboundedSender<WorkflowActivation>,
     completions_rx: UnboundedReceiver<WorkflowActivationCompletion>,
     completions_sync_tx: crossbeam::channel::Sender<WorkflowActivationCompletion>,
-    future_handle: Option<JoinHandle<WorkflowResult<()>>>,
+    future_handle: Option<JoinHandle<WorkflowResult<Payload>>>,
     was_shutdown: bool,
 }
 
@@ -175,7 +175,7 @@ impl ManagedWFFunc {
         Ok(last_act)
     }
 
-    pub async fn shutdown(&mut self) -> WorkflowResult<()> {
+    pub async fn shutdown(&mut self) -> WorkflowResult<Payload> {
         self.was_shutdown = true;
         // Send an eviction to ensure wf exits if it has not finished (ex: feeding partial hist)
         let _ = self.activation_tx.send(create_evict_activation(

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1259,6 +1259,13 @@ pub mod coresdk {
         }
     }
 
+    /// Trait to map the Failure to Rust Error for idiomatic error handling in Workflow code <br/>
+    /// NOTE: This is *NOT* the generic
+    /// [failure converter](https://docs.temporal.io/dataconversion#failure-converter)
+    pub trait FromFailureExt: std::error::Error {
+        fn from_failure(failure: Failure) -> Self;
+    }
+
     pub trait FromPayloadsExt {
         fn from_payloads(p: Option<Payloads>) -> Self;
     }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -20,6 +20,7 @@ base64 = "0.21"
 crossbeam = "0.8"
 derive_more = "0.99"
 futures = "0.3"
+futures-core = "0.3"
 once_cell = "1.10"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 prost-types = { version = "0.4", package = "prost-wkt-types" }

--- a/sdk/src/activity_context.rs
+++ b/sdk/src/activity_context.rs
@@ -60,7 +60,7 @@ impl ActContext {
         task_queue: String,
         task_token: Vec<u8>,
         task: activity_task::Start,
-    ) -> (Self, Payload) {
+    ) -> Self {
         let activity_task::Start {
             workflow_namespace,
             workflow_type,
@@ -68,7 +68,7 @@ impl ActContext {
             activity_id,
             activity_type,
             header_fields,
-            mut input,
+            input,
             heartbeat_details,
             scheduled_time,
             current_attempt_scheduled_time,
@@ -86,37 +86,32 @@ impl ActContext {
             start_to_close_timeout.as_ref(),
             schedule_to_close_timeout.as_ref(),
         );
-        let first_arg = input.pop().unwrap_or_default();
 
-        (
-            ActContext {
-                worker,
-                app_data,
-                cancellation_token,
-                input,
-                heartbeat_details,
-                header_fields,
-                info: ActivityInfo {
-                    task_token,
-                    task_queue,
-                    workflow_type,
-                    workflow_namespace,
-                    workflow_execution,
-                    activity_id,
-                    activity_type,
-                    heartbeat_timeout: heartbeat_timeout.try_into_or_none(),
-                    scheduled_time: scheduled_time.try_into_or_none(),
-                    started_time: started_time.try_into_or_none(),
-                    deadline,
-                    attempt,
-                    current_attempt_scheduled_time: current_attempt_scheduled_time
-                        .try_into_or_none(),
-                    retry_policy,
-                    is_local,
-                },
+        ActContext {
+            worker,
+            app_data,
+            cancellation_token,
+            input,
+            heartbeat_details,
+            header_fields,
+            info: ActivityInfo {
+                task_token,
+                task_queue,
+                workflow_type,
+                workflow_namespace,
+                workflow_execution,
+                activity_id,
+                activity_type,
+                heartbeat_timeout: heartbeat_timeout.try_into_or_none(),
+                scheduled_time: scheduled_time.try_into_or_none(),
+                started_time: started_time.try_into_or_none(),
+                deadline,
+                attempt,
+                current_attempt_scheduled_time: current_attempt_scheduled_time.try_into_or_none(),
+                retry_policy,
+                is_local,
             },
-            first_arg,
-        )
+        }
     }
 
     /// Returns a future the completes if and when the activity this was called inside has been
@@ -133,8 +128,8 @@ impl ActContext {
     /// Retrieve extra parameters to the Activity. The first input is always popped and passed to
     /// the Activity function for the currently executing activity. However, if more parameters are
     /// passed, perhaps from another language's SDK, explicit access is available from extra_inputs
-    pub fn extra_inputs(&mut self) -> &mut [Payload] {
-        &mut self.input
+    pub fn get_args(&self) -> &[Payload] {
+        &self.input
     }
 
     /// Extract heartbeat details from last failed attempt. This is used in combination with retry policy.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -48,6 +48,8 @@ mod activity_context;
 mod app_data;
 pub mod interceptors;
 mod payload_converter;
+pub mod prelude;
+pub mod workflow;
 mod workflow_context;
 mod workflow_future;
 
@@ -730,7 +732,7 @@ impl WorkflowFunction {
 pub type WorkflowResult<T> = Result<WfExitValue<T>, anyhow::Error>;
 
 /// Workflow functions may return these values when exiting
-#[derive(Debug, derive_more::From)]
+#[derive(derive_more::From)]
 pub enum WfExitValue<T: Debug> {
     /// Continue the workflow as a new execution
     #[from(ignore)]

--- a/sdk/src/prelude.rs
+++ b/sdk/src/prelude.rs
@@ -1,0 +1,55 @@
+//! Prelude for easy importing of required types when defining workflow and activity definitions
+
+/// Registry prelude
+#[allow(unused_imports)]
+pub mod registry {
+    pub use crate::workflow::{
+        into_activity_0_args, into_activity_0_args_without_ctx, into_activity_1_args,
+        into_activity_1_args_exit_value, into_activity_1_args_with_errors, into_activity_2_args,
+        into_workflow_0_args, into_workflow_1_args, into_workflow_1_args_exit_value,
+        into_workflow_1_args_with_errors, into_workflow_2_args,
+    };
+}
+
+/// Activity prelude
+#[allow(unused_imports)]
+pub mod activity {
+    pub use crate::{ActContext, ActExitValue, ActivityCancelledError, NonRetryableActivityError};
+    pub use serde::{Deserialize, Serialize};
+    pub use temporal_sdk_core_protos::{
+        coresdk::FromFailureExt, temporal::api::failure::v1::Failure,
+    };
+}
+
+/// Workflow prelude
+#[allow(unused_imports)]
+pub mod workflow {
+    pub use crate::workflow::{
+        execute_activity_0_args, execute_activity_0_args_without_ctx, execute_activity_1_args,
+        execute_activity_1_args_exit_value, execute_activity_1_args_with_errors,
+        execute_activity_2_args, execute_child_workflow_0_args_exit_value,
+        execute_child_workflow_1_args, execute_child_workflow_2_args,
+        execute_child_workflow_2_args_exit_value,
+    };
+    pub use crate::workflow::{AsyncFn0, AsyncFn1, AsyncFn2, AsyncFn3};
+    pub use crate::{
+        ActivityOptions, ChildWorkflowOptions, LocalActivityOptions, Signal, SignalData,
+        SignalWorkflowOptions, WfContext, WfExitValue, WorkflowResult,
+    };
+    use futures::FutureExt;
+    pub use serde::{Deserialize, Serialize};
+    pub use std::{
+        fmt::{Debug, Display},
+        future::Future,
+        time::Duration,
+    };
+    pub use temporal_sdk_core_protos::{
+        coresdk::{
+            activity_result::{self, activity_resolution},
+            child_workflow::{child_workflow_result, Failure, Success},
+            workflow_commands::ActivityCancellationType,
+            AsJsonPayloadExt, FromFailureExt, FromJsonPayloadExt,
+        },
+        temporal::api::common::v1::Payload,
+    };
+}

--- a/sdk/src/workflow.rs
+++ b/sdk/src/workflow.rs
@@ -1,0 +1,1186 @@
+//! Abstractions based on SDK [crate] for defining workflow and activity definitions in idiomatic Async Rust
+//!
+//! This module has a large API surface mainly due to Rust's lack of [reflection](https://en.wikipedia.org/wiki/Reflective_programming)
+//! capability and variadic arguments/generics on which other language SDKs depend on. Once the API is good enough, the variations can be hidden behind macros.
+//!
+//! Even though we can just use 'tuples' as arguments for all the functions for easy implementation,
+//! the goal is to support general enough Workflow and Activity functions to the most extent possible but only with some limitations on arguments and results
+//! as required by [temporal_sdk_core] and [Workflow definitions](https://docs.temporal.io/workflows#workflow-definition) and in general by Temporal platform.
+//!
+//! There are two main types of high-level functions. Other convenience facilities and possibly macros will be included in the future.
+//! 1) Register functions (Example: [into_activity_1_args_exit_value], [into_workflow_0_args]) to register Activity/Workflow functions.
+//! 2) Command functions (Example: [execute_activity_1_args], [execute_child_workflow_2_args_exit_value]) for workflow [commands](https://docs.temporal.io/workflows#command).
+//!
+//! These functions vary in which type of user-defined Activity/Workflow functions they accept.
+//! Generic traits representing the user-defined functions are defined in the module. For example [AsyncFn2] is a function which takes two arguments.
+//!
+//! Currently, Activity/Workflow Functions with below arguments and result variations are supported.
+//!
+//! Argument variations
+//! 1) Activity Functions which take [ActContext] and zero or more arguments
+//! 2) Workflow Functions which take [WfContext] and zero or more arguments
+//! 3) Activity Functions which take zero or more arguments. These are for simple Activity implementations which do not rely on Activity Context (Cancellation, Heartbeats etc.)
+//!
+//! Result variations
+//! 1) Returning [ActExitValue]/[WfExitValue] and [anyhow::Error].
+//! 2) Returning [ActExitValue]/[WfExitValue] and user-defined error types.<br/>
+//!    Define Activity/Workflow Functions as these if you want to return typed errors(Ex: errors defined using [thiserror](https://docs.rs/thiserror/latest/thiserror/)).
+//!    These require an implementation of [FromFailureExt] to map [Failure](temporal_sdk_core_protos::temporal::api::failure::v1::Failure) to the user-defined error types in addition to Activity/Workflow definitions.
+//! 3) Returning just the user-defined result and [anyhow::Error]
+//! 4) Returning just the user-defined result and error types.(Same requirements as type 2 above)
+//!
+//! Note: Any type `T` which implements [Debug] has generic implementation of [`Into<ActExitValue<T>>`] and [`Into<WfExitValue<T>>`]
+//!
+//! Defining workflows should feel like just a normal Rust(Async) program. Use [Prelude](crate::prelude) for easy import of types needed.
+//!
+//!
+//! An example workflow definition is below. For more, refer to tests and examples.
+//! ```no_run
+//! use temporal_sdk::prelude::registry::*;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut worker = worker::worker().await.unwrap();
+//!
+//!     worker.register_activity(
+//!         "sdk_example_activity",
+//!         into_activity_1_args_with_errors(activity::sdk_example_activity),
+//!     );
+//!
+//!     worker.register_wf(
+//!         "sdk_example_workflow",
+//!         into_workflow_1_args(workflow::sdk_example_workflow),
+//!     );
+//!
+//!     worker.run().await?;
+//!
+//!     Ok(())
+//! }
+//!
+//! mod worker {
+//!     use std::{str::FromStr, sync::Arc};
+//!     use temporal_sdk::{sdk_client_options, Worker};
+//!     use temporal_sdk_core::{init_worker, CoreRuntime, Url};
+//!     use temporal_sdk_core_api::{telemetry::TelemetryOptionsBuilder, worker::WorkerConfigBuilder};
+//!     pub(crate) async fn worker() -> Result<Worker, Box<dyn std::error::Error>> {
+//!         let server_options = sdk_client_options(Url::from_str("http://!localhost:7233")?).build()?;
+//!
+//!         let client = server_options.connect("default", None, None).await?;
+//!
+//!         let telemetry_options = TelemetryOptionsBuilder::default().build()?;
+//!         let runtime = CoreRuntime::new_assume_tokio(telemetry_options)?;
+//!
+//!         let worker_config = WorkerConfigBuilder::default()
+//!             .namespace("default")
+//!             .task_queue("task_queue")
+//!             .build()?;
+//!
+//!         let core_worker = init_worker(&runtime, worker_config, client)?;
+//!
+//!         Ok(Worker::new_from_core(Arc::new(core_worker), "task_queue"))
+//!     }
+//! }
+//!
+//! mod activity {
+//!     use temporal_sdk::prelude::activity::*;
+//!
+//!     #[derive(Debug, thiserror::Error)]
+//!     #[non_exhaustive]
+//!     pub enum Error {
+//!         #[error(transparent)]
+//!         Io(#[from] std::io::Error),
+//!         #[error(transparent)]
+//!         Any(anyhow::Error),
+//!     }
+//!
+//!     impl FromFailureExt for Error {
+//!         fn from_failure(failure: Failure) -> Error {
+//!             Error::Any(anyhow::anyhow!("{:?}", failure.message))
+//!         }
+//!     }
+//!
+//!     #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+//!     pub struct ActivityInput {
+//!         pub activity: String,
+//!         pub workflow: String,
+//!     }
+//!
+//!     #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+//!     pub struct ActivityOutput {
+//!         pub language: String,
+//!         pub platform: String,
+//!     }
+//!
+//!     pub async fn sdk_example_activity(
+//!         _ctx: ActContext,
+//!         input: ActivityInput,
+//!     ) -> Result<(String, ActivityOutput), Error> {
+//!         Ok((
+//!             format!("{}-{}", input.activity, input.workflow),
+//!             ActivityOutput {
+//!                 language: "rust".to_string(),
+//!                 platform: "temporal".to_string(),
+//!             },
+//!         ))
+//!     }
+//! }
+//!
+//! mod workflow {
+//!     use super::activity::*;
+//!     use temporal_sdk::prelude::workflow::*;
+//!
+//!     #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+//!     pub struct WorkflowInput {
+//!         pub activity: String,
+//!         pub workflow: String,
+//!     }
+//!
+//!     pub async fn sdk_example_workflow(
+//!         ctx: WfContext,
+//!         input: WorkflowInput,
+//!     ) -> Result<WfExitValue<ActivityOutput>, anyhow::Error> {
+//!         let activity_timeout = Duration::from_secs(5);
+//!         let output = execute_activity_1_args_with_errors(
+//!             &ctx,
+//!             ActivityOptions {
+//!                 activity_id: Some("sdk_example_activity".to_string()),
+//!                 activity_type: "sdk_example_activity".to_string(),
+//!                 schedule_to_close_timeout: Some(activity_timeout),
+//!                 ..Default::default()
+//!             },
+//!             sdk_example_activity,
+//!             ActivityInput {
+//!                 activity: input.activity,
+//!                 workflow: input.workflow,
+//!             },
+//!         )
+//!         .await;
+//!         match output {
+//!             Ok(output) => Ok(WfExitValue::Normal(output.1)),
+//!             Err(e) => Err(anyhow::Error::from(e)),
+//!         }
+//!     }
+//! }
+//! ```
+
+// TODO: Remove this after complete implementation
+#![allow(unused_imports)]
+
+// TODO: Create ActivityOptions, ChildOptions type and builders for workflow abstractions
+
+use crate::{
+    ActContext, ActExitValue, ActivityOptions, ChildWorkflowOptions, WfContext, WfExitValue,
+};
+use anyhow::anyhow;
+use futures::FutureExt;
+use futures_core::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, future::Future};
+use temporal_sdk_core_protos::{
+    coresdk::{
+        activity_result::{self, activity_resolution},
+        child_workflow::{self, child_workflow_result},
+        workflow_commands::ActivityCancellationType,
+        AsJsonPayloadExt, FromFailureExt, FromJsonPayloadExt,
+    },
+    temporal::api::common::v1::Payload,
+};
+
+/// Trait to represent an async function with 0 arguments
+pub trait AsyncFn0: Fn() -> Self::OutputFuture {
+    /// Output type of the async function which implements serde traits
+    type Output;
+    /// Future of the output
+    type OutputFuture: Future<Output = <Self as AsyncFn0>::Output> + Send + 'static;
+}
+
+impl<F: ?Sized, Fut> AsyncFn0 for F
+where
+    F: Fn() -> Fut,
+    Fut: Future + Send + 'static,
+{
+    type Output = Fut::Output;
+    type OutputFuture = Fut;
+}
+
+/// Trait to represent an async function with 1 argument
+pub trait AsyncFn1<Arg0>: Fn(Arg0) -> Self::OutputFuture {
+    /// Output type of the async function which implements serde traits
+    type Output;
+    /// Future of the output
+    type OutputFuture: Future<Output = <Self as AsyncFn1<Arg0>>::Output> + Send + 'static;
+}
+
+impl<F: ?Sized, Fut, Arg0> AsyncFn1<Arg0> for F
+where
+    F: Fn(Arg0) -> Fut,
+    Fut: Future + Send + 'static,
+{
+    type Output = Fut::Output;
+    type OutputFuture = Fut;
+}
+
+/// Trait to represent an async function with 2 arguments
+pub trait AsyncFn2<Arg0, Arg1>: Fn(Arg0, Arg1) -> Self::OutputFuture {
+    /// Output type of the async function which implements serde traits
+    type Output;
+    /// Future of the output
+    type OutputFuture: Future<Output = <Self as AsyncFn2<Arg0, Arg1>>::Output> + Send + 'static;
+}
+
+impl<F: ?Sized, Fut, Arg0, Arg1> AsyncFn2<Arg0, Arg1> for F
+where
+    F: Fn(Arg0, Arg1) -> Fut,
+    Fut: Future + Send + 'static,
+{
+    type Output = Fut::Output;
+    type OutputFuture = Fut;
+}
+
+/// Trait to represent an async function with 3 arguments
+pub trait AsyncFn3<Arg0, Arg1, Arg2>: Fn(Arg0, Arg1, Arg2) -> Self::OutputFuture {
+    /// Output type of the async function which implements serde traits
+    type Output;
+    /// Future of the output
+    type OutputFuture: Future<Output = <Self as AsyncFn3<Arg0, Arg1, Arg2>>::Output>
+        + Send
+        + 'static;
+}
+
+impl<F: ?Sized, Fut, Arg0, Arg1, Arg2> AsyncFn3<Arg0, Arg1, Arg2> for F
+where
+    F: Fn(Arg0, Arg1, Arg2) -> Fut,
+    Fut: Future + Send + 'static,
+{
+    type Output = Fut::Output;
+    type OutputFuture = Fut;
+}
+
+/// Register activity which takes [ActContext] with 0 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_activity_0_args] to execute the activity in the workflow definition.
+pub fn into_activity_0_args<F, R, O>(
+    f: F,
+) -> impl Fn(ActContext) -> BoxFuture<'static, Result<ActExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    F: AsyncFn1<ActContext, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<ActExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |ctx: ActContext| {
+        (f)(ctx)
+            .map(|r| {
+                r.and_then(|r| {
+                    let r = r.into();
+                    Ok(match r {
+                        ActExitValue::WillCompleteAsync => ActExitValue::WillCompleteAsync,
+                        ActExitValue::Normal(o) => ActExitValue::Normal(o.as_json_payload()?),
+                    })
+                })
+            })
+            .boxed()
+    }
+}
+
+/// Execute activity which takes [ActContext] with 0 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload]. <br/>
+/// Use [into_activity_0_args] to register the activity with the worker.
+pub async fn execute_activity_0_args<'a, F, R>(
+    ctx: &WfContext,
+    options: ActivityOptions,
+    _f: F,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn1<ActContext, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let activity_type = if options.activity_type.is_empty() {
+        std::any::type_name::<F>().to_string()
+    } else {
+        options.activity_type
+    };
+    let options = ActivityOptions {
+        activity_type,
+        input: vec![],
+        ..options
+    };
+    let activity_resolution = ctx.activity(options).await;
+
+    match activity_resolution.status {
+        Some(activity_resolution::Status::Completed(activity_result::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(activity_resolution::Status::Failed(activity_result::Failure { failure })) => {
+            Err(anyhow::anyhow!("{:?}", failure))
+        }
+        _ => panic!("activity task failed {activity_resolution:?}"),
+    }
+}
+
+/// Execute activity which takes [ActContext] with 0 arguments and returns a [ActExitValue] wrapping 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_activity_0_args] to register the activity with the worker.
+pub async fn execute_activity_0_args_exit_value<'a, F, R>(
+    ctx: &WfContext,
+    options: ActivityOptions,
+    _f: F,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn1<ActContext, Output = Result<ActExitValue<R>, anyhow::Error>>
+        + Send
+        + Sync
+        + 'static,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let activity_type = if options.activity_type.is_empty() {
+        std::any::type_name::<F>().to_string()
+    } else {
+        options.activity_type
+    };
+    let options = ActivityOptions {
+        activity_type,
+        input: vec![],
+        ..options
+    };
+    let activity_resolution = ctx.activity(options).await;
+
+    match activity_resolution.status {
+        Some(activity_resolution::Status::Completed(activity_result::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(activity_resolution::Status::Failed(activity_result::Failure { failure })) => {
+            Err(anyhow::anyhow!("{:?}", failure))
+        }
+        _ => panic!("activity task failed {activity_resolution:?}"),
+    }
+}
+
+/// Register activity which takes 0 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_activity_0_args_without_ctx] to execute the activity in the workflow definition.
+pub fn into_activity_0_args_without_ctx<F, R, O>(
+    f: F,
+) -> impl Fn(ActContext) -> BoxFuture<'static, Result<ActExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    F: AsyncFn0<Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<ActExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |_ctx: ActContext| {
+        (f)()
+            .map(|r| {
+                r.and_then(|r| {
+                    let r: ActExitValue<O> = r.into();
+                    Ok(match r {
+                        ActExitValue::WillCompleteAsync => ActExitValue::WillCompleteAsync,
+                        ActExitValue::Normal(o) => ActExitValue::Normal(o.as_json_payload()?),
+                    })
+                })
+            })
+            .boxed()
+    }
+}
+
+/// Execute activity which takes 0 arguments.
+/// Use this for an activity which does not need to handle
+/// [Cancellation](https://docs.temporal.io/activities#cancellation),
+/// [Heartbeat](https://docs.temporal.io/activities#activity-heartbeat)
+/// or any context dependent actions.
+/// Use [into_activity_0_args_without_ctx] to register the activity with the worker.
+pub async fn execute_activity_0_args_without_ctx<'a, F, R>(
+    ctx: &WfContext,
+    options: ActivityOptions,
+    _f: F,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn0<Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let activity_type = if options.activity_type.is_empty() {
+        std::any::type_name::<F>().to_string()
+    } else {
+        options.activity_type
+    };
+    let options = ActivityOptions {
+        activity_type,
+        input: vec![],
+        ..options
+    };
+    let activity_resolution = ctx.activity(options).await;
+
+    match activity_resolution.status {
+        Some(activity_resolution::Status::Completed(activity_result::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(activity_resolution::Status::Failed(activity_result::Failure { failure })) => {
+            Err(anyhow::anyhow!("{:?}", failure))
+        }
+        _ => panic!("activity task failed {activity_resolution:?}"),
+    }
+}
+
+/// Execute activity which takes 0 arguments.
+/// Use this for an activity which does not need to handle
+/// [Cancellation](https://docs.temporal.io/activities#cancellation),
+/// [Heartbeat](https://docs.temporal.io/activities#activity-heartbeat)
+/// or any context dependent actions.
+/// Use [into_activity_0_args_without_ctx] to register the activity with the worker.
+pub async fn execute_activity_0_args_without_ctx_exit_value<'a, F, R>(
+    ctx: &WfContext,
+    options: ActivityOptions,
+    _f: F,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn0<Output = Result<ActExitValue<R>, anyhow::Error>> + Send + Sync + 'static,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let activity_type = if options.activity_type.is_empty() {
+        std::any::type_name::<F>().to_string()
+    } else {
+        options.activity_type
+    };
+    let options = ActivityOptions {
+        activity_type,
+        input: vec![],
+        ..options
+    };
+    let activity_resolution = ctx.activity(options).await;
+
+    match activity_resolution.status {
+        Some(activity_resolution::Status::Completed(activity_result::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(activity_resolution::Status::Failed(activity_result::Failure { failure })) => {
+            Err(anyhow::anyhow!("{:?}", failure))
+        }
+        _ => panic!("activity task failed {activity_resolution:?}"),
+    }
+}
+
+/// Register activity which takes [ActContext] with 1 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_activity_1_args] to execute the activity in the workflow definition.
+pub fn into_activity_1_args<A, F, R, O>(
+    f: F,
+) -> impl Fn(ActContext) -> BoxFuture<'static, Result<ActExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    A: FromJsonPayloadExt + Send,
+    F: AsyncFn2<ActContext, A, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<ActExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |ctx: ActContext| match A::from_json_payload(&ctx.get_args()[0]) {
+        Ok(a) => (f)(ctx, a)
+            .map(|r| {
+                r.and_then(|r| {
+                    let r = r.into();
+                    Ok(match r {
+                        ActExitValue::WillCompleteAsync => ActExitValue::WillCompleteAsync,
+                        ActExitValue::Normal(o) => ActExitValue::Normal(o.as_json_payload()?),
+                    })
+                })
+            })
+            .boxed(),
+        Err(e) => async move { Err(anyhow::Error::new(e)) }.boxed(),
+    }
+}
+
+/// Execute activity which takes [ActContext] with 1 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_activity_1_args] to register the activity with the worker.
+pub async fn execute_activity_1_args<'a, A, F, R>(
+    ctx: &WfContext,
+    options: ActivityOptions,
+    _f: F,
+    a: A,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn2<ActContext, A, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let activity_type = if options.activity_type.is_empty() {
+        std::any::type_name::<F>().to_string()
+    } else {
+        options.activity_type
+    };
+    let options = ActivityOptions {
+        activity_type,
+        input: vec![a],
+        ..options
+    };
+    let activity_resolution = ctx.activity(options).await;
+
+    match activity_resolution.status {
+        Some(activity_resolution::Status::Completed(activity_result::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(activity_resolution::Status::Failed(activity_result::Failure { failure })) => {
+            Err(anyhow::anyhow!("{:?}", failure))
+        }
+        _ => panic!("activity task failed {activity_resolution:?}"),
+    }
+}
+
+/// Register activity which takes [ActContext] with 1 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_activity_1_args] to execute the activity in the workflow definition.
+pub fn into_activity_1_args_exit_value<A, F, R, O>(
+    f: F,
+) -> impl Fn(ActContext) -> BoxFuture<'static, Result<ActExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    A: FromJsonPayloadExt + Send,
+    F: AsyncFn2<ActContext, A, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<ActExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |ctx: ActContext| match A::from_json_payload(&ctx.get_args()[0]) {
+        Ok(a) => (f)(ctx, a)
+            .map(|r| {
+                r.and_then(|r| {
+                    let r = r.into();
+                    Ok(match r {
+                        ActExitValue::WillCompleteAsync => ActExitValue::WillCompleteAsync,
+                        ActExitValue::Normal(o) => ActExitValue::Normal(o.as_json_payload()?),
+                    })
+                })
+            })
+            .boxed(),
+        Err(e) => async move { Err(anyhow::Error::new(e)) }.boxed(),
+    }
+}
+
+/// Execute activity which takes [ActContext] with 1 arguments and returns a [ActExitValue] wrapping 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_activity_1_args] to register the activity with the worker.
+pub async fn execute_activity_1_args_exit_value<'a, A, F, R>(
+    ctx: &WfContext,
+    options: ActivityOptions,
+    _f: F,
+    a: A,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn2<ActContext, A, Output = Result<ActExitValue<R>, anyhow::Error>>
+        + Send
+        + Sync
+        + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let activity_type = if options.activity_type.is_empty() {
+        std::any::type_name::<F>().to_string()
+    } else {
+        options.activity_type
+    };
+    let options = ActivityOptions {
+        activity_type,
+        input: vec![a],
+        ..options
+    };
+    let activity_resolution = ctx.activity(options).await;
+
+    match activity_resolution.status {
+        Some(activity_resolution::Status::Completed(activity_result::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(activity_resolution::Status::Failed(activity_result::Failure { failure })) => {
+            Err(anyhow::anyhow!("{:?}", failure))
+        }
+        _ => panic!("activity task failed {activity_resolution:?}"),
+    }
+}
+
+/// Register activity which takes [ActContext] with 1 arguments and returns a result [Result<R,E>] where 'R'
+/// implements [serde] traits for serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// and 'E' is custom error type
+/// Use [execute_activity_1_args_with_errors] to execute the activity in the workflow definition.
+pub fn into_activity_1_args_with_errors<A, F, R, O, E>(
+    f: F,
+) -> impl Fn(ActContext) -> BoxFuture<'static, Result<ActExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    A: FromJsonPayloadExt + Send,
+    F: AsyncFn2<ActContext, A, Output = Result<R, E>> + Send + Sync + 'static,
+    R: Into<ActExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    move |ctx: ActContext| match A::from_json_payload(&ctx.get_args()[0]) {
+        Ok(a) => (f)(ctx, a)
+            .map(|r| match r {
+                Ok(r) => {
+                    let exit_val: ActExitValue<O> = r.into();
+                    Ok(match exit_val {
+                        ActExitValue::WillCompleteAsync => ActExitValue::WillCompleteAsync,
+                        ActExitValue::Normal(x) => ActExitValue::Normal(x.as_json_payload()?),
+                    })
+                }
+                Err(e) => Err(anyhow::Error::from(e)),
+            })
+            .boxed(),
+        Err(e) => async move { Err(anyhow::Error::from(e)) }.boxed(),
+    }
+}
+
+/// Execute activity which takes [ActContext] with 1 arguments and returns a result [Result<R,E>] where 'R'
+/// implements [serde] traits for serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// and 'E' is custom error type
+/// Use [into_activity_1_args_with_errors] to register the activity with the worker.
+pub async fn execute_activity_1_args_with_errors<'a, A, F, R, E>(
+    ctx: &WfContext,
+    options: ActivityOptions,
+    _f: F,
+    a: A,
+) -> Result<R, E>
+where
+    F: AsyncFn2<ActContext, A, Output = Result<R, E>> + Send + Sync + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+    E: FromFailureExt,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let activity_type = if options.activity_type.is_empty() {
+        std::any::type_name::<F>().to_string()
+    } else {
+        options.activity_type
+    };
+    let options = ActivityOptions {
+        activity_type,
+        input: vec![a],
+        ..options
+    };
+    let activity_resolution = ctx.activity(options).await;
+    match activity_resolution.status {
+        Some(activity_resolution::Status::Completed(activity_result::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(activity_resolution::Status::Failed(activity_result::Failure { failure })) => {
+            Err(E::from_failure(failure.unwrap()))
+        }
+        _ => panic!("Unexpected activity resolution status"),
+    }
+}
+
+/// Register activity which takes [ActContext] with 2 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_activity_2_args] to execute the activity in the workflow definition.
+pub fn into_activity_2_args<A, B, F, R, O>(
+    f: F,
+) -> impl Fn(ActContext) -> BoxFuture<'static, Result<ActExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    A: FromJsonPayloadExt + Send,
+    B: FromJsonPayloadExt + Send,
+    F: AsyncFn3<ActContext, A, B, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<ActExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |ctx: ActContext| match A::from_json_payload(&ctx.get_args()[0]) {
+        Ok(a) => match B::from_json_payload(&ctx.get_args()[1]) {
+            Ok(b) => (f)(ctx, a, b)
+                .map(|r| {
+                    r.and_then(|r| {
+                        let r = r.into();
+                        Ok(match r {
+                            ActExitValue::WillCompleteAsync => ActExitValue::WillCompleteAsync,
+                            ActExitValue::Normal(o) => ActExitValue::Normal(o.as_json_payload()?),
+                        })
+                    })
+                })
+                .boxed(),
+            Err(e) => async move { Err(e.into()) }.boxed(),
+        },
+        Err(e) => async move { Err(e.into()) }.boxed(),
+    }
+}
+
+/// Execute activity which takes [ActContext] with 2 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_activity_2_args] to register the activity with the worker.
+pub async fn execute_activity_2_args<'a, 'b, A, B, F, R>(
+    ctx: &WfContext,
+    options: ActivityOptions,
+    _f: F,
+    a: A,
+    b: B,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn3<ActContext, A, B, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    B: Serialize + Deserialize<'b> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let b = B::as_json_payload(&b).expect("serializes fine");
+    let activity_type = if options.activity_type.is_empty() {
+        std::any::type_name::<F>().to_string()
+    } else {
+        options.activity_type
+    };
+    let options = ActivityOptions {
+        activity_type,
+        input: vec![a, b],
+        //input,
+        ..options
+    };
+    let output = ctx.activity(options).await.unwrap_ok_payload();
+    Ok(R::from_json_payload(&output).unwrap())
+}
+
+/// Register child workflow which takes [WfContext] with 0 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_child_workflow_0_args] to execute the workflow in the workflow definition.
+pub fn into_workflow_0_args<F, R, O>(
+    f: F,
+) -> impl Fn(WfContext) -> BoxFuture<'static, Result<WfExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    F: AsyncFn1<WfContext, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<WfExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |ctx: WfContext| {
+        (f)(ctx)
+            .map(|r| {
+                r.and_then(|r| {
+                    let r = r.into();
+                    Ok(match r {
+                        WfExitValue::ContinueAsNew(b) => WfExitValue::ContinueAsNew(b),
+                        WfExitValue::Cancelled => WfExitValue::Cancelled,
+                        WfExitValue::Evicted => WfExitValue::Evicted,
+                        WfExitValue::Normal(a) => WfExitValue::Normal(a.as_json_payload()?),
+                    })
+                })
+            })
+            .boxed()
+    }
+}
+
+/// Execute child workflow which takes [WfContext] with 0 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_workflow_0_args] to register the workflow with the worker.
+pub async fn execute_child_workflow_0_args<'a, F, R>(
+    ctx: &WfContext,
+    options: ChildWorkflowOptions,
+    _f: F,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn1<WfContext, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let workflow_type = std::any::type_name::<F>();
+
+    let child = ctx.child_workflow(ChildWorkflowOptions {
+        workflow_type: workflow_type.to_string(),
+        input: vec![],
+        ..options
+    });
+
+    let started = child
+        .start(ctx)
+        .await
+        .into_started()
+        .expect("Child should start OK");
+
+    match started.result().await.status {
+        Some(child_workflow_result::Status::Completed(child_workflow::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        _ => Err(anyhow!("Unexpected child WF status")),
+    }
+}
+
+/// Execute child workflow which takes [WfContext] with 0 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_workflow_0_args] to register the workflow with the worker.
+pub async fn execute_child_workflow_0_args_exit_value<'a, F, R>(
+    ctx: &WfContext,
+    options: ChildWorkflowOptions,
+    _f: F,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn1<WfContext, Output = Result<WfExitValue<R>, anyhow::Error>> + Send + Sync + 'static,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let workflow_type = std::any::type_name::<F>();
+
+    let child = ctx.child_workflow(ChildWorkflowOptions {
+        workflow_type: workflow_type.to_string(),
+        input: vec![],
+        ..options
+    });
+
+    let started = child
+        .start(ctx)
+        .await
+        .into_started()
+        .expect("Child should start OK");
+
+    match started.result().await.status {
+        Some(child_workflow_result::Status::Completed(child_workflow::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        _ => Err(anyhow!("Unexpected child WF status")),
+    }
+}
+
+/// Register child workflow which takes [WfContext] with 1 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_child_workflow_1_args] to execute the workflow in the workflow definition.
+pub fn into_workflow_1_args<A, F, R, O>(
+    f: F,
+) -> impl Fn(WfContext) -> BoxFuture<'static, Result<WfExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    A: FromJsonPayloadExt + Send,
+    F: AsyncFn2<WfContext, A, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<WfExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |ctx: WfContext| match A::from_json_payload(&ctx.get_args()[0]) {
+        Ok(a) => (f)(ctx, a)
+            .map(|r| {
+                r.and_then(|r| {
+                    let r: WfExitValue<O> = r.into();
+                    Ok(match r {
+                        WfExitValue::ContinueAsNew(b) => WfExitValue::ContinueAsNew(b),
+                        WfExitValue::Cancelled => WfExitValue::Cancelled,
+                        WfExitValue::Evicted => WfExitValue::Evicted,
+                        WfExitValue::Normal(a) => WfExitValue::Normal(a.as_json_payload()?),
+                    })
+                })
+            })
+            .boxed(),
+        Err(e) => async move { Err(e.into()) }.boxed(),
+    }
+}
+
+/// Execute child workflow which takes [WfContext] with 2 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_workflow_1_args] to register the workflow with the worker
+pub async fn execute_child_workflow_1_args<'a, A, F, R>(
+    ctx: &WfContext,
+    options: ChildWorkflowOptions,
+    _f: F,
+    a: A,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn2<WfContext, A, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let workflow_type = std::any::type_name::<F>();
+
+    let child = ctx.child_workflow(ChildWorkflowOptions {
+        workflow_type: workflow_type.to_string(),
+        input: vec![a],
+        ..options
+    });
+
+    let started = child
+        .start(ctx)
+        .await
+        .into_started()
+        .expect("Child should start OK");
+
+    match started.result().await.status {
+        Some(child_workflow_result::Status::Completed(child_workflow::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        _ => Err(anyhow!("Unexpected child WF status")),
+    }
+}
+
+/// Register child workflow which takes [WfContext] with 1 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_child_workflow_1_args_exit_value] to execute the workflow in the workflow definition.
+pub fn into_workflow_1_args_exit_value<A, F, R, O>(
+    f: F,
+) -> impl Fn(WfContext) -> BoxFuture<'static, Result<WfExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    A: FromJsonPayloadExt + Send,
+    F: AsyncFn2<WfContext, A, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<WfExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |ctx: WfContext| match A::from_json_payload(&ctx.get_args()[0]) {
+        Ok(a) => (f)(ctx, a)
+            .map(|r| {
+                r.and_then(|r| {
+                    let r = r.into();
+                    Ok(match r {
+                        WfExitValue::ContinueAsNew(b) => WfExitValue::ContinueAsNew(b),
+                        WfExitValue::Cancelled => WfExitValue::Cancelled,
+                        WfExitValue::Evicted => WfExitValue::Evicted,
+                        WfExitValue::Normal(a) => WfExitValue::Normal(a.as_json_payload()?),
+                    })
+                })
+            })
+            .boxed(),
+        Err(e) => async move { Err(anyhow::Error::new(e)) }.boxed(),
+    }
+}
+
+/// Execute child workflow which takes [WfContext] with 1 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_workflow_1_args_exit_value] to register the workflow with the worker.
+pub async fn execute_child_workflow_1_args_exit_value<'a, A, F, R>(
+    ctx: &WfContext,
+    options: ChildWorkflowOptions,
+    _f: F,
+    a: A,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn2<WfContext, A, Output = Result<WfExitValue<R>, anyhow::Error>>
+        + Send
+        + Sync
+        + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let workflow_type = std::any::type_name::<F>();
+
+    let child = ctx.child_workflow(ChildWorkflowOptions {
+        workflow_type: workflow_type.to_string(),
+        input: vec![a],
+        ..options
+    });
+
+    let started = child
+        .start(ctx)
+        .await
+        .into_started()
+        .expect("Child should start OK");
+
+    match started.result().await.status {
+        Some(child_workflow_result::Status::Completed(child_workflow::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(child_workflow_result::Status::Failed(child_workflow::Failure { failure })) => {
+            Err(anyhow::anyhow!("{:?}", failure))
+        }
+        _ => Err(anyhow!("Unexpected child WF status")),
+    }
+}
+
+/// Execute activity which takes [ActContext] with 1 arguments and returns a result [Result<R,E>] where 'R'
+/// implements [serde] traits for serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// and 'E' is custom error type
+/// Use [execute_child_workflow_1_args_with_errors] to register the activity with the worker.
+pub fn into_workflow_1_args_with_errors<A, F, R, O, E>(
+    f: F,
+) -> impl Fn(WfContext) -> BoxFuture<'static, Result<WfExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    A: FromJsonPayloadExt + Send,
+    F: AsyncFn2<WfContext, A, Output = Result<R, E>> + Send + Sync + 'static,
+    R: Into<WfExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    move |ctx: WfContext| match A::from_json_payload(&ctx.get_args()[0]) {
+        Ok(a) => (f)(ctx, a)
+            .map(|r| match r {
+                Ok(r) => {
+                    let r: WfExitValue<O> = r.into();
+                    Ok(match r {
+                        WfExitValue::ContinueAsNew(b) => WfExitValue::ContinueAsNew(b),
+                        WfExitValue::Cancelled => WfExitValue::Cancelled,
+                        WfExitValue::Evicted => WfExitValue::Evicted,
+                        WfExitValue::Normal(a) => WfExitValue::Normal(a.as_json_payload()?),
+                    })
+                }
+                Err(e) => Err(anyhow::Error::from(e)),
+            })
+            .boxed(),
+        Err(e) => async move { Err(anyhow::Error::from(e)) }.boxed(),
+    }
+}
+
+/// Execute child workflow which takes [WfContext] with 1 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_workflow_0_args] to register the workflow with the worker.
+pub async fn execute_child_workflow_1_args_with_errors<'a, A, F, R, E>(
+    ctx: &WfContext,
+    options: ChildWorkflowOptions,
+    _f: F,
+    a: A,
+) -> Result<R, E>
+where
+    F: AsyncFn2<WfContext, A, Output = Result<R, E>> + Send + Sync + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+    E: FromFailureExt,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let workflow_type = std::any::type_name::<F>();
+
+    let child = ctx.child_workflow(ChildWorkflowOptions {
+        workflow_type: workflow_type.to_string(),
+        input: vec![a],
+        ..options
+    });
+
+    let started = child
+        .start(ctx)
+        .await
+        .into_started()
+        .expect("Child should start OK");
+
+    match started.result().await.status {
+        Some(child_workflow_result::Status::Completed(child_workflow::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        Some(child_workflow_result::Status::Failed(child_workflow::Failure { failure })) => {
+            Err(E::from_failure(failure.unwrap()))
+        }
+        _ => panic!("Unexpected child WF status"),
+    }
+}
+
+/// Register child workflow which takes [WfContext] with 1 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [execute_child_workflow_2_args] to execute the workflow in the workflow definition.
+pub fn into_workflow_2_args<A, B, F, R, O>(
+    f: F,
+) -> impl Fn(WfContext) -> BoxFuture<'static, Result<WfExitValue<Payload>, anyhow::Error>> + Send + Sync
+where
+    A: FromJsonPayloadExt + Send,
+    B: FromJsonPayloadExt + Send,
+    F: AsyncFn3<WfContext, A, B, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    R: Into<WfExitValue<O>>,
+    O: AsJsonPayloadExt + Debug,
+{
+    move |ctx: WfContext| match A::from_json_payload(&ctx.get_args()[0]) {
+        Ok(a) => match B::from_json_payload(&ctx.get_args()[1]) {
+            Ok(b) => (f)(ctx, a, b)
+                .map(|r| {
+                    r.and_then(|r| {
+                        let exit_val: WfExitValue<O> = r.into();
+                        Ok(match exit_val {
+                            WfExitValue::ContinueAsNew(b) => WfExitValue::ContinueAsNew(b),
+                            WfExitValue::Cancelled => WfExitValue::Cancelled,
+                            WfExitValue::Evicted => WfExitValue::Evicted,
+                            WfExitValue::Normal(a) => WfExitValue::Normal(a.as_json_payload()?),
+                        })
+                    })
+                })
+                .boxed(),
+            Err(e) => async move { Err(e.into()) }.boxed(),
+        },
+        Err(e) => async move { Err(e.into()) }.boxed(),
+    }
+}
+
+/// Execute child workflow which takes [WfContext] with 2 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_workflow_2_args] to register the workflow with the worker
+pub async fn execute_child_workflow_2_args<'a, A, B, F, R>(
+    ctx: &WfContext,
+    options: ChildWorkflowOptions,
+    _f: F,
+    a: A,
+    b: B,
+) -> Result<R, anyhow::Error>
+where
+    F: AsyncFn3<WfContext, A, B, Output = Result<R, anyhow::Error>> + Send + Sync + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    B: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let b = B::as_json_payload(&b).expect("serializes fine");
+    let workflow_type = std::any::type_name::<F>();
+
+    let child = ctx.child_workflow(ChildWorkflowOptions {
+        workflow_type: workflow_type.to_string(),
+        input: vec![a, b],
+        ..options
+    });
+
+    let started = child
+        .start(ctx)
+        .await
+        .into_started()
+        .expect("Child should start OK");
+
+    match started.result().await.status {
+        Some(child_workflow_result::Status::Completed(child_workflow::Success { result })) => {
+            Ok(R::from_json_payload(&result.unwrap()).unwrap())
+        }
+        _ => Err(anyhow!("Unexpected child WF status")),
+    }
+}
+
+/// Execute child workflow which takes [WfContext] with 2 arguments and returns a [Result] with 'R'
+/// and [anyhow::Error] where 'R' implements [serde] traits for
+/// serialization into Temporal [Payload](temporal_sdk_core_protos::temporal::api::common::v1::Payload).
+/// Use [into_workflow_2_args] to register the workflow with the worker
+pub async fn execute_child_workflow_2_args_exit_value<'a, A, B, F, R>(
+    ctx: &WfContext,
+    options: ChildWorkflowOptions,
+    _f: F,
+    a: A,
+    b: B,
+) -> Result<WfExitValue<R>, anyhow::Error>
+where
+    F: AsyncFn3<WfContext, A, B, Output = Result<WfExitValue<R>, anyhow::Error>>
+        + Send
+        + Sync
+        + 'static,
+    A: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    B: Serialize + Deserialize<'a> + AsJsonPayloadExt + Debug,
+    R: Serialize + Deserialize<'a> + FromJsonPayloadExt + Debug,
+{
+    let a = A::as_json_payload(&a).expect("serializes fine");
+    let b = B::as_json_payload(&b).expect("serializes fine");
+    let workflow_type = std::any::type_name::<F>();
+
+    let child = ctx.child_workflow(ChildWorkflowOptions {
+        workflow_type: workflow_type.to_string(),
+        input: vec![a, b],
+        ..options
+    });
+
+    let started = child
+        .start(ctx)
+        .await
+        .into_started()
+        .expect("Child should start OK");
+
+    match started.result().await.status {
+        Some(child_workflow_result::Status::Completed(child_workflow::Success { result })) => Ok(
+            WfExitValue::Normal(R::from_json_payload(&result.unwrap()).unwrap()),
+        ),
+        _ => Err(anyhow!("Unexpected child WF status")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_trait_bounds() {
+        assert_eq!(6, 6);
+    }
+}

--- a/sdk/src/workflow_context/options.rs
+++ b/sdk/src/workflow_context/options.rs
@@ -36,7 +36,7 @@ pub struct ActivityOptions {
     /// Type of activity to schedule
     pub activity_type: String,
     /// Input to the activity
-    pub input: Payload,
+    pub input: Vec<Payload>,
     /// Task queue to schedule the activity in
     pub task_queue: String,
     /// Time that the Activity Task can stay in the Task Queue before it is picked up by a Worker.
@@ -88,7 +88,7 @@ impl IntoWorkflowCommand for ActivityOptions {
             start_to_close_timeout: self.start_to_close_timeout.and_then(|d| d.try_into().ok()),
             heartbeat_timeout: self.heartbeat_timeout.and_then(|d| d.try_into().ok()),
             cancellation_type: self.cancellation_type as i32,
-            arguments: vec![self.input],
+            arguments: self.input,
             retry_policy: self.retry_policy,
             ..Default::default()
         }
@@ -107,7 +107,7 @@ pub struct LocalActivityOptions {
     /// Type of activity to schedule
     pub activity_type: String,
     /// Input to the activity
-    pub input: Payload,
+    pub input: Vec<Payload>,
     /// Retry policy
     pub retry_policy: RetryPolicy,
     /// Override attempt number rather than using 1.
@@ -154,7 +154,7 @@ impl IntoWorkflowCommand for LocalActivityOptions {
                 Some(aid) => aid,
             },
             activity_type: self.activity_type,
-            arguments: vec![self.input],
+            arguments: self.input,
             retry_policy: Some(self.retry_policy),
             local_retry_threshold: self.timer_backoff_threshold.and_then(|d| d.try_into().ok()),
             cancellation_type: self.cancel_type.into(),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -27,7 +27,7 @@ use temporal_client::{
 };
 use temporal_sdk::{
     interceptors::{FailOnNondeterminismInterceptor, WorkerInterceptor},
-    IntoActivityFunc, Worker, WorkflowFunction,
+    ActivityFunction, Worker, WorkflowFunction,
 };
 use temporal_sdk_core::{
     ephemeral_server::{EphemeralExe, EphemeralExeVersion},
@@ -386,10 +386,10 @@ impl TestWorker {
         self.inner.register_wf(workflow_type, wf_function)
     }
 
-    pub fn register_activity<A, R, O>(
+    pub fn register_activity(
         &mut self,
         activity_type: impl Into<String>,
-        act_function: impl IntoActivityFunc<A, R, O>,
+        act_function: impl Into<ActivityFunction>,
     ) {
         self.inner.register_activity(activity_type, act_function)
     }

--- a/test-utils/src/workflows.rs
+++ b/test-utils/src/workflows.rs
@@ -1,12 +1,15 @@
 use crate::prost_dur;
 use std::time::Duration;
-use temporal_sdk::{ActivityOptions, LocalActivityOptions, WfContext, WorkflowResult};
-use temporal_sdk_core_protos::{coresdk::AsJsonPayloadExt, temporal::api::common::v1::RetryPolicy};
+use temporal_sdk::{ActivityOptions, LocalActivityOptions, WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::{
+    coresdk::AsJsonPayloadExt,
+    temporal::api::common::v1::{Payload, RetryPolicy},
+};
 
-pub async fn la_problem_workflow(ctx: WfContext) -> WorkflowResult<()> {
+pub async fn la_problem_workflow(ctx: WfContext) -> WorkflowResult<Payload> {
     ctx.local_activity(LocalActivityOptions {
         activity_type: "delay".to_string(),
-        input: "hi".as_json_payload().expect("serializes fine"),
+        input: vec!["hi".as_json_payload().expect("serializes fine")],
         retry_policy: RetryPolicy {
             initial_interval: Some(prost_dur!(from_micros(15))),
             backoff_coefficient: 1_000.,
@@ -21,9 +24,11 @@ pub async fn la_problem_workflow(ctx: WfContext) -> WorkflowResult<()> {
     ctx.activity(ActivityOptions {
         activity_type: "delay".to_string(),
         start_to_close_timeout: Some(Duration::from_secs(20)),
-        input: "hi!".as_json_payload().expect("serializes fine"),
+        input: vec!["hi!".as_json_payload().expect("serializes fine")],
         ..Default::default()
     })
     .await;
-    Ok(().into())
+    Ok(WfExitValue::Normal(
+        "success".as_json_payload().expect("serializes fine"),
+    ))
 }

--- a/tests/integ_tests/activity_functions.rs
+++ b/tests/integ_tests/activity_functions.rs
@@ -1,5 +1,6 @@
-use temporal_sdk::ActContext;
+use temporal_sdk::{ActContext, ActExitValue};
+use temporal_sdk_core_protos::temporal::api::common::v1::Payload;
 
-pub async fn echo(_ctx: ActContext, e: String) -> anyhow::Result<String> {
-    Ok(e)
+pub async fn echo(ctx: ActContext) -> anyhow::Result<ActExitValue<Payload>> {
+    Ok(ActExitValue::Normal(ctx.get_args()[0].clone()))
 }

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
 use temporal_client::{WfClientExt, WorkflowOptions};
-use temporal_sdk::{ActContext, ActivityOptions, WfContext};
+use temporal_sdk::{ActContext, ActExitValue, ActivityOptions, WfContext, WfExitValue};
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::{
@@ -180,18 +180,15 @@ async fn activity_doesnt_heartbeat_hits_timeout_then_completes() {
     let mut starter = CoreWfStarter::new(wf_name);
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
-    worker.register_activity(
-        "echo_activity",
-        |_ctx: ActContext, echo_me: String| async move {
-            sleep(Duration::from_secs(4)).await;
-            Ok(echo_me)
-        },
-    );
+    worker.register_activity("echo_activity", |ctx: ActContext| async move {
+        sleep(Duration::from_secs(4)).await;
+        Ok(ActExitValue::Normal(ctx.get_args()[0].clone()))
+    });
     worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
         let res = ctx
             .activity(ActivityOptions {
                 activity_type: "echo_activity".to_string(),
-                input: "hi!".as_json_payload().expect("serializes fine"),
+                input: vec!["hi!".as_json_payload().expect("serializes fine")],
                 start_to_close_timeout: Some(Duration::from_secs(10)),
                 heartbeat_timeout: Some(Duration::from_secs(2)),
                 retry_policy: Some(RetryPolicy {
@@ -202,7 +199,9 @@ async fn activity_doesnt_heartbeat_hits_timeout_then_completes() {
             })
             .await;
         assert_eq!(res.timed_out(), Some(TimeoutType::Heartbeat));
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     });
 
     let run_id = worker

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -5,6 +5,7 @@ mod cancel_wf;
 mod child_workflows;
 mod continue_as_new;
 mod determinism;
+mod examples;
 mod local_activities;
 mod modify_wf_properties;
 mod patches;

--- a/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -1,11 +1,14 @@
 use temporal_client::WorkflowOptions;
-use temporal_sdk::{WfContext, WorkflowResult};
-use temporal_sdk_core_protos::coresdk::common::NamespacedWorkflowExecution;
+use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::{
+    coresdk::{common::NamespacedWorkflowExecution, AsJsonPayloadExt},
+    temporal::api::common::v1::Payload,
+};
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
 const RECEIVER_WFID: &str = "sends-cancel-receiver";
 
-async fn cancel_sender(ctx: WfContext) -> WorkflowResult<()> {
+async fn cancel_sender(ctx: WfContext) -> WorkflowResult<Payload> {
     let run_id = std::str::from_utf8(&ctx.get_args()[0].data)
         .unwrap()
         .to_owned();
@@ -22,12 +25,16 @@ async fn cancel_sender(ctx: WfContext) -> WorkflowResult<()> {
     } else {
         sigres.unwrap();
     }
-    Ok(().into())
+    Ok(WfExitValue::Normal(
+        "success".as_json_payload().expect("serializes fine"),
+    ))
 }
 
-async fn cancel_receiver(mut ctx: WfContext) -> WorkflowResult<()> {
+async fn cancel_receiver(mut ctx: WfContext) -> WorkflowResult<Payload> {
     ctx.cancelled().await;
-    Ok(().into())
+    Ok(WfExitValue::Normal(
+        "success".as_json_payload().expect("serializes fine"),
+    ))
 }
 
 #[tokio::test]

--- a/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -1,10 +1,11 @@
 use std::time::Duration;
 use temporal_client::WorkflowClientTrait;
 use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::temporal::api::common::v1::Payload;
 use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowExecutionStatus;
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
-async fn cancelled_wf(mut ctx: WfContext) -> WorkflowResult<()> {
+async fn cancelled_wf(mut ctx: WfContext) -> WorkflowResult<Payload> {
     let cancelled = tokio::select! {
         _ = ctx.timer(Duration::from_secs(500)) => false,
         _ = ctx.cancelled() => true

--- a/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -2,9 +2,11 @@ use std::time::Duration;
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
 use temporal_sdk_core_protos::coresdk::workflow_commands::ContinueAsNewWorkflowExecution;
+use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
+use temporal_sdk_core_protos::temporal::api::common::v1::Payload;
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
-async fn continue_as_new_wf(ctx: WfContext) -> WorkflowResult<()> {
+async fn continue_as_new_wf(ctx: WfContext) -> WorkflowResult<Payload> {
     let run_ct = ctx.get_args()[0].data[0];
     ctx.timer(Duration::from_millis(500)).await;
     Ok(if run_ct < 5 {
@@ -13,7 +15,7 @@ async fn continue_as_new_wf(ctx: WfContext) -> WorkflowResult<()> {
             ..Default::default()
         })
     } else {
-        ().into()
+        WfExitValue::Normal("success".as_json_payload().expect("serializes fine"))
     })
 }
 

--- a/tests/integ_tests/workflow_tests/determinism.rs
+++ b/tests/integ_tests/workflow_tests/determinism.rs
@@ -2,11 +2,12 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
-use temporal_sdk::{ActivityOptions, WfContext, WorkflowResult};
+use temporal_sdk::{ActivityOptions, WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::{coresdk::AsJsonPayloadExt, temporal::api::common::v1::Payload};
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
 static RUN_CT: AtomicUsize = AtomicUsize::new(1);
-pub async fn timer_wf_nondeterministic(ctx: WfContext) -> WorkflowResult<()> {
+pub async fn timer_wf_nondeterministic(ctx: WfContext) -> WorkflowResult<Payload> {
     let run_ct = RUN_CT.fetch_add(1, Ordering::Relaxed);
 
     match run_ct {
@@ -28,7 +29,9 @@ pub async fn timer_wf_nondeterministic(ctx: WfContext) -> WorkflowResult<()> {
         }
         _ => panic!("Ran too many times"),
     }
-    Ok(().into())
+    Ok(WfExitValue::Normal(
+        "success".as_json_payload().expect("serializes fine"),
+    ))
 }
 
 #[tokio::test]

--- a/tests/integ_tests/workflow_tests/examples.rs
+++ b/tests/integ_tests/workflow_tests/examples.rs
@@ -1,0 +1,469 @@
+use serde_json::json;
+use temporal_client::WorkflowOptions;
+use temporal_sdk::prelude::registry::*;
+use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
+use temporal_sdk_core_test_utils::CoreWfStarter;
+
+mod activity {
+    use temporal_sdk::prelude::activity::*;
+
+    #[derive(Debug, thiserror::Error)]
+    #[non_exhaustive]
+    pub enum Error {
+        #[error(transparent)]
+        Io(#[from] std::io::Error),
+        #[error(transparent)]
+        Any(anyhow::Error),
+    }
+
+    impl FromFailureExt for Error {
+        fn from_failure(failure: Failure) -> Error {
+            Error::Any(anyhow::anyhow!("{:?}", failure.message))
+        }
+    }
+
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct ActivityOutput0 {
+        pub echo: String,
+        pub name: Option<String>,
+    }
+    pub async fn activity_0_args(
+        _ctx: ActContext,
+    ) -> Result<(String, ActivityOutput0), anyhow::Error> {
+        Ok((
+            "Temporal".to_string(),
+            ActivityOutput0 {
+                echo: "Hello".to_string(),
+                name: Some("Rust".to_string()),
+            },
+        ))
+    }
+    pub async fn activity_0_args_exit_value(
+        _ctx: ActContext,
+    ) -> Result<ActExitValue<ActivityOutput0>, anyhow::Error> {
+        Ok(ActExitValue::Normal(ActivityOutput0 {
+            echo: "Hello".to_string(),
+            name: Some("Rust".to_string()),
+        }))
+    }
+    pub async fn activity_0_args_without_ctx() -> Result<(String, ActivityOutput0), anyhow::Error> {
+        Ok((
+            "test_tuple".to_string(),
+            ActivityOutput0 {
+                echo: "Hello".to_string(),
+                name: Some("Rust".to_string()),
+            },
+        ))
+    }
+    pub async fn activity_0_args_without_ctx_exit_value(
+    ) -> Result<ActExitValue<ActivityOutput0>, anyhow::Error> {
+        Ok(ActExitValue::Normal(ActivityOutput0 {
+            echo: "Hello".to_string(),
+            name: Some("Rust".to_string()),
+        }))
+    }
+
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct ActivityInput1(pub String, pub i32);
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct ActivityOutput1(pub String, pub i32);
+    pub async fn activity_1_args(
+        _ctx: ActContext,
+        input: ActivityInput1,
+    ) -> Result<ActivityOutput1, anyhow::Error> {
+        Ok(ActivityOutput1(input.0, input.1))
+    }
+    pub async fn activity_1_args_exit_value(
+        _ctx: ActContext,
+        input: ActivityInput1,
+    ) -> Result<ActExitValue<ActivityOutput1>, anyhow::Error> {
+        Ok(ActExitValue::Normal(ActivityOutput1(input.0, input.1)))
+    }
+    pub async fn activity_1_args_with_errors(
+        _ctx: ActContext,
+        input: ActivityInput1,
+    ) -> Result<ActivityOutput1, Error> {
+        Ok(ActivityOutput1(input.0, input.1))
+    }
+
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct ActivityOutput2(pub Vec<i32>, pub String);
+    pub async fn activity_2_args(
+        _ctx: ActContext,
+        name: String,
+        size: i32,
+    ) -> Result<ActivityOutput2, anyhow::Error> {
+        Ok(ActivityOutput2(vec![42; size as usize], name))
+    }
+}
+
+mod workflow {
+    use crate::integ_tests::workflow_tests::examples::activity::{self, *};
+    use std::collections::HashMap;
+    use temporal_sdk::prelude::workflow::*;
+    use temporal_sdk::workflow;
+
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct ChildInput1 {
+        pub echo: (String,),
+    }
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct ChildOutput1 {
+        pub result: (String,),
+    }
+    pub async fn child_workflow_0_args(_ctx: WfContext) -> Result<ChildOutput1, anyhow::Error> {
+        Ok(ChildOutput1 {
+            result: ("success".to_string(),),
+        })
+    }
+    pub async fn child_workflow_0_args_exit_value(
+        _ctx: WfContext,
+    ) -> Result<WfExitValue<String>, anyhow::Error> {
+        Ok(WfExitValue::Normal("success".to_string()))
+    }
+
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct ChildInput2 {
+        pub echo_again: (String,),
+    }
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct ChildOutput2 {
+        pub result: HashMap<String, i32>,
+    }
+    pub async fn child_workflow_1_args(
+        _ctx: WfContext,
+        _input: ChildInput1,
+    ) -> Result<ChildOutput1, anyhow::Error> {
+        Ok(ChildOutput1 {
+            result: ("success".to_string(),),
+        })
+    }
+    pub async fn child_workflow_1_args_exit_value(
+        _ctx: WfContext,
+        _input: ChildInput1,
+    ) -> Result<WfExitValue<ChildOutput1>, anyhow::Error> {
+        Ok(WfExitValue::Normal(ChildOutput1 {
+            result: ("success".to_string(),),
+        }))
+    }
+    pub async fn child_workflow_1_args_with_errors(
+        ctx: WfContext,
+        _input: (String,),
+    ) -> Result<activity::ActivityOutput1, Error> {
+        let activity_timeout = Duration::from_secs(5);
+        let output = execute_activity_1_args_with_errors(
+            &ctx,
+            ActivityOptions {
+                activity_id: Some("activity_1_args_with_errors".to_string()),
+                schedule_to_close_timeout: Some(activity_timeout),
+                ..Default::default()
+            },
+            activity::activity_1_args_with_errors,
+            activity::ActivityInput1("hello".to_string(), 7),
+        )
+        .await;
+        match output {
+            Ok(output) => Ok(output),
+            Err(e) => Err(e),
+        }
+    }
+    pub async fn child_workflow_2_args(
+        _ctx: WfContext,
+        _input: ChildInput1,
+        _input2: ChildInput2,
+    ) -> Result<ChildOutput2, anyhow::Error> {
+        let mut result = HashMap::new();
+        result.insert("one".to_string(), 1);
+        result.insert("two".to_string(), 2);
+        Ok(ChildOutput2 { result })
+    }
+
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct Input {
+        pub one: String,
+        pub two: i64,
+    }
+    #[derive(Default, Deserialize, Serialize, Debug, Clone)]
+    pub struct Output {
+        pub result: HashMap<String, i32>,
+    }
+    pub async fn examples_workflow(ctx: WfContext) -> Result<Output, anyhow::Error> {
+        let activity_timeout = Duration::from_secs(5);
+
+        let _output = workflow::execute_activity_0_args(
+            &ctx,
+            ActivityOptions {
+                activity_id: Some("activity_0_args".to_string()),
+                schedule_to_close_timeout: Some(activity_timeout),
+                ..Default::default()
+            },
+            activity::activity_0_args,
+        )
+        .await;
+
+        let _output = workflow::execute_activity_0_args_exit_value(
+            &ctx,
+            ActivityOptions {
+                activity_id: Some("activity_0_args_exit_value".to_string()),
+                schedule_to_close_timeout: Some(activity_timeout),
+                ..Default::default()
+            },
+            activity::activity_0_args_exit_value,
+        )
+        .await;
+
+        let _output = workflow::execute_activity_0_args_without_ctx(
+            &ctx,
+            ActivityOptions {
+                activity_id: Some("activity_0_args_without_ctx".to_string()),
+                schedule_to_close_timeout: Some(activity_timeout),
+                ..Default::default()
+            },
+            activity::activity_0_args_without_ctx,
+        )
+        .await;
+
+        let _output = workflow::execute_activity_0_args_without_ctx_exit_value(
+            &ctx,
+            ActivityOptions {
+                activity_id: Some("activity_0_args_without_ctx_exit_value".to_string()),
+                schedule_to_close_timeout: Some(activity_timeout),
+                ..Default::default()
+            },
+            activity::activity_0_args_without_ctx_exit_value,
+        )
+        .await;
+
+        let _stop = workflow::execute_activity_1_args(
+            &ctx,
+            ActivityOptions {
+                activity_id: Some("activity_1_args".to_string()),
+                schedule_to_close_timeout: Some(activity_timeout),
+                ..Default::default()
+            },
+            activity::activity_1_args,
+            ActivityInput1("hello".to_string(), 7),
+        )
+        .await;
+
+        let _stop = workflow::execute_activity_1_args_exit_value(
+            &ctx,
+            ActivityOptions {
+                activity_id: Some("stop_activity".to_string()),
+                schedule_to_close_timeout: Some(activity_timeout),
+                ..Default::default()
+            },
+            activity::activity_1_args_exit_value,
+            ActivityInput1("hello".to_string(), 7),
+        )
+        .await;
+
+        let _output = workflow::execute_activity_2_args(
+            &ctx,
+            ActivityOptions {
+                activity_id: Some("activity_2_args".to_string()),
+                schedule_to_close_timeout: Some(activity_timeout),
+                ..Default::default()
+            },
+            activity::activity_2_args,
+            "hello".to_string(),
+            7,
+        )
+        .await;
+
+        let _child_output0 = workflow::execute_child_workflow_0_args(
+            &ctx,
+            ChildWorkflowOptions {
+                workflow_id: "child_workflow_0_args".to_owned(),
+                ..Default::default()
+            },
+            child_workflow_0_args,
+            //"test".to_string(),
+        )
+        .await;
+
+        let _child_output0 = workflow::execute_child_workflow_0_args_exit_value(
+            &ctx,
+            ChildWorkflowOptions {
+                workflow_id: "child_workflow_0_args_exit_value".to_owned(),
+                ..Default::default()
+            },
+            child_workflow_0_args_exit_value,
+            //"test".to_string(),
+        )
+        .await;
+
+        let _child_output3 = workflow::execute_child_workflow_1_args(
+            &ctx,
+            ChildWorkflowOptions {
+                workflow_id: "child_workflow_1_args".to_owned(),
+                ..Default::default()
+            },
+            child_workflow_1_args,
+            ChildInput1 {
+                echo: ("child_workflow_1_args".to_string(),),
+            },
+        )
+        .await
+        .unwrap();
+
+        let _child_output3 = workflow::execute_child_workflow_1_args_exit_value(
+            &ctx,
+            ChildWorkflowOptions {
+                workflow_id: "child_workflow_1_args_exit_value".to_owned(),
+                ..Default::default()
+            },
+            child_workflow_1_args_exit_value,
+            ChildInput1 {
+                echo: ("child_workflow_1_args_exit_value".to_string(),),
+            },
+        )
+        .await
+        .unwrap();
+
+        let _child_output4 = workflow::execute_child_workflow_1_args_with_errors(
+            &ctx,
+            ChildWorkflowOptions {
+                workflow_id: "child_workflow_1_args_with_errors".to_owned(),
+                ..Default::default()
+            },
+            child_workflow_1_args_with_errors,
+            ("hello".to_string(),),
+        )
+        .await
+        .unwrap();
+
+        let child_output5 = workflow::execute_child_workflow_2_args(
+            &ctx,
+            ChildWorkflowOptions {
+                workflow_id: "child_workflow_2_args".to_owned(),
+                ..Default::default()
+            },
+            child_workflow_2_args,
+            ChildInput1 {
+                echo: ("hello".to_string(),),
+            },
+            ChildInput2 {
+                echo_again: ("hello".to_string(),),
+            },
+        )
+        .await;
+
+        match child_output5 {
+            Ok(r) => Ok(Output { result: r.result }),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[tokio::test]
+async fn example_workflows_test() {
+    use crate::integ_tests::workflow_tests::examples::activity;
+    use crate::integ_tests::workflow_tests::examples::workflow;
+
+    let mut starter = CoreWfStarter::new("sdk-example-workflows");
+    let mut worker = starter.worker().await;
+
+    // Register zero argument activities
+
+    worker.register_activity(
+        "integ_tests::integ_tests::workflow_tests::examples::activity::activity_0_args",
+        into_activity_0_args(activity::activity_0_args),
+    );
+    worker.register_activity(
+        "integ_tests::integ_tests::workflow_tests::examples::activity::activity_0_args_exit_value",
+        into_activity_0_args(activity::activity_0_args_exit_value),
+    );
+    worker.register_activity(
+        "integ_tests::integ_tests::workflow_tests::examples::activity::activity_0_args_without_ctx",
+        into_activity_0_args_without_ctx(activity::activity_0_args_without_ctx),
+    );
+    worker.register_activity(
+        "integ_tests::integ_tests::workflow_tests::examples::activity::activity_0_args_without_ctx_exit_value",
+        into_activity_0_args_without_ctx(activity::activity_0_args_without_ctx_exit_value),
+    );
+
+    // Register one argument activities
+
+    worker.register_activity(
+        "integ_tests::integ_tests::workflow_tests::examples::activity::activity_1_args",
+        into_activity_1_args(activity::activity_1_args),
+    );
+
+    worker.register_activity(
+        "integ_tests::integ_tests::workflow_tests::examples::activity::activity_1_args_exit_value",
+        into_activity_1_args_exit_value(activity::activity_1_args_exit_value),
+    );
+
+    worker.register_activity(
+        "integ_tests::integ_tests::workflow_tests::examples::activity::activity_1_args_with_errors",
+        into_activity_1_args_with_errors(activity::activity_1_args_with_errors),
+    );
+
+    // Register two argument activities
+
+    worker.register_activity(
+        "integ_tests::integ_tests::workflow_tests::examples::activity::activity_2_args",
+        into_activity_2_args(activity::activity_2_args),
+    );
+
+    // Register zero argument workflows
+
+    worker.register_wf(
+        "integ_tests::integ_tests::workflow_tests::examples::workflow::child_workflow_0_args",
+        into_workflow_0_args(workflow::child_workflow_0_args),
+    );
+
+    worker.register_wf(
+        "integ_tests::integ_tests::workflow_tests::examples::workflow::child_workflow_0_args_exit_value",
+        into_workflow_0_args(workflow::child_workflow_0_args_exit_value),
+    );
+
+    // Register one argument workflows
+
+    worker.register_wf(
+        "integ_tests::integ_tests::workflow_tests::examples::workflow::child_workflow_1_args",
+        into_workflow_1_args(workflow::child_workflow_1_args),
+    );
+
+    worker.register_wf(
+        "integ_tests::integ_tests::workflow_tests::examples::workflow::child_workflow_1_args_exit_value",
+        into_workflow_1_args_exit_value(workflow::child_workflow_1_args_exit_value),
+    );
+
+    worker.register_wf(
+        "integ_tests::integ_tests::workflow_tests::examples::workflow::child_workflow_1_args_with_errors",
+        into_workflow_1_args_with_errors(workflow::child_workflow_1_args_with_errors),
+    );
+
+    // Register two argument workflows
+
+    worker.register_wf(
+        "integ_tests::integ_tests::workflow_tests::examples::workflow::child_workflow_2_args",
+        into_workflow_2_args(workflow::child_workflow_2_args),
+    );
+
+    worker.register_wf(
+        "integ_tests::integ_tests::workflow_tests::examples::workflow::examples_workflow",
+        into_workflow_0_args(workflow::examples_workflow),
+    );
+
+    // Run parent workflow
+
+    worker
+        .submit_wf(
+            "examples_workflow".to_string(),
+            "integ_tests::integ_tests::workflow_tests::examples::workflow::examples_workflow"
+                .to_string(),
+            vec![json!({
+                "one":"one",
+                "two":42
+            })
+            .as_json_payload()
+            .expect("serialize fine")],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}

--- a/tests/integ_tests/workflow_tests/modify_wf_properties.rs
+++ b/tests/integ_tests/workflow_tests/modify_wf_properties.rs
@@ -1,18 +1,23 @@
 use temporal_client::WorkflowClientTrait;
-use temporal_sdk::{WfContext, WorkflowResult};
-use temporal_sdk_core_protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
+use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::{
+    coresdk::{AsJsonPayloadExt, FromJsonPayloadExt},
+    temporal::api::common::v1::Payload,
+};
 use temporal_sdk_core_test_utils::CoreWfStarter;
 use uuid::Uuid;
 
 static FIELD_A: &str = "cat_name";
 static FIELD_B: &str = "cute_level";
 
-async fn memo_upserter(ctx: WfContext) -> WorkflowResult<()> {
+async fn memo_upserter(ctx: WfContext) -> WorkflowResult<Payload> {
     ctx.upsert_memo([
         (FIELD_A.to_string(), "enchi".as_json_payload().unwrap()),
         (FIELD_B.to_string(), 9001.as_json_payload().unwrap()),
     ]);
-    Ok(().into())
+    Ok(WfExitValue::Normal(
+        "success".as_json_payload().expect("serializes fine"),
+    ))
 }
 
 #[tokio::test]

--- a/tests/integ_tests/workflow_tests/replay.rs
+++ b/tests/integ_tests/workflow_tests/replay.rs
@@ -2,7 +2,9 @@ use crate::integ_tests::workflow_tests::patches::changes_wf;
 use assert_matches::assert_matches;
 use parking_lot::Mutex;
 use std::{collections::HashSet, sync::Arc, time::Duration};
-use temporal_sdk::{interceptors::WorkerInterceptor, WfContext, Worker, WorkflowFunction};
+use temporal_sdk::{
+    interceptors::WorkerInterceptor, WfContext, WfExitValue, Worker, WorkflowFunction,
+};
 use temporal_sdk_core::replay::{HistoryFeeder, HistoryForReplay};
 use temporal_sdk_core_api::errors::{PollActivityError, PollWfError};
 use temporal_sdk_core_protos::{
@@ -10,6 +12,7 @@ use temporal_sdk_core_protos::{
         workflow_activation::remove_from_cache::EvictionReason,
         workflow_commands::{ScheduleActivity, StartTimer},
         workflow_completion::WorkflowActivationCompletion,
+        AsJsonPayloadExt,
     },
     temporal::api::enums::v1::EventType,
     TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE,
@@ -274,7 +277,9 @@ fn timers_wf(num_timers: u32) -> WorkflowFunction {
         for _ in 1..=num_timers {
             ctx.timer(Duration::from_secs(1)).await;
         }
-        Ok(().into())
+        Ok(WfExitValue::Normal(
+            "success".as_json_payload().expect("serializes fine"),
+        ))
     })
 }
 

--- a/tests/integ_tests/workflow_tests/resets.rs
+++ b/tests/integ_tests/workflow_tests/resets.rs
@@ -1,9 +1,12 @@
 use futures::StreamExt;
 use std::{sync::Arc, time::Duration};
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions, WorkflowService};
-use temporal_sdk::WfContext;
-use temporal_sdk_core_protos::temporal::api::{
-    common::v1::WorkflowExecution, workflowservice::v1::ResetWorkflowExecutionRequest,
+use temporal_sdk::{WfContext, WfExitValue};
+use temporal_sdk_core_protos::{
+    coresdk::AsJsonPayloadExt,
+    temporal::api::{
+        common::v1::WorkflowExecution, workflowservice::v1::ResetWorkflowExecutionRequest,
+    },
 };
 use temporal_sdk_core_test_utils::{CoreWfStarter, NAMESPACE};
 use tokio::sync::Notify;
@@ -33,7 +36,9 @@ async fn reset_workflow() {
                 .next()
                 .await
                 .unwrap();
-            Ok(().into())
+            Ok(WfExitValue::Normal(
+                "success".as_json_payload().expect("serializes fine"),
+            ))
         }
     });
 

--- a/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
+++ b/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
@@ -1,7 +1,10 @@
 use std::{collections::HashMap, env};
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
-use temporal_sdk::{WfContext, WorkflowResult};
-use temporal_sdk_core_protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
+use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::{
+    coresdk::{AsJsonPayloadExt, FromJsonPayloadExt},
+    temporal::api::common::v1::Payload,
+};
 use temporal_sdk_core_test_utils::{CoreWfStarter, INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR};
 use tracing::warn;
 use uuid::Uuid;
@@ -11,12 +14,14 @@ use uuid::Uuid;
 static TXT_ATTR: &str = "CustomTextField";
 static INT_ATTR: &str = "CustomIntField";
 
-async fn search_attr_updater(ctx: WfContext) -> WorkflowResult<()> {
+async fn search_attr_updater(ctx: WfContext) -> WorkflowResult<Payload> {
     ctx.upsert_search_attributes([
         (TXT_ATTR.to_string(), "goodbye".as_json_payload().unwrap()),
         (INT_ATTR.to_string(), 98.as_json_payload().unwrap()),
     ]);
-    Ok(().into())
+    Ok(WfExitValue::Normal(
+        "success".as_json_payload().expect("serializes fine"),
+    ))
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

1) Modified SDK to handle 'Payload' as the return value of workflow function instead of an empty tuple.
2) Minor changes to SDK workflow and activity functions to accommodate generic user-defined functions.
3) Added 'workflow' module to create abstractions to define workflow definitions in idiomatic Rust(Async)
4) Added 'prelude' module for easy importing of types in workflow definitions.
5) Updated tests

I use Rust a lot and I write workflows a lot and a lot.  So created the abstraction functions needed to define workflows similar to other SDKs (Go). Submitting this PR to receive feedback on design and approach.

TODO

- [ ] Factor in the feedback
- [ ] Move the repeating and boilerplate into Macros once the API is good enough
- [ ] Create more convenient functions similar to other SDKs. 
- [ ] Add more examples

## Why?

A step towards https://github.com/temporalio/sdk-core/issues/222

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/539

2. How was this tested:
Updated tests and added new tests

3. Any docs updates needed?
Updated crate documentation and added new module documentation
