### PR TITLE
Log pushing support

### DIFF
--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -3,6 +3,7 @@ pub mod metrics;
 use crate::telemetry::metrics::CoreMeter;
 use std::{
     collections::HashMap,
+    fmt::Debug,
     net::SocketAddr,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -94,6 +95,13 @@ pub enum Logger {
         /// An [EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html) filter string.
         filter: String,
     },
+    // Push logs to Lang. Can used with temporal_sdk_core::telemetry::CoreLogBufferedConsumer to buffer.
+    Push {
+        /// An [EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html) filter string.
+        filter: String,
+        /// Trait invoked on each log.
+        consumer: Arc<dyn CoreLogConsumer>,
+    },
 }
 
 /// Types of aggregation temporality for metric export.
@@ -139,4 +147,10 @@ impl CoreLog {
             .unwrap_or(Duration::ZERO)
             .as_millis()
     }
+}
+
+/// Consumer trait for use with push logger.
+pub trait CoreLogConsumer: Send + Sync + Debug {
+    /// Invoked synchronously for every single log.
+    fn on_log(&self, log: CoreLog);
 }

--- a/core/src/telemetry/log_export.rs
+++ b/core/src/telemetry/log_export.rs
@@ -1,33 +1,35 @@
 use parking_lot::Mutex;
 use ringbuf::{Consumer, HeapRb, Producer};
-use std::{collections::HashMap, sync::Arc, time::SystemTime};
-use temporal_sdk_core_api::telemetry::CoreLog;
+use std::{collections::HashMap, fmt, sync::Arc, time::SystemTime};
+use temporal_sdk_core_api::telemetry::{CoreLog, CoreLogConsumer};
 use tracing_subscriber::Layer;
 
-const RB_SIZE: usize = 2048;
-
-pub(super) type CoreLogsOut = Consumer<CoreLog, Arc<HeapRb<CoreLog>>>;
-
-pub(super) struct CoreLogExportLayer {
-    logs_in: Mutex<Producer<CoreLog, Arc<HeapRb<CoreLog>>>>,
-}
+type CoreLogsOut = Consumer<CoreLog, Arc<HeapRb<CoreLog>>>;
 
 #[derive(Debug)]
 struct CoreLogFieldStorage(HashMap<String, serde_json::Value>);
 
-impl CoreLogExportLayer {
-    pub(super) fn new() -> (Self, CoreLogsOut) {
-        let (lin, lout) = HeapRb::new(RB_SIZE).split();
+pub(super) struct CoreLogConsumerLayer {
+    consumer: Arc<dyn CoreLogConsumer>,
+}
+
+impl CoreLogConsumerLayer {
+    pub(super) fn new(consumer: Arc<dyn CoreLogConsumer>) -> Self {
+        Self { consumer }
+    }
+
+    pub(super) fn new_buffered(ringbuf_capacity: usize) -> (Self, CoreLogBuffer) {
+        let (consumer, buffer) = CoreLogBufferedConsumer::new(ringbuf_capacity);
         (
             Self {
-                logs_in: Mutex::new(lin),
+                consumer: Arc::new(consumer),
             },
-            lout,
+            buffer,
         )
     }
 }
 
-impl<S> Layer<S> for CoreLogExportLayer
+impl<S> Layer<S> for CoreLogConsumerLayer
 where
     S: tracing::Subscriber,
     S: for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
@@ -93,7 +95,49 @@ where
             fields,
             span_contexts: spans,
         };
+        self.consumer.on_log(log);
+    }
+}
+
+/// Core log consumer implementation backed by a ring buffer.
+pub struct CoreLogBufferedConsumer {
+    logs_in: Mutex<Producer<CoreLog, Arc<HeapRb<CoreLog>>>>,
+}
+
+impl CoreLogBufferedConsumer {
+    /// Create a log consumer and drainable buffer for the given capacity.
+    pub fn new(ringbuf_capacity: usize) -> (Self, CoreLogBuffer) {
+        let (logs_in, logs_out) = HeapRb::new(ringbuf_capacity).split();
+        (
+            Self {
+                logs_in: Mutex::new(logs_in),
+            },
+            CoreLogBuffer { logs_out },
+        )
+    }
+}
+
+impl CoreLogConsumer for CoreLogBufferedConsumer {
+    fn on_log(&self, log: CoreLog) {
         let _ = self.logs_in.lock().push(log);
+    }
+}
+
+impl fmt::Debug for CoreLogBufferedConsumer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<buffered consumer>")
+    }
+}
+
+/// Buffer of core logs that can be drained.
+pub struct CoreLogBuffer {
+    logs_out: CoreLogsOut,
+}
+
+impl CoreLogBuffer {
+    /// Drain the buffer of its logs.
+    pub fn drain(&mut self) -> Vec<CoreLog> {
+        self.logs_out.pop_iter().collect()
     }
 }
 
