### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 license-file = "LICENSE.txt"
 
 [workspace.dependencies]
+derive_builder = "0.12"
 derive_more = { version = "0.99", default-features = false, features = ["constructor", "display", "from", "into"] }
 once_cell = "1.16"
 tonic = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 license-file = "LICENSE.txt"
 
 [workspace.dependencies]
-derive_builder = "0.12"
+derive_builder = "0.20"
 derive_more = { version = "0.99", default-features = false, features = ["constructor", "display", "from", "into"] }
 once_cell = "1.16"
 tonic = "0.9"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 anyhow = "1.0"
 async-trait = "0.1"
 backoff = "0.4"
-derive_builder = "0.12"
+derive_builder = { workspace = true }
 derive_more = "0.99"
 futures = "0.3"
 futures-retry = "0.6.0"

--- a/core-api/Cargo.toml
+++ b/core-api/Cargo.toml
@@ -17,7 +17,7 @@ otel_impls = ["opentelemetry"]
 
 [dependencies]
 async-trait = "0.1"
-derive_builder = "0.12"
+derive_builder = { workspace = true }
 derive_more = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 prost-types = "0.11"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,7 @@ console-subscriber = { version = "0.1", optional = true }
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"
 dashmap = "5.5"
-derive_builder = "0.12"
+derive_builder = { workspace = true }
 derive_more = { workspace = true }
 enum_dispatch = "0.3"
 enum-iterator = "1.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ dashmap = "5.5"
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 enum_dispatch = "0.3"
-enum-iterator = "1.4"
+enum-iterator = "2"
 flate2 = { version = "1.0", optional = true }
 futures = "0.3"
 futures-util = "0.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,7 +40,7 @@ futures-util = "0.3"
 governor = "0.6"
 http = "0.2"
 hyper = "0.14"
-itertools = "0.11"
+itertools = "0.12"
 lru = "0.11"
 mockall = "0.11"
 nix = { version = "0.27", optional = true, features = ["process", "signal"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,7 +43,7 @@ hyper = "0.14"
 itertools = "0.12"
 lru = "0.11"
 mockall = "0.11"
-nix = { version = "0.27", optional = true, features = ["process", "signal"] }
+nix = { version = "0.28", optional = true, features = ["process", "signal"] }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.21", features = ["rt-tokio", "metrics"] }


### PR DESCRIPTION
## What was changed

Update outdated dependencies

## Why?

Should help reduce duplicate dependencies in downstream user's repositories. In particular, I noticed that the older derive_builder version pulls in older versions of syn and the darling crates.

## Checklist

1. How was this tested: `cargo lint && cargo test-lint`
2. Any docs updates needed: no