### PR TITLE
Apply rate limiter at the poller level

### DIFF
--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: integ-test
-          args: -c "--release" -c "--all-features" -t heavy_tests -- --test-threads 1
+          args: -c "--release" -c "--features=save_wf_inputs" -t heavy_tests -- --test-threads 1

--- a/cargo-tokio-console.sh
+++ b/cargo-tokio-console.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export RUSTFLAGS="--cfg tokio_unstable"
+
+cargo "$1" --features "tokio-console" "${@:2}"

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -164,6 +164,19 @@ impl WorkerConfigBuilder {
                 );
             }
         }
+        if matches!(self.max_concurrent_wft_polls, Some(1))
+            && self.max_cached_workflows > Some(0)
+            && self
+                .max_outstanding_workflow_tasks
+                .unwrap_or(MAX_OUTSTANDING_WFT_DEFAULT)
+                <= 1
+        {
+            return Err(
+                "`max_outstanding_workflow_tasks` must be at at least 2 when \
+                 `max_cached_workflows` is nonzero"
+                    .to_owned(),
+            );
+        }
         if self
             .max_concurrent_wft_polls
             .unwrap_or(MAX_CONCURRENT_WFT_POLLS_DEFAULT)

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,12 +17,14 @@ categories = ["development-tools"]
 # record WF input data, we can build them a custom SDK or they can build - it adds significant extra
 # code size in the form of [de]serializers.
 save_wf_inputs = ["rmp-serde", "temporal-sdk-core-protos/serde_serialize"]
+tokio-console = ["console-subscriber"]
 
 [dependencies]
 anyhow = "1.0"
 arc-swap = "1.3"
 async-trait = "0.1"
 base64 = "0.21"
