### PR TITLE
Lang metrics export

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -33,7 +33,9 @@ uuid = { version = "1.1", features = ["v4"] }
 
 [dependencies.temporal-sdk-core-protos]
 path = "../sdk-core-protos"
-version = "0.1"
+
+[dependencies.temporal-sdk-core-api]
+path = "../core-api"
 
 [dev-dependencies]
 assert_matches = "1"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -43,7 +43,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use temporal_sdk_core_api::telemetry::metrics::CoreMeter;
+use temporal_sdk_core_api::telemetry::metrics::TemporalMeter;
 use temporal_sdk_core_protos::{
     coresdk::{workflow_commands::QueryResult, IntoPayloadsExt},
     grpc::health::v1::health_client::HealthClient,
@@ -294,7 +294,7 @@ impl ClientOptions {
     pub async fn connect(
         &self,
         namespace: impl Into<String>,
-        metrics_meter: Option<&dyn CoreMeter>,
+        metrics_meter: Option<TemporalMeter>,
         headers: Option<Arc<RwLock<HashMap<String, String>>>>,
     ) -> Result<RetryClient<Client>, ClientInitError> {
         let client = self
@@ -312,7 +312,7 @@ impl ClientOptions {
     /// See [RetryClient] for more
     pub async fn connect_no_namespace(
         &self,
-        metrics_meter: Option<&dyn CoreMeter>,
+        metrics_meter: Option<TemporalMeter>,
         headers: Option<Arc<RwLock<HashMap<String, String>>>>,
     ) -> Result<RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>, ClientInitError>
     {
@@ -325,9 +325,9 @@ impl ClientOptions {
         };
         let channel = channel.connect().await?;
         let service = ServiceBuilder::new()
-            .layer_fn(|channel| GrpcMetricSvc {
+            .layer_fn(move |channel| GrpcMetricSvc {
                 inner: channel,
-                metrics: metrics_meter.map(|mm| MetricsContext::new(mm)),
+                metrics: metrics_meter.clone().map(MetricsContext::new),
             })
             .service(channel);
         let headers = headers.unwrap_or_default();

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -25,8 +25,8 @@ pub struct MetricsContext {
     long_svc_request: Arc<dyn Counter>,
     long_svc_request_failed: Arc<dyn Counter>,
 
-    svc_request_latency: Histogram<u64>,
-    long_svc_request_latency: Histogram<u64>,
+    svc_request_latency: Arc<dyn Histogram>,
+    long_svc_request_latency: Arc<dyn Histogram>,
 }
 
 impl MetricsContext {

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -35,12 +35,12 @@ impl MetricsContext {
         Self {
             kvs: meter.new_attributes(tm.default_attribs),
             poll_is_long: false,
-            svc_request: meter.counter("request"),
-            svc_request_failed: meter.counter("request_failure"),
-            long_svc_request: meter.counter("long_request"),
-            long_svc_request_failed: meter.counter("long_request_failure"),
-            svc_request_latency: meter.histogram("request_latency"),
-            long_svc_request_latency: meter.histogram("long_request_latency"),
+            svc_request: meter.counter("request".into()),
+            svc_request_failed: meter.counter("request_failure".into()),
+            long_svc_request: meter.counter("long_request".into()),
+            long_svc_request_failed: meter.counter("long_request_failure".into()),
+            svc_request_latency: meter.histogram("request_latency".into()),
+            long_svc_request_latency: meter.histogram("long_request_latency".into()),
         }
     }
 

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -6,7 +6,8 @@ use std::{
     time::{Duration, Instant},
 };
 use temporal_sdk_core_api::telemetry::metrics::{
-    CoreMeter, Counter, Histogram, MetricAttributes, MetricKeyValue, TemporalMeter,
+    CoreMeter, Counter, Histogram, MetricAttributes, MetricKeyValue, MetricParameters,
+    TemporalMeter,
 };
 use tonic::{body::BoxBody, transport::Channel};
 use tower::Service;
@@ -35,12 +36,36 @@ impl MetricsContext {
         Self {
             kvs: meter.new_attributes(tm.default_attribs),
             poll_is_long: false,
-            svc_request: meter.counter("request".into()),
-            svc_request_failed: meter.counter("request_failure".into()),
-            long_svc_request: meter.counter("long_request".into()),
-            long_svc_request_failed: meter.counter("long_request_failure".into()),
-            svc_request_latency: meter.histogram("request_latency".into()),
-            long_svc_request_latency: meter.histogram("long_request_latency".into()),
+            svc_request: meter.counter(MetricParameters {
+                name: "request".into(),
+                description: "Count of client request successes by rpc name".into(),
+                unit: "".into(),
+            }),
+            svc_request_failed: meter.counter(MetricParameters {
+                name: "request_failure".into(),
+                description: "Count of client request failures by rpc name".into(),
+                unit: "".into(),
+            }),
+            long_svc_request: meter.counter(MetricParameters {
+                name: "long_request".into(),
+                description: "Count of long-poll request successes by rpc name".into(),
+                unit: "".into(),
+            }),
+            long_svc_request_failed: meter.counter(MetricParameters {
+                name: "long_request_failure".into(),
+                description: "Count of long-poll request failures by rpc name".into(),
+                unit: "".into(),
+            }),
+            svc_request_latency: meter.histogram(MetricParameters {
+                name: "request_latency".into(),
+                unit: "ms".into(),
+                description: "Histogram of client request latencies".into(),
+            }),
+            long_svc_request_latency: meter.histogram(MetricParameters {
+                name: "long_request_latency".into(),
+                unit: "ms".into(),
+                description: "Histogram of client long-poll request latencies".into(),
+            }),
         }
     }
 

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 use temporal_sdk_core_api::telemetry::metrics::{
-    CoreMeter, Counter, Histogram, MetricAttributes, MetricKeyValue, MetricsAttributesOptions,
+    CoreMeter, Counter, Histogram, MetricAttributes, MetricKeyValue, TemporalMeter,
 };
 use tonic::{body::BoxBody, transport::Channel};
 use tower::Service;
@@ -30,16 +30,17 @@ pub struct MetricsContext {
 }
 
 impl MetricsContext {
-    pub(crate) fn new(metric_provider: &dyn CoreMeter) -> Self {
+    pub(crate) fn new(tm: TemporalMeter) -> Self {
+        let meter = tm.inner;
         Self {
-            kvs: metric_provider.new_attributes(MetricsAttributesOptions::default()),
+            kvs: meter.new_attributes(tm.default_attribs),
             poll_is_long: false,
-            svc_request: metric_provider.counter("request"),
-            svc_request_failed: metric_provider.counter("request_failure"),
-            long_svc_request: metric_provider.counter("long_request"),
-            long_svc_request_failed: metric_provider.counter("long_request_failure"),
-            svc_request_latency: metric_provider.histogram("request_latency"),
-            long_svc_request_latency: metric_provider.histogram("long_request_latency"),
+            svc_request: meter.counter("request"),
+            svc_request_failed: meter.counter("request_failure"),
+            long_svc_request: meter.counter("long_request"),
+            long_svc_request_failed: meter.counter("long_request_failure"),
+            svc_request_latency: meter.histogram("request_latency"),
+            long_svc_request_latency: meter.histogram("long_request_latency"),
         }
     }
 

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -1,13 +1,12 @@
 use crate::{AttachMetricLabels, LONG_POLL_METHOD_NAMES};
 use futures::{future::BoxFuture, FutureExt};
-use opentelemetry::{
-    metrics::{Counter, Histogram},
-    KeyValue,
-};
 use std::{
     sync::Arc,
     task::{Context, Poll},
     time::{Duration, Instant},
+};
+use temporal_sdk_core_api::telemetry::metrics::{
+    CoreMeter, Counter, Histogram, MetricAttributes, MetricKeyValue, MetricsAttributesOptions,
 };
 use tonic::{body::BoxBody, transport::Channel};
 use tower::Service;
@@ -15,35 +14,25 @@ use tower::Service;
 /// Used to track context associated with metrics, and record/update them
 // Possible improvement: make generic over some type tag so that methods are only exposed if the
 // appropriate k/vs have already been set.
-#[derive(Clone, Debug)]
+#[derive(Clone, derive_more::DebugCustom)]
+#[debug(fmt = "MetricsContext {{ attribs: {kvs:?}, poll_is_long: {poll_is_long} }}")]
 pub struct MetricsContext {
-    kvs: Arc<Vec<KeyValue>>,
+    kvs: MetricAttributes,
     poll_is_long: bool,
 
-    svc_request: Counter<u64>,
-    svc_request_failed: Counter<u64>,
-    long_svc_request: Counter<u64>,
-    long_svc_request_failed: Counter<u64>,
+    svc_request: Arc<dyn Counter>,
+    svc_request_failed: Arc<dyn Counter>,
+    long_svc_request: Arc<dyn Counter>,
+    long_svc_request_failed: Arc<dyn Counter>,
 
     svc_request_latency: Histogram<u64>,
     long_svc_request_latency: Histogram<u64>,
 }
 
-/// Things that can provide metrics for the client implement this. Trait exists to avoid having
-/// to make a whole new lower-level crate just for a tiny shared wrapper around OTel meters.
-pub trait ClientMetricProvider: Send + Sync {
-    /// Construct a counter metric
-    fn counter(&self, name: &'static str) -> Counter<u64>;
-    /// Construct a histogram metric
-    fn histogram(&self, name: &'static str) -> Histogram<u64>;
-    /// Returns labels that should always be attached to metric record calls
-    fn fixed_labels(&self) -> &[KeyValue];
-}
-
 impl MetricsContext {
-    pub(crate) fn new(kvs: Vec<KeyValue>, metric_provider: &dyn ClientMetricProvider) -> Self {
+    pub(crate) fn new(metric_provider: &dyn CoreMeter) -> Self {
         Self {
-            kvs: Arc::new(kvs),
+            kvs: metric_provider.new_attributes(MetricsAttributesOptions::default()),
             poll_is_long: false,
             svc_request: metric_provider.counter("request"),
             svc_request_failed: metric_provider.counter("request_failure"),
@@ -55,15 +44,15 @@ impl MetricsContext {
     }
 
     /// Extend an existing metrics context with new attributes, returning a new one
-    pub(crate) fn with_new_attrs(&self, new_kvs: impl IntoIterator<Item = KeyValue>) -> Self {
+    pub(crate) fn with_new_attrs(&self, new_kvs: impl IntoIterator<Item = MetricKeyValue>) -> Self {
         let mut r = self.clone();
         r.add_new_attrs(new_kvs);
         r
     }
 
     /// Add new attributes to the context, mutating it
-    pub(crate) fn add_new_attrs(&mut self, new_kvs: impl IntoIterator<Item = KeyValue>) {
-        Arc::make_mut(&mut self.kvs).extend(new_kvs);
+    pub(crate) fn add_new_attrs(&mut self, new_kvs: impl IntoIterator<Item = MetricKeyValue>) {
+        self.kvs.add_new_attrs(new_kvs);
     }
 
     pub(crate) fn set_is_long_poll(&mut self) {
@@ -104,16 +93,16 @@ const KEY_NAMESPACE: &str = "namespace";
 const KEY_SVC_METHOD: &str = "operation";
 const KEY_TASK_QUEUE: &str = "task_queue";
 
-pub(crate) fn namespace_kv(ns: String) -> KeyValue {
-    KeyValue::new(KEY_NAMESPACE, ns)
+pub(crate) fn namespace_kv(ns: String) -> MetricKeyValue {
+    MetricKeyValue::new(KEY_NAMESPACE, ns)
 }
 
-pub(crate) fn task_queue_kv(tq: String) -> KeyValue {
-    KeyValue::new(KEY_TASK_QUEUE, tq)
+pub(crate) fn task_queue_kv(tq: String) -> MetricKeyValue {
+    MetricKeyValue::new(KEY_TASK_QUEUE, tq)
 }
 
-pub(crate) fn svc_operation(op: String) -> KeyValue {
-    KeyValue::new(KEY_SVC_METHOD, op)
+pub(crate) fn svc_operation(op: String) -> MetricKeyValue {
+    MetricKeyValue::new(KEY_SVC_METHOD, op)
 }
 
 /// Implements metrics functionality for gRPC (really, any http) calls

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -9,6 +9,7 @@ use crate::{
     LONG_POLL_TIMEOUT,
 };
 use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use temporal_sdk_core_api::telemetry::metrics::MetricKeyValue;
 use temporal_sdk_core_protos::{
     grpc::health::v1::{health_client::HealthClient, *},
     temporal::api::{
@@ -199,10 +200,10 @@ fn req_cloner<T: Clone>(cloneme: &Request<T>) -> Request<T> {
 
 #[derive(Debug)]
 pub(super) struct AttachMetricLabels {
-    pub(super) labels: Vec<opentelemetry::KeyValue>,
+    pub(super) labels: Vec<MetricKeyValue>,
 }
 impl AttachMetricLabels {
-    pub fn new(kvs: impl Into<Vec<opentelemetry::KeyValue>>) -> Self {
+    pub fn new(kvs: impl Into<Vec<MetricKeyValue>>) -> Self {
         Self { labels: kvs.into() }
     }
     pub fn namespace(ns: impl Into<String>) -> Self {

--- a/core-api/Cargo.toml
+++ b/core-api/Cargo.toml
@@ -12,9 +12,14 @@ categories = ["development-tools"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+otel_impls = ["opentelemetry"]
+
 [dependencies]
 async-trait = "0.1"
 derive_builder = "0.12"
+derive_more = "0.99"
+opentelemetry = { version = "0.18", optional = true }
 prost-types = "0.11"
 serde = { version = "1.0", default_features = false, features = ["derive"] }
 serde_json = "1.0"
@@ -26,8 +31,4 @@ url = "2.3"
 
 [dependencies.temporal-sdk-core-protos]
 path = "../sdk-core-protos"
-version = "0.1"
-
-[dependencies.temporal-client]
-path = "../client"
 version = "0.1"

--- a/core-api/Cargo.toml
+++ b/core-api/Cargo.toml
@@ -19,7 +19,7 @@ otel_impls = ["opentelemetry"]
 async-trait = "0.1"
 derive_builder = "0.12"
 derive_more = "0.99"
-opentelemetry = { version = "0.18", optional = true }
+opentelemetry = { workspace = true, optional = true }
 prost-types = "0.11"
 serde = { version = "1.0", default_features = false, features = ["derive"] }
 serde_json = "1.0"

--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -1,6 +1,10 @@
+pub mod metrics;
+
+use crate::telemetry::metrics::CoreMeter;
 use std::{
     collections::HashMap,
     net::SocketAddr,
+    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tracing_core::Level;
@@ -90,6 +94,9 @@ pub enum MetricsExporter {
     Otel(OtelCollectorOptions),
     /// Expose metrics directly via an embedded http server bound to the provided address.
     Prometheus(SocketAddr),
+    /// Export metrics calls to lang where it can inject them into whatever metrics system the
+    /// user likes
+    Lang(Arc<dyn CoreMeter>),
 }
 
 /// Control where logs go

--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -82,6 +82,13 @@ pub struct PrometheusExporterOptions {
     /// A prefix to be applied to all metrics. Defaults to "temporal_".
     #[builder(default = "METRIC_PREFIX")]
     pub metric_prefix: &'static str,
+    /// If set true, all counters will include a "_total" suffix
+    #[builder(default = "false")]
+    pub counters_total_suffix: bool,
+    /// If set true, all histograms will include the unit in their name as a suffix.
+    /// Ex: "_milliseconds".
+    #[builder(default = "false")]
+    pub unit_suffix: bool,
 }
 
 /// Configuration for the external export of traces

--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -42,6 +42,7 @@ pub struct TelemetryOptions {
     #[builder(default)]
     pub no_temporal_prefix_for_metrics: bool,
 
+    // TODO: Will move inside constructors for otel/prom
     /// Specifies the aggregation temporality for metric export. Defaults to cumulative.
     #[builder(default = "MetricTemporality::Cumulative")]
     pub metric_temporality: MetricTemporality,

--- a/core-api/src/telemetry/metrics.rs
+++ b/core-api/src/telemetry/metrics.rs
@@ -1,0 +1,263 @@
+use std::{fmt::Debug, sync::Arc};
+
+/// Implementors of this trait are expected to be defined in each language's bridge.
+/// The implementor is responsible for the allocation/instantiation of new metric meters which
+/// Core has requested.
+pub trait CoreMeter: Send + Sync + Debug {
+    fn new_attributes(&self, attribs: MetricsAttributesOptions) -> MetricAttributes;
+    fn counter(&self, name: &str) -> Arc<dyn Counter>;
+    fn histogram(&self, name: &str) -> Arc<dyn Histogram>;
+    fn gauge(&self, name: &str) -> Arc<dyn Gauge>;
+}
+
+#[derive(Debug)]
+pub struct NoOpCoreMeter;
+impl CoreMeter for NoOpCoreMeter {
+    fn new_attributes(&self, _: MetricsAttributesOptions) -> MetricAttributes {
+        MetricAttributes::Lang {
+            id: 0,
+            new_attributes: vec![],
+        }
+    }
+
+    fn counter(&self, _: &str) -> Arc<dyn Counter> {
+        Arc::new(NoOpInstrument)
+    }
+
+    fn histogram(&self, _: &str) -> Arc<dyn Histogram> {
+        Arc::new(NoOpInstrument)
+    }
+
+    fn gauge(&self, _: &str) -> Arc<dyn Gauge> {
+        Arc::new(NoOpInstrument)
+    }
+}
+
+#[derive(Debug)]
+pub struct PrefixedMetricsMeter<CM>(&'static str, CM);
+impl<CM> PrefixedMetricsMeter<CM> {
+    pub fn new(prefix: &'static str, core_meter: CM) -> Self {
+        PrefixedMetricsMeter(prefix, core_meter)
+    }
+}
+impl<CM: CoreMeter> CoreMeter for PrefixedMetricsMeter<CM> {
+    fn new_attributes(&self, attribs: MetricsAttributesOptions) -> MetricAttributes {
+        self.1.new_attributes(attribs)
+    }
+
+    fn counter(&self, name: &str) -> Arc<dyn Counter> {
+        self.1.counter(&(self.0.to_string() + name))
+    }
+
+    fn histogram(&self, name: &str) -> Arc<dyn Histogram> {
+        self.1.histogram(&(self.0.to_string() + name))
+    }
+
+    fn gauge(&self, name: &str) -> Arc<dyn Gauge> {
+        self.1.gauge(&(self.0.to_string() + name))
+    }
+}
+
+impl CoreMeter for Arc<dyn CoreMeter> {
+    fn new_attributes(&self, attribs: MetricsAttributesOptions) -> MetricAttributes {
+        self.as_ref().new_attributes(attribs)
+    }
+
+    fn counter(&self, name: &str) -> Arc<dyn Counter> {
+        self.as_ref().counter(name)
+    }
+
+    fn histogram(&self, name: &str) -> Arc<dyn Histogram> {
+        self.as_ref().histogram(name)
+    }
+
+    fn gauge(&self, name: &str) -> Arc<dyn Gauge> {
+        self.as_ref().gauge(name)
+    }
+}
+
+/// Attributes which are provided every time a call to record a specific metric is made.
+/// Implementors must be very cheap to clone, as these attributes will be re-used frequently.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum MetricAttributes {
+    #[cfg(feature = "otel_impls")]
+    OTel {
+        kvs: Arc<Vec<opentelemetry::KeyValue>>,
+        ctx: opentelemetry::Context,
+    },
+    Lang {
+        /// An opaque reference to attributes stored in lang memory
+        id: u64,
+        /// If populated, these key values should also be used in addition to the referred-to
+        /// existing attributes when recording
+        new_attributes: Vec<MetricKeyValue>,
+    },
+}
+
+impl MetricAttributes {
+    /// Extend existing metrics attributes with new k/vs, returning a new instance
+    pub fn with_new_attrs(&self, new_kvs: impl IntoIterator<Item = MetricKeyValue>) -> Self {
+        let mut me = self.clone();
+        me.add_new_attrs(new_kvs);
+        me
+    }
+
+    /// Mutate self to add new kvs
+    pub fn add_new_attrs(&mut self, new_kvs: impl IntoIterator<Item = MetricKeyValue>) {
+        match self {
+            #[cfg(feature = "otel_impls")]
+            MetricAttributes::OTel { ref mut kvs, .. } => {
+                Arc::make_mut(kvs).extend(new_kvs.into_iter().map(Into::into));
+            }
+            MetricAttributes::Lang {
+                ref mut new_attributes,
+                ..
+            } => {
+                new_attributes.extend(new_kvs.into_iter());
+            }
+        }
+    }
+}
+
+/// Options that are attached to metrics on a per-call basis
+#[derive(Clone, Default, derive_more::Constructor)]
+pub struct MetricsAttributesOptions {
+    attributes: Vec<MetricKeyValue>,
+}
+impl MetricsAttributesOptions {
+    pub fn extend(&mut self, new_kvs: impl IntoIterator<Item = MetricKeyValue>) {
+        self.attributes.extend(new_kvs.into_iter())
+    }
+}
+
+/// A K/V pair that can be used to label a specific recording of a metric
+#[derive(Clone, Debug)]
+pub struct MetricKeyValue {
+    key: String,
+    value: MetricValue,
+}
+impl MetricKeyValue {
+    pub fn new(key: impl Into<String>, value: impl Into<MetricValue>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// Values metric labels may assume
+#[derive(Clone, Debug, derive_more::From)]
+pub enum MetricValue {
+    String(String),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    // can add array if needed
+}
+impl From<&'static str> for MetricValue {
+    fn from(value: &'static str) -> Self {
+        MetricValue::String(value.to_string())
+    }
+}
+
+/// Histogram buckets
+#[derive(Clone, Debug)]
+pub struct Buckets {
+    buckets: Vec<f64>,
+}
+
+pub trait Counter: Send + Sync {
+    fn add(&self, value: u64, attributes: &MetricAttributes);
+}
+
+pub trait Histogram: Send + Sync {
+    // When referring to durations, this value is in millis
+    fn record(&self, value: u64, attributes: &MetricAttributes);
+}
+
+pub trait Gauge: Send + Sync {
+    // When referring to durations, this value is in millis
+    fn record(&self, value: u64, attributes: &MetricAttributes);
+}
+
+pub struct NoOpInstrument;
+impl Counter for NoOpInstrument {
+    fn add(&self, _: u64, _: &MetricAttributes) {}
+}
+impl Histogram for NoOpInstrument {
+    fn record(&self, _: u64, _: &MetricAttributes) {}
+}
+impl Gauge for NoOpInstrument {
+    fn record(&self, _: u64, _: &MetricAttributes) {}
+}
+
+#[cfg(feature = "otel_impls")]
+mod otel_impls {
+    use super::*;
+    use opentelemetry::{metrics, metrics::Meter, KeyValue};
+
+    impl From<MetricKeyValue> for KeyValue {
+        fn from(kv: MetricKeyValue) -> Self {
+            KeyValue::new(kv.key, kv.value)
+        }
+    }
+
+    impl From<MetricValue> for opentelemetry::Value {
+        fn from(mv: MetricValue) -> Self {
+            match mv {
+                MetricValue::String(s) => opentelemetry::Value::String(s.into()),
+                MetricValue::Int(i) => opentelemetry::Value::I64(i),
+                MetricValue::Float(f) => opentelemetry::Value::F64(f),
+                MetricValue::Bool(b) => opentelemetry::Value::Bool(b),
+            }
+        }
+    }
+
+    impl CoreMeter for Meter {
+        fn new_attributes(&self, attribs: MetricsAttributesOptions) -> MetricAttributes {
+            MetricAttributes::OTel {
+                kvs: Arc::new(attribs.attributes.into_iter().map(KeyValue::from).collect()),
+                // TODO: Pass in? Hard to make work with trait
+                ctx: opentelemetry::Context::current(),
+            }
+        }
+
+        fn counter(&self, name: &str) -> Arc<dyn Counter> {
+            Arc::new(self.u64_counter(name).init())
+        }
+
+        fn histogram(&self, name: &str) -> Arc<dyn Histogram> {
+            Arc::new(self.u64_histogram(name).init())
+        }
+
+        fn gauge(&self, name: &str) -> Arc<dyn Gauge> {
+            Arc::new(self.u64_histogram(name).init())
+        }
+    }
+
+    // TODO: Dbg panic
+    impl Counter for metrics::Counter<u64> {
+        fn add(&self, value: u64, attributes: &MetricAttributes) {
+            if let MetricAttributes::OTel { ctx, kvs } = attributes {
+                self.add(ctx, value, kvs);
+            }
+        }
+    }
+
+    impl Histogram for metrics::Histogram<u64> {
+        fn record(&self, value: u64, attributes: &MetricAttributes) {
+            if let MetricAttributes::OTel { ctx, kvs } = attributes {
+                self.record(ctx, value, kvs);
+            }
+        }
+    }
+
+    impl Gauge for metrics::Histogram<u64> {
+        fn record(&self, value: u64, attributes: &MetricAttributes) {
+            if let MetricAttributes::OTel { ctx, kvs } = attributes {
+                self.record(ctx, value, kvs);
+            }
+        }
+    }
+}

--- a/core-api/src/telemetry/metrics.rs
+++ b/core-api/src/telemetry/metrics.rs
@@ -50,7 +50,7 @@ pub enum MetricUpdateVal {
 }
 
 pub trait MetricCallBufferer: Send + Sync {
-    fn retrieve(&mut self) -> Vec<MetricEvent>;
+    fn retrieve(&self) -> Vec<MetricEvent>;
 }
 
 impl CoreMeter for Arc<dyn CoreMeter> {
@@ -134,8 +134,8 @@ impl MetricsAttributesOptions {
 /// A K/V pair that can be used to label a specific recording of a metric
 #[derive(Clone, Debug)]
 pub struct MetricKeyValue {
-    key: String,
-    value: MetricValue,
+    pub key: String,
+    pub value: MetricValue,
 }
 impl MetricKeyValue {
     pub fn new(key: impl Into<String>, value: impl Into<MetricValue>) -> Self {

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -115,6 +115,7 @@ pub struct WorkerConfig {
     #[builder(default = "5")]
     pub fetching_concurrency: usize,
 
+    // TODO: Move this out - dependency on tokio should not exist just for this
     /// If set, and the `save_wf_inputs` feature is enabled in core, will be sent a serialized
     /// instance of every input to workflow state in order. This is for testing purposes, SDK
     /// implementations never need to care about it.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -78,20 +78,17 @@ zip = { version = "0.6.3", optional = true }
 # 1st party local deps
 [dependencies.temporal-sdk-core-api]
 path = "../core-api"
-version = "0.1"
+features = ["otel_impls"]
 
 [dependencies.temporal-sdk-core-protos]
 path = "../sdk-core-protos"
-version = "0.1"
 features = ["history_builders"]
 
 [dependencies.temporal-client]
 path = "../client"
-version = "0.1"
 
 [dependencies.rustfsm]
 path = "../fsm"
-version = "0.1"
 
 [dev-dependencies]
 assert_matches = "1.4"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,9 +45,8 @@ pub use worker::{Worker, WorkerConfig, WorkerConfigBuilder};
 use crate::{
     replay::{mock_client_from_histories, Historator, HistoryForReplay},
     telemetry::{
-        metrics::{MetricsContext, TemporalMeter},
-        remove_trace_subscriber_for_current_thread, set_trace_subscriber_for_current_thread,
-        telemetry_init, TelemetryInstance,
+        metrics::MetricsContext, remove_trace_subscriber_for_current_thread,
+        set_trace_subscriber_for_current_thread, telemetry_init, TelemetryInstance,
     },
     worker::client::WorkerClientBag,
 };
@@ -56,7 +55,7 @@ use std::sync::Arc;
 use temporal_client::{ConfiguredClient, TemporalServiceClientWithMetrics};
 use temporal_sdk_core_api::{
     errors::{CompleteActivityError, PollActivityError, PollWfError},
-    telemetry::TelemetryOptions,
+    telemetry::{metrics::CoreMeter, TelemetryOptions},
     Worker as WorkerTrait,
 };
 use temporal_sdk_core_protos::coresdk::ActivityHeartbeat;
@@ -264,7 +263,7 @@ impl CoreRuntime {
     }
 
     /// Returns the metric meter used for recording metrics, if they were enabled.
-    pub fn metric_meter(&self) -> Option<TemporalMeter> {
+    pub fn metric_meter(&self) -> Option<Arc<dyn CoreMeter>> {
         self.telemetry.get_metric_meter()
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -55,7 +55,7 @@ use std::sync::Arc;
 use temporal_client::{ConfiguredClient, TemporalServiceClientWithMetrics};
 use temporal_sdk_core_api::{
     errors::{CompleteActivityError, PollActivityError, PollWfError},
-    telemetry::{metrics::CoreMeter, TelemetryOptions},
+    telemetry::{metrics::TemporalMeter, TelemetryOptions},
     Worker as WorkerTrait,
 };
 use temporal_sdk_core_protos::coresdk::ActivityHeartbeat;
@@ -263,7 +263,7 @@ impl CoreRuntime {
     }
 
     /// Returns the metric meter used for recording metrics, if they were enabled.
-    pub fn metric_meter(&self) -> Option<Arc<dyn CoreMeter>> {
+    pub fn metric_meter(&self) -> Option<TemporalMeter> {
         self.telemetry.get_metric_meter()
     }
 

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -50,7 +50,7 @@ struct Instruments {
     sticky_cache_hit: Counter<u64>,
     sticky_cache_miss: Counter<u64>,
     sticky_cache_size: MemoryGaugeU64,
-    sticky_cache_evictions: Counter<u64>,
+    sticky_cache_evictions: Arc<dyn Counter>,
 }
 
 impl MetricsContext {

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -721,6 +721,7 @@ mod tests {
         // Verify all metrics are created. This number will need to get updated any time a metric
         // is added.
         let num_metrics = 22;
+        #[allow(clippy::needless_range_loop)] // Sorry clippy, this reads easier.
         for metric_num in 1..=num_metrics {
             assert_matches!(&events[metric_num],
                 MetricEvent::Create { id, .. }

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -262,34 +262,125 @@ impl MetricsContext {
 impl Instruments {
     fn new(meter: &dyn CoreMeter) -> Self {
         Self {
-            wf_completed_counter: meter.counter("workflow_completed".into()),
-            wf_canceled_counter: meter.counter("workflow_canceled".into()),
-            wf_failed_counter: meter.counter("workflow_failed".into()),
-            wf_cont_counter: meter.counter("workflow_continue_as_new".into()),
-            wf_e2e_latency: meter.histogram(WF_E2E_LATENCY_NAME.into()),
-            wf_task_queue_poll_empty_counter: meter
-                .counter("workflow_task_queue_poll_empty".into()),
-            wf_task_queue_poll_succeed_counter: meter
-                .counter("workflow_task_queue_poll_succeed".into()),
-            wf_task_execution_failure_counter: meter
-                .counter("workflow_task_execution_failed".into()),
-            wf_task_sched_to_start_latency: meter
-                .histogram(WF_TASK_SCHED_TO_START_LATENCY_NAME.into()),
-            wf_task_replay_latency: meter.histogram(WF_TASK_REPLAY_LATENCY_NAME.into()),
-            wf_task_execution_latency: meter.histogram(WF_TASK_EXECUTION_LATENCY_NAME.into()),
-            act_poll_no_task: meter.counter("activity_poll_no_task".into()),
-            act_task_received_counter: meter.counter("activity_task_received".into()),
-            act_execution_failed: meter.counter("activity_execution_failed".into()),
-            act_sched_to_start_latency: meter.histogram(ACT_SCHED_TO_START_LATENCY_NAME.into()),
-            act_exec_latency: meter.histogram(ACT_EXEC_LATENCY_NAME.into()),
+            wf_completed_counter: meter.counter(MetricParameters {
+                name: "workflow_completed".into(),
+                description: "Count of successfully completed workflows".into(),
+                unit: "".into(),
+            }),
+            wf_canceled_counter: meter.counter(MetricParameters {
+                name: "workflow_canceled".into(),
+                description: "Count of canceled workflows".into(),
+                unit: "".into(),
+            }),
+            wf_failed_counter: meter.counter(MetricParameters {
+                name: "workflow_failed".into(),
+                description: "Count of failed workflows".into(),
+                unit: "".into(),
+            }),
+            wf_cont_counter: meter.counter(MetricParameters {
+                name: "workflow_continue_as_new".into(),
+                description: "Count of continued-as-new workflows".into(),
+                unit: "".into(),
+            }),
+            wf_e2e_latency: meter.histogram(MetricParameters {
+                name: WF_E2E_LATENCY_NAME.into(),
+                unit: "ms".into(),
+                description: "Histogram of total workflow execution latencies".into(),
+            }),
+            wf_task_queue_poll_empty_counter: meter.counter(MetricParameters {
+                name: "workflow_task_queue_poll_empty".into(),
+                description: "Count of workflow task queue poll timeouts (no new task)".into(),
+                unit: "".into(),
+            }),
+            wf_task_queue_poll_succeed_counter: meter.counter(MetricParameters {
+                name: "workflow_task_queue_poll_succeed".into(),
+                description: "Count of workflow task queue poll successes".into(),
+                unit: "".into(),
+            }),
+            wf_task_execution_failure_counter: meter.counter(MetricParameters {
+                name: "workflow_task_execution_failed".into(),
+                description: "Count of workflow task execution failures".into(),
+                unit: "".into(),
+            }),
+            wf_task_sched_to_start_latency: meter.histogram(MetricParameters {
+                name: WF_TASK_SCHED_TO_START_LATENCY_NAME.into(),
+                unit: "ms".into(),
+                description: "Histogram of workflow task schedule-to-start latencies".into(),
+            }),
+            wf_task_replay_latency: meter.histogram(MetricParameters {
+                name: WF_TASK_REPLAY_LATENCY_NAME.into(),
+                unit: "ms".into(),
+                description: "Histogram of workflow task replay latencies".into(),
+            }),
+            wf_task_execution_latency: meter.histogram(MetricParameters {
+                name: WF_TASK_EXECUTION_LATENCY_NAME.into(),
+                unit: "ms".into(),
+                description: "Histogram of workflow task execution (not replay) latencies".into(),
+            }),
+            act_poll_no_task: meter.counter(MetricParameters {
+                name: "activity_poll_no_task".into(),
+                description: "Count of activity task queue poll timeouts (no new task)".into(),
+                unit: "".into(),
+            }),
+            act_task_received_counter: meter.counter(MetricParameters {
+                name: "activity_task_received".into(),
+                description: "Count of activity task queue poll successes".into(),
+                unit: "".into(),
+            }),
+            act_execution_failed: meter.counter(MetricParameters {
+                name: "activity_execution_failed".into(),
+                description: "Count of activity task execution failures".into(),
+                unit: "".into(),
+            }),
+            act_sched_to_start_latency: meter.histogram(MetricParameters {
+                name: ACT_SCHED_TO_START_LATENCY_NAME.into(),
+                unit: "ms".into(),
+                description: "Histogram of activity schedule-to-start latencies".into(),
+            }),
+            act_exec_latency: meter.histogram(MetricParameters {
+                name: ACT_EXEC_LATENCY_NAME.into(),
+                unit: "ms".into(),
+                description: "Histogram of activity execution latencies".into(),
+            }),
             // name kept as worker start for compat with old sdk / what users expect
-            worker_registered: meter.counter("worker_start".into()),
-            num_pollers: meter.gauge(NUM_POLLERS_NAME.into()),
-            task_slots_available: meter.gauge(TASK_SLOTS_AVAILABLE_NAME.into()),
-            sticky_cache_hit: meter.counter("sticky_cache_hit".into()),
-            sticky_cache_miss: meter.counter("sticky_cache_miss".into()),
-            sticky_cache_size: meter.gauge(STICKY_CACHE_SIZE_NAME.into()),
-            sticky_cache_evictions: meter.counter("sticky_cache_total_forced_eviction".into()),
+            worker_registered: meter.counter(MetricParameters {
+                name: "worker_start".into(),
+                description: "Count of the number of initialized workers".into(),
+                unit: "".into(),
+            }),
+            num_pollers: meter.gauge(MetricParameters {
+                name: NUM_POLLERS_NAME.into(),
+                description: "Current number of active pollers per queue type".into(),
+                unit: "".into(),
+            }),
+            task_slots_available: meter.gauge(MetricParameters {
+                name: TASK_SLOTS_AVAILABLE_NAME.into(),
+                description: "Current number of available slots per task type".into(),
+                unit: "".into(),
+            }),
+            sticky_cache_hit: meter.counter(MetricParameters {
+                name: "sticky_cache_hit".into(),
+                description: "Count of times the workflow cache was used for a new workflow task"
+                    .into(),
+                unit: "".into(),
+            }),
+            sticky_cache_miss: meter.counter(MetricParameters {
+                name: "sticky_cache_miss".into(),
+                description:
+                    "Count of times the workflow cache was missing a workflow for a sticky task"
+                        .into(),
+                unit: "".into(),
+            }),
+            sticky_cache_size: meter.gauge(MetricParameters {
+                name: STICKY_CACHE_SIZE_NAME.into(),
+                description: "Current number of cached workflows".into(),
+                unit: "".into(),
+            }),
+            sticky_cache_evictions: meter.counter(MetricParameters {
+                name: "sticky_cache_total_forced_eviction".into(),
+                description: "Count of evictions of cached workflows".into(),
+                unit: "".into(),
+            }),
         }
     }
 }
@@ -529,7 +620,7 @@ pub struct StartedPromServer {
 pub fn start_prometheus_metric_exporter(
     opts: PrometheusExporterOptions,
 ) -> Result<StartedPromServer, anyhow::Error> {
-    let (srv, exporter) = PromServer::new(opts.socket_addr, SDKAggSelector::default())?;
+    let (srv, exporter) = PromServer::new(&opts, SDKAggSelector::default())?;
     let meter_provider = augment_meter_provider_with_defaults(
         MeterProvider::builder().with_reader(exporter),
         &opts.global_tags,

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -105,8 +105,14 @@ impl MetricsContext {
     }
 
     /// Extend an existing metrics context with new attributes
-    pub(crate) fn with_new_attrs(&self, new_kvs: impl IntoIterator<Item = MetricKeyValue>) -> Self {
-        let kvs = self.kvs.with_new_attrs(new_kvs);
+    pub(crate) fn with_new_attrs(
+        &self,
+        new_attrs: impl IntoIterator<Item = MetricKeyValue>,
+    ) -> Self {
+        let as_attrs = self.meter.new_attributes(MetricsAttributesOptions::new(
+            new_attrs.into_iter().collect(),
+        ));
+        let kvs = self.kvs.merge(as_attrs);
         Self {
             kvs,
             instruments: self.instruments.clone(),
@@ -569,7 +575,7 @@ impl CoreMeter for MetricsCallBuffer {
             attributes: opts.attributes,
         });
         MetricAttributes::Lang(LangMetricAttributes {
-            id: HashSet::from([id]),
+            ids: HashSet::from([id]),
             new_attributes: vec![],
         })
     }

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -10,7 +10,9 @@ use crate::telemetry::{
     metrics::TemporalMeter,
     prometheus_server::PromServer,
 };
-pub use metrics::{build_otlp_metric_exporter, start_prometheus_metric_exporter};
+pub use metrics::{
+    build_otlp_metric_exporter, start_prometheus_metric_exporter, MetricsCallBuffer,
+};
 
 use crate::telemetry::log_export::{CoreLogExportLayer, CoreLogsOut};
 use crossbeam::channel::Receiver;
@@ -268,7 +270,7 @@ pub fn telemetry_init(opts: TelemetryOptions) -> Result<TelemetryInstance, anyho
             Arc::new(reg),
             logs_out,
             metric_prefix,
-            meter_provider,
+            opts.metrics,
             opts.attach_service_name,
             keepalive_rx,
         ))

--- a/core/src/telemetry/prometheus_server.rs
+++ b/core/src/telemetry/prometheus_server.rs
@@ -38,9 +38,8 @@ impl PromServer {
     pub async fn run(self) -> hyper::Result<()> {
         // Spin up hyper server to serve metrics for scraping. We use hyper since we already depend
         // on it via Tonic.
-        let regclone = self.registry.clone();
         let svc = make_service_fn(move |_conn| {
-            let regclone = regclone.clone();
+            let regclone = self.registry.clone();
             async move { Ok::<_, Infallible>(service_fn(move |req| metrics_req(req, regclone.clone()))) }
         });
         let server = Server::builder(self.bound_addr).serve(svc);

--- a/core/src/telemetry/prometheus_server.rs
+++ b/core/src/telemetry/prometheus_server.rs
@@ -24,6 +24,7 @@ impl PromServer {
         let exporter = opentelemetry_prometheus::exporter()
             .with_aggregation_selector(aggregation)
             .without_scope_info()
+            .without_counter_suffixes()
             .with_registry(registry.clone());
         let bound_addr = AddrIncoming::bind(&addr)?;
         Ok((

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -195,8 +195,7 @@ impl Worker {
     ) -> Self {
         info!(task_queue=%config.task_queue, namespace=%config.namespace, "Initializing worker");
         let metrics = if let Some(ti) = telem_instance {
-            MetricsContext::top_level(config.namespace.clone(), ti)
-                .with_task_q(config.task_queue.clone())
+            MetricsContext::top_level(config.namespace.clone(), config.task_queue.clone(), ti)
         } else {
             MetricsContext::no_op()
         };

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -594,7 +594,7 @@ pub fn get_integ_telem_options() -> TelemetryOptions {
             filter: filter_string.clone(),
             exporter: TraceExporter::Otel(opts.clone()),
         });
-        ob.metrics(build_otlp_metric_exporter(opts).unwrap() as Arc<dyn CoreMeter>);
+        ob.metrics(Arc::new(build_otlp_metric_exporter(opts).unwrap()) as Arc<dyn CoreMeter>);
     }
     if let Some(addr) = env::var(PROM_ENABLE_ENV_VAR)
         .ok()

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -53,7 +53,7 @@ fn prom_metrics() -> (TelemetryOptions, SocketAddr, AbortOnDrop) {
             .unwrap(),
     )
     .unwrap();
-    telemopts.metrics = Some(prom_info.meter_provider as Arc<dyn CoreMeter>);
+    telemopts.metrics = Some(prom_info.meter as Arc<dyn CoreMeter>);
     (
         telemopts,
         prom_info.bound_addr,
@@ -69,7 +69,7 @@ async fn prometheus_metrics_exported() {
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
     let opts = get_integ_server_options();
     let mut raw_client = opts
-        .connect_no_namespace(rt.metric_meter().as_deref(), None)
+        .connect_no_namespace(rt.metric_meter(), None)
         .await
         .unwrap();
     assert!(raw_client.get_client().capabilities().is_some());

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -417,7 +417,6 @@ async fn query_of_closed_workflow_doesnt_tick_terminal_metric(
 
     // Verify there is still only one tick
     let body = get_text(format!("http://{addr}/metrics")).await;
-    dbg!(&body);
     let matching_line = body
         .lines()
         .find(|l| l.starts_with(metric_name))

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -53,7 +53,7 @@ fn prom_metrics() -> (TelemetryOptions, SocketAddr, AbortOnDrop) {
             .unwrap(),
     )
     .unwrap();
-    telemopts.metrics = Some(prom_info.meter as Arc<dyn CoreMeter>);
+    telemopts.metrics = Some(prom_info.meter_provider as Arc<dyn CoreMeter>);
     (
         telemopts,
         prom_info.bound_addr,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -37,7 +37,7 @@ mod integ_tests {
         let opts = get_integ_server_options();
         let runtime = CoreRuntime::new_assume_tokio(get_integ_telem_options()).unwrap();
         let mut retrying_client = opts
-            .connect_no_namespace(runtime.metric_meter().as_deref(), None)
+            .connect_no_namespace(runtime.metric_meter(), None)
             .await
             .unwrap();
 


### PR DESCRIPTION
This takes a crack at what it will look like to export metrics to lang.

DRAFT since it's still subject to change, though the existing implementation being backed by the new interface does work.