### PR TITLE
Job ordering updates

### DIFF
--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -462,7 +462,7 @@ async fn activity_timeout_no_double_resolve() {
         WorkflowCachingPolicy::NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_id,
                     activity_id: activity_id.to_string(),

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -636,7 +636,7 @@ async fn la_resolve_during_legacy_query_does_not_combine(#[case] impossible_quer
         assert_matches!(
             task.jobs.as_slice(),
             &[WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
             },]
         );
         core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
@@ -1239,7 +1239,7 @@ async fn queries_can_be_received_while_heartbeating() {
     assert_matches!(
         task.jobs.as_slice(),
         &[WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
         },]
     );
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(

--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -474,7 +474,7 @@ async fn query_cache_miss_causes_page_fetch_dont_reply_wft_too_early(
     assert_matches!(
         task.jobs.as_slice(),
         [WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
         }]
     );
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
@@ -696,7 +696,7 @@ async fn new_query_fail() {
     assert_matches!(
         task.jobs[0],
         WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
         }
     );
 

--- a/core/src/core_tests/updates.rs
+++ b/core/src/core_tests/updates.rs
@@ -46,10 +46,10 @@ async fn replay_with_empty_first_task() {
         task.jobs.as_slice(),
         [
             WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::DoUpdate(_)),
+                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
             },
             WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::DoUpdate(_)),
             },
         ]
     );

