### PR TITLE
Fix possible shutdown hang if pollers keep getting gRPC errors

### DIFF
--- a/core-api/src/errors.rs
+++ b/core-api/src/errors.rs
@@ -14,12 +14,6 @@ pub enum PollWfError {
     /// errors, so lang should consider this fatal.
     #[error("Unhandled grpc error when workflow polling: {0:?}")]
     TonicError(#[from] tonic::Status),
-    // TODO: Remove this
-    /// Unhandled error when completing a workflow during a poll -- this can happen when there is no
-    /// work for lang to perform, but the server sent us a workflow task (EX: An activity completed
-    /// even though we already cancelled it)
-    #[error("Unhandled error when auto-completing workflow task: {0:?}")]
-    AutocompleteError(#[from] CompleteWfError),
 }
 
 /// Errors thrown by [crate::Worker::poll_activity_task]

--- a/core-api/src/errors.rs
+++ b/core-api/src/errors.rs
@@ -6,14 +6,15 @@ use temporal_sdk_core_protos::coresdk::activity_result::ActivityExecutionResult;
 #[derive(thiserror::Error, Debug)]
 pub enum PollWfError {
     /// [crate::Worker::shutdown] was called, and there are no more replay tasks to be handled. Lang
-    /// must call [crate::Worker::complete_workflow_activation] for any remaining tasks, and then may
-    /// exit.
+    /// must call [crate::Worker::complete_workflow_activation] for any remaining tasks, and then
+    /// may exit.
     #[error("Core is shut down and there are no more workflow replay tasks")]
     ShutDown,
     /// Unhandled error when calling the temporal server. Core will attempt to retry any non-fatal
     /// errors, so lang should consider this fatal.
     #[error("Unhandled grpc error when workflow polling: {0:?}")]
     TonicError(#[from] tonic::Status),
+    // TODO: Remove this
     /// Unhandled error when completing a workflow during a poll -- this can happen when there is no
     /// work for lang to perform, but the server sent us a workflow task (EX: An activity completed
     /// even though we already cancelled it)

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -276,7 +276,6 @@ async fn worker_can_shutdown_after_never_polling_ok() {
         mock,
     );
 
-    // TODO: Make sure to try without activity call too
     loop {
         // Must continue polling until both poll types return shutdown.
         let res = core.poll_workflow_activation().await.unwrap_err();

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -261,13 +261,16 @@ async fn worker_does_not_panic_on_retry_exhaustion_of_nonfatal_net_err() {
     );
 }
 
+#[rstest::rstest]
 #[tokio::test]
-async fn worker_can_shutdown_after_never_polling_ok() {
+async fn worker_can_shutdown_after_never_polling_ok(#[values(true, false)] poll_workflow: bool) {
     let mut mock = mock_workflow_client();
     mock.expect_poll_activity_task()
         .returning(|_, _| Err(tonic::Status::permission_denied("you shall not pass")));
-    mock.expect_poll_workflow_task()
-        .returning(|_| Err(tonic::Status::permission_denied("you shall not pass")));
+    if poll_workflow {
+        mock.expect_poll_workflow_task()
+            .returning(|_| Err(tonic::Status::permission_denied("you shall not pass")));
+    }
     let core = worker::Worker::new_test(
         test_worker_cfg()
             .max_concurrent_at_polls(1_usize)
@@ -277,10 +280,12 @@ async fn worker_can_shutdown_after_never_polling_ok() {
     );
 
     loop {
-        // Must continue polling until both poll types return shutdown.
-        let res = core.poll_workflow_activation().await.unwrap_err();
-        if !matches!(res, PollWfError::ShutDown) {
-            continue;
+        // Must continue polling until polls return shutdown.
+        if poll_workflow {
+            let res = core.poll_workflow_activation().await.unwrap_err();
+            if !matches!(res, PollWfError::ShutDown) {
+                continue;
+            }
         }
         let res = core.poll_activity_task().await.unwrap_err();
         if !matches!(res, PollActivityError::ShutDown) {

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -1,9 +1,10 @@
 use crate::{
     prost_dur,
     test_help::{
-        build_fake_worker, build_mock_pollers, canned_histories, mock_worker, MockPollCfg,
-        MockWorkerInputs, MocksHolder, ResponseType, WorkerExt,
+        build_fake_worker, build_mock_pollers, canned_histories, mock_worker, test_worker_cfg,
+        MockPollCfg, MockWorkerInputs, MocksHolder, ResponseType, WorkerExt,
     },
+    worker,
     worker::client::mocks::mock_workflow_client,
     PollActivityError, PollWfError,
 };
@@ -258,4 +259,19 @@ async fn worker_does_not_panic_on_retry_exhaustion_of_nonfatal_net_err() {
         res.jobs[0].variant,
         Some(workflow_activation_job::Variant::RemoveFromCache(_))
     );
+}
+
+#[tokio::test]
+async fn worker_can_shutdown_after_never_polling_ok() {
+    crate::telemetry::test_telem_console();
+    let mut mock = mock_workflow_client();
+    mock.expect_poll_workflow_task()
+        .returning(|_| Err(tonic::Status::permission_denied("you shall not pass")));
+    let core = worker::Worker::new_test(test_worker_cfg().build().unwrap(), mock);
+
+    // Will be the error
+    let res = core.poll_workflow_activation().await;
+    dbg!(res);
+    core.shutdown().await;
+    core.finalize_shutdown().await;
 }

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -263,7 +263,6 @@ async fn worker_does_not_panic_on_retry_exhaustion_of_nonfatal_net_err() {
 
 #[tokio::test]
 async fn worker_can_shutdown_after_never_polling_ok() {
-    crate::telemetry::test_telem_console();
     let mut mock = mock_workflow_client();
     mock.expect_poll_activity_task()
         .returning(|_, _| Err(tonic::Status::permission_denied("you shall not pass")));
@@ -281,12 +280,10 @@ async fn worker_can_shutdown_after_never_polling_ok() {
     loop {
         // Must continue polling until both poll types return shutdown.
         let res = core.poll_workflow_activation().await.unwrap_err();
-        dbg!(&res);
         if !matches!(res, PollWfError::ShutDown) {
             continue;
         }
         let res = core.poll_activity_task().await.unwrap_err();
-        dbg!(&res);
         if !matches!(res, PollActivityError::ShutDown) {
             continue;
         }

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -222,7 +222,7 @@ pub(crate) struct MockWorkerInputs {
 
 impl Default for MockWorkerInputs {
     fn default() -> Self {
-        Self::new(stream::empty().boxed())
+        Self::new(stream::pending().boxed())
     }
 }
 

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -614,13 +614,15 @@ impl Worker {
     #[instrument(skip(self), fields(run_id, workflow_id, task_queue=%self.config.task_queue))]
     pub(crate) async fn next_workflow_activation(&self) -> Result<WorkflowActivation, PollWfError> {
         let r = self.workflows.next_workflow_activation().await;
-        // In the event workflows are shutdown, begin shutdown of everything else, since that's
-        // about to happen anyway. Tell the local activity manager that, so that it can know to
-        // cancel any remaining outstanding LAs and shutdown.
-        if matches!(r, Err(_)) {
+        // In the event workflows are shutdown or erroring, begin shutdown of everything else. Once
+        // they are shut down, tell the local activity manager that, so that it can know to cancel
+        // any remaining outstanding LAs and shutdown.
+        if let Err(ref e) = r {
             // This is covering the situation where WFT pollers dying is the reason for shutdown
             self.initiate_shutdown();
-            self.local_act_mgr.workflows_have_shutdown();
+            if matches!(e, PollWfError::ShutDown) {
+                self.local_act_mgr.workflows_have_shutdown();
+            }
         }
         r
     }

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -617,7 +617,7 @@ impl Worker {
         // In the event workflows are shutdown, begin shutdown of everything else, since that's
         // about to happen anyway. Tell the local activity manager that, so that it can know to
         // cancel any remaining outstanding LAs and shutdown.
-        if matches!(r, Err(PollWfError::ShutDown)) {
+        if matches!(r, Err(_)) {
             // This is covering the situation where WFT pollers dying is the reason for shutdown
             self.initiate_shutdown();
             self.local_act_mgr.workflows_have_shutdown();

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -223,9 +223,11 @@ impl Workflows {
                                         .expect("Activation processor channel not dropped");
                                 }
                             }
-                            Err(e) => activation_tx
-                                .send(Err(e))
-                                .expect("Activation processor channel not dropped"),
+                            Err(e) => {
+                                let _ = activation_tx.send(Err(e)).inspect_err(|e| {
+                                    error!(activation=?e.0, "Activation processor channel dropped");
+                                });
+                            }
                         }
                     }
                 });

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -269,33 +269,41 @@ impl Workflows {
                     break Ok(act);
                 }
                 ActivationOrAuto::Autocomplete { run_id } => {
-                    self.activation_completed(
-                        WorkflowActivationCompletion {
-                            run_id,
-                            status: Some(
-                                workflow_completion::Success::from_variants(vec![]).into(),
-                            ),
-                        },
-                        true,
-                        // We need to say a type, but the type is irrelevant, so imagine some
-                        // boxed function we'll never call.
-                        Option::<Box<dyn Fn(PostActivateHookData) + Send>>::None,
-                    )
-                    .await?;
+                    if let Err(e) = self
+                        .activation_completed(
+                            WorkflowActivationCompletion {
+                                run_id,
+                                status: Some(
+                                    workflow_completion::Success::from_variants(vec![]).into(),
+                                ),
+                            },
+                            true,
+                            // We need to say a type, but the type is irrelevant, so imagine some
+                            // boxed function we'll never call.
+                            Option::<Box<dyn Fn(PostActivateHookData) + Send>>::None,
+                        )
+                        .await
+                    {
+                        error!(error=?e, "Error while auto-completing workflow task");
+                    }
                 }
                 ActivationOrAuto::AutoFail {
                     run_id,
                     machines_err,
                 } => {
-                    self.activation_completed(
-                        WorkflowActivationCompletion {
-                            run_id,
-                            status: Some(machines_err.as_failure().into()),
-                        },
-                        true,
-                        Option::<Box<dyn Fn(PostActivateHookData) + Send>>::None,
-                    )
-                    .await?;
+                    if let Err(e) = self
+                        .activation_completed(
+                            WorkflowActivationCompletion {
+                                run_id,
+                                status: Some(machines_err.as_failure().into()),
+                            },
+                            true,
+                            Option::<Box<dyn Fn(PostActivateHookData) + Send>>::None,
+                        )
+                        .await
+                    {
+                        error!(error=?e, "Error while auto-failing workflow task");
+                    }
                 }
             }
         }

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -165,7 +165,6 @@ impl WFStream {
                         None
                     }
                     WFStreamInput::PollerError(e) => {
-                        warn!("WFT poller errored, shutting down");
                         return Err(PollWfError::TonicError(e));
                     }
                 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed a scenario where Core wouldn't properly shut itself down if it only gets poll error responses

## Why?
Hang on shutdown bad

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/667

2. How was this tested:
Added reproing unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