@@ -147,7 +191,11 @@ impl<'a> tracing::field::Visit for JsonVisitor<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{telemetry::construct_filter_string, telemetry_init};
-    use temporal_sdk_core_api::telemetry::{CoreTelemetry, Logger, TelemetryOptionsBuilder};
+    use std::fmt;
+    use std::sync::{Arc, Mutex};
+    use temporal_sdk_core_api::telemetry::{
+        CoreLog, CoreLogConsumer, CoreTelemetry, Logger, TelemetryOptionsBuilder,
+    };
     use tracing::Level;
 
     #[instrument(fields(bros = "brohemian"))]
@@ -155,6 +203,28 @@ mod tests {
         warn!("warn");
         info!(foo = "bar", "info");
         debug!("debug");
+    }
+
+    fn write_logs() {
+        let top_span = span!(Level::INFO, "yayspan", huh = "wat");
+        let _guard = top_span.enter();
+        info!("Whata?");
+        instrumented("hi");
+        info!("Donezo");
+    }
+
+    fn assert_logs(logs: Vec<CoreLog>) {
+        // Verify debug log was not forwarded
+        assert!(!logs.iter().any(|l| l.message == "debug"));
+        assert_eq!(logs.len(), 4);
+        // Ensure fields are attached to events properly
+        let info_msg = &logs[2];
+        assert_eq!(info_msg.message, "info");
+        assert_eq!(info_msg.fields.len(), 4);
+        assert_eq!(info_msg.fields.get("huh"), Some(&"wat".into()));
+        assert_eq!(info_msg.fields.get("foo"), Some(&"bar".into()));
+        assert_eq!(info_msg.fields.get("bros"), Some(&"brohemian".into()));
+        assert_eq!(info_msg.fields.get("thing"), Some(&"hi".into()));
     }
 
     #[tokio::test]
@@ -168,23 +238,38 @@ mod tests {
         let instance = telemetry_init(opts).unwrap();
         let _g = tracing::subscriber::set_default(instance.trace_subscriber().unwrap().clone());
 
-        let top_span = span!(Level::INFO, "yayspan", huh = "wat");
-        let _guard = top_span.enter();
-        info!("Whata?");
-        instrumented("hi");
-        info!("Donezo");
+        write_logs();
+        assert_logs(instance.fetch_buffered_logs());
+    }
 
-        let logs = instance.fetch_buffered_logs();
-        // Verify debug log was not forwarded
-        assert!(!logs.iter().any(|l| l.message == "debug"));
-        assert_eq!(logs.len(), 4);
-        // Ensure fields are attached to events properly
-        let info_msg = &logs[2];
-        assert_eq!(info_msg.message, "info");
-        assert_eq!(info_msg.fields.len(), 4);
-        assert_eq!(info_msg.fields.get("huh"), Some(&"wat".into()));
-        assert_eq!(info_msg.fields.get("foo"), Some(&"bar".into()));
-        assert_eq!(info_msg.fields.get("bros"), Some(&"brohemian".into()));
-        assert_eq!(info_msg.fields.get("thing"), Some(&"hi".into()));
+    struct CaptureConsumer(Mutex<Vec<CoreLog>>);
+
+    impl CoreLogConsumer for CaptureConsumer {
+        fn on_log(&self, log: CoreLog) {
+            self.0.lock().unwrap().push(log);
+        }
+    }
+
+    impl fmt::Debug for CaptureConsumer {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("<capture consumer>")
+        }
+    }
+
+    #[tokio::test]
+    async fn test_push_output() {
+        let consumer = Arc::new(CaptureConsumer(Mutex::new(Vec::new())));
+        let opts = TelemetryOptionsBuilder::default()
+            .logging(Logger::Push {
+                filter: construct_filter_string(Level::INFO, Level::WARN),
+                consumer: consumer.clone(),
+            })
+            .build()
+            .unwrap();
+        let instance = telemetry_init(opts).unwrap();
+        let _g = tracing::subscriber::set_default(instance.trace_subscriber().unwrap().clone());
+
+        write_logs();
+        assert_logs(consumer.0.lock().unwrap().drain(..).collect());
     }
 }

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -10,7 +10,7 @@ pub use metrics::{
     MetricsCallBuffer,
 };
 
