### PR TITLE
Fix dashmap version in Cargo.toml

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1"
 base64 = "0.21"
 console-subscriber = { version = "0.1", optional = true }
 crossbeam = "0.8"
-dashmap = "5.0"
+dashmap = "5.5"
 derive_builder = "0.12"
 derive_more = "0.99"
 enum_dispatch = "0.3"


### PR DESCRIPTION
We're using APIs that are [only available](https://github.com/xacrimon/dashmap/compare/v5.4.0...v5.5.0) in v5.5 (e.g. `.insert()` is used in `core/src/worker/activities.rs`). In practice, when compiling sdk-core alone, v5.5 was already what was being picked up and there was no problem. However, when sdk-core is compiled as a crate in the sdk-typescript core-bridge project, v5.4 is getting picked up, with the result that sdk-core fails to build in that context.