### PR TITLE
client: clarify encoding of ClientTlsConfig field data

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -151,9 +151,9 @@ pub struct TlsConfig {
 /// If using mTLS, both the client cert and private key must be specified, this contains them.
 #[derive(Clone)]
 pub struct ClientTlsConfig {
-    /// The certificate for this client
+    /// The certificate for this client, encoded as PEM
     pub client_cert: Vec<u8>,
-    /// The private key for this client
+    /// The private key for this client, encoded as PEM
     pub client_private_key: Vec<u8>,
 }
 


### PR DESCRIPTION
## What was changed
Add a `_pem` suffix to both `ClientTlsConfig` fields, and remove the `client_` prefix (which is redundant with the `ClientTlsConfig` type name) to try to balance the length increase.

## Why?
While trying to get a Rust SDK worker connected to Temporal Cloud, I got a `TonicTransportError(tonic::transport::Error(Transport, PrivateKeyParseError))`. This turned out to because I was passing DER-encoded private key and certificate to `ClientTlsConfig` instead of PEM. tonic's [`Identity::from_pem()`](https://docs.rs/tonic/latest/tonic/transport/struct.Identity.html#method.from_pem) makes it obvious that they should be PEM, but that context isn't obvious when looking at the rustdoc for `temporal_client::ClientTlsConfig` (and in fact, because it uses a `Vec<u8>` type instead of a `String` type, it suggests using DER over PEM).

## Checklist
1. How was this tested: no logic affected, so relying on the compiler
2. Any doc updates needed: should be reflected in rustdoc automatically