### PR TITLE
Debugger Client in core

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp",
     "dep:opentelemetry-prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-util"]
 tokio-console = ["console-subscriber"]
 ephemeral-server = ["dep:flate2", "dep:reqwest", "dep:tar", "dep:zip"]
+debug-plugin = ["dep:reqwest"]
 
 [dependencies]
 anyhow = "1.0"

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -37,7 +37,8 @@ impl DebugClient {
 
     async fn post_wft_started(&self, event_id: &i64) -> Result<reqwest::Response, anyhow::Error> {
         let url = self.debugger_url.clone() + "/current-wft-started";
-        Ok(self.client
+        Ok(self
+            .client
             .get(url)
             .header("Temporal-Client-Name", CLIENT_NAME)
             .header("Temporal-Client-Version", CLIENT_VERSION)

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -63,10 +63,11 @@ impl DebugClient {
     }
 }
 
-#[ignore]
 #[cfg(test)]
 mod tests {
+    use super::*;
     // this test wont work without a local instance of the debugger running.
+    #[ignore]
     #[tokio::test]
     async fn test_debug_client_delete() {
         let dc = DebugClient::new("http://127.0.0.1:51563".into());

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -27,7 +27,7 @@ impl DebugClient {
         }
     }
 
-    /// Get the history from the instance of the debug plugin server, then return the protobinary if successful.
+    /// Get the history from the instance of the debug plugin server
     pub async fn get_history(&self) -> Result<History, anyhow::Error> {
         let url = self.debugger_url.clone() + "/history";
         let resp = self

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -8,20 +8,27 @@ use temporal_sdk_core_protos::temporal::api::history::v1::History;
 const CLIENT_NAME: &str = "temporal-core";
 const CLIENT_VERSION: &str = "0.1.0";
 
-struct DebugClient {
+/// Struct representing the internal debug client
+#[derive(Clone)]
+pub struct DebugClient {
+    /// URL for the local instance of the debugger server
     debugger_url: String,
+
+    /// reqwest::Client to avoid re-creating a client for every request.
     client: reqwest::Client,
 }
 
 impl DebugClient {
-    fn new(url: String) -> DebugClient {
+    /// Create a new instance of a DebugClient with the specified url.
+    pub fn new(url: String) -> DebugClient {
         DebugClient {
             debugger_url: url,
             client: reqwest::Client::new(),
         }
     }
 
-    async fn get_history(&self) -> Result<History, anyhow::Error> {
+    /// Get the history from the instance of the debug plugin server, then return the protobinary if successful.
+    pub async fn get_history(&self) -> Result<History, anyhow::Error> {
         let url = self.debugger_url.clone() + "/history";
         let resp = self
             .client
@@ -35,7 +42,11 @@ impl DebugClient {
         Ok(History::decode(bytes)?) // decode_length_delimited() does not work
     }
 
-    async fn post_wft_started(&self, event_id: &i64) -> Result<reqwest::Response, anyhow::Error> {
+    /// Post to current-wft-started to communicate with debug plugin server
+    pub async fn post_wft_started(
+        &self,
+        event_id: &i64,
+    ) -> Result<reqwest::Response, anyhow::Error> {
         let url = self.debugger_url.clone() + "/current-wft-started";
         Ok(self
             .client
@@ -47,21 +58,14 @@ impl DebugClient {
             .send()
             .await?)
     }
-
-    // debating whether this is necessary at all
-    fn content_length(response: &reqwest::Response) -> Result<u64, String> {
-        match response.content_length() {
-            Some(length) => Ok(length),
-            None => Err("Content length unavailable. The header is unavailable or the response was gzipped.".to_owned())
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    #[tokio::test]
-    async fn test_debug_client_delete() {
-        let dc = DebugClient::new("http://127.0.0.1:51563".into());
-        dc.get_history().await.unwrap();
-    }
+    // this test wont work without a local instance of the debugger running.
+    // #[tokio::test]
+    // async fn test_debug_client_delete() {
+    //     let dc = DebugClient::new("http://127.0.0.1:51563".into());
+    //     dc.get_history().await.unwrap();
+    // }
 }

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -8,7 +8,7 @@ use temporal_sdk_core_protos::temporal::api::history::v1::History;
 const CLIENT_NAME: &str = "temporal-core";
 const CLIENT_VERSION: &str = "0.1.0";
 
-/// Struct representing the internal debug client
+/// A client for interacting with the VSCode debug plugin
 #[derive(Clone)]
 pub struct DebugClient {
     /// URL for the local instance of the debugger server

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -1,18 +1,17 @@
-use reqwest;
 use prost::Message;
-use temporal_sdk_core_protos::temporal::api::history::v1::History;
+use reqwest;
 use std::time::Duration;
+use temporal_sdk_core_protos::temporal::api::history::v1::History;
 
 const CLIENT_NAME: &str = "temporal-core";
 const CLIENT_VERSION: &str = "0.1.0";
 
 struct DebugClient {
     debugger_url: String,
-    client: reqwest::Client
+    client: reqwest::Client,
 }
 
 impl DebugClient {
-
     fn new(url: String) -> DebugClient {
         DebugClient {
             debugger_url: url,
@@ -22,7 +21,9 @@ impl DebugClient {
 
     async fn get_history(&self) -> Result<History, anyhow::Error> {
         let url = self.debugger_url.clone() + "/history";
-        let resp = self.client.get(url)
+        let resp = self
+            .client
+            .get(url)
             .header("Temporal-Client-Name", CLIENT_NAME)
             .header("Temporal-Client-Version", CLIENT_VERSION)
             .send()
@@ -30,12 +31,12 @@ impl DebugClient {
 
         let bytes = resp.bytes().await?;
         Ok(History::decode(bytes)?) // decode_length_delimited() does not work
-
     }
 
     async fn post_wft_started(&self, event_id: &i64) -> Result<Response, anyhow::Error> {
         let url = self.debugger_url.clone() + "/current-wft-started";
-        self.client.get(url)
+        self.client
+            .get(url)
             .header("Temporal-Client-Name", CLIENT_NAME)
             .header("Temporal-Client-Version", CLIENT_VERSION)
             .timeout(Duration::from_secs(5))

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -39,7 +39,7 @@ impl DebugClient {
             .await?;
 
         let bytes = resp.bytes().await?;
-        Ok(History::decode(bytes)?) // decode_length_delimited() does not work
+        Ok(History::decode(bytes)?)
     }
 
     /// Post to current-wft-started to communicate with debug plugin server

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -14,7 +14,7 @@ pub struct DebugClient {
     /// URL for the local instance of the debugger server
     debugger_url: String,
 
-    /// reqwest::Client to avoid re-creating a client for every request.
+    /// Underlying HTTP client
     client: reqwest::Client,
 }
 

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -1,3 +1,5 @@
+//! This module contains code for an http client that is used for the VSCode debug plugin.
+
 use prost::Message;
 use reqwest;
 use std::time::Duration;
@@ -35,14 +37,14 @@ impl DebugClient {
 
     async fn post_wft_started(&self, event_id: &i64) -> Result<reqwest::Response, anyhow::Error> {
         let url = self.debugger_url.clone() + "/current-wft-started";
-        self.client
+        Ok(self.client
             .get(url)
             .header("Temporal-Client-Name", CLIENT_NAME)
             .header("Temporal-Client-Version", CLIENT_VERSION)
             .timeout(Duration::from_secs(5))
             .json(event_id)
             .send()
-            .await?
+            .await?)
     }
 
     // debating whether this is necessary at all

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -33,7 +33,7 @@ impl DebugClient {
         Ok(History::decode(bytes)?) // decode_length_delimited() does not work
     }
 
-    async fn post_wft_started(&self, event_id: &i64) -> Result<Response, anyhow::Error> {
+    async fn post_wft_started(&self, event_id: &i64) -> Result<reqwest::Response, anyhow::Error> {
         let url = self.debugger_url.clone() + "/current-wft-started";
         self.client
             .get(url)

--- a/core/src/debug_client.rs
+++ b/core/src/debug_client.rs
@@ -1,0 +1,65 @@
+use reqwest;
+use prost::Message;
+use temporal_sdk_core_protos::temporal::api::history::v1::History;
+use std::time::Duration;
+
+struct DebugClient {
+    debugger_url: String,
+    _client: reqwest::Client
+}
+
+impl DebugClient {
+
+    fn new(url: String) -> DebugClient {
+        DebugClient {
+            debugger_url: url,
+            _client: reqwest::Client::new(),
+        }
+    }
+
+    async fn get_history(&self) -> Result<History, anyhow::Error> {
+        let url = self.debugger_url.clone() + "/history";
+        let resp = self._client.get(url)
+            .header("Temporal-Client-Name", "temporal-core")
+            .header("Temporal-Client-Version", "0.1.0")
+            .send()
+            .await?;
+
+        let bytes = resp.bytes().await?;
+        Ok(History::decode(bytes)?) // decode_length_delimited() does not work
+
+    }
+
+    async fn post_wft_started(&self, event_id: &i64) -> bool {
+        let url = self.debugger_url.clone() + "/current-wft-started";
+        let resp = self._client.get(url)
+            .header("Temporal-Client-Name", "temporal-debug-core")
+            .header("Temporal-Client-Version", "0.1.0")
+            .timeout(Duration::from_secs(5))
+            .json(event_id)
+            .send()
+            .await;
+
+        match resp {
+            Ok(r) => { r.status() == reqwest::StatusCode::OK },
+            Err(_) => false
+        }
+    }
+
+    // debating whether this is necessary at all
+    fn content_length(response: &reqwest::Response) -> Result<u64, String> {
+        match response.content_length() {
+            Some(length) => Ok(length),
+            None => Err("Content length unavailable. The header is unavailable or the response was gzipped.".to_owned())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn test_debug_client_delete() {
+        let dc = DebugClient::new("http://127.0.0.1:51563".into());
+        dc.get_history().await.unwrap();
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,8 @@ extern crate core;
 mod abstractions;
 #[cfg(feature = "ephemeral-server")]
 pub mod ephemeral_server;
+#[cfg(feature = "debug-plugin")]
+pub mod debug_client;
 mod internal_flags;
 mod pollers;
 mod protosext;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,10 +12,10 @@ extern crate tracing;
 extern crate core;
 
 mod abstractions;
-#[cfg(feature = "ephemeral-server")]
-pub mod ephemeral_server;
 #[cfg(feature = "debug-plugin")]
 pub mod debug_client;
+#[cfg(feature = "ephemeral-server")]
+pub mod ephemeral_server;
 mod internal_flags;
 mod pollers;
 mod protosext;

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -43,10 +43,12 @@ use futures_util::{stream, StreamExt};
 use parking_lot::Mutex;
 use slot_provider::SlotProvider;
 use std::{
-    convert::TryInto, future, sync::{
+    convert::TryInto,
+    future,
+    sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
-    }
+    },
 };
 use temporal_client::{ConfiguredClient, TemporalServiceClientWithMetrics, WorkerKey};
 use temporal_sdk_core_protos::{

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -41,13 +41,12 @@ use crate::{
 use activities::WorkerActivityTasks;
 use futures_util::{stream, StreamExt};
 use parking_lot::Mutex;
-use prost::Message;
 use slot_provider::SlotProvider;
 use std::{
     convert::TryInto, future, sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
-    }, time::Duration
+    }
 };
 use temporal_client::{ConfiguredClient, TemporalServiceClientWithMetrics, WorkerKey};
 use temporal_sdk_core_protos::{
@@ -62,7 +61,6 @@ use temporal_sdk_core_protos::{
         enums::v1::TaskQueueKind,
         taskqueue::v1::{StickyExecutionAttributes, TaskQueue},
         workflowservice::v1::get_system_info_response,
-        history::v1::History,
     },
     TaskToken,
 };
@@ -744,58 +742,6 @@ pub(crate) enum TaskPollers {
     },
 }
 
-struct DebugClient {
-    debugger_url: String,
-    _client: reqwest::Client
-}
-
-impl DebugClient {
-
-    fn new(url: String) -> DebugClient {
-        DebugClient {
-            debugger_url: url,
-            _client: reqwest::Client::new(),
-        }
-    }
-
-    async fn get_history(&self) -> Result<History, anyhow::Error> {
-        let url = self.debugger_url.clone() + "/history";
-        let resp = self._client.get(url)
-            .header("Temporal-Client-Name", "temporal-core")
-            .header("Temporal-Client-Version", "0.1.0")
-            .send()
-            .await?;
-
-        let bytes = resp.bytes().await?;
-        Ok(History::decode(bytes)?) // decode_length_delimited() does not work
-
-    }
-
-    async fn post_wft_started(&self, event_id: &i64) -> bool {
-        let url = self.debugger_url.clone() + "/current-wft-started";
-        let resp = self._client.get(url)
-            .header("Temporal-Client-Name", "temporal-debug-core")
-            .header("Temporal-Client-Version", "0.1.0")
-            .timeout(Duration::from_secs(5))
-            .json(event_id)
-            .send()
-            .await;
-
-        match resp {
-            Ok(r) => { r.status() == reqwest::StatusCode::OK },
-            Err(_) => false
-        }
-    }
-
-    // debating whether this is necessary at all
-    fn content_length(response: &reqwest::Response) -> Result<u64, String> {
-        match response.content_length() {
-            Some(length) => Ok(length),
-            None => Err("Content length unavailable. The header is unavailable or the response was gzipped.".to_owned())
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -847,12 +793,6 @@ mod tests {
             worker.at_task_mgr.unwrap().remaining_activity_capacity(),
             Some(5)
         );
-    }
-
-    #[tokio::test]
-    async fn test_debug_client_delete() {
-        let dc = DebugClient::new("http://127.0.0.1:51563".into());
-        dc.get_history().await.unwrap();
     }
 
     #[test]

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -762,7 +762,7 @@ impl DebugClient {
         let url = self.debugger_url.clone() + "/history";
         let resp = self._client.get(url)
             .header("Temporal-Client-Name", "temporal-core")
-            .header("Temporal-Client-Version", "test v1")
+            .header("Temporal-Client-Version", "0.1.0")
             .send()
             .await?;
 
@@ -775,7 +775,7 @@ impl DebugClient {
         let url = self.debugger_url.clone() + "/current-wft-started";
         let resp = self._client.get(url)
             .header("Temporal-Client-Name", "temporal-debug-core")
-            .header("Temporal-Client-Version", "test v1")
+            .header("Temporal-Client-Version", "0.1.0")
             .timeout(Duration::from_secs(5))
             .json(event_id)
             .send()


### PR DESCRIPTION
Adding methods for using our VSCode extension into core, so the debugger can be extended into other languages without having to reimplement these basic methods.

Drafted while I'm still working on it.