### PR TITLE
Fix possibly sending LA marker after WF Complete command

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -1322,7 +1322,7 @@ async fn local_activity_after_wf_complete_is_discarded() {
                 assert_eq!(wft.commands.len(), 2);
                 assert_eq!(wft.commands[0].command_type(), CommandType::RecordMarker);
                 assert_eq!(
-                    wft.commands[0].command_type(),
+                    wft.commands[1].command_type(),
                     CommandType::CompleteWorkflowExecution
                 );
             });
@@ -1368,18 +1368,6 @@ async fn local_activity_after_wf_complete_is_discarded() {
         );
         barr.wait().await;
         core.complete_execution(&task.run_id).await;
-        let shutdown = core.poll_workflow_activation().await.unwrap_err();
-        assert_matches!(shutdown, PollWfError::ShutDown);
-        // dbg!(&task);
-        // assert_matches!(
-        //     task.jobs.as_slice(),
-        //     [WorkflowActivationJob {
-        //         variant: Some(workflow_activation_job::Variant::ResolveActivity(_)),
-        //     }]
-        // );
-        // core.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
-        //     .await
-        //     .unwrap();
     };
 
     let at_poller = async {
@@ -1401,6 +1389,6 @@ async fn local_activity_after_wf_complete_is_discarded() {
     };
 
     join!(wf_poller, at_poller);
-
-    core.shutdown().await;
+    dbg!("Just waiting for shutdown!");
+    core.drain_pollers_and_shutdown().await;
 }

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -2,8 +2,8 @@ use crate::{
     prost_dur,
     replay::{default_wes_attribs, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE},
     test_help::{
-        hist_to_poll_resp, mock_sdk, mock_sdk_cfg, mock_worker, single_hist_mock_sg, MockPollCfg,
-        ResponseType, WorkerExt,
+        build_mock_pollers, hist_to_poll_resp, mock_sdk, mock_sdk_cfg, mock_worker,
+        single_hist_mock_sg, MockPollCfg, ResponseType, WorkerExt,
     },
     worker::{client::mocks::mock_workflow_client, LEGACY_QUERY_ID},
 };
@@ -38,7 +38,7 @@ use temporal_sdk_core_protos::{
     },
     temporal::api::{
         common::v1::RetryPolicy,
-        enums::v1::{EventType, TimeoutType, WorkflowTaskFailedCause},
+        enums::v1::{CommandType, EventType, TimeoutType, WorkflowTaskFailedCause},
         failure::v1::{failure::FailureInfo, Failure},
         query::v1::WorkflowQuery,
     },