+console-subscriber = { version = "0.1", optional = true }
 crossbeam = "0.8"
 dashmap = "5.0"
 derive_builder = "0.12"

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2019,8 +2019,8 @@ async fn no_race_acquiring_permits() {
 
     let worker = Worker::new_test(
         test_worker_cfg()
-            .max_outstanding_workflow_tasks(1_usize)
-            .max_cached_workflows(10_usize)
+            .max_outstanding_workflow_tasks(2_usize)
+            .max_cached_workflows(0_usize)
             .build()
             .unwrap(),
         mock_client,
@@ -2057,6 +2057,7 @@ async fn no_race_acquiring_permits() {
         task_barr.wait().await;
     };
     join!(poll_1_f, poll_2_f, other_f);
+    worker.drain_pollers_and_shutdown().await;
 }
 
 #[tokio::test]

--- a/core/src/pollers/poll_buffer.rs
+++ b/core/src/pollers/poll_buffer.rs
@@ -247,6 +247,7 @@ pub(crate) fn new_workflow_task_buffer(
 }
 
 pub type PollActivityTaskBuffer = LongPollBuffer<PollActivityTaskQueueResponse>;
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn new_activity_task_buffer(
     client: Arc<dyn WorkerClient>,
     task_queue: String,
@@ -255,9 +256,9 @@ pub(crate) fn new_activity_task_buffer(
     max_tps: Option<f64>,
     shutdown: CancellationToken,
     num_pollers_handler: Option<impl Fn(usize) + Send + Sync + 'static>,
-    mac_worker_aps: Option<f64>,
+    max_worker_acts_per_sec: Option<f64>,
 ) -> PollActivityTaskBuffer {
-    let rate_limiter = mac_worker_aps.and_then(|ps| {
+    let rate_limiter = max_worker_acts_per_sec.and_then(|ps| {
         Quota::with_period(Duration::from_secs_f64(ps.recip()))
             .map(|q| Arc::new(RateLimiter::direct(q)))
     });

--- a/core/src/pollers/poll_buffer.rs
+++ b/core/src/pollers/poll_buffer.rs
@@ -4,6 +4,8 @@ use crate::{
     worker::client::WorkerClient,
 };
 use futures::{prelude::stream::FuturesUnordered, StreamExt};
+use futures_util::{future::BoxFuture, FutureExt};
+use governor::{Quota, RateLimiter};
 use std::{
     fmt::Debug,
     future::Future,
@@ -11,6 +13,7 @@ use std::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
+    time::Duration,
 };
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::{
     PollActivityTaskQueueResponse, PollWorkflowTaskQueueResponse,
@@ -63,15 +66,17 @@ impl<T> LongPollBuffer<T>
 where
     T: Send + Debug + 'static,
 {
-    pub(crate) fn new<FT>(
+    pub(crate) fn new<FT, DelayFut>(
         poll_fn: impl Fn() -> FT + Send + Sync + 'static,
         poll_semaphore: Arc<MeteredSemaphore>,
         max_pollers: usize,
         shutdown: CancellationToken,
         num_pollers_handler: Option<impl Fn(usize) + Send + Sync + 'static>,
+        pre_permit_delay: Option<impl Fn() -> DelayFut + Send + Sync + 'static>,
     ) -> Self
     where
         FT: Future<Output = pollers::Result<T>> + Send,
+        DelayFut: Future<Output = ()> + Send,
     {
         let (tx, rx) = unbounded_channel();
         let (starter, wait_for_start) = broadcast::channel(1);
@@ -79,6 +84,7 @@ where
         let join_handles = FuturesUnordered::new();
         let pf = Arc::new(poll_fn);
         let nph = num_pollers_handler.map(Arc::new);
+        let pre_permit_delay = pre_permit_delay.map(Arc::new);
         for _ in 0..max_pollers {
             let tx = tx.clone();
             let pf = pf.clone();
@@ -86,6 +92,7 @@ where
             let ap = active_pollers.clone();
             let poll_semaphore = poll_semaphore.clone();
             let nph = nph.clone();
+            let pre_permit_delay = pre_permit_delay.clone();
             let mut wait_for_start = wait_for_start.resubscribe();
             let jh = tokio::spawn(async move {
                 tokio::select! {
@@ -98,6 +105,12 @@ where
                 loop {
                     if shutdown.is_cancelled() {
                         break;
+                    }
+                    if let Some(ref ppd) = pre_permit_delay {
+                        tokio::select! {
+                            _ = ppd() => (),
+                            _ = shutdown.cancelled() => break,
+                        }
                     }
                     let permit = tokio::select! {
                         p = poll_semaphore.acquire_owned() => p,
@@ -229,6 +242,7 @@ pub(crate) fn new_workflow_task_buffer(
         concurrent_pollers,
         shutdown,
         num_pollers_handler,
+        None::<fn() -> BoxFuture<'static, ()>>,
     )
 }
 
@@ -241,7 +255,12 @@ pub(crate) fn new_activity_task_buffer(
     max_tps: Option<f64>,
     shutdown: CancellationToken,
     num_pollers_handler: Option<impl Fn(usize) + Send + Sync + 'static>,
+    mac_worker_aps: Option<f64>,
 ) -> PollActivityTaskBuffer {
+    let rate_limiter = mac_worker_aps.and_then(|ps| {
+        Quota::with_period(Duration::from_secs_f64(ps.recip()))
+            .map(|q| Arc::new(RateLimiter::direct(q)))
+    });
     LongPollBuffer::new(
         move || {
             let client = client.clone();
@@ -252,6 +271,12 @@ pub(crate) fn new_activity_task_buffer(
         concurrent_pollers,
         shutdown,
         num_pollers_handler,
+        rate_limiter.map(|rl| {
+            move || {
+                let rl = rl.clone();
+                async move { rl.until_ready().await }.boxed()
+            }
+        }),
     )
 }
 

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -297,6 +297,9 @@ pub fn telemetry_init(opts: TelemetryOptions) -> Result<TelemetryInstance, anyho
             .with(forward_layer)
             .with(export_layer);
 
+        #[cfg(feature = "tokio-console")]
+        let reg = reg.with(console_subscriber::spawn());
+
         tx.send(TelemetryInstance::new(
             Arc::new(reg),
             logs_out,

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -622,8 +622,7 @@ mod tests {
                     task_token: vec![1],
                     activity_id: "act1".to_string(),
                     ..Default::default()
-                }
-                .into())
+                })
             });
         mock_client
             .expect_poll_activity_task()
@@ -633,8 +632,7 @@ mod tests {
                     task_token: vec![2],
                     activity_id: "act2".to_string(),
                     ..Default::default()
-                }
-                .into())
+                })
             });
         mock_client
             .expect_complete_activity_task()

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -31,7 +31,6 @@ use futures::{
     stream::{BoxStream, PollNext},
     Stream, StreamExt,
 };
-use governor::{Quota, RateLimiter};
 use std::{
     convert::TryInto,
     future,
@@ -157,7 +156,6 @@ impl WorkerActivityTasks {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         semaphore: Arc<MeteredSemaphore>,
-        max_worker_act_per_sec: Option<f64>,
         poller: BoxedActPoller,
         client: Arc<dyn WorkerClient>,
         metrics: MetricsContext,
@@ -166,16 +164,9 @@ impl WorkerActivityTasks {
         graceful_shutdown: Option<Duration>,
     ) -> Self {
         let shutdown_initiated_token = CancellationToken::new();
-        let rate_limiter = max_worker_act_per_sec.and_then(|ps| {
-            Quota::with_period(Duration::from_secs_f64(ps.recip())).map(RateLimiter::direct)
-        });
         let outstanding_activity_tasks = Arc::new(DashMap::new());
-        let server_poller_stream = new_activity_task_poller(
-            poller,
-            rate_limiter,
-            metrics.clone(),
-            shutdown_initiated_token.clone(),
-        );
+        let server_poller_stream =
+            new_activity_task_poller(poller, metrics.clone(), shutdown_initiated_token.clone());
         let (eager_activities_tx, eager_activities_rx) = unbounded_channel();
         let eager_activities_semaphore = ClosableMeteredSemaphore::new_arc(semaphore);
 
@@ -617,48 +608,87 @@ fn worker_shutdown_failure() -> Failure {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        pollers::MockPermittedPollBuffer, test_help::mock_poller_from_resps,
-        worker::client::mocks::mock_manual_workflow_client,
-    };
+    use crate::{pollers::new_activity_task_buffer, worker::client::mocks::mock_workflow_client};
+    use temporal_sdk_core_protos::coresdk::activity_result::ActivityExecutionResult;
 
     #[tokio::test]
     async fn per_worker_ratelimit() {
+        let mut mock_client = mock_workflow_client();
+        mock_client
+            .expect_poll_activity_task()
+            .times(1)
+            .returning(move |_, _| {
+                Ok(PollActivityTaskQueueResponse {
+                    task_token: vec![1],
+                    activity_id: "act1".to_string(),
+                    ..Default::default()
+                }
+                .into())
+            });
+        mock_client
+            .expect_poll_activity_task()
+            .times(1)
+            .returning(move |_, _| {
+                Ok(PollActivityTaskQueueResponse {
+                    task_token: vec![2],
+                    activity_id: "act2".to_string(),
+                    ..Default::default()
+                }
+                .into())
+            });
+        mock_client
+            .expect_complete_activity_task()
+            .times(2)
+            .returning(|_, _| Ok(Default::default()));
+        let mock_client = Arc::new(mock_client);
         let sem = Arc::new(MeteredSemaphore::new(
             10,
             MetricsContext::no_op(),
             MetricsContext::available_task_slots,
         ));
-        let poller = mock_poller_from_resps([
-            PollActivityTaskQueueResponse {
-                task_token: vec![1],
-                activity_id: "act1".to_string(),
-                ..Default::default()
-            }
-            .into(),
-            PollActivityTaskQueueResponse {
-                task_token: vec![2],
-                activity_id: "act2".to_string(),
-                ..Default::default()
-            }
-            .into(),
-        ]);
+        let shutdown_token = CancellationToken::new();
+        let ap = new_activity_task_buffer(
+            mock_client.clone(),
+            "tq".to_string(),
+            5, // Lots of concurrent pollers, to ensure we don't poll to much when that's the case
+            sem.clone(),
+            None,
+            shutdown_token.clone(),
+            None::<fn(usize)>,
+            Some(2.0),
+        );
         let atm = WorkerActivityTasks::new(
             sem.clone(),
-            Some(2.0),
-            Box::new(MockPermittedPollBuffer::new(sem, poller)),
-            Arc::new(mock_manual_workflow_client()),
+            Box::new(ap),
+            mock_client.clone(),
             MetricsContext::no_op(),
             Duration::from_secs(1),
             Duration::from_secs(1),
             None,
         );
         let start = Instant::now();
-        atm.poll().await.unwrap();
-        atm.poll().await.unwrap();
+        let t1 = atm.poll().await.unwrap();
+        let t2 = atm.poll().await.unwrap();
         // At least half a second will have elapsed since we only allow 2 tasks per second.
         // With no ratelimit, even on a slow CI server with lots of load, this would typically take
         // low single digit ms or less.
         assert!(start.elapsed() > Duration::from_secs_f64(0.5));
+        shutdown_token.cancel();
+        // Need to complete the tasks so shutdown will resolve
+        atm.complete(
+            TaskToken(t1.task_token),
+            ActivityExecutionResult::ok(vec![1].into()).status.unwrap(),
+            mock_client.as_ref(),
+        )
+        .await;
+        atm.complete(
+            TaskToken(t2.task_token),
+            ActivityExecutionResult::ok(vec![1].into()).status.unwrap(),
+            mock_client.as_ref(),
+        )
+        .await;
+        atm.initiate_shutdown();
+        assert_matches!(atm.poll().await.unwrap_err(), PollActivityError::ShutDown);
+        atm.shutdown().await;
     }
 }

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -284,6 +284,7 @@ impl Worker {
                         config.max_task_queue_activities_per_second,
                         shutdown_token.child_token(),
                         Some(move |np| act_metrics.record_num_pollers(np)),
+                        config.max_worker_activities_per_second,
                     );
                     Some(Box::from(ap) as BoxedActPoller)
                 };
@@ -329,7 +330,6 @@ impl Worker {
         let at_task_mgr = act_poller.map(|ap| {
             WorkerActivityTasks::new(
                 act_semaphore,
-                config.max_worker_activities_per_second,
                 ap,
                 client.clone(),
                 metrics.clone(),

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -59,10 +59,11 @@ async fn one_slot_worker_reports_available_slot() {
         .namespace(NAMESPACE)
         .task_queue(tq)
         .worker_build_id("test_build_id")
-        .max_cached_workflows(1_usize)
+        .max_cached_workflows(2_usize)
         .max_outstanding_activities(1_usize)
         .max_outstanding_local_activities(1_usize)
-        .max_outstanding_workflow_tasks(1_usize)
+        // Need to use two for WFTs because there are a minimum of 2 pollers b/c of sticky polling
+        .max_outstanding_workflow_tasks(2_usize)
         .max_concurrent_wft_polls(1_usize)
         .build()
         .unwrap();
@@ -147,7 +148,7 @@ async fn one_slot_worker_reports_available_slot() {
         assert!(body.contains(&format!(
             "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
              service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
-             worker_type=\"WorkflowWorker\"}} 1"
+             worker_type=\"WorkflowWorker\"}} 2"
         )));
 
         // Start a workflow so that a task will get delivered
@@ -175,7 +176,7 @@ async fn one_slot_worker_reports_available_slot() {
         assert!(body.contains(&format!(
             "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
              service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
-             worker_type=\"WorkflowWorker\"}} 0"
+             worker_type=\"WorkflowWorker\"}} 1"
         )));
         assert!(body.contains(&format!(
             "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
@@ -198,7 +199,7 @@ async fn one_slot_worker_reports_available_slot() {
         assert!(body.contains(&format!(
             "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\
              service_name=\"temporal-core-sdk\",task_queue=\"one_slot_worker_tq\",\
-             worker_type=\"WorkflowWorker\"}} 1"
+             worker_type=\"WorkflowWorker\"}} 2"
         )));
         assert!(body.contains(&format!(
             "temporal_worker_task_slots_available{{namespace=\"{NAMESPACE}\",\

--- a/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/tests/integ_tests/workflow_tests/stickyness.rs
@@ -55,7 +55,10 @@ async fn timer_workflow_timeout_on_sticky() {
 async fn cache_miss_ok() {
     let wf_name = "cache_miss_ok";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.no_remote_activities().max_wft(1);
+    starter
+        .no_remote_activities()
+        .max_wft(2)
+        .max_cached_workflows(0);
     starter.worker_config.max_concurrent_wft_polls(1_usize);
     let mut worker = starter.worker().await;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Move ratelimiter capability inside pollers to make activity ratelimiting work properly with concurrent pollers

## Why?
Recent change to make pollers genuinely concurrent could cause task timeouts in the event users have enabled ratelimiting

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing UT made more accurate w/ mock client rather than mock poller

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
