### PR TITLE
Only set trace subscriber when useful

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["core", "client", "core-api", "fsm", "test-utils", "sdk-core-protos", "sdk"]
+resolver = "2"
 
 [workspace.dependencies]
 tonic = "0.9"

--- a/core-api/src/telemetry/metrics.rs
+++ b/core-api/src/telemetry/metrics.rs
@@ -136,7 +136,7 @@ impl MetricAttributes {
                 Arc::make_mut(kvs).extend(new_kvs.into_iter().map(Into::into));
             }
             MetricAttributes::Lang(ref mut attrs, ..) => {
-                attrs.new_attributes.extend(new_kvs.into_iter());
+                attrs.new_attributes.extend(new_kvs);
             }
         }
     }
@@ -149,7 +149,7 @@ pub struct MetricsAttributesOptions {
 }
 impl MetricsAttributesOptions {
     pub fn extend(&mut self, new_kvs: impl IntoIterator<Item = MetricKeyValue>) {
-        self.attributes.extend(new_kvs.into_iter())
+        self.attributes.extend(new_kvs)
     }
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,7 +43,7 @@ itertools = "0.11"
 lazy_static = "1.4"
 lru = "0.11"
 mockall = "0.11"
-nix = { version = "0.26", optional = true }
+nix = { version = "0.27", optional = true, features = ["process", "signal"] }
 once_cell = "1.5"
 opentelemetry = { workspace = true, features = ["rt-tokio", "metrics"] }
 opentelemetry_sdk = { version = "0.20", features = ["metrics"] }
@@ -60,7 +60,7 @@ ringbuf = "0.3"
 rmp-serde = { version = "1.1", optional = true }
 serde = "1.0"
 serde_json = "1.0"
-siphasher = "0.3"
+siphasher = "1.0"
 slotmap = "1.0"
 tar = { version = "0.4", optional = true }
 thiserror = "1.0"

--- a/core/src/internal_flags.rs
+++ b/core/src/internal_flags.rs
@@ -75,7 +75,7 @@ impl InternalFlags {
             ..
         } = self
         {
-            lang_since_last_complete.extend(flags.into_iter());
+            lang_since_last_complete.extend(flags);
         }
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -223,7 +223,9 @@ impl CoreRuntime {
         let runtime = tokio_builder
             .enable_all()
             .on_thread_start(move || {
-                set_trace_subscriber_for_current_thread(subscriber.clone());
+                if let Some(sub) = subscriber.as_ref() {
+                    set_trace_subscriber_for_current_thread(sub.clone());
+                }
             })
             .build()?;
         let _rg = runtime.enter();
@@ -249,7 +251,9 @@ impl CoreRuntime {
     /// If there is no currently active Tokio runtime
     pub fn new_assume_tokio_initialized_telem(telemetry: TelemetryInstance) -> Self {
         let runtime_handle = tokio::runtime::Handle::current();
-        set_trace_subscriber_for_current_thread(telemetry.trace_subscriber());
+        if let Some(sub) = telemetry.trace_subscriber() {
+            set_trace_subscriber_for_current_thread(sub);
+        }
         Self {
             telemetry,
             runtime: None,

--- a/core/src/telemetry/log_export.rs
+++ b/core/src/telemetry/log_export.rs
@@ -166,7 +166,7 @@ mod tests {
             .build()
             .unwrap();
         let instance = telemetry_init(opts).unwrap();
-        let _g = tracing::subscriber::set_default(instance.trace_subscriber.clone());
+        let _g = tracing::subscriber::set_default(instance.trace_subscriber().unwrap().clone());
 
         let top_span = span!(Level::INFO, "yayspan", huh = "wat");
         let _guard = top_span.enter();

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -813,7 +813,7 @@ mod tests {
         let no_op_subscriber = Arc::new(NoSubscriber::new());
         let call_buffer = Arc::new(MetricsCallBuffer::new(100));
         let telem_instance = TelemetryInstance::new(
-            no_op_subscriber,
+            Some(no_op_subscriber),
             None,
             METRIC_PREFIX.to_string(),
             Some(call_buffer.clone()),

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -620,7 +620,7 @@ impl Workflows {
             }
             let with_permits = reserved_act_permits
                 .into_iter()
-                .zip(eager_acts.into_iter())
+                .zip(eager_acts)
                 .map(|(permit, resp)| TrackedPermittedTqResp { permit, resp });
             if with_permits.len() > 0 {
                 debug!(

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -185,7 +185,7 @@ impl Workflows {
         let (start_polling_tx, start_polling_rx) = oneshot::channel();
         // We must spawn a task to constantly poll the activation stream, because otherwise
         // activation completions would not cause anything to happen until the next poll.
-        let tracing_sub = telem_instance.map(|ti| ti.trace_subscriber());
+        let tracing_sub = telem_instance.and_then(|ti| ti.trace_subscriber());
         let processing_task = thread::spawn(move || {
             if let Some(ts) = tracing_sub {
                 set_trace_subscriber_for_current_thread(ts);

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -187,7 +187,7 @@ impl WFStream {
                     }
                 };
 
-                activations.extend(maybe_act.into_iter());
+                activations.extend(maybe_act);
                 activations.extend(state.reconcile_buffered());
 
                 // Always flush *after* actually handling the input, as this allows LA sink

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -298,7 +298,7 @@ impl WfContext {
         self.send(RustWfCmd::NewNonblockingCmd(
             workflow_command::Variant::UpsertWorkflowSearchAttributes(
                 UpsertWorkflowSearchAttributes {
-                    search_attributes: HashMap::from_iter(attr_iter.into_iter()),
+                    search_attributes: HashMap::from_iter(attr_iter),
                 },
             ),
         ))
@@ -309,7 +309,7 @@ impl WfContext {
         self.send(RustWfCmd::NewNonblockingCmd(
             workflow_command::Variant::ModifyWorkflowProperties(ModifyWorkflowProperties {
                 upserted_memo: Some(Memo {
-                    fields: HashMap::from_iter(attr_iter.into_iter()),
+                    fields: HashMap::from_iter(attr_iter),
                 }),
             }),
         ))

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -146,7 +146,9 @@ pub fn init_integ_telem() {
         let telemetry_options = get_integ_telem_options();
         let rt =
             CoreRuntime::new_assume_tokio(telemetry_options).expect("Core runtime inits cleanly");
-        let _ = tracing::subscriber::set_global_default(rt.telemetry().trace_subscriber());
+        if let Some(sub) = rt.telemetry().trace_subscriber() {
+            let _ = tracing::subscriber::set_global_default(sub);
+        }
         rt
     });
 }
@@ -528,7 +530,7 @@ impl WorkerInterceptor for TestWorkerCompletionIceptor {
             func(completion);
         }
         if completion.has_execution_ending() {
-            info!("Workflow {} says it's finishing", &completion.run_id);
+            debug!("Workflow {} says it's finishing", &completion.run_id);
         }
         if let Some(n) = self.next.as_ref() {
             n.on_workflow_activation_completion(completion).await;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Do not register a trace subscriber on threads unless the telemetry config actually asked to do anything.

## Why?
Causes problems with user created global subscribers

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/601

3. How was this tested:
Existing tests

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
