### PR TITLE
Prefix some errors with rule identifiers

### DIFF
--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -1331,7 +1331,7 @@ impl From<OutgoingJob> for WorkflowActivationJob {
 /// Errors thrown inside of workflow machines
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum WFMachinesError {
-    #[error("Nondeterminism error: {0}")]
+    #[error("[TMPRL1100] Nondeterminism error: {0}")]
     Nondeterminism(String),
     #[error("Fatal error in workflow machines: {0}")]
     Fatal(String),


### PR DESCRIPTION
## What was changed

Add a couple of https://github.com/temporalio/rules references as error prefixes