### PR TITLE
Explicit API key option on client

### DIFF
--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -1015,7 +1015,7 @@ mod tests {
     #[allow(dead_code)]
     async fn raw_client_retry_compiles() {
         let opts = ClientOptionsBuilder::default().build().unwrap();
-        let raw_client = opts.connect_no_namespace(None, None).await.unwrap();
+        let raw_client = opts.connect_no_namespace(None).await.unwrap();
         let mut retry_client = RetryClient::new(raw_client, opts.retry_config);
 
         let list_ns_req = ListNamespacesRequest::default();

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -307,11 +307,7 @@ impl EphemeralServer {
             .build()?;
         for _ in 0..50 {
             sleep(Duration::from_millis(100)).await;
-            if client_options
-                .connect_no_namespace(None, None)
-                .await
-                .is_ok()
-            {
+            if client_options.connect_no_namespace(None).await.is_ok() {
                 return success;
             }
         }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -17,7 +17,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let server_options = sdk_client_options(Url::from_str("http://localhost:7233")?).build()?;
 //!
-//!     let client = server_options.connect("default", None, None).await?;
+//!     let client = server_options.connect("default", None).await?;
 //!
 //!     let telemetry_options = TelemetryOptionsBuilder::default().build()?;
 //!     let runtime = CoreRuntime::new_assume_tokio(telemetry_options)?;

--- a/test-utils/src/histfetch.rs
+++ b/test-utils/src/histfetch.rs
@@ -11,7 +11,7 @@ use temporal_sdk_core_test_utils::get_integ_server_options;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let gw_opts = get_integ_server_options();
-    let client = gw_opts.connect("default", None, None).await?;
+    let client = gw_opts.connect("default", None).await?;
     let wf_id = std::env::args()
         .nth(1)
         .expect("must provide workflow id as only argument");

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -378,7 +378,7 @@ impl CoreWfStarter {
                     .expect("Worker config must be valid");
                 let client = Arc::new(
                     get_integ_server_options()
-                        .connect(cfg.namespace.clone(), None, None)
+                        .connect(cfg.namespace.clone(), None)
                         .await
                         .expect("Must connect"),
                 );

--- a/tests/integ_tests/client_tests.rs
+++ b/tests/integ_tests/client_tests.rs
@@ -17,7 +17,7 @@ async fn can_use_retry_client() {
 #[tokio::test]
 async fn can_use_retry_raw_client() {
     let opts = get_integ_server_options();
-    let raw_client = opts.connect_no_namespace(None, None).await.unwrap();
+    let raw_client = opts.connect_no_namespace(None).await.unwrap();
     let mut retry_client = RetryClient::new(raw_client, opts.retry_config);
     retry_client
         .describe_namespace(DescribeNamespaceRequest {
@@ -31,6 +31,6 @@ async fn can_use_retry_raw_client() {
 #[tokio::test]
 async fn calls_get_system_info() {
     let opts = get_integ_server_options();
-    let raw_client = opts.connect_no_namespace(None, None).await.unwrap();
+    let raw_client = opts.connect_no_namespace(None).await.unwrap();
     assert!(raw_client.get_client().capabilities().is_some());
 }

--- a/tests/integ_tests/ephemeral_server_tests.rs
+++ b/tests/integ_tests/ephemeral_server_tests.rs
@@ -124,7 +124,7 @@ async fn assert_ephemeral_server(server: &EphemeralServer) {
         .client_version("0.1.0".to_string())
         .build()
         .unwrap()
-        .connect_no_namespace(None, None)
+        .connect_no_namespace(None)
         .await
         .unwrap();
     let resp = client

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -72,7 +72,7 @@ async fn prometheus_metrics_exported() {
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
     let opts = get_integ_server_options();
     let mut raw_client = opts
-        .connect_no_namespace(rt.telemetry().get_temporal_metric_meter(), None)
+        .connect_no_namespace(rt.telemetry().get_temporal_metric_meter())
         .await
         .unwrap();
     assert!(raw_client.get_client().capabilities().is_some());
@@ -125,7 +125,7 @@ async fn one_slot_worker_reports_available_slot() {
 
     let client = Arc::new(
         get_integ_server_options()
-            .connect(worker_cfg.namespace.clone(), None, None)
+            .connect(worker_cfg.namespace.clone(), None)
             .await
             .expect("Must connect"),
     );
@@ -453,7 +453,7 @@ fn runtime_new() {
     let opts = get_integ_server_options();
     handle.block_on(async {
         let mut raw_client = opts
-            .connect_no_namespace(rt.telemetry().get_temporal_metric_meter(), None)
+            .connect_no_namespace(rt.telemetry().get_temporal_metric_meter())
             .await
             .unwrap();
         assert!(raw_client.get_client().capabilities().is_some());

--- a/tests/integ_tests/visibility_tests.rs
+++ b/tests/integ_tests/visibility_tests.rs
@@ -91,7 +91,7 @@ async fn client_list_open_closed_workflow_executions() {
 async fn client_create_namespace() {
     let client = Arc::new(
         get_integ_server_options()
-            .connect(NAMESPACE.to_owned(), None, None)
+            .connect(NAMESPACE.to_owned(), None)
             .await
             .expect("Must connect"),
     );
@@ -138,7 +138,7 @@ async fn client_create_namespace() {
 async fn client_describe_namespace() {
     let client = Arc::new(
         get_integ_server_options()
-            .connect(NAMESPACE.to_owned(), None, None)
+            .connect(NAMESPACE.to_owned(), None)
             .await
             .expect("Must connect"),
     );

--- a/tests/integ_tests/workflow_tests/eager.rs
+++ b/tests/integ_tests/workflow_tests/eager.rs
@@ -33,7 +33,7 @@ async fn eager_wf_start_different_clients() {
     worker.register_wf(wf_name.to_owned(), eager_wf);
 
     let client = get_integ_server_options()
-        .connect(NAMESPACE.to_string(), None, None)
+        .connect(NAMESPACE.to_string(), None)
         .await
         .expect("Should connect");
     let w = starter.get_worker().await;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -38,7 +38,7 @@ mod integ_tests {
         let opts = get_integ_server_options();
         let runtime = CoreRuntime::new_assume_tokio(get_integ_telem_options()).unwrap();
         let mut retrying_client = opts
-            .connect_no_namespace(runtime.telemetry().get_temporal_metric_meter(), None)
+            .connect_no_namespace(runtime.telemetry().get_temporal_metric_meter())
             .await
             .unwrap();
 
@@ -85,7 +85,7 @@ mod integ_tests {
             .build()
             .unwrap();
         let con = sgo
-            .connect("spencer.temporal-dev".to_string(), None, None)
+            .connect("spencer.temporal-dev".to_string(), None)
             .await
             .unwrap();
         dbg!(con


### PR DESCRIPTION
## What was changed

* Move `headers` from `connect` to the `ClientOptions` (💥 - intentional compatibility break)
* Add `api_key` to `ClientOptions` and `set_api_key` on client to use as an "Authorization" bearer header if that header not already set

## Checklist

1. Closes #695