### PR TITLE
Remove temporalite ephemeral server and expose child process ID

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -93,6 +93,7 @@ bimap = "0.6.1"
 clap = { version = "4.0", features = ["derive"] }
 criterion = "0.5"
 rstest = "0.18"
+sysinfo = "0.30"
 temporal-sdk-core-test-utils = { path = "../test-utils" }
 temporal-sdk = { path = "../sdk" }
 

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -22,99 +22,6 @@ use zip::read::read_zipfile_from_stream;
 use std::os::unix::fs::OpenOptionsExt;
 use std::process::Stdio;
 
-/// Configuration for Temporalite.
-/// Will be removed eventually as its successor, Temporal CLI matures.
-/// We don't care for the duplication between this struct and [TemporalDevServerConfig] and prefer that over another
-/// abstraction since the existence of this struct is temporary.
-#[derive(Debug, Clone, derive_builder::Builder)]
-pub struct TemporaliteConfig {
-    /// Required path to executable or download info.
-    pub exe: EphemeralExe,
-    /// Namespace to use.
-    #[builder(default = "\"default\".to_owned()")]
-    pub namespace: String,
-    /// IP to bind to.
-    #[builder(default = "\"127.0.0.1\".to_owned()")]
-    pub ip: String,
-    /// Port to use or obtains a free one if none given.
-    #[builder(default)]
-    pub port: Option<u16>,
-    /// Sqlite DB filename if persisting or non-persistent if none.
-    #[builder(default)]
-    pub db_filename: Option<String>,
-    /// Whether to enable the UI.
-    #[builder(default)]
-    pub ui: bool,
-    /// Log format and level
-    #[builder(default = "(\"pretty\".to_owned(), \"warn\".to_owned())")]
-    pub log: (String, String),
-    /// Additional arguments to Temporalite.
-    #[builder(default)]
-    pub extra_args: Vec<String>,
-}
-
-impl TemporaliteConfig {
-    /// Start a Temporalite server.
-    pub async fn start_server(&self) -> anyhow::Result<EphemeralServer> {
-        self.start_server_with_output(Stdio::inherit(), Stdio::inherit())
-            .await
-    }
-
-    /// Start a Temporalite server with configurable stdout destination.
-    pub async fn start_server_with_output(
-        &self,
-        output: Stdio,
-        err_output: Stdio,
-    ) -> anyhow::Result<EphemeralServer> {
-        // Get exe path
-        let exe_path = self
-            .exe
-            .get_or_download("temporalite", "temporalite", None)
-            .await?;
-
-        // Get free port if not already given
-        let port = self.port.unwrap_or_else(|| get_free_port(&self.ip));
-
-        // Build arg set
-        let mut args = vec![
-            "start".to_owned(),
-            "--port".to_owned(),
-            port.to_string(),
-            "--namespace".to_owned(),
-            self.namespace.clone(),
-            "--ip".to_owned(),
-            self.ip.clone(),
-            "--log-format".to_owned(),
-            self.log.0.clone(),
-            "--log-level".to_owned(),
-            self.log.1.clone(),
-            "--dynamic-config-value".to_owned(),
-            "frontend.enableServerVersionCheck=false".to_owned(),
-        ];
-        if let Some(db_filename) = &self.db_filename {
-            args.push("--filename".to_owned());
-            args.push(db_filename.clone());
-        } else {
-            args.push("--ephemeral".to_owned());
-        }
-        if !self.ui {
-            args.push("--headless".to_owned());
-        }
-        args.extend(self.extra_args.clone());
-
-        // Start
-        EphemeralServer::start(EphemeralServerConfig {
-            exe_path,
-            port,
-            args,
-            has_test_service: false,
-            output,
-            err_output,
-        })
-        .await
-    }
-}
-
 /// Configuration for Temporal CLI dev server.
 #[derive(Debug, Clone, derive_builder::Builder)]
 pub struct TemporalDevServerConfig {
@@ -325,6 +232,12 @@ impl EphemeralServer {
         } else {
             Ok(())
         }
+    }
+
+    /// Get the process ID of the child. This will be None if the process is
+    /// considered to be complete.
+    pub fn child_process_id(&self) -> Option<u32> {
+        self.child.id()
     }
 }
 

