### PR TITLE
sdk: remove unnecessary Debug constraints

### DIFF
--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -271,9 +271,7 @@ impl TemporalitySelector for ConstantTemporality {
         self.0
     }
 }
-fn metric_temporality_to_selector(
-    t: MetricTemporality,
-) -> impl TemporalitySelector + Send + Sync + Clone {
+fn metric_temporality_to_selector(t: MetricTemporality) -> impl TemporalitySelector + Clone {
     match t {
         MetricTemporality::Cumulative => ConstantTemporality(Temporality::Cumulative),
         MetricTemporality::Delta => ConstantTemporality(Temporality::Delta),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -772,13 +772,17 @@ impl<T> WfExitValue<T> {
 }
 
 /// Activity functions may return these values when exiting
-#[derive(derive_more::From)]
-pub enum ActExitValue<T: Debug> {
+pub enum ActExitValue<T> {
     /// Completion requires an asynchronous callback
-    #[from(ignore)]
     WillCompleteAsync,
     /// Finish with a result
     Normal(T),
+}
+
+impl<T: AsJsonPayloadExt> From<T> for ActExitValue<T> {
+    fn from(t: T) -> Self {
+        Self::Normal(t)
+    }
 }
 
 type BoxActFn = Arc<

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -711,7 +711,7 @@ impl<F, Fut, O> From<F> for WorkflowFunction
 where
     F: Fn(WfContext) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<WfExitValue<O>, anyhow::Error>> + Send + 'static,
-    O: Serialize + Debug,
+    O: Serialize,
 {
     fn from(wf_func: F) -> Self {
         Self::new(wf_func)
@@ -724,7 +724,7 @@ impl WorkflowFunction {
     where
         F: Fn(WfContext) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<WfExitValue<O>, anyhow::Error>> + Send + 'static,
-        O: Serialize + Debug,
+        O: Serialize,
     {
         Self {
             wf_func: Box::new(move |ctx: WfContext| {
@@ -750,7 +750,7 @@ pub type WorkflowResult<T> = Result<WfExitValue<T>, anyhow::Error>;
 
 /// Workflow functions may return these values when exiting
 #[derive(Debug, derive_more::From)]
-pub enum WfExitValue<T: Debug> {
+pub enum WfExitValue<T> {
     /// Continue the workflow as a new execution
     #[from(ignore)]
     ContinueAsNew(Box<ContinueAsNewWorkflowExecution>),
@@ -764,7 +764,7 @@ pub enum WfExitValue<T: Debug> {
     Normal(T),
 }
 
-impl<T: Debug> WfExitValue<T> {
+impl<T> WfExitValue<T> {
     /// Construct a [WfExitValue::ContinueAsNew] variant (handles boxing)
     pub fn continue_as_new(can: ContinueAsNewWorkflowExecution) -> Self {
         Self::ContinueAsNew(Box::new(can))
@@ -835,7 +835,7 @@ where
     A: FromJsonPayloadExt + Send,
     Rf: Future<Output = Result<R, anyhow::Error>> + Send + 'static,
     R: Into<ActExitValue<O>>,
-    O: AsJsonPayloadExt + Debug,
+    O: AsJsonPayloadExt,
 {
     fn into_activity_fn(self) -> BoxActFn {
         let wrapper = move |ctx: ActContext, input: Payload| {


### PR DESCRIPTION
## What was changed
Removed the `Debug` constraint for `ActExitValue` and `WfExitValue` type parameters.

## Why?
I ran into this while trying to convert some code to a Temporal activity, and was surprised by these constraints. They don't seem to actually be used by anything in the core SDK repo, so it seems safe to remove?

## Checklist
1. How was this tested: `cargo check --all-targets` still passes
2. Any docs updates needed: rustdoc should take care of this