### PR TITLE
Don't overwrite grpc-timeout header on update requests

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -529,9 +529,7 @@ impl Interceptor for ServiceCallInterceptor {
             );
         }
         self.headers.read().apply_to_metadata(metadata);
-        if !metadata.contains_key("grpc-timeout") {
-            request.set_timeout(OTHER_CALL_TIMEOUT);
-        }
+        request.set_default_timeout(OTHER_CALL_TIMEOUT);
 
         Ok(request)
     }
@@ -1618,6 +1616,18 @@ pub trait WfClientExt: WfHandleClient + Sized + Clone {
 }
 
 impl<T> WfClientExt for T where T: WfHandleClient + Clone + Sized {}
+
+trait RequestExt {
+    /// Set a timeout for a request if one is not already specified in the metadata
+    fn set_default_timeout(&mut self, duration: Duration);
+}
+impl<T> RequestExt for tonic::Request<T> {
+    fn set_default_timeout(&mut self, duration: Duration) {
+        if !self.metadata().contains_key("grpc-timeout") {
+            self.set_timeout(duration)
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -567,7 +567,7 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
-            if r.get_ref().wait_new_event {
+            if r.get_ref().wait_new_event && !r.metadata().contains_key("grpc-timeout") {
                 r.set_timeout(LONG_POLL_TIMEOUT);
             }
         }

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -6,8 +6,8 @@ use crate::{
     metrics::{namespace_kv, task_queue_kv},
     raw::sealed::RawClientLike,
     worker_registry::{Slot, SlotManager},
-    Client, ConfiguredClient, InterceptedMetricsSvc, RetryClient, TemporalServiceClient,
-    LONG_POLL_TIMEOUT,
+    Client, ConfiguredClient, InterceptedMetricsSvc, RequestExt, RetryClient,
+    TemporalServiceClient, LONG_POLL_TIMEOUT,
 };
 use futures::{future::BoxFuture, FutureExt, TryFutureExt};
 use std::sync::Arc;
@@ -567,8 +567,8 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
-            if r.get_ref().wait_new_event && !r.metadata().contains_key("grpc-timeout") {
-                r.set_timeout(LONG_POLL_TIMEOUT);
+            if r.get_ref().wait_new_event {
+                r.set_default_timeout(LONG_POLL_TIMEOUT);
             }
         }
     );
@@ -589,7 +589,7 @@ proxier! {
             let mut labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             labels.task_q(r.get_ref().task_queue.clone());
             r.extensions_mut().insert(labels);
-            r.set_timeout(LONG_POLL_TIMEOUT);
+            r.set_default_timeout(LONG_POLL_TIMEOUT);
         }
     );
     (
@@ -618,7 +618,7 @@ proxier! {
             let mut labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             labels.task_q(r.get_ref().task_queue.clone());
             r.extensions_mut().insert(labels);
-            r.set_timeout(LONG_POLL_TIMEOUT);
+            r.set_default_timeout(LONG_POLL_TIMEOUT);
         }
     );
     (
@@ -973,9 +973,7 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
-            if !r.metadata().contains_key("grpc-timeout")  {
-                r.set_timeout(LONG_POLL_TIMEOUT);
-            }
+            r.set_default_timeout(LONG_POLL_TIMEOUT);
         }
     );
     (
@@ -985,9 +983,7 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
-            if !r.metadata().contains_key("grpc-timeout")  {
-                r.set_timeout(LONG_POLL_TIMEOUT);
-            }
+            r.set_default_timeout(LONG_POLL_TIMEOUT);
         }
     );
     (

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -973,7 +973,9 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
-            r.set_timeout(LONG_POLL_TIMEOUT);
+            if !r.metadata().contains_key("grpc-timeout")  {
+                r.set_timeout(LONG_POLL_TIMEOUT);
+            }
         }
     );
     (
@@ -983,7 +985,9 @@ proxier! {
         |r| {
             let labels = AttachMetricLabels::namespace(r.get_ref().namespace.clone());
             r.extensions_mut().insert(labels);
-            r.set_timeout(LONG_POLL_TIMEOUT);
+            if !r.metadata().contains_key("grpc-timeout")  {
+                r.set_timeout(LONG_POLL_TIMEOUT);
+            }
         }
     );
     (

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -96,6 +96,7 @@ rstest = "0.21"
 sysinfo = "0.30"
 temporal-sdk-core-test-utils = { path = "../test-utils" }
 temporal-sdk = { path = "../sdk" }
+tokio-stream = { version = "0.1", features = ["net"] }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/tests/integ_tests/client_tests.rs
+++ b/tests/integ_tests/client_tests.rs
@@ -1,9 +1,21 @@
 use assert_matches::assert_matches;
-use std::{collections::HashMap, time::Duration};
-use temporal_client::{WorkflowClientTrait, WorkflowService};
+use futures_util::{future::BoxFuture, FutureExt};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    task::{Context, Poll},
+    time::Duration,
+};
+use temporal_client::{RetryConfig, WorkflowClientTrait, WorkflowService};
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::DescribeNamespaceRequest;
 use temporal_sdk_core_test_utils::{get_integ_server_options, CoreWfStarter, NAMESPACE};
-use tonic::{Code, Request};
+use tokio::{
+    net::TcpListener,
+    sync::{mpsc::UnboundedSender, oneshot},
+};
+use tonic::{
+    body::BoxBody, codegen::Service, server::NamedService, transport::Server, Code, Request,
+};
 
 #[tokio::test]
 async fn can_use_retry_client() {
@@ -68,4 +80,83 @@ async fn per_call_timeout_respected_one_call() {
         res.unwrap_err().code(),
         Code::DeadlineExceeded | Code::Cancelled
     );
+}
+
+#[derive(Clone)]
+struct GenericService {
+    timeouts_tx: UnboundedSender<String>,
+}
+impl Service<tonic::codegen::http::Request<tonic::transport::Body>> for GenericService {
+    type Response = tonic::codegen::http::Response<BoxBody>;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: tonic::codegen::http::Request<tonic::transport::Body>) -> Self::Future {
+        self.timeouts_tx
+            .send(
+                String::from_utf8_lossy(req.headers().get("grpc-timeout").unwrap().as_bytes())
+                    .to_string(),
+            )
+            .unwrap();
+        async move { Ok(Self::Response::new(tonic::codegen::empty_body())) }.boxed()
+    }
+}
+impl NamedService for GenericService {
+    const NAME: &'static str = "temporal.api.workflowservice.v1.WorkflowService";
+}
+
+#[tokio::test]
+async fn timeouts_respected_one_call_fake_server() {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let (timeouts_tx, mut timeouts_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(GenericService { timeouts_tx })
+            .serve_with_incoming_shutdown(
+                tokio_stream::wrappers::TcpListenerStream::new(listener),
+                async {
+                    shutdown_rx.await.ok();
+                },
+            )
+            .await
+            .unwrap();
+    });
+
+    let mut opts = get_integ_server_options();
+    let uri = format!("http://localhost:{}", addr.port()).parse().unwrap();
+    opts.target_url = uri;
+    opts.skip_get_system_info = true;
+    opts.retry_config = RetryConfig {
+        max_retries: 1,
+        ..Default::default()
+    };
+
+    let mut client = opts.connect_no_namespace(None).await.unwrap();
+
+    macro_rules! call_client {
+        ($client:ident, $trx:ident, $client_fn:ident) => {
+            let mut req = Request::new(Default::default());
+            req.set_timeout(Duration::from_millis(100));
+            // Response is always error b/c empty body
+            let _ = $client.$client_fn(req).await;
+            let timeout = $trx.recv().await.unwrap();
+            assert_eq!("100000u", timeout);
+        };
+    }
+
+    call_client!(client, timeouts_rx, get_workflow_execution_history);
+    call_client!(client, timeouts_rx, update_workflow_execution);
+    call_client!(client, timeouts_rx, poll_workflow_execution_update);
+
+    // Shutdown the server
+    shutdown_tx.send(()).unwrap();
+    server_handle.await.unwrap();
 }


### PR DESCRIPTION
#780 caused the `sdk-python` test `tests/worker/test_workflow.py::test_workflow_update_timeout_or_cancel` to fail, because the grpc-timeout header set here was not honored:

https://github.com/temporalio/sdk-python/blob/c4b1a019ad2627edb20a954edfd57c9ba414f3d5/tests/worker/test_workflow.py#L4482

https://github.com/temporalio/sdk-python/blob/c4b1a019ad2627edb20a954edfd57c9ba414f3d5/tests/worker/test_workflow.py#L4523 

@Sushisource defer to you on the correct resolution. FWIW, this PR makes the test pass again.