--- a/core/src/core_tests/updates.rs
+++ b/core/src/core_tests/updates.rs
@@ -46,7 +46,7 @@ async fn replay_with_empty_first_task() {
         task.jobs.as_slice(),
         [
             WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
             },
             WorkflowActivationJob {
                 variant: Some(workflow_activation_job::Variant::DoUpdate(_)),

--- a/core/src/core_tests/workflow_cancels.rs
+++ b/core/src/core_tests/workflow_cancels.rs
@@ -58,7 +58,7 @@ async fn timer_then_cancel_req(
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![start_timer_cmd(timer_seq, Duration::from_secs(1))],
             ),
             gen_assert_and_reply(
@@ -84,7 +84,7 @@ async fn timer_then_cancel_req_then_timer_then_cancelled() {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![start_timer_cmd(1, Duration::from_secs(1))],
             ),
             gen_assert_and_reply(
@@ -114,7 +114,7 @@ async fn immediate_cancel() {
         NonSticky,
         &[gen_assert_and_reply(
             &job_assert!(
-                workflow_activation_job::Variant::StartWorkflow(_),
+                workflow_activation_job::Variant::InitializeWorkflow(_),
                 workflow_activation_job::Variant::CancelWorkflow(_)
             ),
             vec![CancelWorkflowExecution {}.into()],

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -692,17 +692,19 @@ async fn workflow_update_random_seed_on_workflow_reset() {
                 },
                 vec![start_timer_cmd(timer_1_id, Duration::from_secs(1))],
             ),
+            // The random seed update should always be the first job
             gen_assert_and_reply(
                 &|res| {
                     assert_matches!(
                         res.jobs.as_slice(),
                         [WorkflowActivationJob {
-                            variant: Some(workflow_activation_job::Variant::FireTimer(_),),
-                        },
-                        WorkflowActivationJob {
                             variant: Some(workflow_activation_job::Variant::UpdateRandomSeed(
                                 UpdateRandomSeed{randomness_seed})),
-                        }] => {
+                        },
+                            WorkflowActivationJob {
+                            variant: Some(workflow_activation_job::Variant::FireTimer(_),),
+                        },
+                        ] => {
                             assert_ne!(randomness_seed_from_start.load(Ordering::SeqCst),
                                       *randomness_seed);
                         }

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -42,8 +42,8 @@ use temporal_sdk_core_protos::{
         activity_result::{self as ar, activity_resolution, ActivityResolution},
         common::VersioningIntent,
         workflow_activation::{
-            remove_from_cache::EvictionReason, workflow_activation_job, FireTimer, ResolveActivity,
-            StartWorkflow, UpdateRandomSeed, WorkflowActivationJob,
+            remove_from_cache::EvictionReason, workflow_activation_job, FireTimer,
+            InitializeWorkflow, ResolveActivity, UpdateRandomSeed, WorkflowActivationJob,
         },
         workflow_commands::{
             update_response::Response, workflow_command, ActivityCancellationType, CancelTimer,
@@ -683,7 +683,7 @@ async fn workflow_update_random_seed_on_workflow_reset() {
                         res.jobs.as_slice(),
                         [WorkflowActivationJob {
                             variant: Some(workflow_activation_job::Variant::InitializeWorkflow(
-                            StartWorkflow{randomness_seed, ..}
+                            InitializeWorkflow{randomness_seed, ..}
                             )),
                         }] => {
                         randomness_seed_from_start.store(*randomness_seed, Ordering::SeqCst);

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2641,14 +2641,13 @@ async fn jobs_are_in_appropriate_order() {
     let core = mock_worker(mock);
 
     let act = core.poll_workflow_activation().await.unwrap();
-    // Patch notifications always come first
     assert_matches!(
         act.jobs[0].variant.as_ref().unwrap(),
-        workflow_activation_job::Variant::NotifyHasPatch(_)
+        workflow_activation_job::Variant::InitializeWorkflow(_)
     );
     assert_matches!(
         act.jobs[1].variant.as_ref().unwrap(),
-        workflow_activation_job::Variant::InitializeWorkflow(_)
+        workflow_activation_job::Variant::NotifyHasPatch(_)
     );
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         act.run_id,

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -112,7 +112,7 @@ async fn single_timer(#[case] worker: Worker, #[case] evict: WorkflowCachingPoli
         evict,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![start_timer_cmd(1, Duration::from_secs(1))],
             ),
             gen_assert_and_reply(
@@ -137,7 +137,7 @@ async fn single_activity_completion(worker: Worker) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     activity_id: "fake_activity".to_string(),
                     ..default_act_sched()
@@ -171,7 +171,7 @@ async fn parallel_timer_test_across_wf_bridge(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![
                     start_timer_cmd(timer_1_id, Duration::from_secs(1)),
                     start_timer_cmd(timer_2_id, Duration::from_secs(1)),
@@ -223,7 +223,7 @@ async fn timer_cancel(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![
                     start_timer_cmd(cancel_timer_id, Duration::from_secs(1)),
                     start_timer_cmd(timer_id, Duration::from_secs(1)),
@@ -260,7 +260,7 @@ async fn scheduled_activity_cancellation_try_cancel(hist_batches: &'static [usiz
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_seq,
                     activity_id: activity_id.to_string(),
@@ -297,7 +297,7 @@ async fn scheduled_activity_timeout(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_seq,
                     activity_id: activity_id.to_string(),
@@ -350,7 +350,7 @@ async fn started_activity_timeout(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_seq,
                     activity_id: activity_seq.to_string(),
@@ -405,7 +405,7 @@ async fn cancelled_activity_timeout(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_seq,
                     activity_id: activity_id.to_string(),
@@ -557,7 +557,7 @@ async fn verify_activity_cancellation(
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_seq,
                     activity_id: activity_seq.to_string(),
@@ -625,7 +625,7 @@ async fn verify_activity_cancellation_wait_for_cancellation(activity_id: u32, wo
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_id,
                     activity_id: activity_id.to_string(),
@@ -682,7 +682,7 @@ async fn workflow_update_random_seed_on_workflow_reset() {
                     assert_matches!(
                         res.jobs.as_slice(),
                         [WorkflowActivationJob {
-                            variant: Some(workflow_activation_job::Variant::StartWorkflow(
+                            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(
                             StartWorkflow{randomness_seed, ..}
                             )),
                         }] => {
@@ -733,7 +733,7 @@ async fn cancel_timer_before_sent_wf_bridge() {
         &core,
         NonSticky,
         &[gen_assert_and_reply(
-            &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+            &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
             vec![
                 start_timer_cmd(cancel_timer_id, Duration::from_secs(1)),
                 CancelTimer {
@@ -804,7 +804,7 @@ async fn simple_timer_fail_wf_execution(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![start_timer_cmd(timer_id, Duration::from_secs(1))],
             ),
             gen_assert_and_reply(
@@ -835,7 +835,7 @@ async fn two_signals(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 // Task is completed with no commands
                 vec![],
             ),
@@ -959,7 +959,7 @@ async fn activity_not_canceled_on_replay_repro(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 // Start timer and activity
                 vec![
                     ScheduleActivity {
@@ -1005,7 +1005,7 @@ async fn activity_not_canceled_when_also_completed_repro(hist_batches: &'static 
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_id,
                     activity_id: "act-1".to_string(),
@@ -1063,7 +1063,7 @@ async fn lots_of_workflows() {
             while let Ok(wft) = worker.poll_workflow_activation().await {
                 let job = &wft.jobs[0];
                 let reply = match job.variant {
-                    Some(workflow_activation_job::Variant::StartWorkflow(_)) => {
+                    Some(workflow_activation_job::Variant::InitializeWorkflow(_)) => {
                         start_timer_cmd(1, Duration::from_secs(1))
                     }
                     Some(workflow_activation_job::Variant::RemoveFromCache(_)) => {
@@ -1106,7 +1106,7 @@ async fn wft_timeout_repro(hist_batches: &'static [usize]) {
         NonSticky,
         &[
             gen_assert_and_reply(
-                &job_assert!(workflow_activation_job::Variant::StartWorkflow(_)),
+                &job_assert!(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 vec![ScheduleActivity {
                     seq: activity_id,
                     activity_id: activity_id.to_string(),
@@ -1228,7 +1228,7 @@ async fn new_server_work_while_eviction_outstanding_doesnt_overwrite_activation(
     let start_again = core.poll_workflow_activation().await.unwrap();
     assert_matches!(
         start_again.jobs[0].variant,
-        Some(workflow_activation_job::Variant::StartWorkflow(_))
+        Some(workflow_activation_job::Variant::InitializeWorkflow(_))
     );
 }
 
@@ -1443,7 +1443,7 @@ async fn lang_slower_than_wft_timeouts() {
     let start_again = core.poll_workflow_activation().await.unwrap();
     assert_matches!(
         start_again.jobs[0].variant,
-        Some(workflow_activation_job::Variant::StartWorkflow(_))
+        Some(workflow_activation_job::Variant::InitializeWorkflow(_))
     );
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         start_again.run_id,
@@ -1604,7 +1604,7 @@ async fn cache_miss_will_fetch_history() {
     assert_matches!(
         activation.jobs.as_slice(),
         [WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
         }]
     );
     // Force an eviction (before complete matters, so that we will be sure the eviction is queued
@@ -1633,7 +1633,7 @@ async fn cache_miss_will_fetch_history() {
             assert_matches!(
                 activation.jobs.as_slice(),
                 [WorkflowActivationJob {
-                    variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                    variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 }]
             );
         }
@@ -1831,7 +1831,7 @@ async fn poll_faster_than_complete_wont_overflow_cache() {
     for (i, p_res) in [&p1, &p2, &p3].into_iter().enumerate() {
         assert_matches!(
             &p_res.jobs[0].variant,
-            Some(workflow_activation_job::Variant::StartWorkflow(sw))
+            Some(workflow_activation_job::Variant::InitializeWorkflow(sw))
             if sw.workflow_id == format!("wf-{}", i + 1)
         );
     }
@@ -1876,7 +1876,7 @@ async fn poll_faster_than_complete_wont_overflow_cache() {
         let res = core.poll_workflow_activation().await.unwrap();
         assert_matches!(
             &res.jobs[0].variant,
-            Some(workflow_activation_job::Variant::StartWorkflow(sw))
+            Some(workflow_activation_job::Variant::InitializeWorkflow(sw))
             if sw.workflow_id == format!("wf-{}", 4)
         );
         res
@@ -1921,7 +1921,7 @@ async fn poll_faster_than_complete_wont_overflow_cache() {
         let res = core.poll_workflow_activation().await.unwrap();
         assert_matches!(
             &res.jobs[0].variant,
-            Some(workflow_activation_job::Variant::StartWorkflow(sw))
+            Some(workflow_activation_job::Variant::InitializeWorkflow(sw))
             if sw.workflow_id == "wf-5"
         );
     };
@@ -2006,7 +2006,7 @@ async fn autocompletes_wft_no_work() {
     assert_matches!(
         act.jobs.as_slice(),
         [WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
         }]
     );
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
@@ -2189,7 +2189,7 @@ async fn ignorable_events_are_ok(#[values(true, false)] attribs_unset: bool) {
     let act = core.poll_workflow_activation().await.unwrap();
     assert_matches!(
         act.jobs[0].variant,
-        Some(workflow_activation_job::Variant::StartWorkflow(_))
+        Some(workflow_activation_job::Variant::InitializeWorkflow(_))
     );
 }
 
@@ -2237,7 +2237,7 @@ async fn fetching_to_continue_replay_works() {
     let act = core.poll_workflow_activation().await.unwrap();
     assert_matches!(
         act.jobs[0].variant,
-        Some(workflow_activation_job::Variant::StartWorkflow(_))
+        Some(workflow_activation_job::Variant::InitializeWorkflow(_))
     );
     core.complete_workflow_activation(WorkflowActivationCompletion::empty(act.run_id))
         .await
@@ -2288,7 +2288,7 @@ async fn fetching_error_evicts_wf() {
     let act = core.poll_workflow_activation().await.unwrap();
     assert_matches!(
         act.jobs[0].variant,
-        Some(workflow_activation_job::Variant::StartWorkflow(_))
+        Some(workflow_activation_job::Variant::InitializeWorkflow(_))
     );
     core.complete_workflow_activation(WorkflowActivationCompletion::empty(act.run_id))
         .await
@@ -2443,7 +2443,7 @@ async fn lang_internal_flag_with_update() {
         act.jobs.as_slice(),
         [
             WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
             },
             WorkflowActivationJob {
                 variant: Some(workflow_activation_job::Variant::DoUpdate(_)),
@@ -2648,7 +2648,7 @@ async fn jobs_are_in_appropriate_order() {
     );
     assert_matches!(
         act.jobs[1].variant.as_ref().unwrap(),
-        workflow_activation_job::Variant::StartWorkflow(_)
+        workflow_activation_job::Variant::InitializeWorkflow(_)
     );
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         act.run_id,

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2443,10 +2443,10 @@ async fn lang_internal_flag_with_update() {
         act.jobs.as_slice(),
         [
             WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::DoUpdate(_)),
+                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
             },
             WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::DoUpdate(_)),
             },
         ]
     );

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -46,7 +46,7 @@ pub struct TemporalDevServerConfig {
     /// Log format and level
     #[builder(default = "(\"pretty\".to_owned(), \"warn\".to_owned())")]
     pub log: (String, String),
-    /// Additional arguments to Temporalite.
+    /// Additional arguments to Temporal dev server.
     #[builder(default)]
     pub extra_args: Vec<String>,
 }
@@ -567,8 +567,10 @@ async fn download_and_extract(
 #[cfg(test)]
 mod tests {
     use super::get_free_port;
-    use std::collections::HashSet;
-    use std::net::{TcpListener, TcpStream};
+    use std::{
+        collections::HashSet,
+        net::{TcpListener, TcpStream},
+    };
 
     #[test]
     fn get_free_port_no_double() {

--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -838,7 +838,7 @@ mod test {
             assert_matches!(
                 a.jobs.as_slice(),
                 [WorkflowActivationJob {
-                    variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                    variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 }]
             )
         });

--- a/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
@@ -133,7 +133,7 @@ mod tests {
             assert_matches!(
                 a.jobs.as_slice(),
                 [WorkflowActivationJob {
-                    variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                    variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 }]
             )
         });

--- a/core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/core/src/worker/workflow/machines/patch_state_machine.rs
@@ -551,10 +551,11 @@ mod tests {
 
         let mut aai = ActivationAssertionsInterceptor::default();
         aai.then(move |act| {
-            // replaying cases should immediately get a resolve change activation when marker is present
+            // replaying cases should immediately get a resolve change activation when marker is
+            // present
             if replaying && marker_type != MarkerType::NoMarker {
                 assert_matches!(
-                    &act.jobs[0],
+                    &act.jobs[1],
                      WorkflowActivationJob {
                         variant: Some(workflow_activation_job::Variant::NotifyHasPatch(
                             NotifyHasPatch {

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -1331,7 +1331,7 @@ impl LocalActivityRequestSink for LAReqSink {
 /// activations must uphold.
 ///
 /// ## Ordering
-/// `patches -> start workflow -> random-seed-updates -> signals/updates -> other -> queries -> evictions`
+/// `init workflow -> patches -> random-seed-updates -> signals/updates -> other -> queries -> evictions`
 ///
 /// ## Invariants:
 /// * Queries always go in their own activation
@@ -1363,8 +1363,8 @@ fn prepare_to_ship_activation(wfa: &mut WorkflowActivation) {
         }
         fn variant_ordinal(v: &workflow_activation_job::Variant) -> u8 {
             match v {
-                workflow_activation_job::Variant::NotifyHasPatch(_) => 0,
-                workflow_activation_job::Variant::InitializeWorkflow(_) => 1,
+                workflow_activation_job::Variant::InitializeWorkflow(_) => 0,
+                workflow_activation_job::Variant::NotifyHasPatch(_) => 1,
                 workflow_activation_job::Variant::UpdateRandomSeed(_) => 2,
                 workflow_activation_job::Variant::SignalWorkflow(_) => 3,
                 workflow_activation_job::Variant::DoUpdate(_) => 3,

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -1364,7 +1364,7 @@ fn prepare_to_ship_activation(wfa: &mut WorkflowActivation) {
         fn variant_ordinal(v: &workflow_activation_job::Variant) -> u8 {
             match v {
                 workflow_activation_job::Variant::NotifyHasPatch(_) => 0,
-                workflow_activation_job::Variant::StartWorkflow(_) => 1,
+                workflow_activation_job::Variant::InitializeWorkflow(_) => 1,
                 workflow_activation_job::Variant::UpdateRandomSeed(_) => 2,
                 workflow_activation_job::Variant::SignalWorkflow(_) => 3,
                 workflow_activation_job::Variant::DoUpdate(_) => 3,

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -1331,7 +1331,7 @@ impl LocalActivityRequestSink for LAReqSink {
 /// activations must uphold.
 ///
 /// ## Ordering
-/// `patches -> signals/updates -> other -> queries -> evictions`
+/// `patches/random-seed-updates -> signals/updates -> other -> queries -> evictions`
 ///
 /// ## Invariants:
 /// * Queries always go in their own activation
@@ -1364,6 +1364,7 @@ fn prepare_to_ship_activation(wfa: &mut WorkflowActivation) {
         fn variant_ordinal(v: &workflow_activation_job::Variant) -> u8 {
             match v {
                 workflow_activation_job::Variant::NotifyHasPatch(_) => 1,
+                workflow_activation_job::Variant::UpdateRandomSeed(_) => 1,
                 workflow_activation_job::Variant::SignalWorkflow(_) => 2,
                 workflow_activation_job::Variant::DoUpdate(_) => 2,
                 // In principle we should never actually need to sort these with the others, since
@@ -1419,6 +1420,11 @@ mod tests {
                     )),
                 },
                 WorkflowActivationJob {
+                    variant: Some(workflow_activation_job::Variant::UpdateRandomSeed(
+                        Default::default(),
+                    )),
+                },
+                WorkflowActivationJob {
                     variant: Some(workflow_activation_job::Variant::SignalWorkflow(
                         SignalWorkflow {
                             signal_name: "2".to_string(),
@@ -1439,6 +1445,7 @@ mod tests {
             variants.as_slice(),
             &[
                 workflow_activation_job::Variant::NotifyHasPatch(_),
+                workflow_activation_job::Variant::UpdateRandomSeed(_),
                 workflow_activation_job::Variant::SignalWorkflow(ref s1),
                 workflow_activation_job::Variant::DoUpdate(_),
                 workflow_activation_job::Variant::SignalWorkflow(ref s2),

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -1331,7 +1331,7 @@ impl LocalActivityRequestSink for LAReqSink {
 /// activations must uphold.
 ///
 /// ## Ordering
-/// `patches/random-seed-updates -> signals/updates -> other -> queries -> evictions`
+/// `patches -> start workflow -> random-seed-updates -> signals/updates -> other -> queries -> evictions`
 ///
 /// ## Invariants:
 /// * Queries always go in their own activation
@@ -1363,18 +1363,19 @@ fn prepare_to_ship_activation(wfa: &mut WorkflowActivation) {
         }
         fn variant_ordinal(v: &workflow_activation_job::Variant) -> u8 {
             match v {
-                workflow_activation_job::Variant::NotifyHasPatch(_) => 1,
-                workflow_activation_job::Variant::UpdateRandomSeed(_) => 1,
-                workflow_activation_job::Variant::SignalWorkflow(_) => 2,
-                workflow_activation_job::Variant::DoUpdate(_) => 2,
+                workflow_activation_job::Variant::NotifyHasPatch(_) => 0,
+                workflow_activation_job::Variant::StartWorkflow(_) => 1,
+                workflow_activation_job::Variant::UpdateRandomSeed(_) => 2,
+                workflow_activation_job::Variant::SignalWorkflow(_) => 3,
+                workflow_activation_job::Variant::DoUpdate(_) => 3,
                 // In principle we should never actually need to sort these with the others, since
                 // queries always get their own activation, but, maintaining the semantic is
                 // reasonable.
-                workflow_activation_job::Variant::QueryWorkflow(_) => 4,
+                workflow_activation_job::Variant::QueryWorkflow(_) => 5,
                 // Also shouldn't ever end up anywhere but the end by construction, but no harm in
                 // double-checking.
-                workflow_activation_job::Variant::RemoveFromCache(_) => 5,
-                _ => 3,
+                workflow_activation_job::Variant::RemoveFromCache(_) => 6,
+                _ => 4,
             }
         }
         variant_ordinal(j1v).cmp(&variant_ordinal(j2v))

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -23,7 +23,7 @@ import "temporal/sdk/core/common/common.proto";
 // ## Job ordering guarantees and semantics
 //
 // Core will, by default, order jobs within the activation as follows:
-// `patches -> signals/updates -> other -> queries -> evictions`
+// `patches/random-seed-updates -> signals/updates -> other -> queries -> evictions`
 //
 // This is because:
 // * Patches are expected to apply to the entire activation

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -74,8 +74,8 @@ message WorkflowActivation {
 
 message WorkflowActivationJob {
     oneof variant {
-        // Begin a workflow for the first time
-        StartWorkflow start_workflow = 1;
+        // A workflow is starting, record all of the information from its start event
+        InitializeWorkflow initialize_workflow = 1;
         // A timer has fired, allowing whatever was waiting on it (if anything) to proceed
         FireTimer fire_timer = 2;
         // Workflow was reset. The randomness seed must be updated.
@@ -110,8 +110,8 @@ message WorkflowActivationJob {
     }
 }
 
-// Start a new workflow
-message StartWorkflow {
+// Initialize a new workflow
+message InitializeWorkflow {
     // The identifier the lang-specific sdk uses to execute workflow code
     string workflow_type = 1;
     // The workflow id used on the temporal server

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -23,7 +23,7 @@ import "temporal/sdk/core/common/common.proto";
 // ## Job ordering guarantees and semantics
 //
 // Core will, by default, order jobs within the activation as follows:
-// `patches/random-seed-updates -> signals/updates -> other -> queries -> evictions`
+// `init-workflow -> patches -> random-seed-updates -> signals/updates -> other -> queries -> evictions`
 //
 // This is because:
 // * Patches are expected to apply to the entire activation

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -560,8 +560,8 @@ pub mod coresdk {
         impl Display for workflow_activation_job::Variant {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 match self {
-                    workflow_activation_job::Variant::StartWorkflow(_) => {
-                        write!(f, "StartWorkflow")
+                    workflow_activation_job::Variant::InitializeWorkflow(_) => {
+                        write!(f, "InitializeWorkflow")
                     }
                     workflow_activation_job::Variant::FireTimer(t) => {
                         write!(f, "FireTimer({})", t.seq)
@@ -662,14 +662,14 @@ pub mod coresdk {
             }
         }
 
-        /// Create a [StartWorkflow] job from corresponding event attributes
+        /// Create a [InitializeWorkflow] job from corresponding event attributes
         pub fn start_workflow_from_attribs(
             attrs: WorkflowExecutionStartedEventAttributes,
             workflow_id: String,
             randomness_seed: u64,
             start_time: Timestamp,
-        ) -> StartWorkflow {
-            StartWorkflow {
+        ) -> InitializeWorkflow {
+            InitializeWorkflow {
                 workflow_type: attrs.workflow_type.map(|wt| wt.name).unwrap_or_default(),
                 workflow_id,
                 arguments: Vec::from_payloads(attrs.input),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -396,10 +396,10 @@ impl WorkflowHalf {
         let mut res = None;
         let run_id = activation.run_id.clone();
 
-        // If the activation is to start a workflow, create a new workflow driver for it,
+        // If the activation is to init a workflow, create a new workflow driver for it,
         // using the function associated with that workflow id
         if let Some(sw) = activation.jobs.iter().find_map(|j| match j.variant {
-            Some(Variant::StartWorkflow(ref sw)) => Some(sw),
+            Some(Variant::InitializeWorkflow(ref sw)) => Some(sw),
             _ => None,
         }) {
             let workflow_type = &sw.workflow_type;

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -129,6 +129,11 @@ impl WfContext {
         RwLockReadGuard::map(self.shared.read(), |s| &s.search_attributes)
     }
 
+    /// Return the workflow's randomness seed
+    pub fn random_seed(&self) -> u64 {
+        self.shared.read().random_seed
+    }
+
     /// A future that resolves if/when the workflow is cancelled
     pub async fn cancelled(&self) {
         if *self.am_cancelled.borrow() {
@@ -419,6 +424,7 @@ pub(crate) struct WfContextSharedData {
     pub(crate) history_length: u32,
     pub(crate) current_build_id: Option<String>,
     pub(crate) search_attributes: SearchAttributes,
+    pub(crate) random_seed: u64,
 }
 
 /// Helper Wrapper that can drain the channel into a Vec<SignalData> in a blocking way.  Useful

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -175,8 +175,8 @@ impl WorkflowFuture {
     ) -> Result<bool, Error> {
         if let Some(v) = variant {
             match v {
-                Variant::StartWorkflow(_) => {
-                    // Don't do anything in here. Start workflow is looked at earlier, before
+                Variant::InitializeWorkflow(_) => {
+                    // Don't do anything in here. Init workflow is looked at earlier, before
                     // jobs are handled, and may have information taken out of it to avoid clones.
                 }
                 Variant::FireTimer(FireTimer { seq }) => {
@@ -344,7 +344,7 @@ impl Future for WorkflowFuture {
             let mut activation_cmds = vec![];
             // Assign initial state from start workflow job
             if let Some(start_info) = activation.jobs.iter_mut().find_map(|j| {
-                if let Some(Variant::StartWorkflow(s)) = j.variant.as_mut() {
+                if let Some(Variant::InitializeWorkflow(s)) = j.variant.as_mut() {
                     Some(s)
                 } else {
                     None
@@ -359,11 +359,11 @@ impl Future for WorkflowFuture {
             if activation
                 .jobs
                 .iter()
-                .any(|j| matches!(j.variant, Some(Variant::StartWorkflow(_))))
+                .any(|j| matches!(j.variant, Some(Variant::InitializeWorkflow(_))))
                 && activation.jobs.iter().all(|j| {
                     matches!(
                         j.variant,
-                        Some(Variant::StartWorkflow(_) | Variant::DoUpdate(_))
+                        Some(Variant::InitializeWorkflow(_) | Variant::DoUpdate(_))
                     )
                 })
             {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -73,11 +73,14 @@ pub const INTEG_USE_TLS_ENV_VAR: &str = "TEMPORAL_USE_TLS";
 pub const INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR: &str = "INTEG_TEMPORAL_DEV_SERVER_ON";
 /// This env var is set (to any value) if the test server is in use
 pub const INTEG_TEST_SERVER_USED_ENV_VAR: &str = "INTEG_TEST_SERVER_ON";
+pub static SEARCH_ATTR_TXT: &str = "CustomTextField";
+pub static SEARCH_ATTR_INT: &str = "CustomIntField";
 
 /// If set, turn export traces and metrics to the OTel collector at the given URL
 const OTEL_URL_ENV_VAR: &str = "TEMPORAL_INTEG_OTEL_URL";
 /// If set, enable direct scraping of prom metrics on the specified port
 const PROM_ENABLE_ENV_VAR: &str = "TEMPORAL_INTEG_PROM_PORT";
+
 #[macro_export]
 macro_rules! prost_dur {
     ($dur_call:ident $args:tt) => {

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -12,7 +12,7 @@ use temporal_sdk_core_protos::{
     temporal::api::{failure::v1::Failure, query::v1::WorkflowQuery},
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, init_core_and_create_wf, WorkerTestHelpers,
+    drain_pollers_and_shutdown, init_core_and_create_wf, CoreWfStarter, WorkerTestHelpers,
 };
 use tokio::join;
 
@@ -215,30 +215,15 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
 #[tokio::test]
 async fn fail_legacy_query() {
     let query_err = "oh no broken";
-    let mut starter = init_core_and_create_wf("fail_legacy_query").await;
+    let mut starter = CoreWfStarter::new("fail_legacy_query");
     let core = starter.get_worker().await;
+    starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
+    starter.start_wf().await;
     let workflow_id = starter.get_task_queue().to_string();
     let task = core.poll_workflow_activation().await.unwrap();
-    let t1_resp = vec![
-        StartTimer {
-            seq: 1,
-            start_to_fire_timeout: Some(prost_dur!(from_millis(500))),
-        }
-        .into(),
-        StartTimer {
-            seq: 2,
-            start_to_fire_timeout: Some(prost_dur!(from_secs(3))),
-        }
-        .into(),
-    ];
-    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
-        task.run_id.clone(),
-        t1_resp.clone(),
-    ))
-    .await
-    .unwrap();
-    tokio::time::sleep(Duration::from_secs(1)).await;
-    // Query after timer should have fired and there should be new WFT
+    // Queries are *always* legacy on closed workflows, so that's the easiest way to ensure that
+    // path is used.
+    core.complete_execution(&task.run_id).await;
     let query_fut = async {
         starter
             .get_client()
@@ -255,33 +240,14 @@ async fn fail_legacy_query() {
             .await
             .unwrap_err()
     };
-    let workflow_completions_future = async {
-        // Give query a beat to get going
-        tokio::time::sleep(Duration::from_millis(400)).await;
-        // This poll *should* have the `queries` field populated, but doesn't, seemingly due to
-        // a server bug. So, complete the WF task of the first timer firing with empty commands
+    let query_responder = async {
         let task = core.poll_workflow_activation().await.unwrap();
-        assert_matches!(
-            task.jobs.as_slice(),
-            [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::FireTimer(_)),
-            }]
-        );
-        core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
-            task.run_id,
-            vec![],
-        ))
-        .await
-        .unwrap();
-        let task = core.poll_workflow_activation().await.unwrap();
-        // Poll again, and we end up getting a `query` field query response
         assert_matches!(
             task.jobs.as_slice(),
             [WorkflowActivationJob {
                 variant: Some(workflow_activation_job::Variant::QueryWorkflow(q)),
             }] => q
         );
-        // Fail this task
         core.complete_workflow_activation(WorkflowActivationCompletion::fail(
             task.run_id,
             Failure {
@@ -292,26 +258,8 @@ async fn fail_legacy_query() {
         ))
         .await
         .unwrap();
-        // Finish the workflow (handling cache removal)
-        let task = core.poll_workflow_activation().await.unwrap();
-        core.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
-            .await
-            .unwrap();
-        let task = core.poll_workflow_activation().await.unwrap();
-        core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
-            task.run_id,
-            t1_resp.clone(),
-        ))
-        .await
-        .unwrap();
-        let task = core.poll_workflow_activation().await.unwrap();
-        core.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
-            .await
-            .unwrap();
-        let task = core.poll_workflow_activation().await.unwrap();
-        core.complete_execution(&task.run_id).await;
     };
-    let (q_resp, _) = join!(query_fut, workflow_completions_future);
+    let (q_resp, _) = join!(query_fut, query_responder);
     // Ensure query response is a failure and has the right message
     assert_eq!(q_resp.message(), query_err);
 }
@@ -522,7 +470,6 @@ async fn query_should_not_be_sent_if_wft_about_to_fail() {
         .unwrap();
         let task = core.poll_workflow_activation().await.unwrap();
         // Should *not* get a query here. If the bug wasn't fixed, this job would have a query.
-        dbg!(&task);
         assert_matches!(
             task.jobs.as_slice(),
             [WorkflowActivationJob {
@@ -543,7 +490,6 @@ async fn query_should_not_be_sent_if_wft_about_to_fail() {
         );
         core.complete_execution(&task.run_id).await;
         let task = core.poll_workflow_activation().await.unwrap();
-        dbg!(&task);
         let qid = assert_matches!(
             task.jobs.as_slice(),
             [WorkflowActivationJob {

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -163,7 +163,7 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
             if matches!(
                 task.jobs.as_slice(),
                 [WorkflowActivationJob {
-                    variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                    variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
                 }]
             ) {
                 core.complete_timer(&task.run_id, 1, Duration::from_millis(500))
@@ -455,7 +455,7 @@ async fn query_should_not_be_sent_if_wft_about_to_fail() {
         assert_matches!(
             task.jobs.as_slice(),
             [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
             }]
         );
         core.complete_workflow_activation(WorkflowActivationCompletion::fail(
@@ -485,7 +485,7 @@ async fn query_should_not_be_sent_if_wft_about_to_fail() {
         assert_matches!(
             task.jobs.as_slice(),
             [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
             }]
         );
         core.complete_execution(&task.run_id).await;

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -580,7 +580,7 @@ async fn update_speculative_wft() {
         assert_matches!(
             res.jobs.as_slice(),
             [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
             }]
         );
         core.complete_workflow_activation(WorkflowActivationCompletion::empty(res.run_id))

--- a/tests/integ_tests/visibility_tests.rs
+++ b/tests/integ_tests/visibility_tests.rs
@@ -29,7 +29,7 @@ async fn client_list_open_closed_workflow_executions() {
     assert_matches!(
         task.jobs.as_slice(),
         [WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
         }]
     );
 

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -79,7 +79,7 @@ async fn parallel_workflows_same_queue() {
         assert_matches!(
             task.jobs.as_slice(),
             [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::StartWorkflow(_)),
+                variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
             }]
         );
         worker

--- a/tests/integ_tests/workflow_tests/resets.rs
+++ b/tests/integ_tests/workflow_tests/resets.rs
@@ -1,9 +1,19 @@
+use crate::integ_tests::activity_functions::echo;
 use futures::StreamExt;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions, WorkflowService};
-use temporal_sdk::WfContext;
-use temporal_sdk_core_protos::temporal::api::{
-    common::v1::WorkflowExecution, workflowservice::v1::ResetWorkflowExecutionRequest,
+use temporal_sdk::{LocalActivityOptions, WfContext};
+use temporal_sdk_core_protos::{
+    coresdk::AsJsonPayloadExt,
+    temporal::api::{
+        common::v1::WorkflowExecution, workflowservice::v1::ResetWorkflowExecutionRequest,
+    },
 };
 use temporal_sdk_core_test_utils::{CoreWfStarter, NAMESPACE};
 use tokio::sync::Notify;
@@ -90,5 +100,130 @@ async fn reset_workflow() {
     };
     let run_fut = worker.run_until_done();
     let (_, rr) = tokio::join!(resetter_fut, run_fut);
+    rr.unwrap();
+}
+
+#[tokio::test]
+async fn reset_randomseed() {
+    let wf_name = "reset_randomseed";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.worker_config.no_remote_activities(true);
+    let mut worker = starter.worker().await;
+    worker.fetch_results = false;
+    let notify = Arc::new(Notify::new());
+
+    const POST_FAIL_SIG: &str = "post-fail";
+    static DID_FAIL: AtomicBool = AtomicBool::new(false);
+    static RAND_SEED: AtomicU64 = AtomicU64::new(0);
+
+    let wf_notify = notify.clone();
+    worker.register_wf(wf_name.to_owned(), move |ctx: WfContext| {
+        let notify = wf_notify.clone();
+        async move {
+            let _ = RAND_SEED.compare_exchange(
+                0,
+                ctx.random_seed(),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+            // Make a couple workflow tasks
+            ctx.timer(Duration::from_millis(100)).await;
+            ctx.timer(Duration::from_millis(100)).await;
+            if DID_FAIL
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                // Tell outer scope to send the post-task-failure-signal
+                notify.notify_one();
+                panic!("Ahh");
+            }
+            // Make a command that is one thing with the initial seed, but another after reset
+            if RAND_SEED.load(Ordering::Relaxed) == ctx.random_seed() {
+                ctx.timer(Duration::from_millis(100)).await;
+            } else {
+                ctx.local_activity(LocalActivityOptions {
+                    activity_type: "echo".to_string(),
+                    input: "hi!".as_json_payload().expect("serializes fine"),
+                    ..Default::default()
+                })
+                .await;
+            }
+            // Wait for the post-task-fail signal
+            let _ = ctx.make_signal_channel(POST_FAIL_SIG).next().await.unwrap();
+            // Tell outer scope to send the reset
+            notify.notify_one();
+            let _ = ctx
+                .make_signal_channel(POST_RESET_SIG)
+                .next()
+                .await
+                .unwrap();
+            Ok(().into())
+        }
+    });
+    worker.register_activity("echo", echo);
+
+    let run_id = worker
+        .submit_wf(
+            wf_name.to_owned(),
+            wf_name.to_owned(),
+            vec![],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    let mut client = starter.get_client().await;
+    let client = Arc::make_mut(&mut client);
+    let client_fur = async {
+        notify.notified().await;
+        WorkflowClientTrait::signal_workflow_execution(
+            client,
+            wf_name.to_owned(),
+            run_id.clone(),
+            POST_FAIL_SIG.to_string(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        notify.notified().await;
+        // Reset the workflow to be after first timer has fired
+        client
+            .reset_workflow_execution(ResetWorkflowExecutionRequest {
+                namespace: NAMESPACE.to_owned(),
+                workflow_execution: Some(WorkflowExecution {
+                    workflow_id: wf_name.to_owned(),
+                    run_id: run_id.clone(),
+                }),
+                workflow_task_finish_event_id: 14,
+                request_id: "test-req-id".to_owned(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        // Unblock the workflow by sending the signal. Run ID will have changed after reset so
+        // we use empty run id
+        WorkflowClientTrait::signal_workflow_execution(
+            client,
+            wf_name.to_owned(),
+            "".to_owned(),
+            POST_RESET_SIG.to_owned(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Wait for the now-reset workflow to finish
+        client
+            .get_untyped_workflow_handle(wf_name.to_owned(), "")
+            .get_workflow_result(Default::default())
+            .await
+            .unwrap();
+        starter.shutdown().await;
+    };
+    let run_fut = worker.run_until_done();
+    let (_, rr) = tokio::join!(client_fur, run_fut);
     rr.unwrap();
 }

--- a/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
+++ b/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
@@ -1,32 +1,26 @@
 use assert_matches::assert_matches;
-use std::{collections::HashMap, env, time::Duration};
+use std::{collections::HashMap, time::Duration};
 use temporal_client::{
     GetWorkflowResultOpts, WfClientExt, WorkflowClientTrait, WorkflowExecutionResult,
     WorkflowOptions,
 };
 use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
 use temporal_sdk_core_protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
-use temporal_sdk_core_test_utils::{CoreWfStarter, INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR};
-use tracing::warn;
+use temporal_sdk_core_test_utils::{CoreWfStarter, SEARCH_ATTR_INT, SEARCH_ATTR_TXT};
 use uuid::Uuid;
-
-// These are initialized on the server as part of the autosetup container which we
-// use for integration tests.
-static TXT_ATTR: &str = "CustomTextField";
-static INT_ATTR: &str = "CustomIntField";
 
 async fn search_attr_updater(ctx: WfContext) -> WorkflowResult<()> {
     let mut int_val = ctx
         .search_attributes()
         .indexed_fields
-        .get(INT_ATTR)
+        .get(SEARCH_ATTR_INT)
         .cloned()
         .unwrap_or_default();
     let orig_val = int_val.data[0];
     int_val.data[0] += 1;
     ctx.upsert_search_attributes([
-        (TXT_ATTR.to_string(), "goodbye".as_json_payload()?),
-        (INT_ATTR.to_string(), int_val),
+        (SEARCH_ATTR_TXT.to_string(), "goodbye".as_json_payload()?),
+        (SEARCH_ATTR_INT.to_string(), int_val),
     ]);
     // 49 is ascii 1
     if orig_val == 49 {
@@ -43,11 +37,6 @@ async fn sends_upsert() {
     let mut starter = CoreWfStarter::new(wf_name);
     starter.worker_config.no_remote_activities(true);
     let mut worker = starter.worker().await;
-    // TODO: this should be supported in server 1.20, remove this condition when CLI is upgraded.
-    if env::var(INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR).is_ok() {
-        warn!("skipping sends_upsert -- does not work on temporal dev server");
-        return;
-    }
 
     worker.register_wf(wf_name, search_attr_updater);
     worker
@@ -57,8 +46,11 @@ async fn sends_upsert() {
             vec![],
             WorkflowOptions {
                 search_attributes: Some(HashMap::from([
-                    (TXT_ATTR.to_string(), "hello".as_json_payload().unwrap()),
-                    (INT_ATTR.to_string(), 1.as_json_payload().unwrap()),
+                    (
+                        SEARCH_ATTR_TXT.to_string(),
+                        "hello".as_json_payload().unwrap(),
+                    ),
+                    (SEARCH_ATTR_INT.to_string(), 1.as_json_payload().unwrap()),
                 ])),
                 execution_timeout: Some(Duration::from_secs(4)),
                 ..Default::default()
@@ -78,8 +70,8 @@ async fn sends_upsert() {
         .search_attributes
         .unwrap()
         .indexed_fields;
-    let txt_attr_payload = search_attrs.get(TXT_ATTR).unwrap();
-    let int_attr_payload = search_attrs.get(INT_ATTR).unwrap();
+    let txt_attr_payload = search_attrs.get(SEARCH_ATTR_TXT).unwrap();
+    let int_attr_payload = search_attrs.get(SEARCH_ATTR_INT).unwrap();
     for payload in [txt_attr_payload, int_attr_payload] {
         assert!(payload.is_json_payload());
     }

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -10,7 +10,7 @@ use temporal_sdk_core::ephemeral_server::{
 };
 use temporal_sdk_core_test_utils::{
     default_cached_download, INTEG_SERVER_TARGET_ENV_VAR, INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR,
-    INTEG_TEST_SERVER_USED_ENV_VAR,
+    INTEG_TEST_SERVER_USED_ENV_VAR, SEARCH_ATTR_INT, SEARCH_ATTR_TXT,
 };
 use tokio::{self, process::Command};
 
@@ -70,11 +70,16 @@ async fn main() -> Result<(), anyhow::Error> {
         ServerKind::TemporalCLI => {
             let config = TemporalDevServerConfigBuilder::default()
                 .exe(default_cached_download())
-                // TODO: Delete when temporalCLI enables it by default.
                 .extra_args(vec![
+                    // TODO: Delete when temporalCLI enables it by default.
                     "--dynamic-config-value".to_string(),
                     "system.enableEagerWorkflowStart=true".to_string(),
+                    "--search-attribute".to_string(),
+                    format!("{SEARCH_ATTR_TXT}=''"),
+                    "--search-attribute".to_string(),
+                    format!("{SEARCH_ATTR_INT}=0"),
                 ])
+                .ui(true)
                 .build()?;
             println!("Using temporal CLI");
             (

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -75,9 +75,9 @@ async fn main() -> Result<(), anyhow::Error> {
                     "--dynamic-config-value".to_string(),
                     "system.enableEagerWorkflowStart=true".to_string(),
                     "--search-attribute".to_string(),
-                    format!("{SEARCH_ATTR_TXT}=''"),
+                    format!("{SEARCH_ATTR_TXT}=Text"),
                     "--search-attribute".to_string(),
-                    format!("{SEARCH_ATTR_INT}=0"),
+                    format!("{SEARCH_ATTR_INT}=Int"),
                 ])
                 .ui(true)
                 .build()?;


### PR DESCRIPTION
## What was changed
Make `UpdateRandomSeed` jobs come after start workflow, but before everything else.

## Why?
These could technically have consequences for later actions, and should go first. It's intuitive.

The more delicate change here is actually sorting `StartWorkflow` before other stuff, which also seems intuitive, but a number of tests at least in core had some expectations around updates being able to come first. Frankly, that doesn't make a ton of sense, and I don't really expect this move to be any kind of real issue, but it might require some changes to langs that are using `StartWorkflow` as a synonym for "do first iteration of the event loop"? If such changes are needed, they should be the ones described here: https://github.com/temporalio/sdk-python/issues/606 (.NET may need an equivalent item) as none of these problems exist if all jobs are all read and applied to state _first_, before doing any iterating of the event loop.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/790

2. How was this tested:
Updated existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
