### PR TITLE
Rename WorkflowExecutionUpdateRequested

### DIFF
--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -782,7 +782,7 @@ impl WorkflowMachines {
             };
         }
         if event.event_type() == EventType::Unspecified
-            || event.event_type() == EventType::WorkflowExecutionUpdateRequested
+            || event.event_type() == EventType::WorkflowExecutionUpdateAdmitted
             || event.attributes.is_none()
         {
             return if !event.worker_may_ignore {

--- a/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/event_type.proto
+++ b/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/event_type.proto
@@ -167,8 +167,8 @@ enum EventType {
     EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY = 45;
     // Workflow properties modified by user workflow code
     EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED = 46;
-    // An update was requested. Note that not all update requests result in this
+    // An update was admitted. Note that not all admitted updates result in this
     // event. See UpdateRequestedEventOrigin for situations in which this event
     // is created.
-    EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REQUESTED = 47;
+    EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED = 47;
 }

--- a/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/update.proto
+++ b/sdk-core-protos/protos/api_upstream/temporal/api/enums/v1/update.proto
@@ -55,13 +55,12 @@ enum UpdateWorkflowExecutionLifecycleStage {
     UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED = 3;
 }
 
-// UpdateRequestedEventOrigin records why an
-// WorkflowExecutionUpdateRequestedEvent was written to history. Note that not
-// all update requests result in a WorkflowExecutionUpdateRequestedEvent.
-enum UpdateRequestedEventOrigin {
-    UPDATE_REQUESTED_EVENT_ORIGIN_UNSPECIFIED = 0;
-    // The UpdateRequested event was created when reapplying events during reset
+// Records why a WorkflowExecutionUpdateAdmittedEvent was written to history.
+// Note that not all admitted updates result in this event.
+enum UpdateAdmittedEventOrigin {
+    UPDATE_ADMITTED_EVENT_ORIGIN_UNSPECIFIED = 0;
+    // The UpdateAdmitted event was created when reapplying events during reset
     // or replication. I.e. an accepted update on one branch of workflow history
-    // was converted into a requested update on a different branch.
-    UPDATE_REQUESTED_EVENT_ORIGIN_REAPPLY = 1;
+    // was converted into an admitted update on a different branch.
+    UPDATE_ADMITTED_EVENT_ORIGIN_REAPPLY = 1;
 }

--- a/sdk-core-protos/protos/api_upstream/temporal/api/history/v1/message.proto
+++ b/sdk-core-protos/protos/api_upstream/temporal/api/history/v1/message.proto
@@ -750,11 +750,11 @@ message WorkflowExecutionUpdateRejectedEventAttributes {
     temporal.api.failure.v1.Failure failure = 5;
 }
 
-message WorkflowExecutionUpdateRequestedEventAttributes {
+message WorkflowExecutionUpdateAdmittedEventAttributes {
     // The update request associated with this event.
     temporal.api.update.v1.Request request = 1;
-    // A record of why this event was written to history.
-    temporal.api.enums.v1.UpdateRequestedEventOrigin origin = 2;
+    // An explanation of why this event was written to history.
+    temporal.api.enums.v1.UpdateAdmittedEventOrigin origin = 2;
 }
 
 // History events are the method by which Temporal SDKs advance (or recreate) workflow state.
@@ -821,7 +821,7 @@ message HistoryEvent {
         WorkflowPropertiesModifiedExternallyEventAttributes workflow_properties_modified_externally_event_attributes = 49;
         ActivityPropertiesModifiedExternallyEventAttributes activity_properties_modified_externally_event_attributes = 50;
         WorkflowPropertiesModifiedEventAttributes workflow_properties_modified_event_attributes = 51;
-        WorkflowExecutionUpdateRequestedEventAttributes workflow_execution_update_requested_event_attributes = 52;
+        WorkflowExecutionUpdateAdmittedEventAttributes workflow_execution_update_admitted_event_attributes = 52;
     }
 }
 

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1957,7 +1957,7 @@ pub mod temporal {
                             Attributes::WorkflowExecutionUpdateRejectedEventAttributes(_) => {EventType::WorkflowExecutionUpdateRejected}
                             Attributes::WorkflowExecutionUpdateAcceptedEventAttributes(_) => {EventType::WorkflowExecutionUpdateAccepted}
                             Attributes::WorkflowExecutionUpdateCompletedEventAttributes(_) => {EventType::WorkflowExecutionUpdateCompleted}
-                            Attributes::WorkflowExecutionUpdateRequestedEventAttributes(_) => {EventType::WorkflowExecutionUpdateRequested}
+                            Attributes::WorkflowExecutionUpdateAdmittedEventAttributes(_) => {EventType::WorkflowExecutionUpdateAdmitted}
                             Attributes::WorkflowPropertiesModifiedExternallyEventAttributes(_) => {EventType::WorkflowPropertiesModifiedExternally}
                             Attributes::ActivityPropertiesModifiedExternallyEventAttributes(_) => {EventType::ActivityPropertiesModifiedExternally}
                             Attributes::WorkflowPropertiesModifiedEventAttributes(_) => {EventType::WorkflowPropertiesModified}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Renamed `WorkflowExecutionUpdateRequested` to `WorkflowExecutionUpdateAdmitted` to match latest API change.

The protos were only updated to match the API rename change as pulling in _all_ changes resulted in compilation errors.

The PR to introduce these was https://github.com/temporalio/sdk-core/pull/677/files

## Why?
<!-- Tell your future self why have you made these changes -->

Follow-up to https://github.com/temporalio/api/pull/387
