### PR TITLE
Update dependencies

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ default = ["otel"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp",
     "dep:opentelemetry-prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-util"]
 tokio-console = ["console-subscriber"]
-ephemeral-server = ["dep:flate2", "dep:nix", "dep:reqwest", "dep:tar", "dep:zip"]
+ephemeral-server = ["dep:flate2", "dep:reqwest", "dep:tar", "dep:zip"]
 
 [dependencies]
 anyhow = "1.0"
@@ -41,7 +41,6 @@ hyper-util = { version = "0.1", features = ["server", "http1", "http2", "tokio"]
 itertools = "0.13"
 lru = "0.12"
 mockall = "0.12"
-nix = { version = "0.28", optional = true, features = ["process", "signal"] }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"], optional = true }
 opentelemetry_sdk = { version = "0.23", features = ["rt-tokio", "metrics"], optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,7 +54,7 @@ prometheus = "0.13"
 prost = { workspace = true }
 prost-types = { version = "0.5", package = "prost-wkt-types" }
 rand = "0.8.3"
-reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls"], default-features = false, optional = true }
+reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], default-features = false, optional = true }
 ringbuf = "0.4"
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Just noticed these. There are some outdated hyper/http dependencies in the client crate, but those interact with tonic which is still on 0.11 (see https://github.com/hyperium/tonic/pull/1670).