### PR TITLE
Honor all non-terminal commands

### DIFF
--- a/core/src/core_tests/determinism.rs
+++ b/core/src/core_tests/determinism.rs
@@ -125,7 +125,7 @@ async fn activity_id_or_type_change_is_nondeterministic(
 ) {
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
-    let mut t = if local_act {
+    let mut t: TestHistoryBuilder = if local_act {
         canned_histories::single_local_activity("1")
     } else {
         canned_histories::single_activity("1")

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2549,15 +2549,9 @@ async fn post_terminal_commands_are_retained_when_replaying_and_flag_set() {
         CompleteWorkflowExecution { result: None }.into(),
         start_timer_cmd(1, Duration::from_secs(1)),
     ];
-    let expected_command_types_emitted = None;
 
-    _do_post_terminal_commands_test(
-        commands_sent_by_lang,
-        [ResponseType::AllHistory],
-        expected_command_types_emitted,
-        t,
-    )
-    .await
+    _do_post_terminal_commands_test(commands_sent_by_lang, [ResponseType::AllHistory], None, t)
+        .await
 }
 
 #[tokio::test]
@@ -2576,15 +2570,9 @@ async fn post_terminal_commands_are_not_retained_when_replaying_and_flag_not_set
         CompleteWorkflowExecution { result: None }.into(),
         start_timer_cmd(1, Duration::from_secs(1)),
     ];
-    let expected_command_types_emitted = None;
 
-    _do_post_terminal_commands_test(
-        commands_sent_by_lang,
-        [ResponseType::AllHistory],
-        expected_command_types_emitted,
-        t,
-    )
-    .await
+    _do_post_terminal_commands_test(commands_sent_by_lang, [ResponseType::AllHistory], None, t)
+        .await
 }
 
 async fn _do_post_terminal_commands_test(

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -382,7 +382,7 @@ pub(crate) fn single_hist_mock_sg(
     build_mock_pollers(mh)
 }
 
-type WFTCompeltionMockFn = dyn FnMut(&WorkflowTaskCompletion) -> Result<RespondWorkflowTaskCompletedResponse, tonic::Status>
+type WFTCompletionMockFn = dyn FnMut(&WorkflowTaskCompletion) -> Result<RespondWorkflowTaskCompletedResponse, tonic::Status>
     + Send;
 
 #[allow(clippy::type_complexity)]
@@ -395,7 +395,7 @@ pub(crate) struct MockPollCfg {
     /// All calls to fail WFTs must match this predicate
     pub(crate) expect_fail_wft_matcher:
         Box<dyn Fn(&TaskToken, &WorkflowTaskFailedCause, &Option<Failure>) -> bool + Send>,
-    pub(crate) completion_mock_fn: Option<Box<WFTCompeltionMockFn>>,
+    pub(crate) completion_mock_fn: Option<Box<WFTCompletionMockFn>>,
     pub(crate) num_expected_completions: Option<TimesRange>,
     /// If being used with the Rust SDK, this is set true. It ensures pollers will not error out
     /// early with no work, since we cannot know the exact number of times polling will happen.
@@ -476,7 +476,7 @@ impl MockPollCfg {
 
 #[allow(clippy::type_complexity)]
 pub(crate) struct CompletionAssertsBuilder<'a> {
-    dest: &'a mut Option<Box<WFTCompeltionMockFn>>,
+    dest: &'a mut Option<Box<WFTCompletionMockFn>>,
     assertions: VecDeque<Box<dyn FnOnce(&WorkflowTaskCompletion) + Send>>,
 }
 

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::{
     abstractions::dbg_panic,
-    internal_flags::InternalFlags,
+    internal_flags::{CoreInternalFlags, InternalFlags},
     protosext::{
         protocol_messages::{IncomingProtocolMessage, IncomingProtocolMessageBody},
         CompleteLocalActivityData, HistoryEventExt, ValidScheduleLA,
@@ -468,6 +468,12 @@ impl WorkflowMachines {
         (*self.observed_internal_flags)
             .borrow_mut()
             .add_lang_used(flags);
+    }
+
+    pub(crate) fn try_use_flag(&self, flag: CoreInternalFlags, should_record: bool) -> bool {
+        self.observed_internal_flags
+            .borrow_mut()
+            .try_use(flag, should_record)
     }
 
     /// Undo a speculative workflow task by resetting to a certain WFT Started ID. This can happen

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -367,7 +367,7 @@ impl ManagedRun {
     pub(super) fn successful_completion(
         &mut self,
         mut commands: Vec<WFCommand>,
-        lang_used_flags: Vec<u32>,
+        used_flags: Vec<u32>,
         resp_chan: Option<oneshot::Sender<ActivationCompleteResult>>,
     ) -> Result<RunUpdateAct, NextPageReq> {
         let activation_was_only_eviction = self.activation_is_eviction();
@@ -436,7 +436,7 @@ impl ManagedRun {
                 activation_was_eviction: self.activation_is_eviction(),
                 has_pending_query,
                 query_responses,
-                lang_used_flags,
+                used_flags,
                 resp_chan,
             };
 
@@ -674,9 +674,7 @@ impl ManagedRun {
             activation_was_eviction: completion.activation_was_eviction,
         };
 
-        self.wfm
-            .machines
-            .add_lang_used_flags(completion.lang_used_flags);
+        self.wfm.machines.add_lang_used_flags(completion.used_flags);
 
         // If this is just bookkeeping after a reply to an eviction activation, we can bypass
         // everything, since there is no reason to continue trying to update machines.
@@ -1447,7 +1445,7 @@ struct RunActivationCompletion {
     activation_was_eviction: bool,
     has_pending_query: bool,
     query_responses: Vec<QueryResult>,
-    lang_used_flags: Vec<u32>,
+    used_flags: Vec<u32>,
     /// Used to notify the worker when the completion is done processing and the completion can
     /// unblock. Must always be `Some` when initialized.
     resp_chan: Option<oneshot::Sender<ActivationCompleteResult>>,

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -1196,11 +1196,11 @@ impl ManagedRun {
 // placed at the end. Return new command sequence and query commands. Note that
 // multiple coroutines may have generated a terminal command, leading to
 // multiple terminal commands in the input to this function.
-fn preprocess_command_sequence(mut commands: Vec<WFCommand>) -> (Vec<WFCommand>, Vec<QueryResult>) {
+fn preprocess_command_sequence(commands: Vec<WFCommand>) -> (Vec<WFCommand>, Vec<QueryResult>) {
     let mut query_results = vec![];
     let mut terminals = vec![];
 
-    commands = std::mem::take(&mut commands)
+    let mut commands: Vec<_> = commands
         .into_iter()
         .filter_map(|c| {
             if let WFCommand::QueryResponse(qr) = c {
@@ -1221,12 +1221,12 @@ fn preprocess_command_sequence(mut commands: Vec<WFCommand>) -> (Vec<WFCommand>,
 }
 
 fn preprocess_command_sequence_old_behavior(
-    mut commands: Vec<WFCommand>,
+    commands: Vec<WFCommand>,
 ) -> (Vec<WFCommand>, Vec<QueryResult>) {
     let mut query_results = vec![];
     let mut seen_terminal = false;
 
-    commands = std::mem::take(&mut commands)
+    let commands: Vec<_> = commands
         .into_iter()
         .filter_map(|c| {
             if let WFCommand::QueryResponse(qr) = c {

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -1043,7 +1043,7 @@ fn validate_completion(
     match completion.status {
         Some(workflow_activation_completion::Status::Successful(success)) => {
             // Convert to wf commands
-            let mut commands = success
+            let commands = success
                 .commands
                 .into_iter()
                 .map(|c| c.try_into())
@@ -1068,16 +1068,6 @@ fn validate_completion(
                     ),
                     run_id: completion.run_id,
                 });
-            }
-
-            // Any non-query-response commands after a terminal command should be ignored
-            if let Some(term_cmd_pos) = commands.iter().position(|c| c.is_terminal()) {
-                // Query responses are just fine, so keep them.
-                let queries = commands
-                    .split_off(term_cmd_pos + 1)
-                    .into_iter()
-                    .filter(|c| matches!(c, WFCommand::QueryResponse(_)));
-                commands.extend(queries);
             }
 
             Ok(ValidatedCompletion::Success {

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -243,6 +243,14 @@ impl TestHistoryBuilder {
         self.build_and_push_event(EventType::WorkflowTaskFailed, attrs.into());
     }
 
+    pub fn add_timer_started(&mut self, timer_id: String) {
+        self.add(TimerStartedEventAttributes {
+            timer_id,
+            workflow_task_completed_event_id: self.previous_task_completed_id,
+            ..Default::default()
+        });
+    }
+
     pub fn add_timer_fired(&mut self, timer_started_evt_id: i64, timer_id: String) {
         self.add(TimerFiredEventAttributes {
             started_event_id: timer_started_evt_id,


### PR DESCRIPTION
Fixes #778 

- Previously, core was truncating commands received from lang at the first terminal command.
- With this PR, if there are terminal commands, we remove them all and replace the first one at the end of the command sequence.

### Evidence this is correct
- unit tests added for new and old logic
- TODO: add tests of replay / flag logic to `core`
- https://github.com/temporalio/sdk-python/pull/569 uses these changes and contains tests demonstrating that update completions are now honored, even when after workflow completion.