### PR TITLE
Make sure to use native roots / add cloud ops API test

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -474,7 +474,7 @@ impl ClientOptions {
     /// Passes it through if TLS options not set.
     async fn add_tls_to_channel(&self, mut channel: Endpoint) -> Result<Endpoint, ClientInitError> {
         if let Some(tls_cfg) = &self.tls_cfg {
-            let mut tls = tonic::transport::ClientTlsConfig::new();
+            let mut tls = tonic::transport::ClientTlsConfig::new().with_native_roots();
 
             if let Some(root_cert) = &tls_cfg.server_root_ca_cert {
                 let server_root_ca_cert = Certificate::from_pem(root_cert);


### PR DESCRIPTION
TLS connections to the Cloud Ops API (which does not use mTLS like other connections) were failing with unknown CA problems.