### PR TITLE
Updates for update reapply 

### DIFF
--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -781,7 +781,10 @@ impl WorkflowMachines {
                 Ok(EventHandlingOutcome::Normal)
             };
         }
-        if event.event_type() == EventType::Unspecified || event.attributes.is_none() {
+        if event.event_type() == EventType::Unspecified
+            || event.event_type() == EventType::WorkflowExecutionUpdateRequested
+            || event.attributes.is_none()
+        {
             return if !event.worker_may_ignore {
                 Err(WFMachinesError::Fatal(format!(
                     "Event type is unspecified! This history is invalid. Event detail: {event:?}"

--- a/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/event_type.proto
+++ b/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/event_type.proto
@@ -167,4 +167,8 @@ enum EventType {
     EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY = 45;
     // Workflow properties modified by user workflow code
     EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED = 46;
+    // An update was requested. Note that not all update requests result in this
+    // event. See UpdateRequestedEventOrigin for situations in which this event
+    // is created.
+    EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REQUESTED = 47;
 }

--- a/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/reset.proto
+++ b/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/reset.proto
@@ -31,13 +31,26 @@ option java_outer_classname = "ResetProto";
 option ruby_package = "Temporalio::Api::Enums::V1";
 option csharp_namespace = "Temporalio.Api.Enums.V1";
 
-// Reset reapply (replay) options
-// * RESET_REAPPLY_TYPE_SIGNAL (default) - Signals are reapplied when workflow is reset
-// * RESET_REAPPLY_TYPE_NONE - nothing is reapplied
+// Event types to exclude when reapplying events.
+enum ResetReapplyExcludeType {
+    RESET_REAPPLY_EXCLUDE_TYPE_UNSPECIFIED = 0;
+    // Exclude signals when reapplying events.
+    RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL = 1;
+    // Exclude updates when reapplying events.
+    RESET_REAPPLY_EXCLUDE_TYPE_UPDATE = 2;
+}
+
+// Event types to include when reapplying events. Deprecated: applications
+// should use ResetReapplyExcludeType to specify exclusions from this set, and
+// new event types should be added to ResetReapplyExcludeType instead of here.
 enum ResetReapplyType {
     RESET_REAPPLY_TYPE_UNSPECIFIED = 0;
+    // Signals are reapplied when workflow is reset.
     RESET_REAPPLY_TYPE_SIGNAL = 1;
+    // No events are reapplied when workflow is reset.
     RESET_REAPPLY_TYPE_NONE = 2;
+    // All eligible events are reapplied when workflow is reset.
+    RESET_REAPPLY_TYPE_ALL_ELIGIBLE = 3;
 }
 
 // Reset type options. Deprecated, see temporal.api.common.v1.ResetOptions.

--- a/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/update.proto
+++ b/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/update.proto
@@ -54,3 +54,14 @@ enum UpdateWorkflowExecutionLifecycleStage {
     // on a worker and has either been rejected or returned a value or an error.
     UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED = 3;
 }
+
+// UpdateRequestedEventOrigin records why an
+// WorkflowExecutionUpdateRequestedEvent was written to history. Note that not
+// all update requests result in a WorkflowExecutionUpdateRequestedEvent.
+enum UpdateRequestedEventOrigin {
+    UPDATE_REQUESTED_EVENT_ORIGIN_UNSPECIFIED = 0;
+    // The UpdateRequested event was created when reapplying events during reset
+    // or replication. I.e. an accepted update on one branch of workflow history
+    // was converted into a requested update on a different branch.
+    UPDATE_REQUESTED_EVENT_ORIGIN_REAPPLY = 1;
+}

--- a/sdk-core-protos/protos/api_upstream/temporal/api/history/v1/message.proto
+++ b/sdk-core-protos/protos/api_upstream/temporal/api/history/v1/message.proto
@@ -36,6 +36,7 @@ import "google/protobuf/timestamp.proto";
 
 import "temporal/api/enums/v1/event_type.proto";
 import "temporal/api/enums/v1/failed_cause.proto";
+import "temporal/api/enums/v1/update.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
@@ -434,6 +435,8 @@ message WorkflowExecutionSignaledEventAttributes {
     temporal.api.common.v1.Header header = 4;
     // Indicates the signal did not generate a new workflow task when received.
     bool skip_generate_workflow_task = 5;
+    // When signal origin is a workflow execution, this field is set.
+    temporal.api.common.v1.WorkflowExecution external_workflow_execution = 6;
 }
 
 message WorkflowExecutionTerminatedEventAttributes {
@@ -747,6 +750,12 @@ message WorkflowExecutionUpdateRejectedEventAttributes {
     temporal.api.failure.v1.Failure failure = 5;
 }
 
+message WorkflowExecutionUpdateRequestedEventAttributes {
+    // The update request associated with this event.
+    temporal.api.update.v1.Request request = 1;
+    // A record of why this event was written to history.
+    temporal.api.enums.v1.UpdateRequestedEventOrigin origin = 2;
+}
 
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.
 // See the `EventType` enum for more info about what each event is for.
@@ -812,6 +821,7 @@ message HistoryEvent {
         WorkflowPropertiesModifiedExternallyEventAttributes workflow_properties_modified_externally_event_attributes = 49;
         ActivityPropertiesModifiedExternallyEventAttributes activity_properties_modified_externally_event_attributes = 50;
         WorkflowPropertiesModifiedEventAttributes workflow_properties_modified_event_attributes = 51;
+        WorkflowExecutionUpdateRequestedEventAttributes workflow_execution_update_requested_event_attributes = 52;
     }
 }
 

--- a/sdk-core-protos/protos/api_upstream/temporal/api/workflowservice/v1/request_response.proto
+++ b/sdk-core-protos/protos/api_upstream/temporal/api/workflowservice/v1/request_response.proto
@@ -669,8 +669,11 @@ message ResetWorkflowExecutionRequest {
     int64 workflow_task_finish_event_id = 4;
     // Used to de-dupe reset requests
     string request_id = 5;
-    // Reset reapply (replay) options.
+    // Event types to be reapplied (deprecated)
+    // Default: RESET_REAPPLY_TYPE_ALL_ELIGIBLE
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
+    // Event types not to be reapplied
+    repeated temporal.api.enums.v1.ResetReapplyExcludeType reset_reapply_exclude_types = 7;
 }
 
 message ResetWorkflowExecutionResponse {

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1981,6 +1981,7 @@ pub mod temporal {
                             Attributes::WorkflowExecutionUpdateRejectedEventAttributes(_) => {EventType::WorkflowExecutionUpdateRejected}
                             Attributes::WorkflowExecutionUpdateAcceptedEventAttributes(_) => {EventType::WorkflowExecutionUpdateAccepted}
                             Attributes::WorkflowExecutionUpdateCompletedEventAttributes(_) => {EventType::WorkflowExecutionUpdateCompleted}
+                            Attributes::WorkflowExecutionUpdateRequestedEventAttributes(_) => {EventType::WorkflowExecutionUpdateRequested}
                             Attributes::WorkflowPropertiesModifiedExternallyEventAttributes(_) => {EventType::WorkflowPropertiesModifiedExternally}
                             Attributes::ActivityPropertiesModifiedExternallyEventAttributes(_) => {EventType::ActivityPropertiesModifiedExternally}
                             Attributes::WorkflowPropertiesModifiedEventAttributes(_) => {EventType::WorkflowPropertiesModified}


### PR DESCRIPTION
Update sdk-core to work with the new `EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REQUESTED` event added in https://github.com/temporalio/api/pull/351

### How this was tested
I have built `sdk-python` against this branch and have an in-progress server branch that demonstrates correct processing of the new update event by `sdk-python`: https://github.com/temporalio/temporal/pull/5361