### PR TITLE
Include SA updates made in-workflow when continuing as new

### DIFF
--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1152,6 +1152,7 @@ impl WorkflowMachines {
                         );
                     }
                     ProtoCmdAttrs::UpsertWorkflowSearchAttributesCommandAttributes(attrs) => {
+                        // TODO: Update here
                         self.add_cmd_to_wf_task(
                             upsert_search_attrs_internal(attrs),
                             CommandIdKind::NeverResolves,

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -13,11 +13,12 @@ use crate::{
 };
 use crossbeam_channel::{Receiver, Sender};
 use futures::{task::Context, FutureExt, Stream, StreamExt};
-use parking_lot::RwLock;
+use parking_lot::{RwLock, RwLockReadGuard};
 use std::{
     collections::HashMap,
     future::Future,
     marker::PhantomData,
+    ops::Deref,
     pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -40,7 +41,7 @@ use temporal_sdk_core_protos::{
             SignalExternalWorkflowExecution, StartTimer, UpsertWorkflowSearchAttributes,
         },
     },
-    temporal::api::common::v1::{Memo, Payload},
+    temporal::api::common::v1::{Memo, Payload, SearchAttributes},
 };
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -121,6 +122,11 @@ impl WfContext {
     /// code is being executed for the first time, return this Worker's Build ID if it has one.
     pub fn current_build_id(&self) -> Option<String> {
         self.shared.read().current_build_id.clone()
+    }
+
+    /// Return current values for workflow search attributes
+    pub fn search_attributes(&self) -> impl Deref<Target = SearchAttributes> + '_ {
+        RwLockReadGuard::map(self.shared.read(), |s| &s.search_attributes)
     }
 
     /// A future that resolves if/when the workflow is cancelled
@@ -412,6 +418,7 @@ pub(crate) struct WfContextSharedData {
     pub(crate) wf_time: Option<SystemTime>,
     pub(crate) history_length: u32,
     pub(crate) current_build_id: Option<String>,
+    pub(crate) search_attributes: SearchAttributes,
 }
 
 /// Helper Wrapper that can drain the channel into a Vec<SignalData> in a blocking way.  Useful

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -176,7 +176,8 @@ impl WorkflowFuture {
         if let Some(v) = variant {
             match v {
                 Variant::StartWorkflow(_) => {
-                    // TODO: Can assign randomness seed whenever needed
+                    // Don't do anything in here. Start workflow is looked at earlier, before
+                    // jobs are handled, and may have information taken out of it to avoid clones.
                 }
                 Variant::FireTimer(FireTimer { seq }) => {
                     self.unblock(UnblockEvent::Timer(seq, TimerResult::Fired))?
@@ -311,7 +312,7 @@ impl Future for WorkflowFuture {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         'activations: loop {
             // WF must always receive an activation first before responding with commands
-            let activation = match self.incoming_activations.poll_recv(cx) {
+            let mut activation = match self.incoming_activations.poll_recv(cx) {
                 Poll::Ready(a) => match a {
                     Some(act) => act,
                     None => {
@@ -339,6 +340,18 @@ impl Future for WorkflowFuture {
 
             let mut die_of_eviction_when_done = false;
             let mut activation_cmds = vec![];
+            // Assign initial state from start workflow job
+            if let Some(start_info) = activation.jobs.iter_mut().find_map(|j| {
+                if let Some(Variant::StartWorkflow(s)) = j.variant.as_mut() {
+                    Some(s)
+                } else {
+                    None
+                }
+            }) {
+                // TODO: Can assign randomness seed whenever needed
+                self.wf_ctx.shared.write().search_attributes =
+                    dbg!(start_info.search_attributes.take().unwrap_or_default());
+            };
             // Lame hack to avoid hitting "unregistered" update handlers in a situation where
             // the history has no commands until an update is accepted. Will go away w/ SDK redesign
             if activation
@@ -352,6 +365,7 @@ impl Future for WorkflowFuture {
                     )
                 })
             {
+                dbg!("Polling first time");
                 // Poll the workflow future once to get things registered
                 if self.poll_wf_future(cx, &run_id, &mut activation_cmds)? {
                     continue;

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -350,7 +350,7 @@ impl Future for WorkflowFuture {
             }) {
                 // TODO: Can assign randomness seed whenever needed
                 self.wf_ctx.shared.write().search_attributes =
-                    dbg!(start_info.search_attributes.take().unwrap_or_default());
+                    start_info.search_attributes.take().unwrap_or_default();
             };
             // Lame hack to avoid hitting "unregistered" update handlers in a situation where
             // the history has no commands until an update is accepted. Will go away w/ SDK redesign
@@ -365,7 +365,6 @@ impl Future for WorkflowFuture {
                     )
                 })
             {
-                dbg!("Polling first time");
                 // Poll the workflow future once to get things registered
                 if self.poll_wf_future(cx, &run_id, &mut activation_cmds)? {
                     continue;

--- a/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
+++ b/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
@@ -5,9 +5,7 @@ use temporal_client::{
     WorkflowOptions,
 };
 use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
-use temporal_sdk_core_protos::coresdk::{
-    workflow_commands::ContinueAsNewWorkflowExecution, AsJsonPayloadExt, FromJsonPayloadExt,
-};
+use temporal_sdk_core_protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
 use temporal_sdk_core_test_utils::{CoreWfStarter, INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR};
 use tracing::warn;
 use uuid::Uuid;
@@ -24,19 +22,15 @@ async fn search_attr_updater(ctx: WfContext) -> WorkflowResult<()> {
         .get(INT_ATTR)
         .cloned()
         .unwrap_or_default();
-    dbg!(&int_val);
     let orig_val = int_val.data[0];
     int_val.data[0] += 1;
     ctx.upsert_search_attributes([
         (TXT_ATTR.to_string(), "goodbye".as_json_payload()?),
         (INT_ATTR.to_string(), int_val),
     ]);
-    dbg!(orig_val);
     // 49 is ascii 1
     if orig_val == 49 {
-        Ok(WfExitValue::ContinueAsNew(Box::new(
-            ContinueAsNewWorkflowExecution::default(),
-        )))
+        Ok(WfExitValue::ContinueAsNew(Box::default()))
     } else {
         Ok(().into())
     }
@@ -93,7 +87,7 @@ async fn sends_upsert() {
         "goodbye",
         String::from_json_payload(txt_attr_payload).unwrap()
     );
-    assert_eq!(2, usize::from_json_payload(int_attr_payload).unwrap());
+    assert_eq!(3, usize::from_json_payload(int_attr_payload).unwrap());
     let handle = client.get_untyped_workflow_handle(wf_id.to_string(), "");
     let res = handle
         .get_workflow_result(GetWorkflowResultOpts::default())

--- a/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
+++ b/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
@@ -1,7 +1,13 @@
-use std::{collections::HashMap, env};
-use temporal_client::{WorkflowClientTrait, WorkflowOptions};
-use temporal_sdk::{WfContext, WorkflowResult};
-use temporal_sdk_core_protos::coresdk::{AsJsonPayloadExt, FromJsonPayloadExt};
+use assert_matches::assert_matches;
+use std::{collections::HashMap, env, time::Duration};
+use temporal_client::{
+    GetWorkflowResultOpts, WfClientExt, WorkflowClientTrait, WorkflowExecutionResult,
+    WorkflowOptions,
+};
+use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
+use temporal_sdk_core_protos::coresdk::{
+    workflow_commands::ContinueAsNewWorkflowExecution, AsJsonPayloadExt, FromJsonPayloadExt,
+};
 use temporal_sdk_core_test_utils::{CoreWfStarter, INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR};
 use tracing::warn;
 use uuid::Uuid;
@@ -12,11 +18,28 @@ static TXT_ATTR: &str = "CustomTextField";
 static INT_ATTR: &str = "CustomIntField";
 
 async fn search_attr_updater(ctx: WfContext) -> WorkflowResult<()> {
+    let mut int_val = ctx
+        .search_attributes()
+        .indexed_fields
+        .get(INT_ATTR)
+        .cloned()
+        .unwrap_or_default();
+    dbg!(&int_val);
+    let orig_val = int_val.data[0];
+    int_val.data[0] += 1;
     ctx.upsert_search_attributes([
-        (TXT_ATTR.to_string(), "goodbye".as_json_payload().unwrap()),
-        (INT_ATTR.to_string(), 98.as_json_payload().unwrap()),
+        (TXT_ATTR.to_string(), "goodbye".as_json_payload()?),
+        (INT_ATTR.to_string(), int_val),
     ]);
-    Ok(().into())
+    dbg!(orig_val);
+    // 49 is ascii 1
+    if orig_val == 49 {
+        Ok(WfExitValue::ContinueAsNew(Box::new(
+            ContinueAsNewWorkflowExecution::default(),
+        )))
+    } else {
+        Ok(().into())
+    }
 }
 
 #[tokio::test]
@@ -33,7 +56,7 @@ async fn sends_upsert() {
     }
 
     worker.register_wf(wf_name, search_attr_updater);
-    let run_id = worker
+    worker
         .submit_wf(
             wf_id.to_string(),
             wf_name,
@@ -43,6 +66,7 @@ async fn sends_upsert() {
                     (TXT_ATTR.to_string(), "hello".as_json_payload().unwrap()),
                     (INT_ATTR.to_string(), 1.as_json_payload().unwrap()),
                 ])),
+                execution_timeout: Some(Duration::from_secs(4)),
                 ..Default::default()
             },
         )
@@ -50,10 +74,9 @@ async fn sends_upsert() {
         .unwrap();
     worker.run_until_done().await.unwrap();
 
-    let search_attrs = starter
-        .get_client()
-        .await
-        .describe_workflow_execution(wf_id.to_string(), Some(run_id))
+    let client = starter.get_client().await;
+    let search_attrs = client
+        .describe_workflow_execution(wf_id.to_string(), None)
         .await
         .unwrap()
         .workflow_execution_info
@@ -70,5 +93,11 @@ async fn sends_upsert() {
         "goodbye",
         String::from_json_payload(txt_attr_payload).unwrap()
     );
-    assert_eq!(98, usize::from_json_payload(int_attr_payload).unwrap());
+    assert_eq!(2, usize::from_json_payload(int_attr_payload).unwrap());
+    let handle = client.get_untyped_workflow_handle(wf_id.to_string(), "");
+    let res = handle
+        .get_workflow_result(GetWorkflowResultOpts::default())
+        .await
+        .unwrap();
+    assert_matches!(res, WorkflowExecutionResult::Succeeded(_));
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Previously we only CAN'd with the initial SAs. This makes us consistent with (at least Go, tbd Java) where we also include updates made during the workflow, which just makes sense.

## Why?
Sensible. Parity.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/791

2. How was this tested:
Updated integ test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
