### PR TITLE
client: allow public access to WorkflowHandle

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -27,7 +27,9 @@ pub use temporal_sdk_core_protos::temporal::api::{
 };
 pub use tonic;
 pub use worker_registry::{Slot, SlotManager, SlotProvider, WorkerKey};
-pub use workflow_handle::{WorkflowExecutionInfo, WorkflowExecutionResult};
+pub use workflow_handle::{
+    GetWorkflowResultOpts, WorkflowExecutionInfo, WorkflowExecutionResult, WorkflowHandle,
+};
 
 use crate::{
     metrics::{GrpcMetricSvc, MetricsContext},

--- a/client/src/workflow_handle/mod.rs
+++ b/client/src/workflow_handle/mod.rs
@@ -91,10 +91,12 @@ where
         }
     }
 
+    /// Get the workflow execution info
     pub fn info(&self) -> &WorkflowExecutionInfo {
         &self.info
     }
 
+    /// Await the result of the workflow execution
     pub async fn get_workflow_result(
         &self,
         opts: GetWorkflowResultOpts,


### PR DESCRIPTION
## What was changed

As discussed in Slack, there is a basic API for awaiting workflow results from a client. Unfortunately the `GetWorkflowResultOpts` type that must be passed into `get_workflow_result()` is not exported, so this function cannot be called by SDK users.

## Why?

I have a use case for awaiting the result of a workflow execution.

## Checklist

1. Closes: no issue
2. How was this tested: untested for now
3. Any docs updates needed: added some docstrings to newly public methods