### PR TITLE
Explicit activity retry delays for local activites

### DIFF
--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -21,8 +21,7 @@ use std::{
 };
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{
-    ActContext, ActivityCancelledError, LocalActivityOptions, WfContext, WorkflowFunction,
-    WorkflowResult,
+    ActContext, ActivityError, LocalActivityOptions, WfContext, WorkflowFunction, WorkflowResult,
 };
 use temporal_sdk_core_api::{
     errors::{PollActivityError, PollWfError},
@@ -49,7 +48,7 @@ use temporal_sdk_core_test_utils::{
 };
 use tokio::{join, select, sync::Barrier};
 
-async fn echo(_ctx: ActContext, e: String) -> anyhow::Result<String> {
+async fn echo(_ctx: ActContext, e: String) -> Result<String, ActivityError> {
     Ok(e)
 }
 
@@ -279,7 +278,7 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
         if 2 == attempts.fetch_add(1, Ordering::Relaxed) && eventually_pass {
             Ok(())
         } else {
-            Err(anyhow!("Oh no I failed!"))
+            Err(anyhow!("Oh no I failed!").into())
         }
     });
     worker
@@ -356,7 +355,7 @@ async fn local_act_retry_long_backoff_uses_timer() {
     worker.register_activity(
         DEFAULT_ACTIVITY_TYPE,
         move |_ctx: ActContext, _: String| async move {
-            Result::<(), _>::Err(anyhow!("Oh no I failed!"))
+            Result::<(), _>::Err(anyhow!("Oh no I failed!").into())
         },
     );
     worker
@@ -928,7 +927,7 @@ async fn start_to_close_timeout_allows_retries(#[values(true, false)] la_complet
                     _ = tokio::time::sleep(Duration::from_millis(100)) => (),
                     _ = ctx.cancelled() => {
                         cancels.fetch_add(1, Ordering::AcqRel);
-                        return Err(anyhow!(ActivityCancelledError::default()));
+                        return Err(ActivityError::cancelled());
                     }
                 }
             }
@@ -991,7 +990,7 @@ async fn wft_failure_cancels_running_las() {
             if res.is_err() {
                 panic!("Activity must be cancelled!!!!");
             }
-            Result::<(), _>::Err(ActivityCancelledError::default().into())
+            Result::<(), _>::Err(ActivityError::cancelled())
         },
     );
     worker
