### PR TITLE
Don't increment terminal command metrics when replaying

### DIFF
--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1107,15 +1107,21 @@ impl WorkflowMachines {
                     self.process_cancellation(CommandID::LocalActivity(attrs.seq))?;
                 }
                 WFCommand::CompleteWorkflow(attrs) => {
-                    self.metrics.wf_completed();
+                    if !self.replaying {
+                        self.metrics.wf_completed();
+                    }
                     self.add_terminal_command(complete_workflow(attrs));
                 }
                 WFCommand::FailWorkflow(attrs) => {
-                    self.metrics.wf_failed();
+                    if !self.replaying {
+                        self.metrics.wf_failed();
+                    }
                     self.add_terminal_command(fail_workflow(attrs));
                 }
                 WFCommand::ContinueAsNew(attrs) => {
-                    self.metrics.wf_continued_as_new();
+                    if !self.replaying {
+                        self.metrics.wf_continued_as_new();
+                    }
                     let attrs = self.augment_continue_as_new_with_current_values(attrs);
                     let use_compat = self.determine_use_compatible_flag(
                         attrs.versioning_intent(),
@@ -1124,7 +1130,9 @@ impl WorkflowMachines {
                     self.add_terminal_command(continue_as_new(attrs, use_compat));
                 }
                 WFCommand::CancelWorkflow(attrs) => {
-                    self.metrics.wf_canceled();
+                    if !self.replaying {
+                        self.metrics.wf_canceled();
+                    }
                     self.add_terminal_command(cancel_workflow(attrs));
                 }
                 WFCommand::SetPatchMarker(attrs) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Only emit these metrics for terminal WF commands when not replaying

## Why?
Previous behavior is not intentional or useful.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added integ test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
