### PR TITLE
Added feature flag for ephemeral server module

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,11 +13,13 @@ categories = ["development-tools"]
 [lib]
 
 [features]
+default = []
 # Do not enable this feature when building production SDKs. If we ever want a user in the field to
 # record WF input data, we can build them a custom SDK or they can build - it adds significant extra
 # code size in the form of [de]serializers.
 save_wf_inputs = ["rmp-serde", "temporal-sdk-core-protos/serde_serialize"]
 tokio-console = ["console-subscriber"]
+ephemeral-server = ["dep:flate2", "dep:nix", "dep:reqwest", "dep:tar", "dep:zip"]
 
 [dependencies]
 anyhow = "1.0"
@@ -31,7 +33,7 @@ derive_builder = "0.12"
 derive_more = "0.99"
 enum_dispatch = "0.3"
 enum-iterator = "1.4"
-flate2 = "1.0"
+flate2 = { version = "1.0", optional = true }
 futures = "0.3"
 futures-util = "0.3"
 governor = "0.5"
@@ -41,7 +43,7 @@ itertools = "0.10"
 lazy_static = "1.4"
 lru = "0.10"
 mockall = "0.11"
-nix = "0.26"
+nix = { version = "0.26", optional = true }
 once_cell = "1.5"
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.11", features = ["tokio", "metrics"] }
@@ -52,14 +54,14 @@ prometheus = "0.13"
 prost = "0.11"
 prost-types = { version = "0.4", package = "prost-wkt-types" }
 rand = "0.8.3"
-reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls", "tokio-rustls"], default-features = false }
+reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls", "tokio-rustls"], default-features = false, optional = true }
 ringbuf = "0.3"
 rmp-serde = { version = "1.1", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 siphasher = "0.3"
 slotmap = "1.0"
-tar = "0.4"
+tar = { version = "0.4", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.26", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs", "process"] }
 tokio-util = { version = "0.7", features = ["io", "io-util"] }
@@ -71,7 +73,7 @@ tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["parking_lot", "env-filter", "registry"] }
 url = "2.2"
 uuid = { version = "1.1", features = ["v4"] }
-zip = "0.6.3"
+zip = { version = "0.6.3", optional = true }
 
 # 1st party local deps
 [dependencies.temporal-sdk-core-api]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@ extern crate tracing;
 extern crate core;
 
 mod abstractions;
+#[cfg(feature = "ephemeral-server")]
 pub mod ephemeral_server;
 mod internal_flags;
 mod pollers;

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -24,7 +24,7 @@ rmp-serde = "1.1"
 serde_json = "1.0"
 temporal-client = { path = "../client" }
 temporal-sdk = { path = "../sdk" }
-temporal-sdk-core = { path = "../core" }
+temporal-sdk-core = { path = "../core", features = ["ephemeral-server"] }
 temporal-sdk-core-api = { path = "../core-api" }
 thiserror = "1.0"
 tokio = "1.1"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a feature flag for ephemeral server functionality.

## Why?
To optimize compilation time for pure Rust usage of SDK.
This is same as https://github.com/temporalio/sdk-core/pull/560 but without default

## Checklist
<!--- add/delete as needed --->

1. Closes #559

3. How was this tested:
Run the existing unit/integration/load tests, 

4. Any docs updates needed?
   No
