### PR TITLE
Separate activations for queries

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -32,9 +32,7 @@ use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::ActivityExecutionResult,
         workflow_activation::{workflow_activation_job, WorkflowActivationJob},
-        workflow_commands::{
-            ActivityCancellationType, QueryResult, QuerySuccess, ScheduleLocalActivity,
-        },
+        workflow_commands::{ActivityCancellationType, ScheduleLocalActivity},
         workflow_completion::WorkflowActivationCompletion,
         ActivityTaskCompletion, AsJsonPayloadExt,
     },
@@ -47,7 +45,7 @@ use temporal_sdk_core_protos::{
     DEFAULT_ACTIVITY_TYPE,
 };
 use temporal_sdk_core_test_utils::{
-    schedule_local_activity_cmd, start_timer_cmd, WorkerTestHelpers,
+    query_ok, schedule_local_activity_cmd, start_timer_cmd, WorkerTestHelpers,
 };
 use tokio::{join, select, sync::Barrier};
 
@@ -527,16 +525,7 @@ async fn query_during_wft_heartbeat_doesnt_accidentally_fail_to_continue_heartbe
         barrier.wait().await;
         core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
             task.run_id,
-            QueryResult {
-                query_id: query.query_id.clone(),
-                variant: Some(
-                    QuerySuccess {
-                        response: Some("whatever".into()),
-                    }
-                    .into(),
-                ),
-            }
-            .into(),
+            query_ok(&query.query_id, "whatev"),
         ))
         .await
         .unwrap();
@@ -699,16 +688,7 @@ async fn la_resolve_during_legacy_query_does_not_combine(#[case] impossible_quer
         );
         core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
             task.run_id,
-            QueryResult {
-                query_id: "q1".to_string(),
-                variant: Some(
-                    QuerySuccess {
-                        response: Some("whatev".into()),
-                    }
-                    .into(),
-                ),
-            }
-            .into(),
+            query_ok("q1", "whatev"),
         ))
         .await
         .unwrap();
@@ -717,18 +697,9 @@ async fn la_resolve_during_legacy_query_does_not_combine(#[case] impossible_quer
         if impossible_query_in_task {
             // finish last query
             let task = core.poll_workflow_activation().await.unwrap();
-            core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+            core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
                 task.run_id,
-                vec![QueryResult {
-                    query_id: LEGACY_QUERY_ID.to_string(),
-                    variant: Some(
-                        QuerySuccess {
-                            response: Some("whatev".into()),
-                        }
-                        .into(),
-                    ),
-                }
-                .into()],
+                query_ok(LEGACY_QUERY_ID, "whatev"),
             ))
             .await
             .unwrap();
