### PR TITLE
Fix worker shutdown during replay test

### DIFF
--- a/client/src/worker_registry/mod.rs
+++ b/client/src/worker_registry/mod.rs
@@ -113,8 +113,6 @@ impl SlotManagerImpl {
 #[derive(Default, Debug)]
 pub struct SlotManager {
     manager: RwLock<SlotManagerImpl>,
-    /// True if this manager is associated with a mock client.
-    mock: bool,
 }
 
 impl SlotManager {
@@ -122,21 +120,7 @@ impl SlotManager {
     pub fn new() -> Self {
         Self {
             manager: RwLock::new(SlotManagerImpl::new()),
-            mock: false,
         }
-    }
-
-    /// Factory method.
-    pub fn new_mock() -> Self {
-        Self {
-            manager: RwLock::new(SlotManagerImpl::new()),
-            mock: true,
-        }
-    }
-
-    /// Return true if this manager is associated with a mock client.
-    pub fn is_mock(&self) -> bool {
-        self.mock
     }
 
     /// Try to reserve a compatible processing slot in any of the registered workers.

--- a/client/src/worker_registry/mod.rs
+++ b/client/src/worker_registry/mod.rs
@@ -113,6 +113,8 @@ impl SlotManagerImpl {
 #[derive(Default, Debug)]
 pub struct SlotManager {
     manager: RwLock<SlotManagerImpl>,
+    /// True if this manager is associated with a mock client.
+    mock: bool,
 }
 
 impl SlotManager {
@@ -120,7 +122,21 @@ impl SlotManager {
     pub fn new() -> Self {
         Self {
             manager: RwLock::new(SlotManagerImpl::new()),
+            mock: false,
         }
+    }
+
+    /// Factory method.
+    pub fn new_mock() -> Self {
+        Self {
+            manager: RwLock::new(SlotManagerImpl::new()),
+            mock: true,
+        }
+    }
+
+    /// Return true if this manager is associated with a mock client.
+    pub fn is_mock(&self) -> bool {
+        self.mock
     }
 
     /// Try to reserve a compatible processing slot in any of the registered workers.

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -145,6 +145,7 @@ pub(crate) trait WorkerClient: Sync + Send {
     #[allow(clippy::needless_lifetimes)] // Clippy is wrong here
     fn capabilities<'a>(&'a self) -> Option<&'a get_system_info_response::Capabilities>;
     fn workers(&self) -> Arc<SlotManager>;
+    fn is_mock(&self) -> bool;
 }
 
 #[async_trait::async_trait]
@@ -386,6 +387,10 @@ impl WorkerClient for WorkerClientBag {
 
     fn workers(&self) -> Arc<SlotManager> {
         self.client.get_client().inner().workers()
+    }
+
+    fn is_mock(&self) -> bool {
+        false
     }
 }
 

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 use temporal_client::SlotManager;
 
 lazy_static! {
-    pub(crate) static ref DEFAULT_WORKERS_REGISTRY: Arc<SlotManager> =
-        Arc::new(SlotManager::new_mock());
+    pub(crate) static ref DEFAULT_WORKERS_REGISTRY: Arc<SlotManager> = Arc::new(SlotManager::new());
 }
 
 pub(crate) static DEFAULT_TEST_CAPABILITIES: &Capabilities = &Capabilities {
@@ -29,6 +28,7 @@ pub(crate) fn mock_workflow_client() -> MockWorkerClient {
         .returning(|| Some(DEFAULT_TEST_CAPABILITIES));
     r.expect_workers()
         .returning(|| DEFAULT_WORKERS_REGISTRY.clone());
+    r.expect_is_mock().returning(|| true);
     r
 }
 
@@ -39,6 +39,7 @@ pub(crate) fn mock_manual_workflow_client() -> MockManualWorkerClient {
         .returning(|| Some(DEFAULT_TEST_CAPABILITIES));
     r.expect_workers()
         .returning(|| DEFAULT_WORKERS_REGISTRY.clone());
+    r.expect_is_mock().returning(|| true);
     r
 }
 
@@ -117,5 +118,7 @@ mockall::mock! {
         fn capabilities(&self) -> Option<&'static get_system_info_response::Capabilities>;
 
         fn workers(&self) -> Arc<SlotManager>;
+
+        fn is_mock(&self) -> bool;
     }
 }

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use temporal_client::SlotManager;
 
 lazy_static! {
-    pub(crate) static ref DEFAULT_WORKERS_REGISTRY: Arc<SlotManager> = Arc::new(SlotManager::new());
+    pub(crate) static ref DEFAULT_WORKERS_REGISTRY: Arc<SlotManager> =
+        Arc::new(SlotManager::new_mock());
 }
 
 pub(crate) static DEFAULT_TEST_CAPABILITIES: &Capabilities = &Capabilities {

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -313,7 +313,7 @@ impl Worker {
                     sticky_queue_poller,
                 ));
                 let wft_stream = new_wft_poller(wf_task_poll_buffer, metrics.clone());
-                if client.workers().is_mock() {
+                if client.is_mock() {
                     // Some replay tests combine a mock client with real pollers,
                     // and they need to close the merged stream for clean worker termination.
                     external_wft_rx.close();


### PR DESCRIPTION
This fixes issue #630 by closing the external channel early when we are using a mock client associated with the worker. 

This will disable Eager Start Workflow with mock clients, but since ESW is a latency optimization, and we do not use mock clients during its testing, this has no practical consequences.

1. Closes <!-- add issue number here -->
#630
