### PR TITLE
Simplify the passing of tuner options from lang to core

### DIFF
--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2913,11 +2913,11 @@ async fn slot_provider_cant_hand_out_more_permits_than_cache_size() {
     let worker = Worker::new_test(
         test_worker_cfg()
             .max_cached_workflows(10_usize)
-            .tuner(
+            .tuner(Arc::new(
                 TunerBuilder::default()
                     .workflow_slot_supplier(Arc::new(EndlessSupplier {}))
                     .build(),
-            )
+            ))
             .max_concurrent_wft_polls(10_usize)
             .no_remote_activities(true)
             .build()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,9 +39,10 @@ pub use temporal_sdk_core_protos as protos;
 pub use temporal_sdk_core_protos::TaskToken;
 pub use url::Url;
 pub use worker::{
-    FixedSizeSlotSupplier, RealSysInfo, ResourceBasedSlots, ResourceBasedSlotsOptions,
-    ResourceBasedSlotsOptionsBuilder, ResourceBasedTuner, ResourceSlotOptions, TunerBuilder,
-    TunerHolder, Worker, WorkerConfig, WorkerConfigBuilder,
+    FixedSizeSlotSupplier, RealSysInfo, ResourceBasedSlotsOptions,
+    ResourceBasedSlotsOptionsBuilder, ResourceBasedTuner, ResourceSlotOptions, SlotSupplierOptions,
+    TunerBuilder, TunerHolder, TunerHolderOptions, TunerHolderOptionsBuilder, Worker, WorkerConfig,
+    WorkerConfigBuilder,
 };
 
 use crate::{

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -6,9 +6,9 @@ mod workflow;
 
 pub use temporal_sdk_core_api::worker::{WorkerConfig, WorkerConfigBuilder};
 pub use tuner::{
-    FixedSizeSlotSupplier, RealSysInfo, ResourceBasedSlots, ResourceBasedSlotsOptions,
-    ResourceBasedSlotsOptionsBuilder, ResourceBasedTuner, ResourceSlotOptions, TunerBuilder,
-    TunerHolder,
+    FixedSizeSlotSupplier, RealSysInfo, ResourceBasedSlotsOptions,
+    ResourceBasedSlotsOptionsBuilder, ResourceBasedTuner, ResourceSlotOptions, SlotSupplierOptions,
+    TunerBuilder, TunerHolder, TunerHolderOptions, TunerHolderOptionsBuilder,
 };
 
 pub(crate) use activities::{
@@ -263,7 +263,7 @@ impl Worker {
             .tuner
             .as_ref()
             .cloned()
-            .unwrap_or_else(|| TunerBuilder::from_config(&config).build());
+            .unwrap_or_else(|| Arc::new(TunerBuilder::from_config(&config).build()));
 
         metrics.worker_registered();
         if let Some(meter) = meter {

--- a/tests/heavy_tests.rs
+++ b/tests/heavy_tests.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{ActContext, ActivityOptions, WfContext, WorkflowResult};
-use temporal_sdk_core::{ResourceBasedSlots, ResourceBasedTuner, ResourceSlotOptions};
+use temporal_sdk_core::{ResourceBasedTuner, ResourceSlotOptions};
 use temporal_sdk_core_protos::{
     coresdk::{workflow_commands::ActivityCancellationType, AsJsonPayloadExt},
     temporal::api::enums::v1::WorkflowIdReusePolicy,
@@ -94,7 +94,7 @@ async fn chunky_activities_resource_based() {
         .clear_max_outstanding_opts()
         .max_concurrent_wft_polls(10_usize)
         .max_concurrent_at_polls(10_usize);
-    let mut tuner = ResourceBasedTuner::new(ResourceBasedSlots::new(0.7, 0.7));
+    let mut tuner = ResourceBasedTuner::new(0.7, 0.7);
     tuner
         .with_workflow_slots_options(ResourceSlotOptions::new(
             25,


### PR DESCRIPTION
Makes the TS PR here (& other upcoming langs) a bit simpler https://github.com/temporalio/sdk-typescript/pull/1433