### PR TITLE
Update WfContext::cancelled to take &self instead of &mut self

### DIFF
--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -165,11 +165,12 @@ impl WfContext {
     }
 
     /// A future that resolves if/when the workflow is cancelled
-    pub async fn cancelled(&mut self) {
+    pub async fn cancelled(&self) {
         if *self.am_cancelled.borrow() {
             return;
         }
         self.am_cancelled
+            .clone()
             .changed()
             .await
             .expect("Cancelled send half not dropped");


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated the receiver for `WfContext::cancelled` to take in &self.

## Why?
<!-- Tell your future self why have you made these changes -->
It's the only method on `WfContext` that takes `&mut self` which makes it tricky to track workflow cancellation in addition to waiting for activities to complete.