### PR TITLE
Remove fallback to workflow execution timeout for LA sched-to-close

### DIFF
--- a/core/src/protosext/mod.rs
+++ b/core/src/protosext/mod.rs
@@ -337,10 +337,7 @@ impl Default for LACloseTimeouts {
 }
 
 impl ValidScheduleLA {
-    pub fn from_schedule_la(
-        v: ScheduleLocalActivity,
-        wf_exe_timeout: Option<Duration>,
-    ) -> Result<Self, anyhow::Error> {
+    pub fn from_schedule_la(v: ScheduleLocalActivity) -> Result<Self, anyhow::Error> {
         let original_schedule_time = v
             .original_schedule_time
             .map(|x| {
@@ -354,9 +351,7 @@ impl ValidScheduleLA {
                 x.try_into()
                     .map_err(|_| anyhow!("Could not convert schedule_to_close_timeout"))
             })
-            .transpose()?
-            // Default to execution timeout if unset
-            .or(wf_exe_timeout);
+            .transpose()?;
         let mut schedule_to_start_timeout = v
             .schedule_to_start_timeout
             .map(|x| {
@@ -392,7 +387,8 @@ impl ValidScheduleLA {
             }
             (None, None) => {
                 return Err(anyhow!(
-                    "One of schedule_to_close or start_to_close timeouts must be set"
+                    "One or both of schedule_to_close or start_to_close timeouts must be set for \
+                     local activities"
                 ))
             }
         };

--- a/core/src/worker/workflow/driven_workflow.rs
+++ b/core/src/worker/workflow/driven_workflow.rs
@@ -40,10 +40,6 @@ impl DrivenWorkflow {
         debug!(run_id = %attribs.original_execution_run_id, "Driven WF start");
         let started_info = WorkflowStartedInfo {
             workflow_task_timeout: attribs.workflow_task_timeout.clone().try_into_or_none(),
-            workflow_execution_timeout: attribs
-                .workflow_execution_timeout
-                .clone()
-                .try_into_or_none(),
             memo: attribs.memo.clone(),
             search_attrs: attribs.search_attributes.clone(),
             retry_policy: attribs.retry_policy.clone(),

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1068,17 +1068,12 @@ impl WorkflowMachines {
                 }
                 WFCommand::AddLocalActivity(attrs) => {
                     let seq = attrs.seq;
-                    let attrs: ValidScheduleLA = ValidScheduleLA::from_schedule_la(
-                        attrs,
-                        self.get_started_info()
-                            .as_ref()
-                            .and_then(|x| x.workflow_execution_timeout),
-                    )
-                    .map_err(|e| {
-                        WFMachinesError::Fatal(format!(
-                            "Invalid schedule local activity request (seq {seq}): {e}"
-                        ))
-                    })?;
+                    let attrs: ValidScheduleLA =
+                        ValidScheduleLA::from_schedule_la(attrs).map_err(|e| {
+                            WFMachinesError::Fatal(format!(
+                                "Invalid schedule local activity request (seq {seq}): {e}"
+                            ))
+                        })?;
                     let (la, mach_resp) = new_local_activity(
                         attrs,
                         self.replaying,

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -1227,7 +1227,6 @@ enum CommandID {
 #[derive(Debug, Clone)]
 pub struct WorkflowStartedInfo {
     workflow_task_timeout: Option<Duration>,
-    workflow_execution_timeout: Option<Duration>,
     memo: Option<Memo>,
     search_attrs: Option<SearchAttributes>,
     retry_policy: Option<RetryPolicy>,


### PR DESCRIPTION
No need for this timeout fallback since you're made to set either one of the appropriate timeouts anyways, and the workflow execution timeout being zero could cause issues.