### PR TITLE
Remove Python 3.7's special ephemeral server kill

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp",
     "dep:opentelemetry-prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-util"]
 tokio-console = ["console-subscriber"]
 ephemeral-server = ["dep:flate2", "dep:nix", "dep:reqwest", "dep:tar", "dep:zip"]
+fix-python-37-zombie-processes = ["ephemeral-server"]
 
 [dependencies]
 anyhow = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,6 @@ otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp",
     "dep:opentelemetry-prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-util"]
 tokio-console = ["console-subscriber"]
 ephemeral-server = ["dep:flate2", "dep:nix", "dep:reqwest", "dep:tar", "dep:zip"]
-fix-python-37-zombie-processes = ["ephemeral-server"]
 
 [dependencies]
 anyhow = "1.0"

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -318,7 +318,7 @@ impl EphemeralServer {
     /// a kill if the child process appears completed, but such a check is not
     /// atomic so a kill could still fail as completed if completed just before
     /// kill.
-    #[cfg(not(target_family = "unix"))]
+    #[cfg(any(not(feature = "fix-python-37-zombie-processes"), not(target_family = "unix")))]
     pub async fn shutdown(&mut self) -> anyhow::Result<()> {
         // Only kill if there is a PID
         if self.child.id().is_some() {
@@ -332,7 +332,7 @@ impl EphemeralServer {
     /// a kill if the child process appears completed, but such a check is not
     /// atomic so a kill could still fail as completed if completed just before
     /// kill.
-    #[cfg(target_family = "unix")]
+    #[cfg(all(feature = "fix-python-37-zombie-processes", target_family = "unix"))]
     pub async fn shutdown(&mut self) -> anyhow::Result<()> {
         // For whatever reason, Tokio is not properly waiting on result
         // after sending kill in some cases which is causing defunct zombie

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -318,39 +318,10 @@ impl EphemeralServer {
     /// a kill if the child process appears completed, but such a check is not
     /// atomic so a kill could still fail as completed if completed just before
     /// kill.
-    #[cfg(any(not(feature = "fix-python-37-zombie-processes"), not(target_family = "unix")))]
     pub async fn shutdown(&mut self) -> anyhow::Result<()> {
         // Only kill if there is a PID
         if self.child.id().is_some() {
             Ok(self.child.kill().await?)
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Shutdown the server (i.e. kill the child process). This does not attempt
-    /// a kill if the child process appears completed, but such a check is not
-    /// atomic so a kill could still fail as completed if completed just before
-    /// kill.
-    #[cfg(all(feature = "fix-python-37-zombie-processes", target_family = "unix"))]
-    pub async fn shutdown(&mut self) -> anyhow::Result<()> {
-        // For whatever reason, Tokio is not properly waiting on result
-        // after sending kill in some cases which is causing defunct zombie
-        // processes to remain and kill() to hang. Therefore, we are sending
-        // SIGKILL and waiting on the process ourselves using a low-level call.
-        //
-        // WARNING: This is based on empirical evidence starting a Python test
-        // run on Linux with Python 3.7 (does not happen on Python 3.10 nor does
-        // it happen on Temporalite nor does it happen in Rust integration
-        // tests). Don't alter without running that scenario. EX: SIGINT works but not SIGKILL
-        if let Some(pid) = self.child.id() {
-            let nix_pid = nix::unistd::Pid::from_raw(pid as i32);
-            Ok(spawn_blocking(move || {
-                nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGINT)?;
-                nix::sys::wait::waitpid(Some(nix_pid), None)
-            })
-            .await?
-            .map(|_| ())?)
         } else {
             Ok(())
         }


### PR DESCRIPTION
## What was changed

- Removed the special handling of "ephemeral server kill" that had been introduced a long time ago to resolve the creation of zombie process on Python 3.7.

## Why

- It appears that this special kill handling was causing high number of CI flakes in TS SDK, and the special handling seems to no longer be required in Python, since we dropped support for Python 3.7, and 3.8+ doesn't reproduce the bug.

