### PR TITLE
Wait for activity completes to reach server before shutdown

### DIFF
--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -1144,8 +1144,8 @@ async fn activities_must_be_flushed_to_server_on_shutdown() {
         .times(1)
         .returning(|_, _| {
             async {
+                // We need some artificial delay here and there's nothing meaningful to sync with
                 tokio::time::sleep(Duration::from_millis(200)).await;
-                dbg!("complete done");
                 if shutdown_finished.load(Ordering::Acquire) {
                     panic!("Shutdown must complete *after* server sees the activity completion");
                 }
@@ -1170,10 +1170,8 @@ async fn activities_must_be_flushed_to_server_on_shutdown() {
     let shutdown_task = async {
         worker.drain_activity_poller_and_shutdown().await;
         shutdown_finished.store(true, Ordering::Release);
-        dbg!("Shutdown done");
     };
     let complete_task = async {
-        // tokio::time::sleep(Duration::from_millis(200)).await;
         worker
             .complete_activity_task(ActivityTaskCompletion {
                 task_token: task.task_token,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make sure we flush activity completions to server before shutting down

## Why?
It's nice. We already wait for outstanding activities to complete. It makes sense to make sure we actually do something with those results.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/594

2. How was this tested:
Added UT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
