### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -15,19 +15,14 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest-16-cores
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: integ-test
-          args: -c "--release" -t heavy_tests -- --test-threads 1
+      - run: cargo integ-test -c "--release" -t heavy_tests -- --test-threads 1

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -16,62 +16,47 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: 1.77.0
-          override: true
       - name: Install protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: rustup component add rustfmt clippy
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --workspace --all-features --no-deps
-      - uses: actions-rs/cargo@v1
-        with:
-          command: lint
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test-lint
+      - run: cargo fmt --all --check
+      - run: cargo doc --workspace --all-features --no-deps
+      - run: cargo lint
+      - run: cargo test-lint
 
   test:
     name: Unit Tests
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: 1.77.0
-          override: true
       - name: Install protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -- --include-ignored --nocapture
-      - uses: actions/upload-artifact@v3
+      - run: cargo test -- --include-ignored --nocapture
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: tarpaulin-report.html
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: state-machine-coverage
           path: machine_coverage/
@@ -81,18 +66,15 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: 1.77.0
-          override: true
       - name: Install protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: integ-test
+      - run: cargo integ-test


### PR DESCRIPTION
## What was changed

- Updated all GHA actions to latest.

## Why?

- GitHub is pulling the plug on `upload-artifact@v3`in October;
- All GHA actions based on Node 16 are deprecated;
- actions-rs/cargo@v1 and actions-rs/toolchain@v1 are no longer maintained