--- a/tests/integ_tests/ephemeral_server_tests.rs
+++ b/tests/integ_tests/ephemeral_server_tests.rs
@@ -36,6 +36,23 @@ async fn temporal_cli_fixed() {
 }
 
 #[tokio::test]
+async fn temporal_cli_shutdown_port_reuse() {
+    // Start, test shutdown, do again immediately on same port to ensure we can
+    // reuse after shutdown
+    let config = TemporalDevServerConfigBuilder::default()
+        .exe(default_cached_download())
+        .port(Some(10123))
+        .build()
+        .unwrap();
+    let mut server = config.start_server().await.unwrap();
+    assert_ephemeral_server(&server).await;
+    server.shutdown().await.unwrap();
+    let mut server = config.start_server().await.unwrap();
+    assert_ephemeral_server(&server).await;
+    server.shutdown().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_server_default() {
     let config = TestServerConfigBuilder::default()
         .exe(default_cached_download())

--- a/tests/integ_tests/ephemeral_server_tests.rs
+++ b/tests/integ_tests/ephemeral_server_tests.rs
@@ -2,7 +2,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use temporal_client::{ClientOptionsBuilder, TestService, WorkflowService};
 use temporal_sdk_core::ephemeral_server::{
     EphemeralExe, EphemeralExeVersion, EphemeralServer, TemporalDevServerConfigBuilder,
-    TemporaliteConfigBuilder, TestServerConfigBuilder,
+    TestServerConfigBuilder,
 };
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::DescribeNamespaceRequest;
 use temporal_sdk_core_test_utils::{default_cached_download, NAMESPACE};
@@ -16,7 +16,12 @@ async fn temporal_cli_default() {
         .unwrap();
     let mut server = config.start_server().await.unwrap();
     assert_ephemeral_server(&server).await;
+
+    // Make sure process is there on start and not there after shutdown
+    let pid = sysinfo::Pid::from_u32(server.child_process_id().unwrap());
+    assert!(sysinfo::System::new_all().process(pid).is_some());
     server.shutdown().await.unwrap();
+    assert!(sysinfo::System::new_all().process(pid).is_none());
 }
 
 #[tokio::test]
@@ -25,45 +30,6 @@ async fn temporal_cli_fixed() {
         .exe(fixed_cached_download("v0.4.0"))
         .build()
         .unwrap();
-    let mut server = config.start_server().await.unwrap();
-    assert_ephemeral_server(&server).await;
-    server.shutdown().await.unwrap();
-}
-
-#[tokio::test]
-async fn temporalite_default() {
-    let config = TemporaliteConfigBuilder::default()
-        .exe(default_cached_download())
-        .build()
-        .unwrap();
-    let mut server = config.start_server().await.unwrap();
-    assert_ephemeral_server(&server).await;
-    server.shutdown().await.unwrap();
-}
-
-#[tokio::test]
-async fn temporalite_fixed() {
-    let config = TemporaliteConfigBuilder::default()
-        .exe(fixed_cached_download("v0.2.0"))
-        .build()
-        .unwrap();
-    let mut server = config.start_server().await.unwrap();
-    assert_ephemeral_server(&server).await;
-    server.shutdown().await.unwrap();
-}
-
-#[tokio::test]
-async fn temporalite_shutdown_port_reuse() {
-    // Start, test shutdown, do again immediately on same port to ensure we can
-    // reuse after shutdown
-    let config = TemporaliteConfigBuilder::default()
-        .exe(default_cached_download())
-        .port(Some(10123))
-        .build()
-        .unwrap();
-    let mut server = config.start_server().await.unwrap();
-    assert_ephemeral_server(&server).await;
-    server.shutdown().await.unwrap();
     let mut server = config.start_server().await.unwrap();
     assert_ephemeral_server(&server).await;
     server.shutdown().await.unwrap();


### PR DESCRIPTION
## What was changed

* Remove Temporalite as an ephemeral server option
* Expose child process ID for ephemeral servers
* Add assertion for CLI dev server that process is gone after shutdown

Done as part of https://github.com/temporalio/features/issues/470

## Checklist
<!--- add/delete as needed --->

1. Closes #731
