### PR TITLE
Better WFT buffer

### DIFF
--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -1221,6 +1221,7 @@ async fn new_server_work_while_eviction_outstanding_doesnt_overwrite_activation(
 
 #[tokio::test]
 async fn buffered_work_drained_on_shutdown() {
+    crate::telemetry::test_telem_console();
     let wfid = "fake_wf_id";
     // Build a one-timer history where first task times out
     let mut t = TestHistoryBuilder::default();

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -1221,7 +1221,6 @@ async fn new_server_work_while_eviction_outstanding_doesnt_overwrite_activation(
 
 #[tokio::test]
 async fn buffered_work_drained_on_shutdown() {
-    crate::telemetry::test_telem_console();
     let wfid = "fake_wf_id";
     // Build a one-timer history where first task times out
     let mut t = TestHistoryBuilder::default();

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -55,8 +55,10 @@ impl Debug for HistoryUpdate {
         if self.is_real() {
             write!(
                 f,
-                "HistoryUpdate(previous_started_event_id: {}, length: {}, first_event_id: {:?})",
+                "HistoryUpdate(previous_started_event_id: {}, started_id: {}, \
+                 length: {}, first_event_id: {:?})",
                 self.previous_wft_started_id,
+                self.wft_started_id,
                 self.events.len(),
                 self.events.first().map(|e| e.event_id)
             )

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -368,6 +368,10 @@ impl WorkflowMachines {
         self.drive_me.get_started_info()
     }
 
+    pub(crate) fn get_last_wft_started_id(&self) -> i64 {
+        self.current_started_event_id
+    }
+
     pub(crate) fn prepare_for_wft_response(&mut self) -> MachinesWFTResponseContent {
         MachinesWFTResponseContent {
             replaying: self.replaying,

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -1046,7 +1046,8 @@ impl BufferedTasks {
         self.wft.is_some() || !self.query_only_tasks.is_empty()
     }
 
-    /// Remove and return the next WFT from the buffer that should be applied
+    /// Remove and return the next WFT from the buffer that should be applied. WFTs which would
+    /// advance workflow state are returned before query-only tasks.
     fn get_next_wft(&mut self) -> Option<PermittedWFT> {
         self.wft
             .take()

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -807,7 +807,7 @@ impl PreparedWFT {
     }
 
     fn is_query_only(&self) -> bool {
-        let no_new_history = self.update.previous_wft_started_id == self.update.wft_started_id;
+        let no_new_history = self.update.wft_started_id == 0;
         no_new_history && self.legacy_query.is_some()
     }
 }

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -442,7 +442,7 @@ impl Workflows {
 
         let maybe_pwft = if let Some(wft) = wft_from_complete {
             match HistoryPaginator::from_poll(wft, self.client.clone()).await {
-                Ok((paginator, pwft)) => Some((pwft, paginator)),
+                Ok((paginator, wft)) => Some(WFTWithPaginator { wft, paginator }),
                 Err(e) => {
                     self.request_eviction(
                         &run_id,
@@ -749,7 +749,8 @@ enum ActivationOrAuto {
     },
 }
 
-/// A processed WFT which has been validated and had a history update extracted from it
+/// A WFT which is considered to be using a slot for metrics purposes and being or about to be
+/// applied to workflow state.
 #[derive(derive_more::DebugCustom)]
 #[cfg_attr(
     feature = "save_wf_inputs",
@@ -769,6 +770,18 @@ pub(crate) struct PermittedWFT {
     )]
     paginator: HistoryPaginator,
 }
+/// A WFT without a permit
+#[derive(Debug)]
+#[cfg_attr(
+    feature = "save_wf_inputs",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+struct WFTWithPaginator {
+    wft: PreparedWFT,
+    paginator: HistoryPaginator,
+}
+
+/// A WFT which has been validated and had a history update extracted from it.
 #[derive(Debug)]
 #[cfg_attr(
     feature = "save_wf_inputs",
@@ -791,6 +804,11 @@ impl PreparedWFT {
         let start_event_id = self.update.first_event_id();
         let poll_resp_is_incremental = start_event_id.map(|eid| eid > 1).unwrap_or_default();
         poll_resp_is_incremental || start_event_id.is_none()
+    }
+
+    fn is_query_only(&self) -> bool {
+        let no_new_history = self.update.previous_wft_started_id == self.update.wft_started_id;
+        no_new_history && self.legacy_query.is_some()
     }
 }
 
@@ -938,7 +956,7 @@ struct LocalResolutionMsg {
 struct PostActivationMsg {
     run_id: String,
     wft_report_status: WFTReportStatus,
-    wft_from_complete: Option<(PreparedWFT, HistoryPaginator)>,
+    wft_from_complete: Option<WFTWithPaginator>,
     is_autocomplete: bool,
 }
 #[derive(Debug, Clone)]
@@ -1002,6 +1020,38 @@ enum WFTReportStatus {
     /// We didn't report, but we want to clear the outstanding workflow task anyway. See
     /// [ActivationCompleteOutcome::WFTFailedDontReport]
     DropWft,
+}
+#[derive(Debug, Default)]
+struct BufferedTasks {
+    /// There should only be one buffered actual WFT at a time, since any new one will immediately
+    /// supersede any old one.
+    wft: Option<PermittedWFT>,
+    /// For query only tasks, multiple may be received concurrently and it's OK to buffer more
+    /// than one - however they should be dropped if, by the time we try to process them, we
+    /// have already processed a newer real WFT than the one the query was targeting (otherwise
+    /// we'd return data from the "future").
+    query_only_tasks: VecDeque<PermittedWFT>,
+}
+
+impl BufferedTasks {
+    fn buffer(&mut self, task: PermittedWFT) {
+        if task.work.is_query_only() {
+            self.query_only_tasks.push_back(task);
+        } else {
+            let _ = self.wft.insert(task);
+        }
+    }
+
+    fn has_tasks(&self) -> bool {
+        self.wft.is_some() || !self.query_only_tasks.is_empty()
+    }
+
+    /// Remove and return the next WFT from the buffer that should be applied
+    fn get_next_wft(&mut self) -> Option<PermittedWFT> {
+        self.wft
+            .take()
+            .or_else(|| self.query_only_tasks.pop_front())
+    }
 }
 
 fn validate_completion(

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -301,10 +301,19 @@ impl WFStream {
                         None
                     }
                 },
-                ValidatedCompletion::Fail { failure, .. } => rh.failed_completion(
-                    failure.force_cause(),
-                    EvictionReason::LangFail,
+                ValidatedCompletion::Fail {
                     failure,
+                    is_autocomplete,
+                    ..
+                } => rh.failed_completion(
+                    failure.force_cause(),
+                    if is_autocomplete {
+                        EvictionReason::Unspecified
+                    } else {
+                        EvictionReason::LangFail
+                    },
+                    failure,
+                    is_autocomplete,
                     complete.response_tx,
                 ),
             },

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -362,15 +362,15 @@ impl WFStream {
                 self.runs.remove(run_id);
             }
 
-            if let Some(wft) = maybe_buffered.get_next_wft() {
-                res = self.instantiate_or_update(wft);
-                // TODO: Insert buffered into newly instantiated run
-            } else {
+            let maybe_buffered_wft = maybe_buffered
+                .get_next_wft()
                 // Attempt to apply a buffered poll for some *other* run, if we didn't have a wft
                 // from complete or a buffered poll for *this* run.
-                if let Some(buff) = self.buffered_polls_need_cache_slot.pop_front() {
-                    res = self.instantiate_or_update(buff);
-                }
+                .or_else(|| self.buffered_polls_need_cache_slot.pop_front());
+            if let Some(wft) = maybe_buffered_wft {
+                res = self.instantiate_or_update(wft);
+                // We accept that there might be tasks remaining in the buffer if we evicted and
+                // re-instantiated here. It's likely those tasks are now invalidated anyway.
             }
         }
 

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -31,7 +31,6 @@ use tracing::{Level, Span};
 pub(super) struct WFStream {
     runs: RunCache,
     /// Buffered polls for new runs which need a cache slot to open up before we can handle them
-    /// TODO: Does this even need to exist any more?
     buffered_polls_need_cache_slot: VecDeque<PermittedWFT>,
     /// Is filled with runs that we decided need to have their history fetched during state
     /// manipulation. Must be drained after handling each input.

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -431,7 +431,7 @@ async fn query_superseded_by_newer_wft_is_discarded() {
             )
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
         core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
             task.run_id,
             QueryResult {


### PR DESCRIPTION


## What was changed
Better task buffering.

## Why?
To avoid timing out concurrent queries. There is no reason to buffer more than one WFT, speculative or not, for the reasons described in the second issue. We already definitely will never try to apply more than one WFT at a time if the split brain edge case mentioned there happens.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/578 and closes https://github.com/temporalio/sdk-core/issues/578

3. How was this tested:
New tests

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
