### PR TITLE
Improve warning message on error response to completion

### DIFF
--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -561,7 +561,7 @@ impl Workflows {
                     should_evict = Some(EvictionReason::TaskNotFound);
                 }
                 _ => {
-                    warn!(error= %err, "Network error while completing workflow activation");
+                    warn!(error= %err, "Error while completing workflow activation");
                     should_evict = Some(EvictionReason::Fatal);
                 }
             }


### PR DESCRIPTION
Ref #521 cc @mjameswh @Sushisource 

Minor tweak to warning message in fall-through case. This case handles a variety of conditions including application-level errors such as bad search attributes, so "Network error" is misleading.
