### PR TITLE
Ensure namespace exists on worker startup

### DIFF
--- a/core-api/src/errors.rs
+++ b/core-api/src/errors.rs
@@ -2,6 +2,17 @@
 
 use temporal_sdk_core_protos::coresdk::activity_result::ActivityExecutionResult;
 
+/// Errors thrown by [crate::Worker::validate]
+#[derive(thiserror::Error, Debug)]
+pub enum WorkerValidationError {
+    /// The namespace provided to the worker does not exist on the server.
+    #[error("Namespace {namespace} was not found or otherwise could not be described: {source:?}")]
+    NamespaceDescribeError {
+        source: tonic::Status,
+        namespace: String,
+    },
+}
+
 /// Errors thrown by [crate::Worker::poll_workflow_activation]
 #[derive(thiserror::Error, Debug)]
 pub enum PollWfError {

--- a/core-api/src/lib.rs
+++ b/core-api/src/lib.rs
@@ -3,7 +3,10 @@ pub mod telemetry;
 pub mod worker;
 
 use crate::{
-    errors::{CompleteActivityError, CompleteWfError, PollActivityError, PollWfError},
+    errors::{
+        CompleteActivityError, CompleteWfError, PollActivityError, PollWfError,
+        WorkerValidationError,
+    },
     worker::WorkerConfig,
 };
 use temporal_sdk_core_protos::coresdk::{
@@ -16,6 +19,11 @@ use temporal_sdk_core_protos::coresdk::{
 /// and is bound to a specific task queue.
 #[async_trait::async_trait]
 pub trait Worker: Send + Sync {
+    /// Validate that the worker can properly connect to server, plus any other validation that
+    /// needs to be done asynchronously. Lang SDKs should call this function once before calling
+    /// any others.
+    async fn validate(&self) -> Result<(), WorkerValidationError>;
+
     /// Ask the worker for some work, returning a [WorkflowActivation]. It is then the language
     /// SDK's responsibility to call the appropriate workflow code with the provided inputs. Blocks
     /// indefinitely until such work is available or [Worker::shutdown] is called.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -51,6 +51,7 @@ use crate::{
     },
     worker::client::WorkerClientBag,
 };
+use anyhow::bail;
 use futures::Stream;
 use std::sync::Arc;
 use temporal_client::{ConfiguredClient, TemporalServiceClientWithMetrics};
@@ -82,7 +83,10 @@ where
 {
     let client = init_worker_client(&worker_config, *client.into().into_inner());
     if client.namespace() != worker_config.namespace {
-        panic!("Passed in client is not bound to the same namespace as the worker");
+        bail!("Passed in client is not bound to the same namespace as the worker");
+    }
+    if client.namespace() == "" {
+        bail!("Namespace cannot be empty");
     }
     let client_ident = client.get_options().identity.clone();
     let sticky_q = sticky_q_name_for_worker(&client_ident, &worker_config);

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -115,12 +115,13 @@ mockall::mock! {
         ) -> impl Future<Output = Result<RespondQueryTaskCompletedResponse>> + Send + 'b
             where 'a: 'b, Self: 'b;
 
+        fn describe_namespace<'a, 'b>(&self) ->
+          impl Future<Output = Result<DescribeNamespaceResponse>> + Send + 'b
+          where 'a: 'b, Self: 'b;
+
         fn replace_client(&self, new_client: RetryClient<Client>);
-
-        fn capabilities(&self) -> Option<get_system_info_response::Capabilities>;
-
+        fn capabilities(&self) -> Option<Capabilities>;
         fn workers(&self) -> Arc<SlotManager>;
-
         fn is_mock(&self) -> bool;
     }
 }

--- a/tests/integ_tests/worker_tests.rs
+++ b/tests/integ_tests/worker_tests.rs
@@ -1,0 +1,32 @@
+use assert_matches::assert_matches;
+use temporal_sdk_core::{init_worker, CoreRuntime};
+use temporal_sdk_core_api::{errors::WorkerValidationError, worker::WorkerConfigBuilder, Worker};
+use temporal_sdk_core_test_utils::{get_integ_server_options, get_integ_telem_options};
+
+#[tokio::test]
+async fn worker_validation_fails_on_nonexistent_namespace() {
+    let opts = get_integ_server_options();
+    let runtime = CoreRuntime::new_assume_tokio(get_integ_telem_options()).unwrap();
+    let retrying_client = opts
+        .connect_no_namespace(runtime.telemetry().get_temporal_metric_meter())
+        .await
+        .unwrap();
+
+    let worker = init_worker(
+        &runtime,
+        WorkerConfigBuilder::default()
+            .namespace("i_dont_exist")
+            .task_queue("Wheee!")
+            .worker_build_id("blah")
+            .build()
+            .unwrap(),
+        retrying_client,
+    )
+    .unwrap();
+
+    let res = worker.validate().await;
+    assert_matches!(
+        res,
+        Err(WorkerValidationError::NamespaceDescribeError { .. })
+    );
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -16,6 +16,7 @@ mod integ_tests {
     mod queries_tests;
     mod update_tests;
     mod visibility_tests;
+    mod worker_tests;
     mod workflow_tests;
 
     use std::str::FromStr;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a new worker validation function that lang SDKs should call before starting polling

## Why?
Eager validation that namespace exists, future room for other validations

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/738

2. How was this tested:
Integ test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
