### PR TITLE
Worker client replacement

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -296,7 +296,7 @@ pub struct ConfiguredClient<C> {
     options: Arc<ClientOptions>,
     headers: Arc<RwLock<ClientHeaders>>,
     /// Capabilities as read from the `get_system_info` RPC call made on client connection
-    capabilities: Option<get_system_info_response::Capabilities>,
+    capabilities: Arc<Option<get_system_info_response::Capabilities>>,
     workers: Arc<SlotManager>,
 }
 
@@ -318,8 +318,8 @@ impl<C> ConfiguredClient<C> {
 
     /// Returns the server capabilities we (may have) learned about when establishing an initial
     /// connection
-    pub fn capabilities(&self) -> Option<&get_system_info_response::Capabilities> {
-        self.capabilities.as_ref()
+    pub fn capabilities(&self) -> Arc<Option<get_system_info_response::Capabilities>> {
+        self.capabilities.clone()
     }
 
     /// Returns a cloned reference to a registry with workers using this client instance
@@ -435,7 +435,7 @@ impl ClientOptions {
             headers,
             client: TemporalServiceClient::new(svc),
             options: Arc::new(self.clone()),
-            capabilities: None,
+            capabilities: Arc::new(None),
             workers: Arc::new(SlotManager::new()),
         };
         match client
@@ -443,7 +443,7 @@ impl ClientOptions {
             .await
         {
             Ok(sysinfo) => {
-                client.capabilities = sysinfo.into_inner().capabilities;
+                client.capabilities = Arc::new(sysinfo.into_inner().capabilities);
             }
             Err(status) => match status.code() {
                 Code::Unimplemented => {}

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -7,25 +7,27 @@ use temporal_client::SlotManager;
 static DEFAULT_WORKERS_REGISTRY: Lazy<Arc<SlotManager>> =
     Lazy::new(|| Arc::new(SlotManager::new()));
 
-pub(crate) static DEFAULT_TEST_CAPABILITIES: &Capabilities = &Capabilities {
-    signal_and_query_header: true,
-    internal_error_differentiation: true,
-    activity_failure_include_heartbeat: true,
-    supports_schedules: true,
-    encoded_failure_attributes: true,
-    build_id_based_versioning: true,
-    upsert_memo: true,
-    eager_workflow_start: true,
-    sdk_metadata: true,
-    count_group_by_execution_status: false,
-};
+pub(crate) static DEFAULT_TEST_CAPABILITIES: Lazy<Arc<Option<Capabilities>>> = Lazy::new(|| {
+    Arc::new(Some(Capabilities {
+        signal_and_query_header: true,
+        internal_error_differentiation: true,
+        activity_failure_include_heartbeat: true,
+        supports_schedules: true,
+        encoded_failure_attributes: true,
+        build_id_based_versioning: true,
+        upsert_memo: true,
+        eager_workflow_start: true,
+        sdk_metadata: true,
+        count_group_by_execution_status: false,
+    }))
+});
 
 #[cfg(test)]
 /// Create a mock client primed with basic necessary expectations
 pub(crate) fn mock_workflow_client() -> MockWorkerClient {
     let mut r = MockWorkerClient::new();
     r.expect_capabilities()
-        .returning(|| Some(DEFAULT_TEST_CAPABILITIES));
+        .returning(|| DEFAULT_TEST_CAPABILITIES.clone());
     r.expect_workers()
         .returning(|| DEFAULT_WORKERS_REGISTRY.clone());
     r.expect_is_mock().returning(|| true);
@@ -36,7 +38,7 @@ pub(crate) fn mock_workflow_client() -> MockWorkerClient {
 pub(crate) fn mock_manual_workflow_client() -> MockManualWorkerClient {
     let mut r = MockManualWorkerClient::new();
     r.expect_capabilities()
-        .returning(|| Some(DEFAULT_TEST_CAPABILITIES));
+        .returning(|| DEFAULT_TEST_CAPABILITIES.clone());
     r.expect_workers()
         .returning(|| DEFAULT_WORKERS_REGISTRY.clone());
     r.expect_is_mock().returning(|| true);
@@ -115,7 +117,9 @@ mockall::mock! {
         ) -> impl Future<Output = Result<RespondQueryTaskCompletedResponse>> + Send + 'b
             where 'a: 'b, Self: 'b;
 
-        fn capabilities(&self) -> Option<&'static get_system_info_response::Capabilities>;
+        fn replace_client(&self, new_client: RetryClient<Client>);
+
+        fn capabilities(&self) -> Arc<Option<get_system_info_response::Capabilities>>;
 
         fn workers(&self) -> Arc<SlotManager>;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -146,7 +146,7 @@ pub async fn history_from_proto_binary(path_from_root: &str) -> Result<History, 
 }
 
 static INTEG_TESTS_RT: once_cell::sync::OnceCell<CoreRuntime> = once_cell::sync::OnceCell::new();
-pub fn init_integ_telem() {
+pub fn init_integ_telem() -> &'static CoreRuntime {
     INTEG_TESTS_RT.get_or_init(|| {
         let telemetry_options = get_integ_telem_options();
         let rt =
@@ -155,7 +155,7 @@ pub fn init_integ_telem() {
             let _ = tracing::subscriber::set_global_default(sub);
         }
         rt
-    });
+    })
 }
 
 /// Implements a builder pattern to help integ tests initialize core and create workflows

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -1,16 +1,26 @@
 use assert_matches::assert_matches;
+use std::sync::Arc;
 use std::time::Duration;
+use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions};
+use temporal_sdk_core::ephemeral_server::TemporalDevServerConfigBuilder;
+use temporal_sdk_core::{init_worker, ClientOptionsBuilder, WorkerConfigBuilder};
+use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::coresdk::{
     activity_task::activity_task as act_task,
     workflow_activation::{workflow_activation_job, FireTimer, WorkflowActivationJob},
-    workflow_commands::{ActivityCancellationType, RequestCancelActivity, StartTimer},
+    workflow_commands::{
+        ActivityCancellationType, CompleteWorkflowExecution, RequestCancelActivity, StartTimer,
+    },
     workflow_completion::WorkflowActivationCompletion,
     IntoCompletion,
 };
 use temporal_sdk_core_test_utils::{
-    init_core_and_create_wf, schedule_activity_cmd, WorkerTestHelpers,
+    default_cached_download, drain_pollers_and_shutdown, init_core_and_create_wf, init_integ_telem,
+    schedule_activity_cmd, WorkerTestHelpers,
 };
 use tokio::time::timeout;
+use tracing::info;
+use url::Url;
 
 #[tokio::test]
 async fn out_of_order_completion_doesnt_hang() {
@@ -87,4 +97,126 @@ async fn out_of_order_completion_doesnt_hang() {
     .unwrap();
 
     jh.await.unwrap();
+}
+
+#[tokio::test]
+async fn switching_worker_client_changes_poll() {
+    // Start two servers
+    info!("Starting servers");
+    let server_config = TemporalDevServerConfigBuilder::default()
+        .exe(default_cached_download())
+        // We need to lower the poll timeout so the poll call rolls over
+        .extra_args(vec![
+            "--dynamic-config-value".to_string(),
+            "matching.longPollExpirationInterval=\"1s\"".to_string(),
+        ])
+        .build()
+        .unwrap();
+    let mut server1 = server_config.start_server().await.unwrap();
+    let mut server2 = server_config.start_server().await.unwrap();
+
+    // Connect clients to both servers
+    info!("Connecting clients");
+    let client1 = ClientOptionsBuilder::default()
+        .identity("integ_tester".to_owned())
+        .target_url(Url::parse(&format!("http://{}", server1.target)).unwrap())
+        .client_name("temporal-core".to_owned())
+        .client_version("0.1.0".to_owned())
+        .build()
+        .unwrap()
+        .connect("default", None)
+        .await
+        .unwrap();
+    let client2 = ClientOptionsBuilder::default()
+        .identity("integ_tester".to_owned())
+        .target_url(Url::parse(&format!("http://{}", server2.target)).unwrap())
+        .client_name("temporal-core".to_owned())
+        .client_version("0.1.0".to_owned())
+        .build()
+        .unwrap()
+        .connect("default", None)
+        .await
+        .unwrap();
+
+    // Start a workflow on both servers
+    info!("Starting workflows");
+    let wf1 = client1
+        .start_workflow(
+            vec![],
+            "my-task-queue".to_owned(),
+            "my-workflow-1".to_owned(),
+            "my-workflow-type".to_owned(),
+            None,
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+    let wf2 = client2
+        .start_workflow(
+            vec![],
+            "my-task-queue".to_owned(),
+            "my-workflow-2".to_owned(),
+            "my-workflow-type".to_owned(),
+            None,
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    // Create a worker only on the first server
+    let worker = init_worker(
+        init_integ_telem(),
+        WorkerConfigBuilder::default()
+            .namespace("default")
+            .task_queue("my-task-queue")
+            .worker_build_id("test_build_id")
+            // We want a cache so we don't get extra remove-job activations
+            .max_cached_workflows(100_usize)
+            .build()
+            .unwrap(),
+        client1.clone(),
+    )
+    .unwrap();
+
+    // Poll for first task, confirm it's first wf, complete, and wait for complete
+    info!("Doing initial poll");
+    let act1 = worker.poll_workflow_activation().await.unwrap();
+    assert_eq!(wf1.run_id, act1.run_id);
+    worker
+        .complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+            act1.run_id,
+            vec![CompleteWorkflowExecution { result: None }.into()],
+        ))
+        .await
+        .unwrap();
+    info!("Waiting on first workflow complete");
+    client1
+        .get_untyped_workflow_handle("my-workflow-1", wf1.run_id)
+        .get_workflow_result(Default::default())
+        .await
+        .unwrap();
+
+    // Swap client, poll for next task, confirm it's second wf, and respond w/ empty
+    info!("Replacing client and polling again");
+    worker.replace_client(client2.get_client().inner().clone());
+    let act2 = worker.poll_workflow_activation().await.unwrap();
+    assert_eq!(wf2.run_id, act2.run_id);
+    worker
+        .complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+            act2.run_id,
+            vec![CompleteWorkflowExecution { result: None }.into()],
+        ))
+        .await
+        .unwrap();
+    info!("Waiting on second workflow complete");
+    client2
+        .get_untyped_workflow_handle("my-workflow-2", wf2.run_id)
+        .get_workflow_result(Default::default())
+        .await
+        .unwrap();
+
+    // Shutdown workers and servers
+    drain_pollers_and_shutdown(&(Arc::new(worker) as Arc<dyn Worker>)).await;
+    server1.shutdown().await.unwrap();
+    server2.shutdown().await.unwrap();
 }


### PR DESCRIPTION
## What was changed

Added `Worker::replace_client`. Notes:

* Replacement unregisters itself with old client and re-registers with new client for eager workflow start
* Uses lock of arc, so no currently operating poll on existing client will be interrupted (this has been tested)
* This is as close as we can reasonably get to dynamic client endpoints without working through Tonic's connectivity
  * This is actually much cleaner for SDKs since they only really care about this for workers and can't interrupt anything running anyways
* Had to change a few internal things but nothing drastic
* Wrote test that starts two servers and swaps between (had to lower polling timeout on them)

## Checklist

1. Closes #477