### PR TITLE
Remove dbg!(a) to improve CI robustness

### DIFF
--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -106,8 +106,7 @@ where
             .boxed()
         });
 
-        client.expect_complete_workflow_task().returning(move |a| {
-            dbg!(a);
+        client.expect_complete_workflow_task().returning(move |_a| {
             async move { Ok(RespondWorkflowTaskCompletedResponse::default()) }.boxed()
         });
         client


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

Remove dbg!(a) in src/replay/mod.rs

## Why?
<!-- Tell your future self why have you made these changes -->

Logging large data structures sometimes hangs the CI tests, forcing manual retries.
