### PR TITLE
sdk: make ChildWorkflowOptions::task_queue an Option

### DIFF
--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -440,7 +440,6 @@ pub mod coresdk {
                 workflow_activation::remove_from_cache::EvictionReason, FromPayloadsExt,
             },
             temporal::api::{
-                common::v1::Header,
                 enums::v1::WorkflowTaskFailedCause,
                 history::v1::{
                     WorkflowExecutionCancelRequestedEventAttributes,
@@ -451,10 +450,7 @@ pub mod coresdk {
             },
         };
         use prost_wkt_types::Timestamp;
-        use std::{
-            collections::HashMap,
-            fmt::{Display, Formatter},
-        };
+        use std::fmt::{Display, Formatter};
 
         tonic::include_proto!("coresdk.workflow_activation");
 
@@ -647,10 +643,7 @@ pub mod coresdk {
                 workflow_id,
                 arguments: Vec::from_payloads(attrs.input),
                 randomness_seed,
-                headers: match attrs.header {
-                    None => HashMap::new(),
-                    Some(Header { fields }) => fields,
-                },
+                headers: attrs.header.unwrap_or_default().fields,
                 identity: attrs.identity,
                 parent_workflow_info: attrs.parent_workflow_execution.map(|pe| {
                     NamespacedWorkflowExecution {

--- a/sdk/src/workflow_context/options.rs
+++ b/sdk/src/workflow_context/options.rs
@@ -179,7 +179,9 @@ pub struct ChildWorkflowOptions {
     /// Type of workflow to schedule
     pub workflow_type: String,
     /// Task queue to schedule the workflow in
-    pub task_queue: String,
+    ///
+    /// If `None`, use the same task queue as the parent workflow.
+    pub task_queue: Option<String>,
     /// Input to send the child Workflow
     pub input: Vec<Payload>,
     /// Cancellation strategy for the child workflow
@@ -197,7 +199,7 @@ impl IntoWorkflowCommand for ChildWorkflowOptions {
             seq,
             workflow_id: self.workflow_id,
             workflow_type: self.workflow_type,
-            task_queue: self.task_queue,
+            task_queue: self.task_queue.unwrap_or_default(),
             input: self.input,
             cancellation_type: self.cancel_type as i32,
             workflow_id_reuse_policy: self.options.id_reuse_policy as i32,


### PR DESCRIPTION
## What was changed

Changed `ChildWorkflowOptions::task_queue` from `String` to `Option<String>`. Apparently when left empty, the task queue for child workflows is inherited from the initiating workflow. In Rust, things like this are usually expressed in the type system rather than with sentinel values -- attempt to reflect that in the SDK interface here.

## Why?

Makes it more obvious that the task queue can be inherited from the initiating activity.