### PR TITLE
Bugfix for failure to send protocol msg when resuming unfinished updates

### DIFF
--- a/client/src/workflow_handle/mod.rs
+++ b/client/src/workflow_handle/mod.rs
@@ -54,6 +54,7 @@ pub struct WorkflowHandle<ClientT, ResultT> {
 }
 
 /// Holds needed information to refer to a specific workflow run, or workflow execution chain
+#[derive(Debug)]
 pub struct WorkflowExecutionInfo {
     /// Namespace the workflow lives in
     pub namespace: String,

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -56,11 +56,16 @@ pub struct TemporaliteConfig {
 impl TemporaliteConfig {
     /// Start a Temporalite server.
     pub async fn start_server(&self) -> anyhow::Result<EphemeralServer> {
-        self.start_server_with_output(Stdio::inherit()).await
+        self.start_server_with_output(Stdio::inherit(), Stdio::inherit())
+            .await
     }
 
     /// Start a Temporalite server with configurable stdout destination.
-    pub async fn start_server_with_output(&self, output: Stdio) -> anyhow::Result<EphemeralServer> {
+    pub async fn start_server_with_output(
+        &self,
+        output: Stdio,
+        err_output: Stdio,
+    ) -> anyhow::Result<EphemeralServer> {
         // Get exe path
         let exe_path = self
             .exe
@@ -104,6 +109,7 @@ impl TemporaliteConfig {
             args,
             has_test_service: false,
             output,
+            err_output,
         })
         .await
     }
@@ -140,11 +146,16 @@ pub struct TemporalDevServerConfig {
 impl TemporalDevServerConfig {
     /// Start a Temporal CLI dev server.
     pub async fn start_server(&self) -> anyhow::Result<EphemeralServer> {
-        self.start_server_with_output(Stdio::inherit()).await
+        self.start_server_with_output(Stdio::inherit(), Stdio::inherit())
+            .await
     }
 
     /// Start a Temporal CLI dev server with configurable stdout destination.
-    pub async fn start_server_with_output(&self, output: Stdio) -> anyhow::Result<EphemeralServer> {
+    pub async fn start_server_with_output(
+        &self,
+        output: Stdio,
+        err_output: Stdio,
+    ) -> anyhow::Result<EphemeralServer> {
         // Get exe path
         let exe_path = self
             .exe
@@ -191,6 +202,7 @@ impl TemporalDevServerConfig {
             args,
             has_test_service: false,
             output,
+            err_output,
         })
         .await
     }
@@ -212,11 +224,16 @@ pub struct TestServerConfig {
 impl TestServerConfig {
     /// Start a test server.
     pub async fn start_server(&self) -> anyhow::Result<EphemeralServer> {
-        self.start_server_with_output(Stdio::inherit()).await
+        self.start_server_with_output(Stdio::inherit(), Stdio::inherit())
+            .await
     }
 
     /// Start a test server with configurable stdout.
-    pub async fn start_server_with_output(&self, output: Stdio) -> anyhow::Result<EphemeralServer> {
+    pub async fn start_server_with_output(
+        &self,
+        output: Stdio,
+        err_output: Stdio,
+    ) -> anyhow::Result<EphemeralServer> {
         // Get exe path
         let exe_path = self
             .exe
@@ -237,6 +254,7 @@ impl TestServerConfig {
             args,
             has_test_service: true,
             output,
+            err_output,
         })
         .await
     }
@@ -248,6 +266,7 @@ struct EphemeralServerConfig {
     args: Vec<String>,
     has_test_service: bool,
     output: Stdio,
+    err_output: Stdio,
 }
 
 /// Server that will be stopped when dropped.
@@ -263,11 +282,11 @@ pub struct EphemeralServer {
 impl EphemeralServer {
     async fn start(config: EphemeralServerConfig) -> anyhow::Result<EphemeralServer> {
         // Start process
-        // TODO(cretz): Offer stdio suppression?
         let child = tokio::process::Command::new(config.exe_path)
             .args(config.args)
             .stdin(Stdio::null())
             .stdout(config.output)
+            .stderr(config.err_output)
             .spawn()?;
         let target = format!("127.0.0.1:{}", config.port);
         let target_url = format!("http://{target}");

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1095,7 +1095,11 @@ impl WorkflowMachines {
                     })
                 }
                 MachineResponse::IssueNewMessage(pm) => {
-                    self.message_outbox.push_back(pm);
+                    // Messages shouldn't be sent back when replaying. This is true for update,
+                    // currently the only user of protocol messages. May eventually change.
+                    if !self.replaying {
+                        self.message_outbox.push_back(pm);
+                    }
                 }
                 MachineResponse::NewCoreOriginatedCommand(attrs) => match attrs {
                     ProtoCmdAttrs::RequestCancelExternalWorkflowExecutionCommandAttributes(

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -73,7 +73,11 @@ async fn main() -> Result<(), anyhow::Error> {
                 .build()?;
             println!("Using temporal CLI");
             (
-                Some(config.start_server_with_output(Stdio::null()).await?),
+                Some(
+                    config
+                        .start_server_with_output(Stdio::null(), Stdio::null())
+                        .await?,
+                ),
                 vec![(INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR, "true")],
             )
         }
@@ -83,7 +87,11 @@ async fn main() -> Result<(), anyhow::Error> {
                 .build()?;
             println!("Using java test server");
             (
-                Some(config.start_server_with_output(Stdio::null()).await?),
+                Some(
+                    config
+                        .start_server_with_output(Stdio::null(), Stdio::null())
+                        .await?,
+                ),
                 vec![(INTEG_TEST_SERVER_USED_ENV_VAR, "true")],
             )
         }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Core would fail to send a protocol message if we began the processing of an update while replaying, but finished replay before finishing it.

:boom: Also added stderr output setting for embedded server because I was SO TIRED of server logspam, which all comes on stderr anyways apparently.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
