### PR TITLE
Updated Activity/Workflow Function bounds to allow a more generic use…

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -21,8 +21,8 @@ use std::{
 };
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{
-    ActContext, ActivityCancelledError, LocalActivityOptions, WfContext, WorkflowFunction,
-    WorkflowResult,
+    ActContext, ActExitValue, ActivityCancelledError, ActivityFunction, LocalActivityOptions,
+    WfContext, WorkflowFunction, WorkflowResult,
 };
 use temporal_sdk_core_api::{
     errors::{PollActivityError, PollWfError},
@@ -101,7 +101,7 @@ async fn local_act_two_wfts_before_marker(#[case] replay: bool, #[case] cached: 
             Ok(().into())
         },
     );
-    worker.register_activity(DEFAULT_ACTIVITY_TYPE, echo);
+    worker.register_activity(DEFAULT_ACTIVITY_TYPE, ActivityFunction::from(echo));
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -151,7 +151,7 @@ async fn local_act_many_concurrent() {
     let mut worker = mock_sdk(mh);
 
     worker.register_wf(DEFAULT_WORKFLOW_TYPE.to_owned(), local_act_fanout_wf);
-    worker.register_activity("echo", echo);
+    worker.register_activity("echo", ActivityFunction::from(echo));
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -207,14 +207,17 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
             Ok(().into())
         },
     );
-    worker.register_activity("echo", move |_ctx: ActContext, str: String| async move {
-        if shutdown_middle {
-            shutdown_barr.wait().await;
-        }
-        // Take slightly more than two workflow tasks
-        tokio::time::sleep(wft_timeout.mul_f32(2.2)).await;
-        Ok(str)
-    });
+    worker.register_activity(
+        "echo",
+        ActivityFunction::from(move |_ctx: ActContext, str: String| async move {
+            if shutdown_middle {
+                shutdown_barr.wait().await;
+            }
+            // Take slightly more than two workflow tasks
+            tokio::time::sleep(wft_timeout.mul_f32(2.2)).await;
+            Ok(str)
+        }),
+    );
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -276,10 +279,10 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
         },
     );
     let attempts: &'static _ = Box::leak(Box::new(AtomicUsize::new(0)));
-    worker.register_activity("echo", move |_ctx: ActContext, _: String| async move {
+    worker.register_activity("echo", move |_ctx: ActContext| async move {
         // Succeed on 3rd attempt (which is ==2 since fetch_add returns prev val)
         if 2 == attempts.fetch_add(1, Ordering::Relaxed) && eventually_pass {
-            Ok(())
+            Ok(().into())
         } else {
             Err(anyhow!("Oh no I failed!"))
         }
@@ -355,12 +358,9 @@ async fn local_act_retry_long_backoff_uses_timer() {
             Ok(().into())
         },
     );
-    worker.register_activity(
-        DEFAULT_ACTIVITY_TYPE,
-        move |_ctx: ActContext, _: String| async move {
-            Result::<(), _>::Err(anyhow!("Oh no I failed!"))
-        },
-    );
+    worker.register_activity(DEFAULT_ACTIVITY_TYPE, move |_ctx: ActContext| async move {
+        Result::<ActExitValue<()>, _>::Err(anyhow!("Oh no I failed!"))
+    });
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -398,7 +398,7 @@ async fn local_act_null_result() {
             Ok(().into())
         },
     );
-    worker.register_activity("nullres", |_ctx: ActContext, _: String| async { Ok(()) });
+    worker.register_activity("nullres", |_ctx: ActContext| async { Ok(().into()) });
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -442,7 +442,7 @@ async fn local_act_command_immediately_follows_la_marker() {
             Ok(().into())
         },
     );
-    worker.register_activity("nullres", |_ctx: ActContext, _: String| async { Ok(()) });
+    worker.register_activity("nullres", |_ctx: ActContext| async { Ok(().into()) });
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -778,10 +778,7 @@ async fn test_schedule_to_start_timeout() {
             Ok(().into())
         },
     );
