### PR TITLE
Query buffering fixes

### DIFF
--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -895,7 +895,6 @@ async fn build_id_set_properly_on_query_on_first_task() {
 
 #[tokio::test]
 async fn queries_arent_lost_in_buffer_void() {
-    crate::telemetry::test_telem_console();
     let wfid = "fake_wf_id";
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -20,6 +20,7 @@ use mockall::TimesRange;
 use parking_lot::RwLock;
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    fmt::Debug,
     ops::{Deref, DerefMut},
     pin::Pin,
     sync::{
@@ -720,6 +721,14 @@ impl<T> Deref for QueueResponse<T> {
 impl<T> DerefMut for QueueResponse<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.resp
+    }
+}
+impl<T> Debug for QueueResponse<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.resp.fmt(f)
     }
 }
 

--- a/sdk-core-protos/src/history_info.rs
+++ b/sdk-core-protos/src/history_info.rs
@@ -6,7 +6,7 @@ use crate::temporal::api::{
     workflowservice::v1::{GetWorkflowExecutionHistoryResponse, PollWorkflowTaskQueueResponse},
 };
 use anyhow::{anyhow, bail};
-use rand::{thread_rng, Rng};
+use rand::random;
 
 /// Contains information about a validated history. Used for replay and other testing.
 #[derive(Clone, Debug, PartialEq)]
@@ -154,7 +154,7 @@ impl HistoryInfo {
     /// randomly generated task token. Caller should attach a meaningful `workflow_execution` if
     /// needed.
     pub fn as_poll_wft_response(&self) -> PollWorkflowTaskQueueResponse {
-        let task_token: [u8; 16] = thread_rng().gen();
+        let task_token: [u8; 16] = random();
         PollWorkflowTaskQueueResponse {
             history: Some(History {
                 events: self.events.clone(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Made buffered queries be appropriately handled before a new "real" WFT if one is received while still handling an outstanding one.

## Why?
The previous implementation banked on failing the tasks with the now "stale" queries if a new "real" WFT is received while they are buffered causing server to retry them while the client is still waiting on the query response. For whatever reason this doesn't always work. Instead, the implementation will now try to handle all buffered queries before applying the next real WFT. This potentially slows things down in very high-query-load scenarios, but that's more-or-less what Go and Java do and no one complains. Users shouldn't spam queries that hard anyway.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/672

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
