### PR TITLE
Allow handing of speculative wft with command events

### DIFF
--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -900,7 +900,7 @@ async fn activity_tasks_from_completion_reserve_slots() {
         ],
         mock,
     );
-    mh.completion_asserts = Some(Box::new(|wftc| {
+    mh.completion_mock_fn = Some(Box::new(|wftc| {
         // Make sure when we see the completion with the schedule act command that it does
         // not have the eager execution flag set the first time, and does the second.
         if let Some(Attributes::ScheduleActivityTaskCommandAttributes(attrs)) = wftc
@@ -914,6 +914,7 @@ async fn activity_tasks_from_completion_reserve_slots() {
                 assert!(attrs.request_eager_execution);
             }
         }
+        Ok(Default::default())
     }));
     let mut mock = build_mock_pollers(mh);
     mock.worker_cfg(|cfg| {

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -1075,11 +1075,12 @@ async fn local_act_records_nonfirst_attempts_ok() {
     let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 3], mock);
     let nonfirst_counts = Arc::new(SegQueue::new());
     let nfc_c = nonfirst_counts.clone();
-    mh.completion_asserts = Some(Box::new(move |c| {
+    mh.completion_mock_fn = Some(Box::new(move |c| {
         nfc_c.push(
             c.metering_metadata
                 .nonfirst_local_activity_execution_attempts,
         );
+        Ok(Default::default())
     }));
     let mut worker = mock_sdk_cfg(mh, |wc| {
         wc.max_cached_workflows = 1;

--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -167,7 +167,7 @@ async fn new_queries(#[values(1, 3)] num_queries: usize) {
     let mut mock_client = mock_workflow_client();
     mock_client.expect_respond_legacy_query().times(0);
     let mut mh = MockPollCfg::from_resp_batches(wfid, t, tasks, mock_workflow_client());
-    mh.completion_asserts = Some(Box::new(move |c| {
+    mh.completion_mock_fn = Some(Box::new(move |c| {
         // If the completion is the one ending the workflow, make sure it includes the query resps
         if c.commands[0].command_type() == CommandType::CompleteWorkflowExecution {
             assert_eq!(c.query_responses.len(), num_queries);
@@ -176,6 +176,7 @@ async fn new_queries(#[values(1, 3)] num_queries: usize) {
         } else {
             panic!("Unexpected command in response")
         }
+        Ok(Default::default())
     }));
     let mut mock = build_mock_pollers(mh);
     mock.worker_cfg(|wc| wc.max_cached_workflows = 10);

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2387,8 +2387,9 @@ async fn lang_internal_flags() {
         [ResponseType::ToTaskNum(2), ResponseType::AllHistory],
         mock_workflow_client(),
     );
-    mh.completion_asserts = Some(Box::new(|c| {
+    mh.completion_mock_fn = Some(Box::new(|c| {
         assert_matches!(c.sdk_metadata.lang_used_flags.as_slice(), &[2]);
+        Ok(Default::default())
     }));
     let mut mock = build_mock_pollers(mh);
     mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
@@ -2424,7 +2425,7 @@ async fn core_internal_flags() {
         [ResponseType::ToTaskNum(1)],
         mock_workflow_client(),
     );
-    mh.completion_asserts = Some(Box::new(move |c| {
+    mh.completion_mock_fn = Some(Box::new(move |c| {
         assert_eq!(
             c.sdk_metadata
                 .core_used_flags
@@ -2435,6 +2436,7 @@ async fn core_internal_flags() {
                 .map(|f| f as u32)
                 .collect()
         );
+        Ok(Default::default())
     }));
     let mut mock = build_mock_pollers(mh);
     mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
@@ -2458,9 +2460,10 @@ async fn post_terminal_commands_are_discarded() {
         [ResponseType::ToTaskNum(1), ResponseType::AllHistory],
         mock_workflow_client(),
     );
-    mh.completion_asserts = Some(Box::new(|c| {
+    mh.completion_mock_fn = Some(Box::new(|c| {
         // Only the complete execution command should actually be sent
         assert_eq!(c.commands.len(), 1);
+        Ok(Default::default())
     }));
     let mut mock = build_mock_pollers(mh);
     mock.worker_cfg(|wc| wc.max_cached_workflows = 1);

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn test_worker_cfg() -> WorkerConfigBuilder {
 #[allow(clippy::large_enum_variant)] // Test only code, whatever.
 pub(crate) enum ResponseType {
     ToTaskNum(usize),
-    /// Returns just the history after the WFT completed of the provided task number - 1, through to
+    /// Returns just the history from the WFT completed of the provided task number - 1, through to
     /// the next WFT started. Simulating the incremental history for just the provided task number
     #[from(ignore)]
     OneTask(usize),

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -65,6 +65,12 @@ impl Debug for HistoryUpdate {
     }
 }
 
+impl HistoryUpdate {
+    pub(crate) fn get_events(&self) -> &[HistoryEvent] {
+        &self.events
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum NextWFT {
     ReplayOver,

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -339,7 +339,7 @@ mod tests {
         );
         // Ensure the upsert command has an empty map when not using the patched command
         if !with_patched_cmd {
-            mp.completion_asserts = Some(Box::new(|wftc| {
+            mp.completion_mock_fn = Some(Box::new(|wftc| {
                 let cmd_attrs = wftc
                     .commands
                     .first()
@@ -349,11 +349,12 @@ mod tests {
                     cmd_attrs,
                     Attributes::CompleteWorkflowExecutionCommandAttributes(_)
                 ) {
-                    return;
+                    return Ok(Default::default());
                 }
                 assert_matches!(cmd_attrs,
                     Attributes::UpsertWorkflowSearchAttributesCommandAttributes(attrs)
                     if attrs.search_attributes.clone().unwrap_or_default().indexed_fields.is_empty());
+                Ok(Default::default())
             }));
         }
         let mut mock = build_mock_pollers(mp);

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -803,6 +803,18 @@ impl PreparedWFT {
         let no_new_history = self.update.wft_started_id == 0;
         no_new_history && self.legacy_query.is_some()
     }
+
+    /// Useful for showing detailed info on incoming WFTs
+    #[allow(dead_code)]
+    fn print_details(&self) -> String {
+        format!(
+            "WFT events: {:?}, messages: {:?}, legacy_query: {:?}, queries: {:?}",
+            self.update.get_events(),
+            &self.messages,
+            &self.legacy_query,
+            &self.query_requests
+        )
+    }
 }
 
 #[derive(Debug)]

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -40,6 +40,7 @@ use crate::{
 use anyhow::anyhow;
 use futures::{stream::BoxStream, Stream, StreamExt};
 use futures_util::{future::abortable, stream};
+use itertools::Itertools;
 use prost_types::TimestampError;
 use std::{
     cell::RefCell,
@@ -808,8 +809,8 @@ impl PreparedWFT {
     #[allow(dead_code)]
     fn print_details(&self) -> String {
         format!(
-            "WFT events: {:?}, messages: {:?}, legacy_query: {:?}, queries: {:?}",
-            self.update.get_events(),
+            "WFT events: [{}], messages: {:?}, legacy_query: {:?}, queries: {:?}",
+            self.update.get_events().iter().format(", "),
             &self.messages,
             &self.legacy_query,
             &self.query_requests

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1920,7 +1920,7 @@ pub mod temporal {
                             f,
                             "HistoryEvent(id: {}, {:?})",
                             self.event_id,
-                            EventType::try_from(self.event_type)
+                            EventType::try_from(self.event_type).unwrap_or_default()
                         )
                     }
                 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Core will now be OK with speculative WFTs which also contain command events

## Why?
Allows server to make a WFT speculative in more situations

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added UT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
