### PR TITLE
Updated workflow function to return Payload instead of empty tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can buld and test the project using cargo:
 Run integ tests with `cargo integ-test`. You will need to already be running the server:
 `docker-compose -f .buildkite/docker/docker-compose.yaml up`
 
+Run load tests with `cargo test --features=save_wf_inputs --test heavy_tests`.
+
 ## Formatting
 To format all code run:
 `cargo fmt --all`

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -21,7 +21,8 @@ use std::{
 };
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{
-    ActContext, ActivityCancelledError, LocalActivityOptions, WfContext, WorkflowResult,
+    ActContext, ActivityCancelledError, LocalActivityOptions, WfContext, WorkflowFunction,
+    WorkflowResult,
 };
 use temporal_sdk_core_api::{
     errors::{PollActivityError, PollWfError},
@@ -964,17 +965,18 @@ async fn resolved_las_not_recorded_if_wft_fails_many_times() {
     mh.num_expected_completions = Some(0.into());
     let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
 
+    #[allow(unreachable_code)]
     worker.register_wf(
         DEFAULT_WORKFLOW_TYPE.to_owned(),
-        |ctx: WfContext| async move {
+        WorkflowFunction::new::<_, _, ()>(|ctx: WfContext| async move {
             ctx.local_activity(LocalActivityOptions {
                 activity_type: "echo".to_string(),
                 input: "hi".as_json_payload().expect("serializes fine"),
                 ..Default::default()
             })
             .await;
-            panic!("Oh nooooo")
-        },
+            panic!()
+        }),
     );
     worker.register_activity(
         "echo",

--- a/core/src/worker/workflow/managed_run/managed_wf_test.rs
+++ b/core/src/worker/workflow/managed_run/managed_wf_test.rs
@@ -61,7 +61,7 @@ pub struct ManagedWFFunc {
     activation_tx: UnboundedSender<WorkflowActivation>,
     completions_rx: UnboundedReceiver<WorkflowActivationCompletion>,
     completions_sync_tx: crossbeam::channel::Sender<WorkflowActivationCompletion>,
-    future_handle: Option<JoinHandle<WorkflowResult<()>>>,
+    future_handle: Option<JoinHandle<WorkflowResult<Payload>>>,
     was_shutdown: bool,
 }
 
@@ -175,7 +175,7 @@ impl ManagedWFFunc {
         Ok(last_act)
     }
 
-    pub async fn shutdown(&mut self) -> WorkflowResult<()> {
+    pub async fn shutdown(&mut self) -> WorkflowResult<Payload> {
         self.was_shutdown = true;
         // Send an eviction to ensure wf exits if it has not finished (ex: feeding partial hist)
         let _ = self.activation_tx.send(create_evict_activation(

--- a/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -91,7 +91,7 @@ async fn abandoned_child_bug_repro() {
     );
     worker.register_wf(CHILD_WF_TYPE.to_string(), |mut ctx: WfContext| async move {
         ctx.cancelled().await;
-        Ok(WfExitValue::Cancelled)
+        Ok(WfExitValue::<()>::Cancelled)
     });
 
     worker


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

1) Modified SDK to handle 'Payload' as the return value of workflow function instead of an empty tuple.
2) Updated tests

## Why?

A step towards https://github.com/temporalio/sdk-core/issues/222

## Checklist
<!--- add/delete as needed --->

1. This part of work in https://github.com/temporalio/sdk-core/issues/539

2. How was this tested:
Updated tests and added new tests

3. Any docs updates needed?
No