-pub use log_export::{CoreLogBuffer, CoreLogBufferedConsumer};
+pub use log_export::{CoreLogBuffer, CoreLogBufferedConsumer, CoreLogStreamConsumer};
 
 use crate::telemetry::log_export::CoreLogConsumerLayer;
 use crate::telemetry::metrics::PrefixedMetricsMeter;

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -10,10 +10,10 @@ pub use metrics::{
     MetricsCallBuffer,
 };
 
-use crate::telemetry::{
-    log_export::{CoreLogExportLayer, CoreLogsOut},
-    metrics::PrefixedMetricsMeter,
-};
+pub use log_export::{CoreLogBuffer, CoreLogBufferedConsumer};
+
+use crate::telemetry::log_export::CoreLogConsumerLayer;
+use crate::telemetry::metrics::PrefixedMetricsMeter;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use opentelemetry::{sdk::Resource, KeyValue};
@@ -37,6 +37,8 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
 const TELEM_SERVICE_NAME: &str = "temporal-core-sdk";
 
+const FORWARD_LOG_BUFFER_SIZE: usize = 2048;
+
 /// Help you construct an [EnvFilter] compatible filter string which will forward all core module
 /// traces at `core_level` and all others (from 3rd party modules, etc) at `other_level`.
 pub fn construct_filter_string(core_level: Level, other_level: Level) -> String {
@@ -48,7 +50,7 @@ pub fn construct_filter_string(core_level: Level, other_level: Level) -> String 
 /// Holds initialized tracing/metrics exporters, etc
 pub struct TelemetryInstance {
     metric_prefix: String,
-    logs_out: Option<Mutex<CoreLogsOut>>,
+    logs_out: Option<Mutex<CoreLogBuffer>>,
     metrics: Option<Arc<dyn CoreMeter + 'static>>,
     /// The tracing subscriber which is associated with this telemetry instance. May be `None` if
     /// the user has not opted into any tracing configuration.
@@ -59,7 +61,7 @@ pub struct TelemetryInstance {
 impl TelemetryInstance {
     fn new(
         trace_subscriber: Option<Arc<dyn Subscriber + Send + Sync>>,
-        logs_out: Option<Mutex<CoreLogsOut>>,
+        logs_out: Option<Mutex<CoreLogBuffer>>,
         metric_prefix: String,
         metrics: Option<Arc<dyn CoreMeter + 'static>>,
         attach_service_name: bool,
@@ -144,7 +146,7 @@ pub fn remove_trace_subscriber_for_current_thread() {
 impl CoreTelemetry for TelemetryInstance {
     fn fetch_buffered_logs(&self) -> Vec<CoreLog> {
         if let Some(logs_out) = self.logs_out.as_ref() {
-            logs_out.lock().pop_iter().collect()
+            logs_out.lock().drain()
         } else {
             vec![]
         }
@@ -203,9 +205,14 @@ pub fn telemetry_init(opts: TelemetryOptions) -> Result<TelemetryInstance, anyho
                 }
             }
             Logger::Forward { filter } => {
-                let (export_layer, lo) = CoreLogExportLayer::new();
+                let (export_layer, lo) =
+                    CoreLogConsumerLayer::new_buffered(FORWARD_LOG_BUFFER_SIZE);
                 logs_out = Some(Mutex::new(lo));
                 forward_layer = Some(export_layer.with_filter(EnvFilter::new(filter)));
+            }
+            Logger::Push { filter, consumer } => {
+                forward_layer =
+                    Some(CoreLogConsumerLayer::new(consumer).with_filter(EnvFilter::new(filter)));
             }
         };
         let reg = tracing_subscriber::registry()


### PR DESCRIPTION
## What was changed

Create a new Telemetry option `temporal_sdk_core_api::telemetry::Logger::Push` which accepts a filter like the others, but also accepts an implementation of the `CoreLogConsumer` trait which is a simple single-function trait invoked for each log.

Also exposed a `temporal_sdk_core::telemetry::CoreLogBufferedConsumer` struct which, upon `new`, will return itself (an implementation of `CoreLogConsumer`) and a `temporal_sdk_core::telemetry::CoreLogBuffer` upon which `drain` can be invoked. Also altered log forwarding to leverage the new abstraction which means the foward.

Also expose a `temporal_sdk_core::telemetry::CoreLogStreamConsumer` that is backed by a bounded mpsc channel.

For langs where they need to buffer/throttle on a max-frequency, they are expected to use `CoreLogStreamConsumer::new` and for the stream response (second part of tuple), they can call [tokio_stream::StreamExt::chunks_timeout](https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.chunks_timeout) on it.


## Checklist

1. Closes #618