### PR TITLE
Fix CI test flake

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --include-ignored --nocapture
+          args: use_cache_2_false::history_responses_case_3_3 -- --include-ignored --nocapture
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-report

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --include-ignored
+          args: -- --include-ignored --nocapture
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-report

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -49,8 +49,6 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
-    env:
-      RUST_BACKTRACE: 1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -67,7 +65,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: use_cache_2_false::history_responses_case_3_3 -- --include-ignored --nocapture
+          args: -- --include-ignored --nocapture
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-report

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -49,6 +49,8 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2735,15 +2735,12 @@ async fn use_compatible_version_flag(
 ) {
     let wfid = "fake_wf_id";
     let mut mock_client = mock_workflow_client();
-    let hist = {
+    let t = {
         let mut t = TestHistoryBuilder::default();
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_full_wf_task();
         t
     };
-    mock_client.expect_poll_workflow_task().returning(move |_| {
-        Ok(hist_to_poll_resp(&hist, wfid.to_owned(), ResponseType::AllHistory).resp)
-    });
     let compat_flag_expected = match intent {
         VersioningIntent::Unspecified => !different_tq,
         VersioningIntent::Compatible => true,
@@ -2768,7 +2765,8 @@ async fn use_compatible_version_flag(
             Ok(Default::default())
         });
 
-    let worker = Worker::new_test(test_worker_cfg().build().unwrap(), mock_client);
+    let mock = single_hist_mock_sg(wfid, t, vec![ResponseType::AllHistory], mock_client, true);
+    let worker = mock_worker(mock);
     let r = worker.poll_workflow_activation().await.unwrap();
     let task_queue = if different_tq {
         "enchi cat!".to_string()
@@ -2804,6 +2802,7 @@ async fn use_compatible_version_flag(
         .complete_workflow_activation(WorkflowActivationCompletion::from_cmd(r.run_id, cmd))
         .await
         .unwrap();
+    worker.shutdown().await;
 }
 
 #[tokio::test]

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2607,6 +2607,7 @@ async fn history_length_with_fail_and_timeout(
         }
     });
     worker.register_wf(DEFAULT_WORKFLOW_TYPE, |ctx: WfContext| async move {
+        dbg!("Workflow starting");
         assert_eq!(ctx.history_length(), 3);
         ctx.timer(Duration::from_secs(1)).await;
         assert_eq!(ctx.history_length(), 14);

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2612,6 +2612,7 @@ async fn history_length_with_fail_and_timeout(
         assert_eq!(ctx.history_length(), 14);
         ctx.timer(Duration::from_secs(1)).await;
         assert_eq!(ctx.history_length(), 19);
+        dbg!("Workflow ending");
         Ok(().into())
     });
     worker

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2624,7 +2624,9 @@ async fn history_length_with_fail_and_timeout(
         )
         .await
         .unwrap();
+    dbg!("Running");
     worker.run_until_done().await.unwrap();
+    dbg!("Done");
 }
 
 #[tokio::test]

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2605,13 +2605,11 @@ async fn history_length_with_fail_and_timeout(
         }
     });
     worker.register_wf(DEFAULT_WORKFLOW_TYPE, |ctx: WfContext| async move {
-        dbg!("Workflow starting");
         assert_eq!(ctx.history_length(), 3);
         ctx.timer(Duration::from_secs(1)).await;
         assert_eq!(ctx.history_length(), 14);
         ctx.timer(Duration::from_secs(1)).await;
         assert_eq!(ctx.history_length(), 19);
-        dbg!("Workflow ending");
         Ok(().into())
     });
     worker
@@ -2623,9 +2621,7 @@ async fn history_length_with_fail_and_timeout(
         )
         .await
         .unwrap();
-    dbg!("Running");
     worker.run_until_done().await.unwrap();
-    dbg!("Done");
 }
 
 #[tokio::test]

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -450,8 +450,7 @@ mod test {
         hm.shutdown().await;
     }
 
-    /// Ensure that heartbeat can be called from a tight loop without any throttle_interval, resulting in two
-    /// interactions with the server - one immediately and one after 500ms after the throttle_interval.
+    /// Ensure that heartbeat can be called from a tight loop and correctly throttle
     #[tokio::test]
     async fn process_tight_loop_and_shutdown() {
         let mut mock_client = mock_workflow_client();

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -1246,7 +1246,7 @@ mod tests {
         // Wait more than the timeout before grabbing the task
         sleep(timeout + Duration::from_millis(10)).await;
 
-        assert!(dbg!(lam.next_pending().await.unwrap()).is_timeout(false));
+        assert!(lam.next_pending().await.unwrap().is_timeout(false));
         assert_eq!(lam.num_in_backoff(), 0);
         assert_eq!(lam.num_outstanding(), 0);
     }

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -1250,7 +1250,6 @@ mod tests {
         });
 
         let mut worker = build_fake_sdk(mock_cfg);
-        dbg!("Past thing");
         worker.register_wf(DEFAULT_WORKFLOW_TYPE, la_wf);
         worker.register_activity(
             DEFAULT_ACTIVITY_TYPE,


### PR DESCRIPTION
A particular test was hanging semi-consistently in CI despite being impossible to repro locally. 

I found a handful of other tests were panicking in the workflow processing thread because they did not perform orderly shutdowns. Fixing those has also fixed the hanging flake.