@@ -1107,7 +1106,7 @@ async fn local_act_records_nonfirst_attempts_ok() {
         },
     );
     worker.register_activity("echo", move |_ctx: ActContext, _: String| async move {
-        Result::<(), _>::Err(anyhow!("I fail"))
+        Result::<(), _>::Err(anyhow!("I fail").into())
     });
     worker
         .submit_wf(
@@ -1389,4 +1388,63 @@ async fn local_activity_after_wf_complete_is_discarded() {
 
     join!(wf_poller, at_poller);
     core.drain_pollers_and_shutdown().await;
+}
+
+#[tokio::test]
+async fn local_act_retry_explicit_delay() {
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_workflow_task_scheduled_and_started();
+
+    let wf_id = "fakeid";
+    let mock = mock_workflow_client();
+    let mh = MockPollCfg::from_resp_batches(wf_id, t, [1], mock);
+    let mut worker = mock_sdk(mh);
+
+    // worker.register_wf(
+    //     DEFAULT_WORKFLOW_TYPE.to_owned(),
+    //     move |ctx: WfContext| async move {
+    //         let la_res = ctx
+    //             .local_activity(LocalActivityOptions {
+    //                 activity_type: "echo".to_string(),
+    //                 input: "hi".as_json_payload().expect("serializes fine"),
+    //                 retry_policy: RetryPolicy {
+    //                     initial_interval: Some(prost_dur!(from_millis(50))),
+    //                     backoff_coefficient: 1.2,
+    //                     maximum_interval: None,
+    //                     maximum_attempts: 5,
+    //                     non_retryable_error_types: vec![],
+    //                 },
+    //                 ..Default::default()
+    //             })
+    //             .await;
+    //         if eventually_pass {
+    //             assert!(la_res.completed_ok())
+    //         } else {
+    //             assert!(la_res.failed())
+    //         }
+    //         Ok(().into())
+    //     },
+    // );
+    // let attempts: &'static _ = Box::leak(Box::new(AtomicUsize::new(0)));
+    // worker.register_activity("echo", move |_ctx: ActContext, _: String| async move {
+    //     // Succeed on 3rd attempt (which is ==2 since fetch_add returns prev val)
+    //     if 2 == attempts.fetch_add(1, Ordering::Relaxed) && eventually_pass {
+    //         Ok(())
+    //     } else {
+    //         Err(anyhow!("Oh no I failed!"))
+    //     }
+    // });
+    // worker
+    //     .submit_wf(
+    //         wf_id.to_owned(),
+    //         DEFAULT_WORKFLOW_TYPE.to_owned(),
+    //         vec![],
+    //         WorkflowOptions::default(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // worker.run_until_done().await.unwrap();
+    // let expected_attempts = if eventually_pass { 3 } else { 5 };
+    // assert_eq!(expected_attempts, attempts.load(Ordering::Relaxed));
 }

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -882,7 +882,7 @@ mod tests {
         time::Duration,
     };
     use temporal_sdk::{
-        ActContext, ActivityCancelledError, CancellableFuture, LocalActivityOptions, WfContext,
+        ActContext, ActivityError, CancellableFuture, LocalActivityOptions, WfContext,
         WorkflowResult,
     };
     use temporal_sdk_core_protos::{
@@ -988,7 +988,7 @@ mod tests {
                 if completes_ok {
                     Ok("hi")
                 } else {
-                    Err(anyhow!("Oh no I failed!"))
+                    Err(anyhow!("Oh no I failed!").into())
                 }
             },
         );
@@ -1450,7 +1450,7 @@ mod tests {
                     ctx.cancelled().await;
                 }
                 allow_cancel_barr_clone.cancelled().await;
-                Result::<(), _>::Err(anyhow!(ActivityCancelledError::default()))
+                Result::<(), _>::Err(ActivityError::cancelled())
             }
         });
         worker.run().await.unwrap();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -72,6 +72,7 @@ use std::{
     future::Future,
     panic::AssertUnwindSafe,
     sync::Arc,
+    time::Duration,
 };
 use temporal_client::ClientOptionsBuilder;
 use temporal_sdk_core::Url;