-    worker.register_activity(
-        "echo",
-        move |_ctx: ActContext, _: String| async move { Ok(()) },
-    );
+    worker.register_activity("echo", move |_ctx: ActContext| async move { Ok(().into()) });
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -868,10 +865,7 @@ async fn test_schedule_to_start_timeout_not_based_on_original_time(
             Ok(().into())
         },
     );
-    worker.register_activity(
-        "echo",
-        move |_ctx: ActContext, _: String| async move { Ok(()) },
-    );
+    worker.register_activity("echo", move |_ctx: ActContext| async move { Ok(().into()) });
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -917,16 +911,13 @@ async fn wft_failure_cancels_running_las() {
             Ok(().into())
         },
     );
-    worker.register_activity(
-        DEFAULT_ACTIVITY_TYPE,
-        move |ctx: ActContext, _: String| async move {
-            let res = tokio::time::timeout(Duration::from_millis(500), ctx.cancelled()).await;
-            if res.is_err() {
-                panic!("Activity must be cancelled!!!!");
-            }
-            Result::<(), _>::Err(ActivityCancelledError::default().into())
-        },
-    );
+    worker.register_activity(DEFAULT_ACTIVITY_TYPE, move |ctx: ActContext| async move {
+        let res = tokio::time::timeout(Duration::from_millis(500), ctx.cancelled()).await;
+        if res.is_err() {
+            panic!("Activity must be cancelled!!!!");
+        }
+        Result::<ActExitValue<()>, _>::Err(ActivityCancelledError::default().into())
+    });
     worker
         .submit_wf(
             wf_id.to_owned(),
@@ -980,7 +971,7 @@ async fn resolved_las_not_recorded_if_wft_fails_many_times() {
     );
     worker.register_activity(
         "echo",
-        move |_: ActContext, _: String| async move { Ok(()) },
+        ActivityFunction::from(move |_: ActContext, _: String| async move { Ok(()) }),
     );
     worker
         .submit_wf(
@@ -1039,9 +1030,12 @@ async fn local_act_records_nonfirst_attempts_ok() {
             Ok(().into())
         },
     );
-    worker.register_activity("echo", move |_ctx: ActContext, _: String| async move {
-        Result::<(), _>::Err(anyhow!("I fail"))
-    });
+    worker.register_activity(
+        "echo",
+        ActivityFunction::from(move |_ctx: ActContext, _: String| async move {
+            Result::<(), _>::Err(anyhow!("I fail"))
+        }),
+    );
     worker
         .submit_wf(
             wf_id.to_owned(),

--- a/sdk/src/activity_context.rs
+++ b/sdk/src/activity_context.rs
@@ -60,7 +60,7 @@ impl ActContext {
         task_queue: String,
         task_token: Vec<u8>,
         task: activity_task::Start,
-    ) -> (Self, Payload) {
+    ) -> Self {
         let activity_task::Start {
             workflow_namespace,
             workflow_type,
@@ -68,7 +68,7 @@ impl ActContext {
             activity_id,
             activity_type,
             header_fields,
-            mut input,
+            input,
             heartbeat_details,
             scheduled_time,
             current_attempt_scheduled_time,
@@ -86,37 +86,32 @@ impl ActContext {
             start_to_close_timeout.as_ref(),
             schedule_to_close_timeout.as_ref(),
         );
-        let first_arg = input.pop().unwrap_or_default();
 
-        (
-            ActContext {
-                worker,
-                app_data,
-                cancellation_token,
-                input,
-                heartbeat_details,
-                header_fields,
-                info: ActivityInfo {
-                    task_token,
-                    task_queue,
-                    workflow_type,
-                    workflow_namespace,
-                    workflow_execution,
-                    activity_id,
-                    activity_type,
-                    heartbeat_timeout: heartbeat_timeout.try_into_or_none(),
-                    scheduled_time: scheduled_time.try_into_or_none(),
-                    started_time: started_time.try_into_or_none(),
-                    deadline,
-                    attempt,
-                    current_attempt_scheduled_time: current_attempt_scheduled_time
-                        .try_into_or_none(),
-                    retry_policy,
-                    is_local,
-                },
+        ActContext {
+            worker,
+            app_data,
+            cancellation_token,
+            input,
+            heartbeat_details,
+            header_fields,
+            info: ActivityInfo {
+                task_token,
+                task_queue,
+                workflow_type,
+                workflow_namespace,
+                workflow_execution,
+                activity_id,
+                activity_type,
+                heartbeat_timeout: heartbeat_timeout.try_into_or_none(),
+                scheduled_time: scheduled_time.try_into_or_none(),
+                started_time: started_time.try_into_or_none(),
+                deadline,
+                attempt,
+                current_attempt_scheduled_time: current_attempt_scheduled_time.try_into_or_none(),
+                retry_policy,
+                is_local,
             },
-            first_arg,
-        )
+        }
     }
 
     /// Returns a future the completes if and when the activity this was called inside has been
@@ -133,8 +128,8 @@ impl ActContext {
     /// Retrieve extra parameters to the Activity. The first input is always popped and passed to
     /// the Activity function for the currently executing activity. However, if more parameters are
     /// passed, perhaps from another language's SDK, explicit access is available from extra_inputs
-    pub fn extra_inputs(&mut self) -> &mut [Payload] {
-        &mut self.input
+    pub fn get_args(&self) -> &[Payload] {
+        &self.input
     }
 
     /// Extract heartbeat details from last failed attempt. This is used in combination with retry policy.

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -27,7 +27,7 @@ use temporal_client::{
 };
 use temporal_sdk::{
     interceptors::{FailOnNondeterminismInterceptor, WorkerInterceptor},
-    IntoActivityFunc, Worker, WorkflowFunction,
+    ActivityFunction, Worker, WorkflowFunction,
 };
 use temporal_sdk_core::{
     ephemeral_server::{EphemeralExe, EphemeralExeVersion},
@@ -385,10 +385,10 @@ impl TestWorker {
         self.inner.register_wf(workflow_type, wf_function)
     }
 
-    pub fn register_activity<A, R, O>(
+    pub fn register_activity(
         &mut self,
         activity_type: impl Into<String>,
-        act_function: impl IntoActivityFunc<A, R, O>,
+        act_function: impl Into<ActivityFunction>,
     ) {
         self.inner.register_activity(activity_type, act_function)
     }

--- a/tests/fuzzy_workflow.rs
+++ b/tests/fuzzy_workflow.rs
@@ -2,7 +2,9 @@ use futures_util::{sink, stream::FuturesUnordered, FutureExt, StreamExt};
 use rand::{prelude::Distribution, rngs::SmallRng, Rng, SeedableRng};
 use std::{future, time::Duration};
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions};
-use temporal_sdk::{ActContext, ActivityOptions, LocalActivityOptions, WfContext, WorkflowResult};
+use temporal_sdk::{
+    ActContext, ActivityFunction, ActivityOptions, LocalActivityOptions, WfContext, WorkflowResult,
+};
 use temporal_sdk_core_protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt, IntoPayloadsExt};
 use temporal_sdk_core_test_utils::CoreWfStarter;
 use tokio_util::sync::CancellationToken;
@@ -82,7 +84,7 @@ async fn fuzzy_workflow() {
     // .enable_wf_state_input_recording();
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), fuzzy_wf_def);
-    worker.register_activity("echo_activity", echo);
+    worker.register_activity("echo_activity", ActivityFunction::from(echo));
     let client = starter.get_client().await;
 
     let mut workflow_handles = vec![];

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
 use temporal_client::{WfClientExt, WorkflowOptions};
-use temporal_sdk::{ActContext, ActivityOptions, WfContext};
+use temporal_sdk::{ActContext, ActivityFunction, ActivityOptions, WfContext};
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::{
@@ -182,10 +182,10 @@ async fn activity_doesnt_heartbeat_hits_timeout_then_completes() {
     let client = starter.get_client().await;
     worker.register_activity(
         "echo_activity",
-        |_ctx: ActContext, echo_me: String| async move {
+        ActivityFunction::from(|_ctx: ActContext, echo_me: String| async move {
             sleep(Duration::from_secs(4)).await;
             Ok(echo_me)
-        },
+        }),
     );
     worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
         let res = ctx

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -27,7 +27,9 @@ use std::{
     time::Duration,
 };
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
-use temporal_sdk::{interceptors::WorkerInterceptor, ActivityOptions, WfContext, WorkflowResult};
+use temporal_sdk::{
+    interceptors::WorkerInterceptor, ActivityFunction, ActivityOptions, WfContext, WorkflowResult,
+};
 use temporal_sdk_core::replay::HistoryForReplay;
 use temporal_sdk_core_api::{errors::PollWfError, Worker};
 use temporal_sdk_core_protos::{
@@ -564,7 +566,7 @@ async fn slow_completes_with_small_cache() {
         }
         Ok(().into())
     });
-    worker.register_activity("echo_activity", echo);
+    worker.register_activity("echo_activity", ActivityFunction::from(echo));
     for i in 0..20 {
         worker
             .submit_wf(

--- a/tests/integ_tests/workflow_tests/appdata_propagation.rs
+++ b/tests/integ_tests/workflow_tests/appdata_propagation.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use std::time::Duration;
 use temporal_client::{WfClientExt, WorkflowExecutionResult, WorkflowOptions};
-use temporal_sdk::{ActContext, ActivityOptions, WfContext, WorkflowResult};
+use temporal_sdk::{ActContext, ActivityFunction, ActivityOptions, WfContext, WorkflowResult};
 use temporal_sdk_core_protos::coresdk::AsJsonPayloadExt;
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
@@ -35,11 +35,11 @@ async fn appdata_access_in_activities_and_workflows() {
     worker.register_wf(wf_name.to_owned(), appdata_activity_wf);
     worker.register_activity(
         "echo_activity",
-        |ctx: ActContext, echo_me: String| async move {
+        ActivityFunction::from(|ctx: ActContext, echo_me: String| async move {
             let data = ctx.app_data::<Data>().expect("appdata exists. qed");
             assert_eq!(data.message, TEST_APPDATA_MESSAGE.to_owned());
             Ok(echo_me)
-        },
+        }),
     );
 
     let run_id = worker

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -7,8 +7,8 @@ use std::{
 };
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{
-    interceptors::WorkerInterceptor, ActContext, ActivityCancelledError, CancellableFuture,
-    LocalActivityOptions, WfContext, WorkflowResult,
+    interceptors::WorkerInterceptor, ActContext, ActExitValue, ActivityCancelledError,
+    ActivityFunction, CancellableFuture, LocalActivityOptions, WfContext, WorkflowResult,
 };
 use temporal_sdk_core::replay::HistoryForReplay;
 use temporal_sdk_core_protos::{
@@ -46,7 +46,7 @@ async fn one_local_activity() {
     let mut starter = CoreWfStarter::new(wf_name);
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), one_local_activity_wf);
-    worker.register_activity("echo_activity", echo);
+    worker.register_activity("echo_activity", ActivityFunction::from(echo));
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -69,7 +69,7 @@ async fn local_act_concurrent_with_timer() {
     let mut starter = CoreWfStarter::new(wf_name);
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), local_act_concurrent_with_timer_wf);
-    worker.register_activity("echo_activity", echo);
+    worker.register_activity("echo_activity", ActivityFunction::from(echo));
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -93,7 +93,7 @@ async fn local_act_then_timer_then_wait_result() {
     let mut starter = CoreWfStarter::new(wf_name);
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), local_act_then_timer_then_wait);
-    worker.register_activity("echo_activity", echo);
+    worker.register_activity("echo_activity", ActivityFunction::from(echo));
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -106,10 +106,13 @@ async fn long_running_local_act_with_timer() {
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), local_act_then_timer_then_wait);
-    worker.register_activity("echo_activity", |_ctx: ActContext, str: String| async {
-        tokio::time::sleep(Duration::from_secs(4)).await;
-        Ok(str)
-    });
+    worker.register_activity(
+        "echo_activity",
+        ActivityFunction::from(|_ctx: ActContext, str: String| async {
+            tokio::time::sleep(Duration::from_secs(4)).await;
+            Ok(str)
+        }),
+    );
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -139,7 +142,7 @@ async fn local_act_fanout() {
     starter.max_local_at(1);
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), local_act_fanout_wf);
-    worker.register_activity("echo_activity", echo);
+    worker.register_activity("echo_activity", ActivityFunction::from(echo));
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -170,8 +173,8 @@ async fn local_act_retry_timer_backoff() {
         assert!(res.failed());
         Ok(().into())
     });
-    worker.register_activity("echo", |_: ActContext, _: String| async {
-        Result::<(), _>::Err(anyhow!("Oh no I failed!"))
+    worker.register_activity("echo", |_: ActContext| async {
+        Result::<ActExitValue<()>, _>::Err(anyhow!("Oh no I failed!"))
     });
 
     let run_id = worker
@@ -216,19 +219,22 @@ async fn cancel_immediate(#[case] cancel_type: ActivityCancellationType) {
     let manual_cancel = CancellationToken::new();
     let manual_cancel_act = manual_cancel.clone();
 
-    worker.register_activity("echo", move |ctx: ActContext, _: String| {
-        let manual_cancel_act = manual_cancel_act.clone();
-        async move {
-            tokio::select! {
-                _ = tokio::time::sleep(Duration::from_secs(10)) => {},
-                _ = ctx.cancelled() => {
-                    return Err(anyhow!(ActivityCancelledError::default()))
+    worker.register_activity(
+        "echo",
+        ActivityFunction::from(move |ctx: ActContext, _: String| {
+            let manual_cancel_act = manual_cancel_act.clone();
+            async move {
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(10)) => {},
+                    _ = ctx.cancelled() => {
+                        return Err(anyhow!(ActivityCancelledError::default()))
+                    }
+                    _ = manual_cancel_act.cancelled() => {}
                 }
-                _ = manual_cancel_act.cancelled() => {}
+                Ok(())
             }
-            Ok(())
-        }
-    });
+        }),
+    );
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker
@@ -320,7 +326,7 @@ async fn cancel_after_act_starts(
     let manual_cancel = CancellationToken::new();
     let manual_cancel_act = manual_cancel.clone();
 
-    worker.register_activity("echo", move |ctx: ActContext, _: String| {
+    worker.register_activity("echo", move |ctx: ActContext| {
         let manual_cancel_act = manual_cancel_act.clone();
         async move {
             if cancel_on_backoff.is_some() {
@@ -336,7 +342,7 @@ async fn cancel_after_act_starts(
                         return Err(anyhow!(ActivityCancelledError::default()))
                     }
                     _ = manual_cancel_act.cancelled() => {
-                        return Ok(())
+                        return Ok(().into())
                     }
                 }
             }
@@ -400,14 +406,14 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
         assert_eq!(res.timed_out(), Some(timeout_type));
         Ok(().into())
     });
-    worker.register_activity("echo", |ctx: ActContext, _: String| async move {
+    worker.register_activity("echo", |ctx: ActContext| async move {
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(100)) => {},
             _ = ctx.cancelled() => {
                 return Err(anyhow!(ActivityCancelledError::default()))
             }
         };
-        Ok(())
+        Ok(().into())
     });
 
     starter.start_with_worker(wf_name, &mut worker).await;
@@ -449,9 +455,9 @@ async fn schedule_to_close_timeout_across_timer_backoff(#[case] cached: bool) {
         Ok(().into())
     });
     let num_attempts: &'static _ = Box::leak(Box::new(AtomicU8::new(0)));
-    worker.register_activity("echo", move |_: ActContext, _: String| async {
+    worker.register_activity("echo", move |_: ActContext| async {
         num_attempts.fetch_add(1, Ordering::Relaxed);
-        Result::<(), _>::Err(anyhow!("Oh no I failed!"))
+        Result::<ActExitValue<()>, _>::Err(anyhow!("Oh no I failed!"))
     });
 
     starter.start_with_worker(wf_name, &mut worker).await;
@@ -469,10 +475,13 @@ async fn eviction_wont_make_local_act_get_dropped(#[values(true, false)] short_w
     starter.max_cached_workflows(0);
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), local_act_then_timer_then_wait);
-    worker.register_activity("echo_activity", |_ctx: ActContext, str: String| async {
-        tokio::time::sleep(Duration::from_secs(4)).await;
-        Ok(str)
-    });
+    worker.register_activity(
+        "echo_activity",
+        ActivityFunction::from(|_ctx: ActContext, str: String| async {
+            tokio::time::sleep(Duration::from_secs(4)).await;
+            Ok(str)
+        }),
+    );
 
     let opts = if short_wft_timeout {
         WorkflowOptions {
@@ -526,8 +535,8 @@ async fn timer_backoff_concurrent_with_non_timer_backoff() {
         assert!(r2.failed());
         Ok(().into())
     });
-    worker.register_activity("echo", |_: ActContext, _: String| async {
-        Result::<(), _>::Err(anyhow!("Oh no I failed!"))
+    worker.register_activity("echo", |_: ActContext| async {
+        Result::<ActExitValue<()>, _>::Err(anyhow!("Oh no I failed!"))
     });
 
     starter.start_with_worker(wf_name, &mut worker).await;
@@ -565,9 +574,9 @@ async fn repro_nondeterminism_with_timer_bug() {
         ctx.timer(Duration::from_secs(1)).await;
         Ok(().into())
     });
-    worker.register_activity("delay", |_: ActContext, _: String| async {
+    worker.register_activity("delay", |_: ActContext| async {
         tokio::time::sleep(Duration::from_secs(2)).await;
-        Ok(())
+        Ok(().into())
     });
 
     let run_id = worker
@@ -609,9 +618,9 @@ async fn weird_la_nondeterminism_repro(#[values(true, false)] fix_hist: bool) {
         "evict_while_la_running_no_interference",
         la_problem_workflow,
     );
-    worker.register_activity("delay", |_: ActContext, _: String| async {
+    worker.register_activity("delay", |_: ActContext| async {
         tokio::time::sleep(Duration::from_secs(15)).await;
-        Ok(())
+        Ok(().into())
     });
     worker.run().await.unwrap();
 }
@@ -635,9 +644,9 @@ async fn second_weird_la_nondeterminism_repro() {
         "evict_while_la_running_no_interference",
         la_problem_workflow,
     );
-    worker.register_activity("delay", |_: ActContext, _: String| async {
+    worker.register_activity("delay", |_: ActContext| async {
         tokio::time::sleep(Duration::from_secs(15)).await;
-        Ok(())
+        Ok(().into())
     });
     worker.run().await.unwrap();
 }
@@ -659,9 +668,9 @@ async fn third_weird_la_nondeterminism_repro() {
         "evict_while_la_running_no_interference",
         la_problem_workflow,
     );
-    worker.register_activity("delay", |_: ActContext, _: String| async {
+    worker.register_activity("delay", |_: ActContext| async {
         tokio::time::sleep(Duration::from_secs(15)).await;
-        Ok(())
+        Ok(().into())
     });
     worker.run().await.unwrap();
 }


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
1) Updated workflow and activity functions to take 0 or 1 arguments and accommodate generic functions as extensions (loosen up bounds)

2) Unfortunately, it touches activity tests, but they are only updating the function signature, all tests pass including load tests.

## Why?
To enable creating a type-safe API using more generic user functions. 
For example, a user function that does not return `anyhow::Error`

With this, we can register
1) 0 arg function similar to how it is done currently

```
worker.register_activity("echo", |_: ActContext| async {
    Result::<ActExitValue<()>, _>::Err(anyhow!("Oh no I failed!"))
});
```

2) 1 arg function as shown below, similar to how workflow function is registered currently.

```
worker.register_activity(
    "echo_activity",
    ActivityFunction::from(|_ctx: ActContext, echo_me: String| async move { Ok(echo_me) }),
);
```


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
1) Updated tests
2) Ran unit tests
3) Ran integration tests
4) Ran heavy tests(load)
All tests passed.

3. Any docs updates needed?
Updated function documentation
