### PR TITLE
fix(deps): Add metrics features for opentelemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ derive_more = { version = "0.99", default-features = false, features = ["constru
 once_cell = "1.16"
 tonic = "0.11"
 tonic-build = "0.11"
-opentelemetry = "0.23"
+opentelemetry = { version = "0.23", features = ["metrics"] }
 prost = "0.12"
 prost-types = "0.12"
 


### PR DESCRIPTION
the core-api currently doesn't compile with otel because the opentelemetry::metrics module is feature gated

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Enabling the opentelemetry::metrics module

## Why?
Compilation error when using otel because of unresolved import