@@ -496,18 +497,18 @@ impl ActivityHalf {
                         Ok(Ok(ActExitValue::WillCompleteAsync)) => {
                             ActivityExecutionResult::will_complete_async()
                         }
-                        Ok(Err(err)) => match err.downcast::<ActivityCancelledError>() {
-                            Ok(ce) => ActivityExecutionResult::cancel_from_details(ce.details),
-                            Err(other_err) => {
-                                match other_err.downcast::<NonRetryableActivityError>() {
-                                    Ok(nre) => ActivityExecutionResult::fail(
-                                        Failure::application_failure_from_error(nre.into(), true),
-                                    ),
-                                    Err(other_err) => ActivityExecutionResult::fail(
-                                        Failure::application_failure_from_error(other_err, false),
-                                    ),
-                                }
+                        Ok(Err(err)) => match err {
+                            ActivityError::Retryable { source, .. } => {
+                                ActivityExecutionResult::fail(
+                                    Failure::application_failure_from_error(source, false),
+                                )
                             }
+                            ActivityError::Cancelled { details } => {
+                                ActivityExecutionResult::cancel_from_details(details)
+                            }
+                            ActivityError::NonRetryable(nre) => ActivityExecutionResult::fail(
+                                Failure::application_failure_from_error(nre.into(), true),
+                            ),
                         },
                     };
                     worker
@@ -788,7 +789,7 @@ impl<T: AsJsonPayloadExt> From<T> for ActExitValue<T> {
 }
 
 type BoxActFn = Arc<
-    dyn Fn(ActContext, Payload) -> BoxFuture<'static, Result<ActExitValue<Payload>, anyhow::Error>>
+    dyn Fn(ActContext, Payload) -> BoxFuture<'static, Result<ActExitValue<Payload>, ActivityError>>
         + Send
         + Sync,
 >;
@@ -799,35 +800,40 @@ pub struct ActivityFunction {
     act_func: BoxActFn,
 }
 
-/// Return this error to indicate your activity is cancelling
-#[derive(Debug, Default)]
-pub struct ActivityCancelledError {
-    details: Option<Payload>,
+#[derive(Debug, thiserror::Error)]
+pub enum ActivityError {
+    /// This error can be returned from activities to allow the explicit configuration of certain
+    /// error properties. It's also the default error type that arbitrary errors will be converted
+    /// into.
+    #[error("Activity error {:?}", .source)]
+    Retryable {
+        source: anyhow::Error,
+        explicit_delay: Option<Duration>,
+    },
+    /// Return this error to indicate your activity is cancelling
+    #[error("Activity cancelled")]
+    Cancelled { details: Option<Payload> },
+    /// Return this error to indicate that your activity non-retryable
+    /// this is a transparent wrapper around anyhow Error so essentially any type of error
+    /// could be used here.
+    #[error(transparent)]
+    NonRetryable(anyhow::Error),
 }
-impl ActivityCancelledError {
-    /// Include some details as part of concluding the activity as cancelled
-    pub fn with_details(payload: Payload) -> Self {
-        Self {
-            details: Some(payload),
+
+impl From<anyhow::Error> for ActivityError {
+    fn from(source: anyhow::Error) -> Self {
+        Self::Retryable {
+            source,
+            explicit_delay: None,
         }
     }
 }
-impl std::error::Error for ActivityCancelledError {}
-impl Display for ActivityCancelledError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Activity cancelled")
+
+impl ActivityError {
+    pub fn cancelled() -> Self {
+        Self::Cancelled { details: None }
     }
 }
-
-/// Return this error to indicate that your activity non-retryable
-/// this is a transparent wrapper around anyhow Error so essentially any type of error
-/// could be used here.
-///
-/// In your activity function. Return something along the lines of:
-/// `Err(NonRetryableActivityError(anyhow::anyhow!("This should *not* be retried")).into())`
-#[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-pub struct NonRetryableActivityError(pub anyhow::Error);
 
 /// Closures / functions which can be turned into activity functions implement this trait
 pub trait IntoActivityFunc<Args, Res, Out> {
@@ -839,7 +845,7 @@ impl<A, Rf, R, O, F> IntoActivityFunc<A, Rf, O> for F
 where
     F: (Fn(ActContext, A) -> Rf) + Sync + Send + 'static,
     A: FromJsonPayloadExt + Send,
-    Rf: Future<Output = Result<R, anyhow::Error>> + Send + 'static,
+    Rf: Future<Output = Result<R, ActivityError>> + Send + 'static,
     R: Into<ActExitValue<O>>,
     O: AsJsonPayloadExt,
 {
@@ -847,20 +853,23 @@ where
         let wrapper = move |ctx: ActContext, input: Payload| {
             // Some minor gymnastics are required to avoid needing to clone the function
             match A::from_json_payload(&input) {
-                Ok(deser) => (self)(ctx, deser)
+                Ok(deser) => self(ctx, deser)
                     .map(|r| {
                         r.and_then(|r| {
                             let exit_val: ActExitValue<O> = r.into();
-                            Ok(match exit_val {
-                                ActExitValue::WillCompleteAsync => ActExitValue::WillCompleteAsync,
-                                ActExitValue::Normal(x) => {
-                                    ActExitValue::Normal(x.as_json_payload()?)
+                            match exit_val {
+                                ActExitValue::WillCompleteAsync => {
+                                    Ok(ActExitValue::WillCompleteAsync)
                                 }
-                            })
+                                ActExitValue::Normal(x) => match x.as_json_payload() {
+                                    Ok(v) => Ok(ActExitValue::Normal(v)),
+                                    Err(e) => Err(ActivityError::NonRetryable(e)),
+                                },
+                            }
                         })
                     })
                     .boxed(),
-                Err(e) => async move { Err(e.into()) }.boxed(),
+                Err(e) => async move { Err(ActivityError::NonRetryable(e.into())) }.boxed(),
             }
         };
         Arc::new(wrapper)

--- a/tests/fuzzy_workflow.rs
+++ b/tests/fuzzy_workflow.rs
@@ -2,7 +2,9 @@ use futures_util::{sink, stream::FuturesUnordered, FutureExt, StreamExt};
 use rand::{prelude::Distribution, rngs::SmallRng, Rng, SeedableRng};
 use std::{future, time::Duration};
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions};
-use temporal_sdk::{ActContext, ActivityOptions, LocalActivityOptions, WfContext, WorkflowResult};
+use temporal_sdk::{
+    ActContext, ActivityError, ActivityOptions, LocalActivityOptions, WfContext, WorkflowResult,
+};
 use temporal_sdk_core_protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt, IntoPayloadsExt};
 use temporal_sdk_core_test_utils::CoreWfStarter;
 use tokio_util::sync::CancellationToken;
@@ -28,7 +30,7 @@ impl Distribution<FuzzyWfAction> for FuzzyWfActionSampler {
     }
 }
 
-async fn echo(_ctx: ActContext, echo_me: String) -> Result<String, anyhow::Error> {
+async fn echo(_ctx: ActContext, echo_me: String) -> Result<String, ActivityError> {
     Ok(echo_me)
 }
 

--- a/tests/integ_tests/activity_functions.rs
+++ b/tests/integ_tests/activity_functions.rs
@@ -1,5 +1,5 @@
-use temporal_sdk::ActContext;
+use temporal_sdk::{ActContext, ActivityError};
 
-pub(crate) async fn echo(_ctx: ActContext, e: String) -> anyhow::Result<String> {
+pub(crate) async fn echo(_ctx: ActContext, e: String) -> Result<String, ActivityError> {
     Ok(e)
 }

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use assert_matches::assert_matches;
 use futures_util::{future, future::join_all, StreamExt};
 use once_cell::sync::Lazy;
@@ -843,7 +843,7 @@ async fn worker_restarted_in_middle_of_update() {
         BARR.wait().await;
         if !ACT_RAN.fetch_or(true, Ordering::Relaxed) {
             // On first run fail the task so we'll get retried on the new worker
-            bail!("Fail first time");
+            return Err(anyhow!("Fail first time").into());
         }
         Ok(echo_me)
     });

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -8,8 +8,8 @@ use std::{
 };
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowExecutionResult, WorkflowOptions};
 use temporal_sdk::{
-    ActContext, ActExitValue, ActivityCancelledError, ActivityOptions, CancellableFuture,
-    WfContext, WorkflowResult,
+    ActContext, ActExitValue, ActivityError, ActivityOptions, CancellableFuture, WfContext,
+    WorkflowResult,
 };
 use temporal_sdk_core_protos::{
     coresdk::{
@@ -946,7 +946,7 @@ async fn graceful_shutdown() {
         // just wait to be cancelled
         ctx.cancelled().await;
         ACTS_DONE.add_permits(1);
-        Result::<(), _>::Err(ActivityCancelledError::default().into())
+        Result::<(), _>::Err(ActivityError::cancelled())
     });
 
     worker


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Allow explicit configuration of next retry backoff for LAs

* Also made breaking changes to the unreleased Rust SDK to make testing this work better. Activity functions may need to call `into()` on returned errors.

## Why?
Parity with normal activities

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/735

2. How was this tested:
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
