### PR TITLE
Fix panic on evict w/ buffered tasks

### DIFF
--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -386,7 +386,7 @@ impl WFStream {
                 // We accept that there might be query tasks remaining in the buffer if we evicted
                 // and re-instantiated here. It's likely those tasks are now invalidated anyway.
                 if maybe_buffered.has_tasks() && should_evict {
-                    panic!("There were leftover buffered tasks");
+                    warn!("There were leftover buffered tasks when evicting run");
                 }
             }
         }


### PR DESCRIPTION
This never should have been a panic in the first place. I think I had it that way while testing and forgot to undo it. It's fairly hard to trigger.