### PR TITLE
Fix request failure metric & add error code labels

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,15 +17,15 @@ telemetry = ["dep:opentelemetry"]
 anyhow = "1.0"
 async-trait = "0.1"
 backoff = "0.4"
-base64 = "0.21.7"
+base64 = "0.22"
 derive_builder = { workspace = true }
 derive_more = "0.99"
 futures = "0.3"
 futures-retry = "0.6.0"
 http = "0.2"
-hyper = { version = "0.14.28" }
+hyper = { version = "0.14" }
 once_cell = { workspace = true }
-opentelemetry = { workspace = true, features = ["metrics"], optional = true  }
+opentelemetry = { workspace = true, features = ["metrics"], optional = true }
 parking_lot = "0.12"
 prost-types = { workspace = true }
 slotmap = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ prost = { workspace = true }
 prost-types = { version = "0.5", package = "prost-wkt-types" }
 rand = "0.8.3"
 reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls"], default-features = false, optional = true }
-ringbuf = "0.3"
+ringbuf = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 siphasher = "1.0"
@@ -71,7 +71,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["parking_lot", "env-filter", "registry"] }
 url = "2.2"
 uuid = { version = "1.1", features = ["v4"] }
-zip = { version = "0.6.3", optional = true }
+zip = { version = "1.2", optional = true }
 
 # 1st party local deps
 [dependencies.temporal-sdk-core-api]
@@ -93,7 +93,7 @@ assert_matches = "1.4"
 bimap = "0.6.1"
 clap = { version = "4.0", features = ["derive"] }
 criterion = "0.5"
-rstest = "0.18"
+rstest = "0.19.0"
 sysinfo = "0.30"
 temporal-sdk-core-test-utils = { path = "../test-utils" }
 temporal-sdk = { path = "../sdk" }

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -505,7 +505,7 @@ async fn download_and_extract(
                 // that requires Seek.
                 if let Some(mut file) = read_zipfile_from_stream(&mut reader)? {
                     // If this is the file we're expecting, extract it
-                    if file.enclosed_name() == Some(&file_to_extract) {
+                    if file.enclosed_name().as_ref() == Some(&file_to_extract) {
                         std::io::copy(&mut file, &mut dest)?;
                         return Ok(());
                     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
The request failure metrics weren't actually being incremented when they should've been due to the interceptor only caring about http errors and not inspecting grpc statuses. That is fixed, and error code labels are attached w/ an option to disable.

## Why?
Part of https://github.com/temporalio/features/issues/144

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added IT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
