### PR TITLE
rust-sdk: prevent panic on non-existing workflow

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -403,9 +403,10 @@ impl WorkflowHalf {
         }) {
             let workflow_type = &sw.workflow_type;
             let wf_fns_borrow = self.workflow_fns.borrow();
-            let wf_function = wf_fns_borrow
-                .get(workflow_type)
-                .ok_or_else(|| anyhow!("Workflow type {workflow_type} not found"))?;
+            let Some(wf_function) = wf_fns_borrow.get(workflow_type) else {
+                warn!("Workflow type {workflow_type} not found");
+                return Ok(None);
+            };
 
             let (wff, activations) = wf_function.start_workflow(
                 common.worker.get_config().namespace.clone(),


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This changes the check to warn about the workflow and allows the worker to continue polling from the queue similar to the other SDKs.

Currently, there is no good way of writing a test to make sure this isn't introduced by a refactor in the future.
Maybe with a custom tracing subscriber to check for the warn output, but that would be something for it's own PR.

## Why?
Previously, the worker would panic due to the error return value of the activation handler.
Other SDKs do not panic/exit upon an unknown workflow. 

## Checklist
<!--- add/delete as needed --->

1. Closes #558

2. How was this tested:
Start an empty worker with a local dev instance and start a workflow with any name. The worker should not exit.

3. Any docs updates needed?
Not really.
