### PR TITLE
Poll concurrently at will

### DIFF
--- a/core/src/pollers/poll_buffer.rs
+++ b/core/src/pollers/poll_buffer.rs
@@ -92,7 +92,7 @@ where
                     }
                     let permit = tokio::select! {
                         p = poll_semaphore.acquire_owned() => p,
-                        _ = shutdown.cancelled() => continue,
+                        _ = shutdown.cancelled() => break,
                     };
                     let permit = if let Ok(p) = permit {
                         p
@@ -102,7 +102,7 @@ where
                     let _active_guard = ActiveCounter::new(ap.as_ref(), nph);
                     let r = tokio::select! {
                         r = pf() => r,
-                        _ = shutdown.cancelled() => continue,
+                        _ = shutdown.cancelled() => break,
                     };
                     let _ = tx.send(r.map(|r| (r, permit)));
                 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -61,6 +61,7 @@ pub const NAMESPACE: &str = "default";
 pub const TEST_Q: &str = "q";
 /// The env var used to specify where the integ tests should point
 pub const INTEG_SERVER_TARGET_ENV_VAR: &str = "TEMPORAL_SERVICE_ADDRESS";
+pub const INTEG_NAMESPACE_ENV_VAR: &str = "TEMPORAL_NAMESPACE";
 pub const INTEG_USE_TLS_ENV_VAR: &str = "TEMPORAL_USE_TLS";
 /// This env var is set (to any value) if temporal CLI dev server is in use
 pub const INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR: &str = "INTEG_TEMPORAL_DEV_SERVER_ON";
@@ -171,7 +172,7 @@ impl CoreWfStarter {
         let task_queue = format!("{test_name}_{task_q_salt}");
         let mut worker_config = WorkerConfigBuilder::default();
         worker_config
-            .namespace(NAMESPACE)
+            .namespace(env::var(INTEG_NAMESPACE_ENV_VAR).unwrap_or(NAMESPACE.to_string()))
             .task_queue(task_queue.clone())
             .worker_build_id("test_build_id")
             .max_cached_workflows(1000_usize);

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -63,6 +63,7 @@ async fn one_slot_worker_reports_available_slot() {
         .max_outstanding_activities(1_usize)
         .max_outstanding_local_activities(1_usize)
         .max_outstanding_workflow_tasks(1_usize)
+        .max_concurrent_wft_polls(1_usize)
         .build()
         .unwrap();
 

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -434,6 +434,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
         // Test needs eviction on and a short timeout
         .max_cached_workflows(0)
         .max_wft(1);
+    wf_starter.worker_config.max_concurrent_wft_polls(1_usize);
     wf_starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
     let core = wf_starter.get_worker().await;
     let client = wf_starter.get_client().await;

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -905,7 +905,9 @@ async fn it_can_complete_async() {
 async fn graceful_shutdown() {
     let wf_name = "graceful_shutdown";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.worker_config.graceful_shutdown_period = Some(Duration::from_millis(500));
+    starter
+        .worker_config
+        .graceful_shutdown_period(Some(Duration::from_millis(500)));
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
     worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {

--- a/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -43,8 +43,8 @@ async fn continue_as_new_multiple_concurrent() {
     let mut starter = CoreWfStarter::new(wf_name);
     starter
         .no_remote_activities()
-        .max_cached_workflows(3)
-        .max_wft(3);
+        .max_cached_workflows(5)
+        .max_wft(5);
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_string(), continue_as_new_wf);
 

--- a/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/tests/integ_tests/workflow_tests/stickyness.rs
@@ -56,6 +56,7 @@ async fn cache_miss_ok() {
     let wf_name = "cache_miss_ok";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.no_remote_activities().max_wft(1);
+    starter.worker_config.max_concurrent_wft_polls(1_usize);
     let mut worker = starter.worker().await;
 
     let barr: &'static Barrier = Box::leak(Box::new(Barrier::new(2)));


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Remove the semaphore that restricted concurrent polls based on requests. This in practice meant we were typically limited to one concurrent poll, except in some situations where polls get put in buffers.

## Why?
Closer to what other SDKs are doing, allows for some concurrency scale-up without getting clever yet, which we'll do later.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/546

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
