### PR TITLE
Fix query related is_replay flag error

### DIFF
--- a/core/src/core_tests/replay_flag.rs
+++ b/core/src/core_tests/replay_flag.rs
@@ -1,8 +1,21 @@
-use crate::{test_help::canned_histories, worker::ManagedWFFunc};
+use crate::{
+    test_help::{
+        build_mock_pollers, canned_histories, hist_to_poll_resp, mock_worker, MockPollCfg,
+    },
+    worker::{client::mocks::mock_workflow_client, ManagedWFFunc, LEGACY_QUERY_ID},
+};
 use rstest::{fixture, rstest};
-use std::time::Duration;
+use std::{collections::VecDeque, time::Duration};
 use temporal_sdk::{WfContext, WorkflowFunction};
-use temporal_sdk_core_protos::temporal::api::enums::v1::CommandType;
+use temporal_sdk_core_api::Worker;
+use temporal_sdk_core_protos::{
+    coresdk::{
+        workflow_commands::{workflow_command::Variant::RespondToQuery, QueryResult, QuerySuccess},
+        workflow_completion::WorkflowActivationCompletion,
+    },
+    temporal::api::{enums::v1::CommandType, query::v1::WorkflowQuery},
+};
+use temporal_sdk_core_test_utils::start_timer_cmd;
 
 fn timers_wf(num_timers: u32) -> WorkflowFunction {
     WorkflowFunction::new(move |command_sink: WfContext| async move {
@@ -62,4 +75,61 @@ async fn replay_flag_is_correct_partial_history() {
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0].command_type, CommandType::StartTimer as i32);
     wfm.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn replay_flag_correct_with_query() {
+    let wfid = "fake_wf_id";
+    let t = canned_histories::single_timer("1");
+    let tasks = VecDeque::from(vec![
+        {
+            let mut pr = hist_to_poll_resp(&t, wfid.to_owned(), 2.into());
+            // Server can issue queries that contain the WFT completion and the subsequent
+            // commands, but not the consequences yet.
+            pr.query = Some(WorkflowQuery {
+                query_type: "query-type".to_string(),
+                query_args: Some(b"hi".into()),
+                header: None,
+            });
+            let h = pr.history.as_mut().unwrap();
+            h.events.truncate(5);
+            pr.started_event_id = 3;
+            dbg!(&pr.resp);
+            pr
+        },
+        hist_to_poll_resp(&t, wfid.to_owned(), 2.into()),
+    ]);
+    let mut mock = MockPollCfg::from_resp_batches(wfid, t, tasks, mock_workflow_client());
+    mock.num_expected_legacy_query_resps = 1;
+    let mut mock = build_mock_pollers(mock);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 10);
+    let core = mock_worker(mock);
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+        task.run_id,
+        start_timer_cmd(1, Duration::from_secs(1)),
+    ))
+    .await
+    .unwrap();
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert!(task.is_replaying);
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+        task.run_id,
+        RespondToQuery(QueryResult {
+            query_id: LEGACY_QUERY_ID.to_string(),
+            variant: Some(
+                QuerySuccess {
+                    response: Some("hi".into()),
+                }
+                .into(),
+            ),
+        }),
+    ))
+    .await
+    .unwrap();
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert!(!task.is_replaying);
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
In some situations server could issue WFTs with queries that also contained the last WFT complete & associated commands. This would confuse the code that determines if we are replaying or not.

Also make all activations containing only queries always be replay.

## Why?
Fixes incorrect semantics

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/589

2. How was this tested:
Added UT, verified existing tests. Fixes James' repro in the bug.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
