### PR TITLE
Add the ability to use the schedule APIs from the rust SDK library client.

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1502,20 +1502,13 @@ impl WorkflowClientTrait for Client {
                     action: Some(ScheduleAction {
                         action: Some(temporal_sdk_core_protos::temporal::api::schedule::v1::schedule_action::Action::StartWorkflow(NewWorkflowExecutionInfo {
                             workflow_id: options.workflow_id.unwrap_or(format!("workflow-{}", schedule_id)),
-                            workflow_type: match options.workflow_type {
-                                Some(workflow_type) => Some(WorkflowType {
-                                    name: workflow_type,
-                                    ..Default::default()
-                                }),
-                                _ => None,
-                            },
-                            task_queue: match options.task_queue {
-                                Some(task_queue) => Some(TaskQueue {
-                                    name: task_queue,
-                                    kind: TaskQueueKind::Unspecified as i32,
-                                }),
-                                _ => None,
-                            },
+                            workflow_type: options.workflow_type.map(|workflow_type| WorkflowType {
+                                name: workflow_type,
+                            }),
+                            task_queue: options.task_queue.map(|task_queue| TaskQueue {
+                                name: task_queue,
+                                kind: TaskQueueKind::Unspecified as i32,
+                            }),
                             // TODO: put the rest of workflow options here
                             ..Default::default()
                         })),

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1509,7 +1509,7 @@ impl WorkflowClientTrait for Client {
                                 name: task_queue,
                                 kind: TaskQueueKind::Unspecified as i32,
                             }),
-                            // TODO: put the rest of workflow options here
+                            // TODO: put the rest of workflow options here...
                             ..Default::default()
                         })),
                     }),

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -1,6 +1,7 @@
 use crate::{
     ClientOptions, ListClosedFilters, ListOpenFilters, Namespace, RegisterNamespaceOptions, Result,
-    RetryConfig, SignalWithStartOptions, StartTimeFilter, WorkflowClientTrait, WorkflowOptions,
+    RetryConfig, ScheduleOptions, SignalWithStartOptions, StartTimeFilter, WorkflowClientTrait,
+    WorkflowOptions,
 };
 use backoff::{backoff::Backoff, exponential::ExponentialBackoff, Clock, SystemClock};
 use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
@@ -540,6 +541,27 @@ where
 
     async fn get_search_attributes(&self) -> Result<GetSearchAttributesResponse> {
         retry_call!(self, get_search_attributes)
+    }
+
+    async fn create_schedule(
+        &self,
+        schedule_id: String,
+        task_queue: String,
+        workflow_id: String,
+        workflow_type: String,
+        request_id: Option<String>,
+        options: ScheduleOptions,
+    ) -> Result<CreateScheduleResponse> {
+        retry_call!(
+            self,
+            create_schedule,
+            schedule_id.clone(),
+            task_queue.clone(),
+            workflow_id.clone(),
+            workflow_type.clone(),
+            request_id.clone(),
+            options.clone()
+        )
     }
 
     fn get_options(&self) -> &ClientOptions {

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -13,6 +13,7 @@ use temporal_sdk_core_protos::{
         enums::v1::WorkflowTaskFailedCause,
         failure::v1::Failure,
         query::v1::WorkflowQuery,
+        schedule::v1::{BackfillRequest, Schedule, TriggerImmediatelyRequest},
         workflowservice::v1::*,
     },
     TaskToken,
@@ -546,9 +547,6 @@ where
     async fn create_schedule(
         &self,
         schedule_id: String,
-        task_queue: String,
-        workflow_id: String,
-        workflow_type: String,
         request_id: Option<String>,
         options: ScheduleOptions,
     ) -> Result<CreateScheduleResponse> {
@@ -556,11 +554,54 @@ where
             self,
             create_schedule,
             schedule_id.clone(),
-            task_queue.clone(),
-            workflow_id.clone(),
-            workflow_type.clone(),
             request_id.clone(),
             options.clone()
+        )
+    }
+
+    async fn delete_schedule(&self, schedule_id: String) -> Result<DeleteScheduleResponse> {
+        retry_call!(self, delete_schedule, schedule_id.clone())
+    }
+
+    async fn describe_schedule(&self, schedule_id: String) -> Result<DescribeScheduleResponse> {
+        retry_call!(self, describe_schedule, schedule_id.clone())
+    }
+
+    async fn patch_schedule(
+        &self,
+        schedule_id: String,
+        trigger_immediately: Option<TriggerImmediatelyRequest>,
+        pause: Option<String>,
+        unpause: Option<String>,
+        backfill_request: Option<BackfillRequest>,
+        request_id: Option<String>,
+    ) -> Result<PatchScheduleResponse> {
+        retry_call!(
+            self,
+            patch_schedule,
+            schedule_id.clone(),
+            trigger_immediately.clone(),
+            pause.clone(),
+            unpause.clone(),
+            backfill_request.clone(),
+            request_id.clone()
+        )
+    }
+
+    async fn update_schedule(
+        &self,
+        schedule_id: String,
+        schedule: Schedule,
+        conflict_token: Vec<u8>,
+        request_id: Option<String>,
+    ) -> Result<UpdateScheduleResponse> {
+        retry_call!(
+            self,
+            update_schedule,
+            schedule_id.clone(),
+            schedule.clone(),
+            conflict_token.clone(),
+            request_id.clone()
         )
     }
 


### PR DESCRIPTION
## What was changed
Added the ability to use the schedule APIs from the rust SDK client library.

## Why?
Because there's currently no way to create, describe, delete, update or patch the schedule.

1. Closes #555 

2. How was this tested:
I tested it using a client in this example library: https://github.com/cosm-eng/temporal-samples-rust/blob/main/schedule/src/bin/client.rs

3. Any docs updates needed?
Seeing as there aren't many docs, no ;)? 