### PR TITLE
Allow `CoreMeter` implementations to use their own custom attribute reference

### DIFF
--- a/core-api/src/telemetry/metrics.rs
+++ b/core-api/src/telemetry/metrics.rs
@@ -4,7 +4,13 @@ use std::{borrow::Cow, collections::HashSet, fmt::Debug, sync::Arc};
 /// The implementor is responsible for the allocation/instantiation of new metric meters which
 /// Core has requested.
 pub trait CoreMeter: Send + Sync + Debug {
+    /// Given some k/v pairs, create a return a new instantiated instance of metric attributes.
+    /// Only [MetricAttributes] created by this meter can be used when calling record on instruments
+    /// created by this meter.
     fn new_attributes(&self, attribs: NewAttributes) -> MetricAttributes;
+    /// Extend some existing attributes with new values. Implementations should create new instances
+    /// when doing so, rather than mutating whatever is backing the passed in `existing` attributes.
+    /// Ideally that new instance retains a ref to the extended old attribute, promoting re-use.
     fn extend_attributes(
         &self,
         existing: MetricAttributes,

--- a/core-api/src/telemetry/metrics.rs
+++ b/core-api/src/telemetry/metrics.rs
@@ -165,7 +165,7 @@ pub trait Gauge: Send + Sync {
 }
 
 #[derive(Debug, Clone)]
-pub enum MetricEvent<I> {
+pub enum MetricEvent<I: BufferInstrumentRef> {
     Create {
         params: MetricParameters,
         /// One you receive this event, call `set` on this with the initialized instrument reference
@@ -200,7 +200,7 @@ pub enum MetricUpdateVal {
     Value(u64),
 }
 
-pub trait MetricCallBufferer<I>: Send + Sync {
+pub trait MetricCallBufferer<I: BufferInstrumentRef>: Send + Sync {
     fn retrieve(&self) -> Vec<MetricEvent<I>>;
 }
 

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -21,20 +21,12 @@ use opentelemetry_sdk::{
     runtime, AttributeSet,
 };
 use parking_lot::RwLock;
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{collections::HashMap, fmt::Debug, net::SocketAddr, sync::Arc, time::Duration};
 use temporal_sdk_core_api::telemetry::{
     metrics::{
-        BufferAttributes, CoreMeter, Counter, Gauge, Histogram, MetricAttributes,
-        MetricCallBufferer, MetricEvent, MetricKeyValue, MetricKind, MetricParameters,
-        MetricUpdateVal, NewAttributes, NoOpCoreMeter,
+        BufferAttributes, CoreMeter, Counter, Gauge, Histogram, LazyBufferInstrument,
+        MetricAttributes, MetricCallBufferer, MetricEvent, MetricKeyValue, MetricKind,
+        MetricParameters, MetricUpdateVal, NewAttributes, NoOpCoreMeter,
     },
     OtelCollectorOptions, PrometheusExporterOptions,
 };
@@ -636,37 +628,44 @@ pub fn start_prometheus_metric_exporter(
 
 /// Buffers [MetricEvent]s for periodic consumption by lang
 #[derive(Debug)]
-pub struct MetricsCallBuffer {
-    instrument_ids: AtomicU64,
-    calls_rx: crossbeam::channel::Receiver<MetricEvent>,
-    calls_tx: crossbeam::channel::Sender<MetricEvent>,
+pub struct MetricsCallBuffer<I> {
+    calls_rx: crossbeam::channel::Receiver<MetricEvent<I>>,
+    calls_tx: crossbeam::channel::Sender<MetricEvent<I>>,
 }
-impl MetricsCallBuffer {
+
+impl<I> MetricsCallBuffer<I>
+where
+    I: Clone,
+{
     /// Create a new buffer with the given capacity
     pub fn new(buffer_size: usize) -> Self {
         let (calls_tx, calls_rx) = crossbeam::channel::bounded(buffer_size);
-        MetricsCallBuffer {
-            instrument_ids: AtomicU64::new(0),
-            calls_rx,
-            calls_tx,
-        }
+        MetricsCallBuffer { calls_rx, calls_tx }
     }
-    fn new_instrument(&self, params: MetricParameters, kind: MetricKind) -> BufferInstrument {
-        let id = self.instrument_ids.fetch_add(1, Ordering::AcqRel);
-        let _ = self.calls_tx.send(MetricEvent::Create { params, id, kind });
+    fn new_instrument(&self, params: MetricParameters, kind: MetricKind) -> BufferInstrument<I> {
+        let hole = LazyBufferInstrument::hole();
+        let _ = self.calls_tx.send(MetricEvent::Create {
+            params,
+            kind,
+            populate_into: hole.clone(),
+        });
         BufferInstrument {
             kind,
-            id,
+            instrument_ref: hole,
             tx: self.calls_tx.clone(),
         }
     }
 }
-impl CoreMeter for MetricsCallBuffer {
+
+impl<I> CoreMeter for MetricsCallBuffer<I>
+where
+    I: Debug + Send + Sync + Clone + 'static,
+{
     fn new_attributes(&self, opts: NewAttributes) -> MetricAttributes {
         let ba = BufferAttributes::hole();
         let _ = self.calls_tx.send(MetricEvent::CreateAttributes {
-            new_hole: ba.clone(),
-            existing_hole: None,
+            populate_into: ba.clone(),
+            append_from: None,
             attributes: opts.attributes,
         });
         MetricAttributes::Buffer(ba)
@@ -680,8 +679,8 @@ impl CoreMeter for MetricsCallBuffer {
         if let MetricAttributes::Buffer(ol) = existing {
             let ba = BufferAttributes::hole();
             let _ = self.calls_tx.send(MetricEvent::CreateAttributes {
-                new_hole: ba.clone(),
-                existing_hole: Some(ol),
+                populate_into: ba.clone(),
+                append_from: Some(ol),
                 attributes: attribs.attributes,
             });
             MetricAttributes::Buffer(ba)
@@ -703,25 +702,31 @@ impl CoreMeter for MetricsCallBuffer {
         Arc::new(self.new_instrument(params, MetricKind::Gauge))
     }
 }
-impl MetricCallBufferer for MetricsCallBuffer {
-    fn retrieve(&self) -> Vec<MetricEvent> {
+impl<I> MetricCallBufferer<I> for MetricsCallBuffer<I>
+where
+    I: Send + Sync,
+{
+    fn retrieve(&self) -> Vec<MetricEvent<I>> {
         self.calls_rx.try_iter().collect()
     }
 }
 
-struct BufferInstrument {
+struct BufferInstrument<I> {
     kind: MetricKind,
-    id: u64,
-    tx: crossbeam::channel::Sender<MetricEvent>,
+    instrument_ref: LazyBufferInstrument<I>,
+    tx: crossbeam::channel::Sender<MetricEvent<I>>,
 }
-impl BufferInstrument {
+impl<I> BufferInstrument<I>
+where
+    I: Clone,
+{
     fn send(&self, value: u64, attributes: &MetricAttributes) {
         let attributes = match attributes {
             MetricAttributes::Buffer(l) => l.clone(),
             _ => panic!("MetricsCallBuffer only works with MetricAttributes::Lang"),
         };
         let _ = self.tx.send(MetricEvent::Update {
-            id: self.id,
+            instrument: self.instrument_ref.clone(),
             update: match self.kind {
                 MetricKind::Counter => MetricUpdateVal::Delta(value),
                 MetricKind::Gauge | MetricKind::Histogram => MetricUpdateVal::Value(value),
@@ -730,17 +735,26 @@ impl BufferInstrument {
         });
     }
 }
-impl Counter for BufferInstrument {
+impl<I> Counter for BufferInstrument<I>
+where
+    I: Send + Sync + Clone,
+{
     fn add(&self, value: u64, attributes: &MetricAttributes) {
         self.send(value, attributes)
     }
 }
-impl Gauge for BufferInstrument {
+impl<I> Gauge for BufferInstrument<I>
+where
+    I: Send + Sync + Clone,
+{
     fn record(&self, value: u64, attributes: &MetricAttributes) {
         self.send(value, attributes)
     }
 }
-impl Histogram for BufferInstrument {
+impl<I> Histogram for BufferInstrument<I>
+where
+    I: Send + Sync + Clone,
+{
     fn record(&self, value: u64, attributes: &MetricAttributes) {
         self.send(value, attributes)
     }
@@ -842,7 +856,10 @@ impl<CM: CoreMeter> CoreMeter for PrefixedMetricsMeter<CM> {
 mod tests {
     use super::*;
     use std::any::Any;
-    use temporal_sdk_core_api::telemetry::{metrics::CustomMetricAttributes, METRIC_PREFIX};
+    use temporal_sdk_core_api::telemetry::{
+        metrics::{BufferInstrumentRef, CustomMetricAttributes},
+        METRIC_PREFIX,
+    };
     use tracing::subscriber::NoSubscriber;
 
     #[derive(Debug)]
@@ -864,6 +881,10 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone)]
+    struct DummyInstrumentRef(usize);
+    impl BufferInstrumentRef for DummyInstrumentRef {}
+
     #[test]
     fn test_buffered_core_context() {
         let no_op_subscriber = Arc::new(NoSubscriber::new());
@@ -881,34 +902,35 @@ mod tests {
         let a1 = assert_matches!(
             &events[0],
             MetricEvent::CreateAttributes {
-                new_hole,
-                existing_hole: None,
+                populate_into,
+                append_from: None,
                 attributes,
             }
             if attributes[0].key == "service_name" &&
                attributes[1].key == "namespace" &&
                attributes[2].key == "task_queue"
-            => new_hole
+            => populate_into
         );
         a1.set(Arc::new(DummyCustomAttrs(1))).unwrap();
         // Verify all metrics are created. This number will need to get updated any time a metric
         // is added.
-        let num_metrics = 22;
+        let num_metrics = 23;
         #[allow(clippy::needless_range_loop)] // Sorry clippy, this reads easier.
         for metric_num in 1..=num_metrics {
-            assert_matches!(&events[metric_num],
-                MetricEvent::Create { id, .. }
-                if *id == (metric_num - 1) as u64
+            let hole = assert_matches!(&events[metric_num],
+                MetricEvent::Create { populate_into, .. }
+                => populate_into
             );
+            hole.set(Arc::new(DummyInstrumentRef(metric_num))).unwrap();
         }
         assert_matches!(
-            &events[num_metrics + 2], // +2 for attrib creation (at start), then this update
+            &events[num_metrics + 1], // +1 for attrib creation (at start), then this update
             MetricEvent::Update {
-                id: 22,
+                instrument,
                 attributes,
                 update: MetricUpdateVal::Delta(1)
             }
-            if DummyCustomAttrs::as_id(attributes) == 1
+            if DummyCustomAttrs::as_id(attributes) == 1 && instrument.get().0 == num_metrics
         );
         // Verify creating a new context with new attributes merges them properly
         let mc2 = mc.with_new_attrs([MetricKeyValue::new("gotta", "go fast")]);
@@ -917,22 +939,22 @@ mod tests {
         let a2 = assert_matches!(
             &events[0],
             MetricEvent::CreateAttributes {
-                new_hole,
-                existing_hole: Some(eh),
+                populate_into,
+                append_from: Some(eh),
                 attributes
             }
             if attributes[0].key == "gotta" && DummyCustomAttrs::as_id(eh) == 1
-            => new_hole
+            => populate_into
         );
         a2.set(Arc::new(DummyCustomAttrs(2))).unwrap();
         assert_matches!(
             &events[1],
             MetricEvent::Update {
-                id: 10,
+                instrument,
                 attributes,
                 update: MetricUpdateVal::Value(1000) // milliseconds
             }
-            if DummyCustomAttrs::as_id(attributes) == 2
+            if DummyCustomAttrs::as_id(attributes) == 2 && instrument.get().0 == 11
         );
     }
 
@@ -966,81 +988,87 @@ mod tests {
 
         let mut calls = call_buffer.retrieve();
         calls.reverse();
-        assert_matches!(
+        let ctr_1 = assert_matches!(
             calls.pop(),
             Some(MetricEvent::Create {
                 params,
-                id: 0,
+                populate_into,
                 kind: MetricKind::Counter
             })
             if params.name == "ctr"
+            => populate_into
         );
-        assert_matches!(
+        ctr_1.set(Arc::new(DummyInstrumentRef(1))).unwrap();
+        let hist_2 = assert_matches!(
             calls.pop(),
             Some(MetricEvent::Create {
                 params,
-                id: 1,
+                populate_into,
                 kind: MetricKind::Histogram
             })
             if params.name == "histo"
+            => populate_into
         );
-        assert_matches!(
+        hist_2.set(Arc::new(DummyInstrumentRef(2))).unwrap();
+        let gauge_3 = assert_matches!(
             calls.pop(),
             Some(MetricEvent::Create {
                 params,
-                id: 2,
+                populate_into,
                 kind: MetricKind::Gauge
             })
             if params.name == "gauge"
+            => populate_into
         );
+        gauge_3.set(Arc::new(DummyInstrumentRef(3))).unwrap();
         let a1 = assert_matches!(
             calls.pop(),
             Some(MetricEvent::CreateAttributes {
-                new_hole,
-                existing_hole: None,
+                populate_into,
+                append_from: None,
                 attributes
             })
             if attributes[0].key == "hi"
-            => new_hole
+            => populate_into
         );
         a1.set(Arc::new(DummyCustomAttrs(1))).unwrap();
         let a2 = assert_matches!(
             calls.pop(),
             Some(MetricEvent::CreateAttributes {
-                new_hole,
-                existing_hole: None,
+                populate_into,
+                append_from: None,
                 attributes
             })
             if attributes[0].key == "run"
-            => new_hole
+            => populate_into
         );
         a2.set(Arc::new(DummyCustomAttrs(2))).unwrap();
         assert_matches!(
             calls.pop(),
             Some(MetricEvent::Update{
-                id: 0,
+                instrument,
                 attributes,
                 update: MetricUpdateVal::Delta(1)
             })
-            if DummyCustomAttrs::as_id(&attributes) == 1
+            if DummyCustomAttrs::as_id(&attributes) == 1 && instrument.get().0 == 1
         );
         assert_matches!(
             calls.pop(),
             Some(MetricEvent::Update{
-                id: 1,
+                instrument,
                 attributes,
                 update: MetricUpdateVal::Value(2)
             })
-            if DummyCustomAttrs::as_id(&attributes) == 1
+            if DummyCustomAttrs::as_id(&attributes) == 1 && instrument.get().0 == 2
         );
         assert_matches!(
             calls.pop(),
             Some(MetricEvent::Update{
-                id: 2,
+                instrument,
                 attributes,
                 update: MetricUpdateVal::Value(3)
             })
-            if DummyCustomAttrs::as_id(&attributes) == 2
+            if DummyCustomAttrs::as_id(&attributes) == 2&& instrument.get().0 == 3
         );
     }
 }

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -29,7 +29,7 @@ use std::{
     },
 };
 use temporal_sdk_core_api::telemetry::{
-    metrics::{CoreMeter, MetricKeyValue, MetricsAttributesOptions, TemporalMeter},
+    metrics::{CoreMeter, MetricKeyValue, NewAttributes, TemporalMeter},
     CoreLog, CoreTelemetry, Logger, MetricTemporality, TelemetryOptions,
 };
 use tracing::{Level, Subscriber};
@@ -92,7 +92,7 @@ impl TelemetryInstance {
     pub fn get_temporal_metric_meter(&self) -> Option<TemporalMeter> {
         self.metrics.clone().map(|m| {
             let kvs = self.default_kvs();
-            let attribs = MetricsAttributesOptions::new(kvs);
+            let attribs = NewAttributes::new(kvs);
             TemporalMeter::new(
                 Arc::new(PrefixedMetricsMeter::new(self.metric_prefix.clone(), m))
                     as Arc<dyn CoreMeter>,
@@ -105,7 +105,7 @@ impl TelemetryInstance {
     pub fn get_metric_meter(&self) -> Option<TemporalMeter> {
         self.metrics.clone().map(|m| {
             let kvs = self.default_kvs();
-            let attribs = MetricsAttributesOptions::new(kvs);
+            let attribs = NewAttributes::new(kvs);
             TemporalMeter::new(m, attribs)
         })
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added `CustomMetricAttributes` trait / variant to `MetricAttributes` to allow langs to have a simple reference based approach to allocating their own attributes.

## Why?
Allows destroying backing attributes on `Drop` of the thing implementing `CustomMetricAttributes`

## Checklist
It may no longer be worth keeping a buffer at all, or, if we do, I need to re-implement it to work in terms of refs.

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
