### PR TITLE
Remove a leftover dbg() statement

### DIFF
--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -107,7 +107,6 @@ where
         });
 
         client.expect_complete_workflow_task().returning(move |a| {
-            dbg!(a);
             async move { Ok(RespondWorkflowTaskCompletedResponse::default()) }.boxed()
         });
         client

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -106,7 +106,7 @@ where
             .boxed()
         });
 
-        client.expect_complete_workflow_task().returning(move |a| {
+        client.expect_complete_workflow_task().returning(move |_a| {
             async move { Ok(RespondWorkflowTaskCompletedResponse::default()) }.boxed()
         });
         client


### PR DESCRIPTION
## What was changed

- Remove a leftover `dbg!()` statement

## Why?

- @antlai-temporal's investigation identified this as probable cause of some recent failures in TS SDK's tests.