### PR TITLE
Fix deprecated patch removal when no subequent command

### DIFF
--- a/client/src/workflow_handle/mod.rs
+++ b/client/src/workflow_handle/mod.rs
@@ -91,6 +91,10 @@ where
         }
     }
 
+    pub fn info(&self) -> &WorkflowExecutionInfo {
+        &self.info
+    }
+
     pub async fn get_workflow_result(
         &self,
         opts: GetWorkflowResultOpts,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -240,9 +240,7 @@ impl CoreWfStarter {
 
     /// Start the workflow defined by the builder and return run id
     pub async fn start_wf(&mut self) -> String {
-        let mut worker = self.worker().await;
-        self.start_with_worker(self.task_queue_name.clone(), &mut worker)
-            .await
+        self.start_wf_with_id(self.task_queue_name.clone()).await
     }
 
     pub async fn start_with_worker(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -240,7 +240,9 @@ impl CoreWfStarter {
 
     /// Start the workflow defined by the builder and return run id
     pub async fn start_wf(&mut self) -> String {
-        self.start_wf_with_id(self.task_queue_name.clone()).await
+        let mut worker = self.worker().await;
+        self.start_with_worker(self.task_queue_name.clone(), &mut worker)
+            .await
     }
 
     pub async fn start_with_worker(

--- a/tests/integ_tests/workflow_tests/patches.rs
+++ b/tests/integ_tests/workflow_tests/patches.rs
@@ -5,6 +5,9 @@ use std::{
     },
     time::Duration,
 };
+use temporal_client::WorkflowClientTrait;
+use tokio::{join, sync::Notify};
+use tokio_stream::StreamExt;
 
 use temporal_sdk::{WfContext, WorkflowResult};
 use temporal_sdk_core_test_utils::CoreWfStarter;
@@ -150,4 +153,50 @@ async fn can_remove_deprecated_patch_near_other_patch() {
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
+}
+
+#[tokio::test]
+async fn deprecated_patch_removal() {
+    let wf_name = "deprecated_patch_removal";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.no_remote_activities();
+    let mut worker = starter.worker().await;
+    let client = starter.get_client().await;
+    let wf_id = starter.get_task_queue().to_string();
+    let did_die = Arc::new(AtomicBool::new(false));
+    let send_sig = Arc::new(Notify::new());
+    let send_sig_c = send_sig.clone();
+    worker.fetch_results = false;
+    worker.register_wf(wf_id.clone(), move |ctx: WfContext| {
+        let did_die = did_die.clone();
+        let send_sig_c = send_sig_c.clone();
+        async move {
+            if !did_die.load(Ordering::Acquire) {
+                assert!(ctx.deprecate_patch("getting-deprecated"));
+            }
+            send_sig_c.notify_one();
+            ctx.make_signal_channel("sig").next().await;
+
+            ctx.timer(Duration::from_millis(1)).await;
+
+            if !did_die.load(Ordering::Acquire) {
+                did_die.store(true, Ordering::Release);
+                ctx.force_task_fail(anyhow::anyhow!("i'm ded"));
+            }
+            Ok(().into())
+        }
+    });
+
+    starter.start_wf().await;
+    let sig_fut = async {
+        send_sig.notified().await;
+        client
+            .signal_workflow_execution(wf_id, "".to_string(), "sig".to_string(), None, None)
+            .await
+            .unwrap()
+    };
+    let run_fut = async {
+        worker.run_until_done().await.unwrap();
+    };
+    join!(sig_fut, run_fut);
 }

--- a/tests/integ_tests/workflow_tests/patches.rs
+++ b/tests/integ_tests/workflow_tests/patches.rs
@@ -166,8 +166,7 @@ async fn deprecated_patch_removal() {
     let did_die = Arc::new(AtomicBool::new(false));
     let send_sig = Arc::new(Notify::new());
     let send_sig_c = send_sig.clone();
-    worker.fetch_results = false;
-    worker.register_wf(wf_id.clone(), move |ctx: WfContext| {
+    worker.register_wf(wf_name, move |ctx: WfContext| {
         let did_die = did_die.clone();
         let send_sig_c = send_sig_c.clone();
         async move {
@@ -187,7 +186,7 @@ async fn deprecated_patch_removal() {
         }
     });
 
-    starter.start_wf().await;
+    starter.start_with_worker(wf_name, &mut worker).await;
     let sig_fut = async {
         send_sig.notified().await;
         client


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixes a bug where removing a deprecated patch call could trigger nondeterminism if there is no subsequent command

## Why?
Bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/670

2. How was this tested:
Added integ test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