@@ -1220,4 +1191,107 @@ async fn local_activities_can_be_delivered_during_shutdown() {
     let (wf_r, act_r) = join!(wf_poller, at_poller);
     assert_matches!(wf_r.unwrap_err(), PollWfError::ShutDown);
     assert_matches!(act_r.unwrap_err(), PollActivityError::ShutDown);
+}
+
+#[tokio::test]
+async fn queries_can_be_received_while_heartbeating() {
+    let wfid = "fake_wf_id";
+    let mut t = TestHistoryBuilder::default();
+    t.add_wfe_started_with_wft_timeout(Duration::from_millis(200));
+    t.add_full_wf_task();
+    t.add_full_wf_task();
+    t.add_full_wf_task();
+
+    let tasks = [
+        hist_to_poll_resp(&t, wfid.to_owned(), ResponseType::ToTaskNum(1)),
+        {
+            let mut pr = hist_to_poll_resp(&t, wfid.to_owned(), ResponseType::OneTask(2));
+            pr.queries = HashMap::new();
+            pr.queries.insert(
+                "q1".to_string(),
+                WorkflowQuery {
+                    query_type: "query-type".to_string(),
+                    query_args: Some(b"hi".into()),
+                    header: None,
+                },
+            );
+            pr
+        },
+        {
+            let mut pr = hist_to_poll_resp(&t, wfid.to_owned(), ResponseType::OneTask(3));
+            pr.query = Some(WorkflowQuery {
+                query_type: "query-type".to_string(),
+                query_args: Some(b"hi".into()),
+                header: None,
+            });
+            pr
+        },
+    ];
+    let mut mock = mock_workflow_client();
+    mock.expect_respond_legacy_query()
+        .times(1)
+        .returning(move |_, _| Ok(Default::default()));
+    let mut mock = single_hist_mock_sg(wfid, t, tasks, mock, true);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
+    let core = mock_worker(mock);
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        &[WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+        },]
+    );
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+        task.run_id,
+        schedule_local_activity_cmd(
+            1,
+            "act-id",
+            ActivityCancellationType::TryCancel,
+            Duration::from_secs(60),
+        ),
+    ))
+    .await
+    .unwrap();
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        &[WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::QueryWorkflow(ref q)),
+        }]
+        if q.query_id == "q1"
+    );
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+        task.run_id,
+        query_ok("q1", "whatev"),
+    ))
+    .await
+    .unwrap();
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        &[WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::QueryWorkflow(ref q)),
+        }]
+        if q.query_id == LEGACY_QUERY_ID
+    );
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+        task.run_id,
+        query_ok(LEGACY_QUERY_ID, "whatev"),
+    ))
+    .await
+    .unwrap();
+
+    // Handle the activity so we can shut down cleanly
+    let act_task = core.poll_activity_task().await.unwrap();
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: act_task.task_token,
+        result: Some(ActivityExecutionResult::ok(vec![1].into())),
+    })
+    .await
+    .unwrap();
+
+    core.drain_pollers_and_shutdown().await;
 }

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -520,6 +520,7 @@ impl WorkflowMachines {
             // them.
             if self.replaying
                 && has_final_event
+                && event.event_id > self.last_history_from_server.previous_wft_started_id
                 && event.event_type() != EventType::WorkflowTaskCompleted
                 && !event.is_command_event()
             {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -47,8 +47,8 @@ use temporal_sdk_core_api::{
 use temporal_sdk_core_protos::{
     coresdk::{
         workflow_commands::{
-            workflow_command, ActivityCancellationType, CompleteWorkflowExecution,
-            ScheduleActivity, ScheduleLocalActivity, StartTimer,
+            workflow_command, ActivityCancellationType, CompleteWorkflowExecution, QueryResult,
+            QuerySuccess, ScheduleActivity, ScheduleLocalActivity, StartTimer,
         },
         workflow_completion::WorkflowActivationCompletion,
     },
@@ -670,6 +670,19 @@ pub fn start_timer_cmd(seq: u32, duration: Duration) -> workflow_command::Varian
     StartTimer {
         seq,
         start_to_fire_timeout: Some(duration.try_into().expect("duration fits")),
+    }
+    .into()
+}
+
+pub fn query_ok(id: impl Into<String>, response: impl Into<Payload>) -> workflow_command::Variant {
+    QueryResult {
+        query_id: id.into(),
+        variant: Some(
+            QuerySuccess {
+                response: Some(response.into()),
+            }
+            .into(),
+        ),
     }
     .into()
 }

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -589,7 +589,6 @@ async fn repro_nondeterminism_with_timer_bug() {
 #[rstest::rstest]
 #[tokio::test]
 async fn weird_la_nondeterminism_repro(#[values(true, false)] fix_hist: bool) {
-    init_integ_telem();
     let mut hist = history_from_proto_binary(
         "histories/evict_while_la_running_no_interference-85_history.bin",
     )
@@ -618,7 +617,6 @@ async fn weird_la_nondeterminism_repro(#[values(true, false)] fix_hist: bool) {
 
 #[tokio::test]
 async fn second_weird_la_nondeterminism_repro() {
-    init_integ_telem();
     let mut hist = history_from_proto_binary(
         "histories/evict_while_la_running_no_interference-23_history.bin",
     )
@@ -644,7 +642,6 @@ async fn second_weird_la_nondeterminism_repro() {
 
 #[tokio::test]
 async fn third_weird_la_nondeterminism_repro() {
-    init_integ_telem();
     let mut hist = history_from_proto_binary(
         "histories/evict_while_la_running_no_interference-16_history.bin",
     )

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -22,8 +22,7 @@ use temporal_sdk_core_protos::{
     TestHistoryBuilder,
 };
 use temporal_sdk_core_test_utils::{
-    history_from_proto_binary, init_integ_telem, replay_sdk_worker, workflows::la_problem_workflow,
-    CoreWfStarter,
+    history_from_proto_binary, replay_sdk_worker, workflows::la_problem_workflow, CoreWfStarter,
 };
 use tokio_util::sync::CancellationToken;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Queries now always go in their own activation

## Why?
We agreed this is the most reasonable way to disambiguate the `is_replaying` flag.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/600

2. How was this tested:
Existing / new tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
