### PR TITLE
Local timeouts for remote activities

### DIFF
--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -127,6 +127,12 @@ pub struct WorkerConfig {
     /// initiated and this amount of time has elapsed.
     #[builder(default)]
     pub graceful_shutdown_period: Option<Duration>,
+
+    /// The amount of time core will wait before timing out activities using its own local timers
+    /// after one of them elapses. This is to avoid racing with server's own tracking of the
+    /// timeout.
+    #[builder(default = "Duration::from_secs(5)")]
+    pub local_timeout_buffer_for_activities: Duration,
 }
 
 impl WorkerConfig {

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -539,7 +539,7 @@ where
                                 // activities can still get cleaned up even if the user isn't
                                 // heartbeating.
                                 let local_timeout_buffer = self.local_timeout_buffer;
-                                let sched_to_close = task
+                                let sched = task
                                     .resp
                                     .schedule_to_close_timeout
                                     .clone()
@@ -559,16 +559,17 @@ where
                                             now.duration_since(sched_time).unwrap_or_default();
                                         Duration::try_from(to).map(|to| to - already_elapsed).ok()
                                     });
-                                let start_to_close = task
-                                    .resp
-                                    .start_to_close_timeout
-                                    .clone()
-                                    .and_then(|t| Duration::try_from(t).ok());
-                                let timeout_at = [sched_to_close, start_to_close]
-                                    .into_iter()
-                                    .flatten()
-                                    .filter(|d| !d.is_zero())
-                                    .min();
+                                let timeout_at = [
+                                    task.resp.heartbeat_timeout.clone(),
+                                    task.resp.start_to_close_timeout.clone(),
+                                ]
+                                .into_iter()
+                                .flatten()
+                                .map(Duration::try_from)
+                                .filter_map(Result::ok)
+                                .chain(sched)
+                                .filter(|d| !d.is_zero())
+                                .min();
                                 if let Some(timeout_at) = timeout_at {
                                     let cancel_tx = cancels_tx.clone();
                                     outstanding_info.local_timeouts_task =
@@ -787,11 +788,22 @@ mod tests {
             .times(1)
             .returning(move |_, _| {
                 Ok(PollActivityTaskQueueResponse {
+                    task_token: vec![2],
+                    activity_id: "act2".to_string(),
+                    heartbeat_timeout: Some(prost_dur!(from_millis(100))),
+                    ..Default::default()
+                })
+            });
+        mock_client
+            .expect_poll_activity_task()
+            .times(1)
+            .returning(move |_, _| {
+                Ok(PollActivityTaskQueueResponse {
                     task_token: vec![3],
                     activity_id: "act3".to_string(),
                     // Verify smaller of the timeouts is chosen
-                    schedule_to_close_timeout: Some(prost_dur!(from_secs(100))),
-                    start_to_close_timeout: Some(prost_dur!(from_millis(100))),
+                    heartbeat_timeout: Some(prost_dur!(from_millis(100))),
+                    start_to_close_timeout: Some(prost_dur!(from_secs(100))),
                     ..Default::default()
                 })
             });
@@ -840,7 +852,7 @@ mod tests {
             Duration::from_millis(100), // Short buffer for unit test
         );
 
-        for _ in 1..=3 {
+        for _ in 1..=4 {
             let start = Instant::now();
             let t = atm.poll().await.unwrap();
             // Just don't do anything when we get the task, wait for the timeout to come.

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -305,7 +305,6 @@ impl WorkerActivityTasks {
                 activity_type(act_info.base.activity_type),
                 workflow_type(act_info.base.workflow_type),
             ]);
-            // TODO: Make sure these get attached to span properly
             Span::current().record("workflow_id", act_info.base.workflow_id);
             Span::current().record("run_id", act_info.base.workflow_run_id);
             act_metrics.act_execution_latency(act_info.base.start_time.elapsed());

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -345,6 +345,7 @@ impl Worker {
                 config.max_heartbeat_throttle_interval,
                 config.default_heartbeat_throttle_interval,
                 config.graceful_shutdown_period,
+                config.local_timeout_buffer_for_activities,
             )
         });
         let poll_on_non_local_activities = at_task_mgr.is_some();

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -68,6 +68,15 @@ pub mod coresdk {
                     })),
                 }
             }
+
+            pub fn is_timeout(&self) -> bool {
+                match &self.variant {
+                    Some(activity_task::Variant::Cancel(Cancel { reason })) => {
+                        *reason == ActivityCancelReason::TimedOut as i32
+                    }
+                    _ => false,
+                }
+            }
         }
 
         impl Display for ActivityTaskCompletion {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Core now will send cancellations if an activity would have already timed out according to server but we haven't learned of that (typically, because it isn't heartbeating). There is a configurable buffer defaulting to 5s, to avoid races with server (we would prefer to learn from server).

## Why?
Nice to have your activities get cancelled when they would have been even if they don't heartbeat

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/features/issues/170

2. How was this tested:
Unit & Integ

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