@@ -1294,4 +1294,113 @@ async fn queries_can_be_received_while_heartbeating() {
     .unwrap();
 
     core.drain_pollers_and_shutdown().await;
+}
+
+#[tokio::test]
+async fn local_activity_after_wf_complete_is_discarded() {
+    crate::telemetry::test_telem_console();
+    let wfid = "fake_wf_id";
+    let mut t = TestHistoryBuilder::default();
+    t.add_wfe_started_with_wft_timeout(Duration::from_millis(500));
+    t.add_full_wf_task();
+    t.add_workflow_task_scheduled_and_started();
+
+    let mock = mock_workflow_client();
+    let mut mock_cfg = MockPollCfg::from_resp_batches(
+        wfid,
+        t,
+        [ResponseType::ToTaskNum(1), ResponseType::ToTaskNum(2)],
+        mock,
+    );
+    mock_cfg.make_poll_stream_interminable = true;
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 0);
+            })
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 2);
+                assert_eq!(wft.commands[0].command_type(), CommandType::RecordMarker);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+            });
+    });
+    let mut mock = build_mock_pollers(mock_cfg);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
+    let core = mock_worker(mock);
+
+    let barr = Barrier::new(2);
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+        task.run_id,
+        vec![
+            ScheduleLocalActivity {
+                seq: 1,
+                activity_id: "1".to_string(),
+                activity_type: "test_act".to_string(),
+                start_to_close_timeout: Some(prost_dur!(from_secs(30))),
+                ..Default::default()
+            }
+            .into(),
+            ScheduleLocalActivity {
+                seq: 2,
+                activity_id: "2".to_string(),
+                activity_type: "test_act".to_string(),
+                start_to_close_timeout: Some(prost_dur!(from_secs(30))),
+                ..Default::default()
+            }
+            .into(),
+        ],
+    ))
+    .await
+    .unwrap();
+
+    let wf_poller = async {
+        let task = core.poll_workflow_activation().await.unwrap();
+        assert_matches!(
+            task.jobs.as_slice(),
+            [WorkflowActivationJob {
+                variant: Some(workflow_activation_job::Variant::ResolveActivity(_)),
+            }]
+        );
+        barr.wait().await;
+        core.complete_execution(&task.run_id).await;
+        let shutdown = core.poll_workflow_activation().await.unwrap_err();
+        assert_matches!(shutdown, PollWfError::ShutDown);
+        // dbg!(&task);
+        // assert_matches!(
+        //     task.jobs.as_slice(),
+        //     [WorkflowActivationJob {
+        //         variant: Some(workflow_activation_job::Variant::ResolveActivity(_)),
+        //     }]
+        // );
+        // core.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
+        //     .await
+        //     .unwrap();
+    };
+
+    let at_poller = async {
+        let act_task = core.poll_activity_task().await.unwrap();
+        core.complete_activity_task(ActivityTaskCompletion {
+            task_token: act_task.task_token,
+            result: Some(ActivityExecutionResult::ok(vec![1].into())),
+        })
+        .await
+        .unwrap();
+        let act_task = core.poll_activity_task().await.unwrap();
+        barr.wait().await;
+        core.complete_activity_task(ActivityTaskCompletion {
+            task_token: act_task.task_token,
+            result: Some(ActivityExecutionResult::ok(vec![2].into())),
+        })
+        .await
+        .unwrap();
+    };
+
+    join!(wf_poller, at_poller);
+
+    core.shutdown().await;
 }

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -1298,10 +1298,9 @@ async fn queries_can_be_received_while_heartbeating() {
 
 #[tokio::test]
 async fn local_activity_after_wf_complete_is_discarded() {
-    crate::telemetry::test_telem_console();
     let wfid = "fake_wf_id";
     let mut t = TestHistoryBuilder::default();
-    t.add_wfe_started_with_wft_timeout(Duration::from_millis(500));
+    t.add_wfe_started_with_wft_timeout(Duration::from_millis(200));
     t.add_full_wf_task();
     t.add_workflow_task_scheduled_and_started();
 
@@ -1389,6 +1388,5 @@ async fn local_activity_after_wf_complete_is_discarded() {
     };
 
     join!(wf_poller, at_poller);
-    dbg!("Just waiting for shutdown!");
     core.drain_pollers_and_shutdown().await;
 }

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1467,6 +1467,9 @@ impl WorkflowMachines {
         let cwfm = self.add_new_command_machine(machine);
         self.workflow_end_time = Some(SystemTime::now());
         self.current_wf_task_commands.push_back(cwfm);
+        // Wipe out any pending / executing local activity data since we're about to terminate
+        // and there's nothing to be done with them.
+        self.local_activity_data.indicate_terminating();
     }
 
     /// Add a new command/machines for that command to the current workflow task

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -368,6 +368,7 @@ impl ManagedRun {
         used_flags: Vec<u32>,
         resp_chan: Option<oneshot::Sender<ActivationCompleteResult>>,
     ) -> Result<RunUpdateAct, NextPageReq> {
+        dbg!(&commands);
         let activation_was_only_eviction = self.activation_has_only_eviction();
         let (task_token, has_pending_query, start_time) = if let Some(entry) = self.wft.as_ref() {
             (
@@ -642,6 +643,7 @@ impl ManagedRun {
         }
 
         let outcome = (|| {
+            let has_terminal_command = completion.commands.iter().any(|c| c.is_terminal());
             // Send commands from lang into the machines then check if the workflow run needs
             // another activation and mark it if so
             self.wfm.push_commands_and_iterate(completion.commands)?;
@@ -652,24 +654,29 @@ impl ManagedRun {
             if !completion.activation_was_eviction {
                 self.wfm.apply_next_task_if_ready()?;
             }
-            let new_local_acts = self.wfm.drain_queued_local_activities();
-            self.sink_la_requests(new_local_acts)?;
-
-            if self.wfm.machines.outstanding_local_activity_count() == 0 {
+            // If this completion is about to terminate the workflow, we can immediately stop
+            // considering any remaining outstanding local activities.
+            if has_terminal_command {
                 Ok(None)
             } else {
-                let wft_timeout: Duration = self
-                    .wfm
-                    .machines
-                    .get_started_info()
-                    .and_then(|attrs| attrs.workflow_task_timeout)
-                    .ok_or_else(|| {
-                        WFMachinesError::Fatal(
-                            "Workflow's start attribs were missing a well formed task timeout"
-                                .to_string(),
-                        )
-                    })?;
-                Ok(Some((completion.start_time, wft_timeout)))
+                let new_local_acts = self.wfm.drain_queued_local_activities();
+                self.sink_la_requests(new_local_acts)?;
+                if self.wfm.machines.outstanding_local_activity_count() == 0 {
+                    Ok(None)
+                } else {
+                    let wft_timeout: Duration = self
+                        .wfm
+                        .machines
+                        .get_started_info()
+                        .and_then(|attrs| attrs.workflow_task_timeout)
+                        .ok_or_else(|| {
+                            WFMachinesError::Fatal(
+                                "Workflow's start attribs were missing a well formed task timeout"
+                                    .to_string(),
+                            )
+                        })?;
+                    Ok(Some((completion.start_time, wft_timeout)))
+                }
             }
         })();
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Detect terminal commands and avoid doing anything else with LAs other than issuing cancels to outstanding ones.

Also fixed a possible shutdown hang that this surfaced.

## Why?
Bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/659

2. How was this tested:
Added unit test which repro'd issue consistently, fixed it.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
