### PR TITLE
Remove lazy-static in favor of once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license-file = "LICENSE.txt"
 
 [workspace.dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["constructor", "display", "from", "into"] }
+once_cell = "1.16"
 tonic = "0.9"
 tonic-build = "0.9"
 opentelemetry = "0.21"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,7 +19,7 @@ derive_more = "0.99"
 futures = "0.3"
 futures-retry = "0.6.0"
 http = "0.2"
-once_cell = "1.13"
+once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 parking_lot = "0.12"
 prost-types = "0.11"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,11 +41,10 @@ governor = "0.6"
 http = "0.2"
 hyper = "0.14"
 itertools = "0.11"
-lazy_static = "1.4"
 lru = "0.11"
 mockall = "0.11"
 nix = { version = "0.27", optional = true, features = ["process", "signal"] }
-once_cell = "1.5"
+once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.21", features = ["rt-tokio", "metrics"] }
 opentelemetry-otlp = { version = "0.14", features = ["tokio", "metrics"] }

--- a/core/src/core_tests/mod.rs
+++ b/core/src/core_tests/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     Worker,
 };
 use futures::FutureExt;
+use once_cell::sync::Lazy;
 use std::time::Duration;
 use temporal_sdk_core_api::Worker as WorkerTrait;
 use temporal_sdk_core_protos::coresdk::workflow_completion::WorkflowActivationCompletion;
@@ -45,9 +46,8 @@ async fn after_shutdown_server_is_not_polled() {
 }
 
 // Better than cloning a billion arcs...
-lazy_static::lazy_static! {
-    static ref BARR: Barrier = Barrier::new(3);
-}
+static BARR: Lazy<Barrier> = Lazy::new(|| Barrier::new(3));
+
 #[tokio::test]
 async fn shutdown_interrupts_both_polls() {
     let mut mock_client = mock_manual_workflow_client();

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -1,12 +1,11 @@
 use super::*;
 use futures::Future;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::sync::Arc;
 use temporal_client::SlotManager;
 
-lazy_static! {
-    pub(crate) static ref DEFAULT_WORKERS_REGISTRY: Arc<SlotManager> = Arc::new(SlotManager::new());
-}
+static DEFAULT_WORKERS_REGISTRY: Lazy<Arc<SlotManager>> =
+    Lazy::new(|| Arc::new(SlotManager::new()));
 
 pub(crate) static DEFAULT_TEST_CAPABILITIES: &Capabilities = &Capabilities {
     signal_and_query_header: true,

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use futures::{future::BoxFuture, FutureExt, Stream};
 use itertools::Itertools;
+use once_cell::sync::Lazy;
 use std::{
     collections::VecDeque,
     fmt::Debug,
@@ -23,12 +24,11 @@ use temporal_sdk_core_protos::temporal::api::{
 };
 use tracing::Instrument;
 
-lazy_static::lazy_static! {
-    static ref EMPTY_FETCH_ERR: tonic::Status
-        = tonic::Status::unknown("Fetched empty history page");
-    static ref EMPTY_TASK_ERR: tonic::Status
-        = tonic::Status::unknown("Received an empty workflow task with no queries or history");
-}
+static EMPTY_FETCH_ERR: Lazy<tonic::Status> =
+    Lazy::new(|| tonic::Status::unknown("Fetched empty history page"));
+static EMPTY_TASK_ERR: Lazy<tonic::Status> = Lazy::new(|| {
+    tonic::Status::unknown("Received an empty workflow task with no queries or history")
+});
 
 /// Represents one or more complete WFT sequences. History events are expected to be consumed from
 /// it and applied to the state machines via [HistoryUpdate::take_next_wft_sequence]

--- a/core/src/worker/workflow/machines/transition_coverage.rs
+++ b/core/src/worker/workflow/machines/transition_coverage.rs
@@ -4,6 +4,7 @@
 //! never ever be removed from behind `#[cfg(test)]` compilation.
 
 use dashmap::{mapref::entry::Entry, DashMap, DashSet};
+use once_cell::sync::Lazy;
 use std::{
     path::PathBuf,
     sync::{
@@ -15,13 +16,11 @@ use std::{
 };
 
 // During test we want to know about which transitions we've covered in state machines
-lazy_static::lazy_static! {
-    static ref COVERED_TRANSITIONS: DashMap<String, DashSet<CoveredTransition>>
-        = DashMap::new();
-    static ref COVERAGE_SENDER: SyncSender<(String, CoveredTransition)> =
-        spawn_save_coverage_at_end();
-    static ref THREAD_HANDLE: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
-}
+static COVERED_TRANSITIONS: Lazy<DashMap<String, DashSet<CoveredTransition>>> =
+    Lazy::new(DashMap::new);
+static COVERAGE_SENDER: Lazy<SyncSender<(String, CoveredTransition)>> =
+    Lazy::new(spawn_save_coverage_at_end);
+static THREAD_HANDLE: Lazy<Mutex<Option<JoinHandle<()>>>> = Lazy::new(|| Mutex::new(None));
 
 #[derive(Eq, PartialEq, Hash, Debug)]
 struct CoveredTransition {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.21"
 crossbeam-channel = "0.5"
 derive_more = { workspace = true }
 futures = "0.3"
-once_cell = "1.10"
+once_cell = { workspace = true }
 parking_lot = { version = "0.12", features = ["send_guard"] }
 prost-types = { version = "0.4", package = "prost-wkt-types" }
 sha2 = "0.10"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.21"
 bytes = "1.3"
 futures = "0.3"
 log = "0.4"
-once_cell = "1.16"
+once_cell = { workspace = true }
 parking_lot = "0.12"
 prost = "0.11"
 prost-types = "0.11"

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail};
 use assert_matches::assert_matches;
 use futures_util::{future, future::join_all, StreamExt};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::{
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     time::Duration,
@@ -817,9 +817,7 @@ async fn worker_restarted_in_middle_of_update() {
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
 
-    lazy_static! {
-        static ref BARR: Barrier = Barrier::new(2);
-    }
+    static BARR: Lazy<Barrier> = Lazy::new(|| Barrier::new(2));
     static ACT_RAN: AtomicBool = AtomicBool::new(false);
     worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
         ctx.update_handler(


### PR DESCRIPTION
## What was changed

Removed dependencies on lazy-static in favor of once_cell. Use a workspace dependency to manage the once_cell dependency in one place.

## Why?

lazy-static is [effectively deprecated](https://github.com/rust-lang-nursery/lazy-static.rs/issues/214) and the ecosystem has largely moved over to once_cell. once_cell has a more ergonomic API.

## Checklist

1. How was this tested: still compiles
2. Any docs updates needed: don't think so?