### PR TITLE
[DRAFT] Trying to fix this unreproducible obnoxious test flake

### DIFF
--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -512,7 +512,7 @@ impl OutstandingWFTMap {
 
     fn release_token(&self, token: &TaskToken) {
         self.map.write().remove_by_right(token);
-        self.waker.notify_one();
+        self.waker.notify_waiters();
     }
 
     pub(crate) fn release_run(&self, run_id: &str) {


### PR DESCRIPTION
This stupid `core_tests::workflow_tasks::history_length_with_fail_and_timeout::use_cache_2_false::history_responses_case_3_3` test hangs like 60% of the time in CI but is literally unreproducible locally.

Using this PR to speculate about fixes and see if I can get it to stop.