### PR TITLE
Attach current Build ID to workflow activations

### DIFF
--- a/core/src/protosext/mod.rs
+++ b/core/src/protosext/mod.rs
@@ -139,6 +139,8 @@ impl TryFrom<PollWorkflowTaskQueueResponse> for ValidPollWFTQResponse {
 pub(crate) trait WorkflowActivationExt {
     /// Returns true if this activation has one and only one job to perform a legacy query
     fn is_legacy_query(&self) -> bool;
+    /// Augment the activation with the worker's Build ID if appropriate
+    fn attach_build_id_if_needed(&mut self, build_id: &str);
 }
 
 impl WorkflowActivationExt for WorkflowActivation {
@@ -146,6 +148,11 @@ impl WorkflowActivationExt for WorkflowActivation {
         matches!(&self.jobs.as_slice(), &[WorkflowActivationJob {
                     variant: Some(workflow_activation_job::Variant::QueryWorkflow(qr))
                 }] if qr.query_id == LEGACY_QUERY_ID)
+    }
+    fn attach_build_id_if_needed(&mut self, build_id: &str) {
+        if !self.is_replaying {
+            self.build_id_for_current_task = build_id.to_string();
+        }
     }
 }
 

--- a/core/src/protosext/mod.rs
+++ b/core/src/protosext/mod.rs
@@ -139,8 +139,6 @@ impl TryFrom<PollWorkflowTaskQueueResponse> for ValidPollWFTQResponse {
 pub(crate) trait WorkflowActivationExt {
     /// Returns true if this activation has one and only one job to perform a legacy query
     fn is_legacy_query(&self) -> bool;
-    /// Augment the activation with the worker's Build ID if appropriate
-    fn attach_build_id_if_needed(&mut self, build_id: &str);
 }
 
 impl WorkflowActivationExt for WorkflowActivation {
@@ -148,11 +146,6 @@ impl WorkflowActivationExt for WorkflowActivation {
         matches!(&self.jobs.as_slice(), &[WorkflowActivationJob {
                     variant: Some(workflow_activation_job::Variant::QueryWorkflow(qr))
                 }] if qr.query_id == LEGACY_QUERY_ID)
-    }
-    fn attach_build_id_if_needed(&mut self, build_id: &str) {
-        if !self.is_replaying {
-            self.build_id_for_current_task = build_id.to_string();
-        }
     }
 }
 

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -13,9 +13,11 @@ pub(crate) use activities::{
 pub(crate) use workflow::{wft_poller::new_wft_poller, LEGACY_QUERY_ID};
 
 use crate::{
-    abstractions::MeteredSemaphore,
+    abstractions::{dbg_panic, MeteredSemaphore},
     errors::CompleteWfError,
-    pollers::{new_activity_task_buffer, new_workflow_task_buffer, WorkflowTaskPoller},
+    pollers::{
+        new_activity_task_buffer, new_workflow_task_buffer, BoxedActPoller, WorkflowTaskPoller,
+    },
     protosext::validate_activity_completion,
     telemetry::{
         metrics::{
@@ -58,7 +60,6 @@ use temporal_sdk_core_protos::{
 use tokio::sync::mpsc::unbounded_channel;
 use tokio_util::sync::CancellationToken;
 
-use crate::{abstractions::dbg_panic, pollers::BoxedActPoller, protosext::WorkflowActivationExt};
 #[cfg(test)]
 use {
     crate::{
@@ -96,7 +97,12 @@ pub struct Worker {
 impl WorkerTrait for Worker {
     async fn poll_workflow_activation(&self) -> Result<WorkflowActivation, PollWfError> {
         self.next_workflow_activation().await.map(|mut a| {
-            a.attach_build_id_if_needed(&self.config.worker_build_id);
+            // Attach this worker's Build ID to the activation if appropriate. This is done here
+            // to avoid cloning the ID for every workflow instance. Can be lowered when
+            // https://github.com/temporalio/sdk-core/issues/567 is done
+            if !a.is_replaying {
+                a.build_id_for_current_task = self.config.worker_build_id.clone();
+            }
             a
         })
     }

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -58,7 +58,7 @@ use temporal_sdk_core_protos::{
 use tokio::sync::mpsc::unbounded_channel;
 use tokio_util::sync::CancellationToken;
 
-use crate::{abstractions::dbg_panic, pollers::BoxedActPoller};
+use crate::{abstractions::dbg_panic, pollers::BoxedActPoller, protosext::WorkflowActivationExt};
 #[cfg(test)]
 use {
     crate::{
@@ -95,7 +95,10 @@ pub struct Worker {
 #[async_trait::async_trait]
 impl WorkerTrait for Worker {
     async fn poll_workflow_activation(&self) -> Result<WorkflowActivation, PollWfError> {
-        self.next_workflow_activation().await
+        self.next_workflow_activation().await.map(|mut a| {
+            a.attach_build_id_if_needed(&self.config.worker_build_id);
+            a
+        })
     }
 
     #[instrument(skip(self))]

--- a/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -40,6 +40,10 @@ message WorkflowActivation {
     uint64 history_size_bytes = 7;
     // Set true if the most recent WFT started event had this suggestion
     bool continue_as_new_suggested = 8;
+    // Set to the Build ID of the worker that processed this task, which may be empty. During replay
+    // this id may not equal the id of the replaying worker. If not replaying and this worker has
+    // a defined Build ID, it will equal that ID. It will also be empty for evict-only activations.
+    string build_id_for_current_task = 9;
 }
 
 message WorkflowActivationJob {

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -556,6 +556,11 @@ impl TestHistoryBuilder {
         Self::set_flags(self.events.iter_mut().rev(), core, lang)
     }
 
+    /// Get the event ID of the most recently added event
+    pub fn current_event_id(&self) -> i64 {
+        self.current_event_id
+    }
+
     fn set_flags<'a>(
         mut events: impl Iterator<Item = &'a mut HistoryEvent>,
         core: &[u32],

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -456,6 +456,7 @@ pub mod coresdk {
                 available_internal_flags: vec![],
                 history_size_bytes: 0,
                 continue_as_new_suggested: false,
+                build_id_for_current_task: "".to_string(),
             }
         }
 

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -96,12 +96,13 @@ impl WfCtxProtectedDat {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct WfContextSharedData {
+pub(crate) struct WfContextSharedData {
     /// Maps change ids -> resolved status
     pub changes: HashMap<String, bool>,
     pub is_replaying: bool,
     pub wf_time: Option<SystemTime>,
     pub history_length: u32,
+    pub current_build_id: Option<String>,
 }
 
 // TODO: Dataconverter type interface to replace Payloads here. Possibly just use serde
@@ -155,6 +156,12 @@ impl WfContext {
     /// Return the length of history so far at this point in the workflow
     pub fn history_length(&self) -> u32 {
         self.shared.read().history_length
+    }
+
+    /// Return the Build ID as it was when this point in the workflow was first reached. If this
+    /// code is being executed for the first time, return this Worker's Build ID if it has one.
+    pub fn current_build_id(&self) -> Option<String> {
+        self.shared.read().current_build_id.clone()
     }
 
     /// A future that resolves if/when the workflow is cancelled

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -320,6 +320,11 @@ impl Future for WorkflowFuture {
                 wlock.is_replaying = activation.is_replaying;
                 wlock.wf_time = activation.timestamp.try_into_or_none();
                 wlock.history_length = activation.history_length;
+                wlock.current_build_id = if activation.build_id_for_current_task.is_empty() {
+                    None
+                } else {
+                    Some(activation.build_id_for_current_task)
+                };
             }
 
             let mut die_of_eviction_when_done = false;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add current build id as a field on workflow activations

## Why?
So users can tell during replay what build id was used to process the current task.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/features/issues/253

2. How was this tested:
Added unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
