### PR TITLE
Ensure some rpcs use long-poll timeout

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1622,6 +1622,7 @@ impl<T> WfClientExt for T where T: WfHandleClient + Clone + Sized {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tonic::metadata::Ascii;
 
     #[test]
     fn applies_headers() {
@@ -1682,6 +1683,16 @@ mod tests {
         let req = interceptor.call(tonic::Request::new(())).unwrap();
         assert!(!req.metadata().contains_key("my-meta-key"));
         assert!(!req.metadata().contains_key("authorization"));
+
+        // Timeout header not overriden
+        let mut req = tonic::Request::new(());
+        req.metadata_mut()
+            .insert("grpc-timeout", "1S".parse().unwrap());
+        let req = interceptor.call(req).unwrap();
+        assert_eq!(
+            req.metadata().get("grpc-timeout").unwrap(),
+            "1S".parse::<MetadataValue<Ascii>>().unwrap()
+        );
     }
 
     #[test]

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -567,7 +567,7 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
-            if r.get_ref().wait_new_event == true {
+            if r.get_ref().wait_new_event {
                 r.set_timeout(LONG_POLL_TIMEOUT);
             }
         }

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -15,8 +15,7 @@ use temporal_sdk_core_api::telemetry::metrics::MetricKeyValue;
 use temporal_sdk_core_protos::{
     grpc::health::v1::{health_client::HealthClient, *},
     temporal::api::{
-        cloud::cloudservice::v1 as cloudreq,
-        cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
+        cloud::cloudservice::{v1 as cloudreq, v1::cloud_service_client::CloudServiceClient},
         operatorservice::v1::{operator_service_client::OperatorServiceClient, *},
         taskqueue::v1::TaskQueue,
         testservice::v1::{test_service_client::TestServiceClient, *},
@@ -568,6 +567,9 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
+            if r.get_ref().wait_new_event == true {
+                r.set_timeout(LONG_POLL_TIMEOUT);
+            }
         }
     );
     (
@@ -971,6 +973,7 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
+            r.set_timeout(LONG_POLL_TIMEOUT);
         }
     );
     (
@@ -980,6 +983,7 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
+            r.set_timeout(LONG_POLL_TIMEOUT);
         }
     );
     (

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,11 +22,11 @@ ephemeral-server = ["dep:flate2", "dep:reqwest", "dep:tar", "dep:zip"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-console-subscriber = { version = "0.2", optional = true }
+console-subscriber = { version = "0.3", optional = true }
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"
 crossbeam-utils = "0.8"
-dashmap = "5.5"
+dashmap = "6.0"
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 enum_dispatch = "0.3"
@@ -92,7 +92,7 @@ assert_matches = "1.4"
 bimap = "0.6.1"
 clap = { version = "4.0", features = ["derive"] }
 criterion = "0.5"
-rstest = "0.19.0"
+rstest = "0.21"
 sysinfo = "0.30"
 temporal-sdk-core-test-utils = { path = "../test-utils" }
 temporal-sdk = { path = "../sdk" }

--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -66,7 +66,7 @@ where
             .map(|ap| ap + self.unused_claimants.load(Ordering::Acquire))
     }
 
-    pub(crate) async fn acquire_owned(&self) -> Result<OwnedMeteredSemPermit<SK>, ()> {
+    pub(crate) async fn acquire_owned(&self) -> OwnedMeteredSemPermit<SK> {
         if let Some(max) = self.max_permits {
             self.extant_permits
                 .1
@@ -76,7 +76,7 @@ where
                 .expect("Extant permit channel is never closed");
         }
         let res = self.supplier.reserve_slot(self).await;
-        Ok(self.build_owned(res))
+        self.build_owned(res)
     }
 
     pub(crate) fn try_acquire_owned(&self) -> Result<OwnedMeteredSemPermit<SK>, ()> {
@@ -351,6 +351,6 @@ pub(crate) mod tests {
         advance_fut!(acquire_fut);
         drop(perm);
         // Now it'll proceed
-        acquire_fut.await.unwrap();
+        acquire_fut.await;
     }
 }

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2415,7 +2415,6 @@ async fn lang_internal_flags() {
 
 #[tokio::test]
 async fn lang_internal_flag_with_update() {
-    crate::telemetry::test_telem_console();
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();

--- a/core/src/pollers/poll_buffer.rs
+++ b/core/src/pollers/poll_buffer.rs
@@ -121,11 +121,6 @@ where
                         p = permit_dealer.acquire_owned() => p,
                         _ = shutdown.cancelled() => break,
                     };
-                    let permit = if let Ok(p) = permit {
-                        p
-                    } else {
-                        break;
-                    };
                     let _active_guard = ActiveCounter::new(ap.as_ref(), nph);
                     let r = tokio::select! {
                         r = pf() => r,
@@ -318,11 +313,7 @@ where
     SK: SlotKind + 'static,
 {
     async fn poll(&self) -> Option<pollers::Result<(T, OwnedMeteredSemPermit<SK>)>> {
-        let p = self
-            .sem
-            .acquire_owned()
-            .await
-            .expect("Semaphore in poller not closed!");
+        let p = self.sem.acquire_owned().await;
         self.inner.poll().await.map(|r| r.map(|r| (r, p)))
     }
 

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -811,10 +811,7 @@ impl RcvChans {
         let new_stream = UnboundedReceiverStream::new(new_reqs)
             // Get a permit for each new activity request
             .zip(stream::unfold(new_sem, |new_sem| async move {
-                let permit = new_sem
-                    .acquire_owned()
-                    .await
-                    .expect("Local activity semaphore is never closed");
+                let permit = new_sem.acquire_owned().await;
                 Some((permit, new_sem))
             }))
             .map(|(req, permit)| NewOrCancel::New(req, permit));

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -371,10 +371,7 @@ impl Worker {
                 let wfs = wft_stream.then(move |s| {
                     let wft_semaphore = wft_semaphore.clone();
                     async move {
-                        let permit = wft_semaphore
-                            .acquire_owned()
-                            .await
-                            .expect("Mock WFT stream should not see closed semaphore");
+                        let permit = wft_semaphore.acquire_owned().await;
                         s.map(|s| (s, permit))
                     }
                 });

--- a/tests/integ_tests/client_tests.rs
+++ b/tests/integ_tests/client_tests.rs
@@ -56,7 +56,7 @@ async fn per_call_timeout_respected_whole_client() {
         })
         .await
         .unwrap_err();
-    assert_eq!(err.code(), Code::DeadlineExceeded);
+    assert_matches!(err.code(), Code::DeadlineExceeded | Code::Cancelled);
 }
 
 #[tokio::test]
@@ -105,7 +105,6 @@ async fn per_call_timeout_respected_one_call() {
     req.set_timeout(Duration::from_millis(500));
     let start = std::time::Instant::now();
     let res = client.update_workflow_execution(req).await;
-    dbg!(&res);
     assert_matches!(
         res.unwrap_err().code(),
         Code::DeadlineExceeded | Code::Cancelled

--- a/tests/integ_tests/client_tests.rs
+++ b/tests/integ_tests/client_tests.rs
@@ -1,7 +1,15 @@
-use std::time::Duration;
-use temporal_client::{RetryClient, WorkflowClientTrait, WorkflowService};
-use temporal_sdk_core_protos::temporal::api::workflowservice::v1::DescribeNamespaceRequest;
+use assert_matches::assert_matches;
+use std::{collections::HashMap, time::Duration};
+use temporal_client::{Client, WorkflowClientTrait, WorkflowOptions, WorkflowService};
+use temporal_sdk_core_protos::temporal::api::{
+    common::v1::WorkflowExecution,
+    enums::v1::{UpdateWorkflowExecutionLifecycleStage, WorkflowIdReusePolicy},
+    update,
+    update::v1::WaitPolicy,
+    workflowservice::v1::{DescribeNamespaceRequest, UpdateWorkflowExecutionRequest},
+};
 use temporal_sdk_core_test_utils::{get_integ_server_options, CoreWfStarter, NAMESPACE};
+use tonic::{Code, Request};
 
 #[tokio::test]
 async fn can_use_retry_client() {
@@ -17,9 +25,8 @@ async fn can_use_retry_client() {
 #[tokio::test]
 async fn can_use_retry_raw_client() {
     let opts = get_integ_server_options();
-    let raw_client = opts.connect_no_namespace(None).await.unwrap();
-    let mut retry_client = RetryClient::new(raw_client, opts.retry_config);
-    retry_client
+    let mut client = opts.connect_no_namespace(None).await.unwrap();
+    client
         .describe_namespace(DescribeNamespaceRequest {
             namespace: NAMESPACE.to_string(),
             ..Default::default()
@@ -33,4 +40,75 @@ async fn calls_get_system_info() {
     let opts = get_integ_server_options();
     let raw_client = opts.connect_no_namespace(None).await.unwrap();
     assert!(raw_client.get_client().capabilities().is_some());
+}
+
+#[tokio::test]
+async fn per_call_timeout_respected_whole_client() {
+    let opts = get_integ_server_options();
+    let mut raw_client = opts.connect_no_namespace(None).await.unwrap();
+    let mut hm = HashMap::new();
+    hm.insert("grpc-timeout".to_string(), "0S".to_string());
+    raw_client.get_client().set_headers(hm);
+    let err = raw_client
+        .describe_namespace(DescribeNamespaceRequest {
+            namespace: NAMESPACE.to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::DeadlineExceeded);
+}
+
+#[tokio::test]
+async fn per_call_timeout_respected_one_call() {
+    let opts = get_integ_server_options();
+    let mut client = opts.connect_no_namespace(None).await.unwrap();
+    // Start a workflow (we don't need to actually make any progress on it)
+    let wfc = Client::new(client.clone().into_inner(), NAMESPACE.to_string());
+    wfc.start_workflow(
+        vec![],
+        "whatever".to_string(),
+        "test-rpc-timeout".to_string(),
+        "whatever".to_string(),
+        None,
+        WorkflowOptions {
+            run_timeout: Some(Duration::from_secs(10)),
+            id_reuse_policy: WorkflowIdReusePolicy::TerminateIfRunning,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut req = Request::new(UpdateWorkflowExecutionRequest {
+        namespace: NAMESPACE.to_string(),
+        wait_policy: Some(WaitPolicy {
+            lifecycle_stage: UpdateWorkflowExecutionLifecycleStage::Completed.into(),
+        }),
+        workflow_execution: Some(WorkflowExecution {
+            workflow_id: "test-rpc-timeout".to_string(),
+            run_id: "".to_string(),
+        }),
+        request: Some(update::v1::Request {
+            meta: Some(update::v1::Meta {
+                update_id: "".into(),
+                identity: "aaaa".to_string(),
+            }),
+            input: Some(update::v1::Input {
+                header: None,
+                name: "update".to_string(),
+                args: None,
+            }),
+        }),
+        ..Default::default()
+    });
+    req.set_timeout(Duration::from_millis(500));
+    let start = std::time::Instant::now();
+    let res = client.update_workflow_execution(req).await;
+    dbg!(&res);
+    assert_matches!(
+        res.unwrap_err().code(),
+        Code::DeadlineExceeded | Code::Cancelled
+    );
+    assert!(start.elapsed() < Duration::from_secs(1));
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added tests for grpc-timeout header (which was already working properly turns out)
Made certain rpcs that do/can act like long-polls use the long poll timeout.
One unrelated bit of cleanup around slot permit reservation I had pending.

## Why?
Better timeouts

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/774

2. How was this tested:
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
