### PR TITLE
Rust-SDK: Handle unknown workflow

### DIFF
--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -272,6 +272,7 @@ async fn legacy_query_failure_on_wft_failure() {
             message: "Ahh i broke".to_string(),
             ..Default::default()
         },
+        None,
     ))
     .await
     .unwrap();

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -950,13 +950,17 @@ pub mod coresdk {
             }
         }
 
-        pub fn fail(run_id: impl Into<String>, failure: Failure) -> Self {
+        pub fn fail(
+            run_id: impl Into<String>,
+            failure: Failure,
+            cause: Option<WorkflowTaskFailedCause>,
+        ) -> Self {
             Self {
                 run_id: run_id.into(),
                 status: Some(workflow_activation_completion::Status::Failed(
                     workflow_completion::Failure {
                         failure: Some(failure),
-                        force_cause: WorkflowTaskFailedCause::Unspecified as i32,
+                        force_cause: cause.unwrap_or(WorkflowTaskFailedCause::Unspecified) as i32,
                     },
                 )),
             }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -97,6 +97,7 @@ use temporal_sdk_core_protos::{
     },
     temporal::api::{
         common::v1::Payload,
+        enums::v1::WorkflowTaskFailedCause,
         failure::v1::{failure, Failure},
     },
     TaskToken,
@@ -405,6 +406,14 @@ impl WorkflowHalf {
             let wf_fns_borrow = self.workflow_fns.borrow();
             let Some(wf_function) = wf_fns_borrow.get(workflow_type) else {
                 warn!("Workflow type {workflow_type} not found");
+
+                completions_tx
+                    .send(WorkflowActivationCompletion::fail(
+                        run_id,
+                        format!("Workflow type {workflow_type} not found").into(),
+                        Some(WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure),
+                    ))
+                    .expect("Completion channel intact");
                 return Ok(None);
             };
 

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -145,7 +145,11 @@ impl WorkflowFuture {
     fn fail_wft(&self, run_id: String, fail: Error) {
         warn!("Workflow task failed for {}: {}", run_id, fail);
         self.outgoing_completions
-            .send(WorkflowActivationCompletion::fail(run_id, fail.into()))
+            .send(WorkflowActivationCompletion::fail(
+                run_id,
+                fail.into(),
+                None,
+            ))
             .expect("Completion channel intact");
     }
 
@@ -443,6 +447,7 @@ impl WorkflowFuture {
                             message: errmsg,
                             ..Default::default()
                         },
+                        None,
                     ))
                     .expect("Completion channel intact");
                 // Loop back up because we're about to get evicted

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -376,6 +376,7 @@ async fn query_of_closed_workflow_doesnt_tick_terminal_metric(
         .complete_workflow_activation(WorkflowActivationCompletion::fail(
             task.run_id,
             "whatever".into(),
+            None,
         ))
         .await
         .unwrap();

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -288,6 +288,7 @@ async fn fail_legacy_query() {
                 message: query_err.to_string(),
                 ..Default::default()
             },
+            None,
         ))
         .await
         .unwrap();

--- a/tests/integ_tests/worker_tests.rs
+++ b/tests/integ_tests/worker_tests.rs
@@ -1,7 +1,20 @@
+use std::cell::Cell;
+use std::sync::Arc;
+
 use assert_matches::assert_matches;
+use temporal_client::WorkflowOptions;
+use temporal_sdk::interceptors::WorkerInterceptor;
 use temporal_sdk_core::{init_worker, CoreRuntime};
 use temporal_sdk_core_api::{errors::WorkerValidationError, worker::WorkerConfigBuilder, Worker};
-use temporal_sdk_core_test_utils::{get_integ_server_options, get_integ_telem_options};
+use temporal_sdk_core_protos::coresdk::workflow_completion::{
+    workflow_activation_completion::Status, Failure, WorkflowActivationCompletion,
+};
+use temporal_sdk_core_protos::temporal::api::failure::v1::Failure as InnerFailure;
+use temporal_sdk_core_test_utils::{
+    drain_pollers_and_shutdown, get_integ_server_options, get_integ_telem_options, CoreWfStarter,
+};
+use tokio::sync::Notify;
+use uuid::Uuid;
 
 #[tokio::test]
 async fn worker_validation_fails_on_nonexistent_namespace() {
@@ -29,4 +42,72 @@ async fn worker_validation_fails_on_nonexistent_namespace() {
         res,
         Err(WorkerValidationError::NamespaceDescribeError { .. })
     );
+}
+
+#[tokio::test]
+async fn worker_handles_unknown_workflow_types_gracefully() {
+    let wf_type = "worker_handles_unknown_workflow_types_gracefully";
+    let mut starter = CoreWfStarter::new(wf_type);
+    let mut worker = starter.worker().await;
+
+    let run_id = worker
+        .submit_wf(
+            format!("wce-{}", Uuid::new_v4()),
+            "unregistered".to_string(),
+            vec![],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    struct GracefulAsserter {
+        notify: Arc<Notify>,
+        run_id: String,
+        unregistered_failure_seen: Cell<bool>,
+    }
+    #[async_trait::async_trait(?Send)]
+    impl WorkerInterceptor for GracefulAsserter {
+        async fn on_workflow_activation_completion(
+            &self,
+            completion: &WorkflowActivationCompletion,
+        ) {
+            if matches!(
+                completion,
+                WorkflowActivationCompletion {
+                    status: Some(Status::Failed(Failure {
+                        failure: Some(InnerFailure { message, .. }),
+                        ..
+                    })),
+                    run_id,
+                } if message == "Workflow type unregistered not found" && *run_id == self.run_id
+            ) {
+                self.unregistered_failure_seen.set(true);
+            }
+            // If we've seen the failure, and the completion is a success for the same run, we're done
+            if matches!(
+                completion,
+                WorkflowActivationCompletion {
+                    status: Some(Status::Successful(..)),
+                    run_id,
+                } if self.unregistered_failure_seen.get() && *run_id == self.run_id
+            ) {
+                // Shutdown the worker
+                self.notify.notify_one();
+            }
+        }
+        fn on_shutdown(&self, _: &temporal_sdk::Worker) {}
+    }
+
+    let inner = worker.inner_mut();
+    let notify = Arc::new(Notify::new());
+    inner.set_worker_interceptor(GracefulAsserter {
+        notify: notify.clone(),
+        run_id,
+        unregistered_failure_seen: Cell::new(false),
+    });
+    tokio::join!(async { inner.run().await.unwrap() }, async move {
+        notify.notified().await;
+        let worker = starter.get_worker().await.clone();
+        drain_pollers_and_shutdown(&worker).await;
+    });
 }

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -222,6 +222,7 @@ async fn fail_wf_task(#[values(true, false)] replay: bool) {
     core.complete_workflow_activation(WorkflowActivationCompletion::fail(
         task.run_id,
         Failure::application_failure("I did an oopsie".to_string(), false),
+        None,
     ))
     .await
     .unwrap();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This makes sure unknown workflows are handled on-par with other SDKs. This is done by emitting a `WorkflowActivationComplete` message with state set to failure.

This is based on feedback from https://github.com/temporalio/sdk-core/pull/784

## Why?
The recent changed avoided panics caused by unknown workflows. The workflow activation was never marked as failed.
This made it hard to add a test for this behavior.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Test is added to check for the correct behavior.
