### PR TITLE
HTTP CONNECT proxy support

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,11 +17,13 @@ telemetry = ["dep:opentelemetry"]
 anyhow = "1.0"
 async-trait = "0.1"
 backoff = "0.4"
+base64 = "0.21.7"
 derive_builder = { workspace = true }
 derive_more = "0.99"
 futures = "0.3"
 futures-retry = "0.6.0"
 http = "0.2"
+hyper = { version = "0.14.28" }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"], optional = true  }
 parking_lot = "0.12"

--- a/client/src/proxy.rs
+++ b/client/src/proxy.rs
@@ -1,0 +1,85 @@
+use base64::prelude::*;
+use hyper::header;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+use tokio::net::TcpStream;
+use tonic::transport::Channel;
+use tonic::transport::Endpoint;
+use tower::{service_fn, Service};
+
+/// Options for HTTP CONNECT proxy.
+#[derive(Clone, Debug)]
+pub struct HttpConnectProxyOptions {
+    /// The host:port to proxy through.
+    pub target_addr: String,
+    /// Optional HTTP basic auth for the proxy.
+    pub basic_auth: Option<(String, String)>,
+}
+
+impl HttpConnectProxyOptions {
+    /// Create a channel from the given endpoint that uses the HTTP CONNECT proxy.
+    pub async fn connect_endpoint(
+        &self,
+        endpoint: &Endpoint,
+    ) -> Result<Channel, tonic::transport::Error> {
+        let proxy_options = self.clone();
+        let svc_fn = service_fn(move |uri: tonic::transport::Uri| {
+            let proxy_options = proxy_options.clone();
+            async move { proxy_options.connect(uri).await }
+        });
+        endpoint.connect_with_connector(svc_fn).await
+    }
+
+    async fn connect(
+        &self,
+        uri: tonic::transport::Uri,
+    ) -> anyhow::Result<hyper::upgrade::Upgraded> {
+        debug!("Connecting to {} via proxy at {}", uri, self.target_addr);
+        // Create CONNECT request
+        let mut req_build = hyper::Request::builder().method("CONNECT").uri(uri);
+        if let Some((user, pass)) = &self.basic_auth {
+            let creds = BASE64_STANDARD.encode(format!("{}:{}", user, pass));
+            req_build = req_build.header(header::PROXY_AUTHORIZATION, format!("Basic {}", creds));
+        }
+        let req = req_build.body(hyper::Body::empty())?;
+
+        // We have to create a client with a specific connector because Hyper is
+        // not letting us change the HTTP/2 authority
+        let client =
+            hyper::Client::builder().build(OverrideAddrConnector(self.target_addr.clone()));
+
+        // Send request
+        let res = client.request(req).await?;
+        if res.status().is_success() {
+            Ok(hyper::upgrade::on(res).await?)
+        } else {
+            Err(anyhow::anyhow!(
+                "CONNECT call failed with status: {}",
+                res.status()
+            ))
+        }
+    }
+}
+
+#[derive(Clone)]
+struct OverrideAddrConnector(String);
+
+impl Service<hyper::Uri> for OverrideAddrConnector {
+    type Response = TcpStream;
+
+    type Error = anyhow::Error;
+
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _ctx: &mut Context<'_>) -> Poll<anyhow::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _uri: hyper::Uri) -> Self::Future {
+        let target_addr = self.0.clone();
+        let fut = async move { Ok(TcpStream::connect(target_addr).await?) };
+        Box::pin(fut)
+    }
+}

--- a/client/src/proxy.rs
+++ b/client/src/proxy.rs
@@ -14,7 +14,7 @@ use tower::{service_fn, Service};
 pub struct HttpConnectProxyOptions {
     /// The host:port to proxy through.
     pub target_addr: String,
-    /// Optional HTTP basic auth for the proxy.
+    /// Optional HTTP basic auth for the proxy as user/pass tuple.
     pub basic_auth: Option<(String, String)>,
 }
 


### PR DESCRIPTION
## What was changed

* Added new `client::proxy` module for HTTP CONNECT support
  * Hyper/Tonic don't support this natively, so some workarounds had to be done
  * Based on user need, this also includes authentication
* Added new `http_connect_proxy` client option

Can't really perform a test of this without a more involved integration test that has a full proxy server implementation. I have manually tested this with Python SDK using this version of core and connecting to Temporal cloud through the proxy. Now that proxies are officially supported by Temporal, there's a feature PR at https://github.com/temporalio/features/pull/447 for testing them, and Python will be added once this is merged and the Python SDK is updated

## Checklist

1. Closes #309