### PR TITLE
sdk: allow example code to run

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -25,6 +25,7 @@
 //!     let worker_config = WorkerConfigBuilder::default()
 //!         .namespace("default")
 //!         .task_queue("task_queue")
+//!         .worker_build_id("rust-sdk")
 //!         .build()?;
 //!
 //!     let core_worker = init_worker(&runtime, worker_config, client)?;


### PR DESCRIPTION
## What was changed
When running the Rust SDK example, the binary exits with `Error: UninitializedField("worker_build_id")`.

## Why?
Would be nice to have the example work out of the box, even while the Rust SDK is not actually released.

## Checklist
1. How was this tested: ran the code after adding this change, it runs without error
2. Any docs updates needed: probably not at this stage?