### PR TITLE
Use fine-grained features for derive_more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 license-file = "LICENSE.txt"
 
 [workspace.dependencies]
+derive_more = { version = "0.99", default-features = false, features = ["constructor", "display", "from", "into"] }
 tonic = "0.9"
 tonic-build = "0.9"
 opentelemetry = "0.21"

--- a/core-api/Cargo.toml
+++ b/core-api/Cargo.toml
@@ -18,7 +18,7 @@ otel_impls = ["opentelemetry"]
 [dependencies]
 async-trait = "0.1"
 derive_builder = "0.12"
-derive_more = "0.99"
+derive_more = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 prost-types = "0.11"
 serde = { version = "1.0", default_features = false, features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,7 +31,7 @@ crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"
 dashmap = "5.5"
 derive_builder = "0.12"
-derive_more = "0.99"
+derive_more = { workspace = true }
 enum_dispatch = "0.3"
 enum-iterator = "1.4"
 flate2 = { version = "1.0", optional = true }

--- a/fsm/rustfsm_procmacro/Cargo.toml
+++ b/fsm/rustfsm_procmacro/Cargo.toml
@@ -14,7 +14,7 @@ name = "tests"
 path = "tests/progress.rs"
 
 [dependencies]
-derive_more = "0.99"
+derive_more = { workspace = true }
 proc-macro2 = "1.0"
 syn = { version = "2.0", features = ["default", "extra-traits"] }
 quote = "1.0"

--- a/sdk-core-protos/Cargo.toml
+++ b/sdk-core-protos/Cargo.toml
@@ -17,7 +17,7 @@ serde_serialize = []
 [dependencies]
 anyhow = "1.0"
 base64 = "0.21"
-derive_more = "0.99"
+derive_more = { workspace = true }
 prost = "0.11"
 prost-wkt = "0.4"
 prost-wkt-types = "0.4"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 base64 = "0.21"
 crossbeam-channel = "0.5"
-derive_more = "0.99"
+derive_more = { workspace = true }
 futures = "0.3"
 once_cell = "1.10"
 parking_lot = { version = "0.12", features = ["send_guard"] }


### PR DESCRIPTION
## What was changed

Changed the derive_more dependency to specify `default-features = "false"` plus a minimal set of derives that are actually used.

## Why?

Helps minimize transitive dependencies brought in by derive_more.

## Checklist

1. Closes: related to #687
2. How was this tested: it still compiles
3. Any docs updates needed: no