### PR TITLE
Slow down retries so we keep retrying for more than 10 seconds.

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -200,7 +200,7 @@ impl Default for RetryConfig {
         Self {
             initial_interval: Duration::from_millis(100), // 100 ms wait by default.
             randomization_factor: 0.2,                    // +-20% jitter.
-            multiplier: 1.5, // each next retry delay will increase by 50%
+            multiplier: 1.7, // each next retry delay will increase by 70%
             max_interval: Duration::from_secs(5), // until it reaches 5 seconds.
             max_elapsed_time: Some(Duration::from_secs(10)), // 10 seconds total allocated time for all retries.
             max_retries: 10,


### PR DESCRIPTION
## What was changed
* Increase backoff factor to 1.7 (from 1.5) for non-poll RPCs

## Why?
The current backoff factor causes clients using the Core SDK to exhaust their retries within 6.011 to 8.966 seconds, depending on random jitter.  We want to ensure that all clients keep retrying for at least 10 seconds.  With the new backoff factor, retries will not be exhausted until 11.878 to 17.767 seconds after the initial failure.

This advances progress on https://github.com/temporalio/features/issues/27 (aka SDK-118 in internal Jira).