### PR TITLE
Move Payload pretty-print from Display to Debug

### DIFF
--- a/sdk-core-protos/Cargo.toml
+++ b/sdk-core-protos/Cargo.toml
@@ -30,6 +30,7 @@ uuid = { version = "1.1", features = ["v4"], optional = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }
+prost-build = "0.13"
 prost-wkt-build = "0.6"
 
 [lints]

--- a/sdk-core-protos/build.rs
+++ b/sdk-core-protos/build.rs
@@ -1,4 +1,9 @@
-use std::{env, path::PathBuf};
+use std::{
+    env,
+    fs::File,
+    io::{BufRead, BufReader},
+    path::PathBuf,
+};
 
 static ALWAYS_SERDE: &str = "#[cfg_attr(not(feature = \"serde_serialize\"), \
                                derive(::serde::Serialize, ::serde::Deserialize))]";
@@ -130,6 +135,59 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "./protos/grpc",
             ],
         )?;
+
+    let file_path = out.join("temporal.api.common.v1.rs");
+    post_process_payload_file(file_path)?;
+
+    Ok(())
+}
+
+fn post_process_payload_file(file_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let file_contents: BufReader<File> = BufReader::new(File::open(file_path.clone())?);
+    let mut new_file_contents = String::new();
+
+    let mut found_payload = false;
+    let mut written = false;
+    for line in file_contents.lines() {
+        let line = line?;
+        if line.contains("pub struct Payload {") {
+            new_file_contents.push_str("#[prost(skip_debug)]\n");
+            found_payload = true;
+        }
+
+        // Write the current line to the new content
+        new_file_contents.push_str(&line);
+        new_file_contents.push('\n');
+
+        if found_payload && line == "}" && !written {
+            let debug_impl = r#"
+impl std::fmt::Debug for Payload {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.data.len() > 64 {
+            let mut windows = self.data.as_slice().windows(32);
+            write!(
+                f,
+                "[{}..{}]",
+                BASE64_STANDARD.encode(windows.next().unwrap_or_default()),
+                BASE64_STANDARD.encode(windows.next_back().unwrap_or_default())
+            )
+        } else {
+            write!(f, "[{}]", BASE64_STANDARD.encode(&self.data))
+        }
+    }
+}
+"#;
+            new_file_contents.push_str(debug_impl);
+            new_file_contents.push('\n');
+
+            written = true;
+        }
+    }
+
+    assert!(found_payload);
+
+    // Replace the original file with the modified content
+    std::fs::write(&file_path, new_file_contents)?;
 
     Ok(())
 }

--- a/sdk-core-protos/build.rs
+++ b/sdk-core-protos/build.rs
@@ -8,9 +8,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
     let descriptor_file = out.join("descriptors.bin");
 
-    let mut config = prost_build::Config::default();
-    config.skip_debug(["temporal.api.common.v1.Payload"]);
-
     tonic_build::configure()
         // We don't actually want to build the grpc definitions - we don't need them (for now).
         // Just build the message structs.
@@ -117,6 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "::prost_wkt_types::Value"
         )
         .file_descriptor_set_path(descriptor_file)
+        .skip_debug("temporal.api.common.v1.Payload")
         .compile_protos(
             &[
                 "./protos/local/temporal/sdk/core/core_interface.proto",

--- a/sdk-core-protos/build.rs
+++ b/sdk-core-protos/build.rs
@@ -7,7 +7,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=./protos");
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
     let descriptor_file = out.join("descriptors.bin");
-
     tonic_build::configure()
         // We don't actually want to build the grpc definitions - we don't need them (for now).
         // Just build the message structs.

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1767,7 +1767,9 @@ pub mod temporal {
 
                 impl std::fmt::Debug for Payload {
                     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                        if self.data.len() > 64 {
+                        if std::env::var("TEMPORAL_PRINT_FULL_PAYLOADS").is_ok()
+                            && self.data.len() > 64
+                        {
                             let mut windows = self.data.as_slice().windows(32);
                             write!(
                                 f,

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1750,17 +1750,7 @@ pub mod temporal {
 
                 impl Display for Payload {
                     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                        if self.data.len() > 64 {
-                            let mut windows = self.data.as_slice().windows(32);
-                            write!(
-                                f,
-                                "[{}..{}]",
-                                BASE64_STANDARD.encode(windows.next().unwrap_or_default()),
-                                BASE64_STANDARD.encode(windows.next_back().unwrap_or_default())
-                            )
-                        } else {
-                            write!(f, "[{}]", BASE64_STANDARD.encode(&self.data))
-                        }
+                        write!(f, "{:?}", self)
                     }
                 }
 

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1748,6 +1748,22 @@ pub mod temporal {
                     }
                 }
 
+                impl std::fmt::Debug for Payload {
+                    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                        if self.data.len() > 64 {
+                            let mut windows = self.data.as_slice().windows(32);
+                            write!(
+                                f,
+                                "[{}..{}]",
+                                BASE64_STANDARD.encode(windows.next().unwrap_or_default()),
+                                BASE64_STANDARD.encode(windows.next_back().unwrap_or_default())
+                            )
+                        } else {
+                            write!(f, "[{}]", BASE64_STANDARD.encode(&self.data))
+                        }
+                    }
+                }
+
                 impl Display for Payload {
                     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                         write!(f, "{:?}", self)

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1767,7 +1767,7 @@ pub mod temporal {
 
                 impl std::fmt::Debug for Payload {
                     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                        if std::env::var("TEMPORAL_PRINT_FULL_PAYLOADS").is_ok()
+                        if std::env::var("TEMPORAL_PRINT_FULL_PAYLOADS").is_err()
                             && self.data.len() > 64
                         {
                             let mut windows = self.data.as_slice().windows(32);


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Spencer previously implemented a pretty-print for `Display` for `Payload`. `Debug` was not touched because prost automatically generated the `Debug` impl for `Payload`. Prost and tonic-build now support skipping the `Debug` impl, https://github.com/tokio-rs/prost/pull/797, so we can leverage this to provide our own `Debug` impl.

Also added support to skip this truncation by specifying the `TEMPORAL_PRINT_FULL_PAYLOADS` env variable

## Why?
<!-- Tell your future self why have you made these changes -->
A nice-to-have feature to make debug logs more readable.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#806

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Generated temporal.api.common.v1.rs now generates 
```
#[cfg_attr(
    feature = "serde_serialize",
    derive(::serde::Serialize, ::serde::Deserialize)
)]
#[allow(clippy::derive_partial_eq_without_eq)]
#[derive(Clone, PartialEq, ::prost::Message)]
#[prost(skip_debug)]
pub struct Payload {
    #[prost(map = "string, bytes", tag = "1")]
    pub metadata: ::std::collections::HashMap<
        ::prost::alloc::string::String,
        ::prost::alloc::vec::Vec<u8>,
    >,
    #[prost(bytes = "vec", tag = "2")]
    pub data: ::prost::alloc::vec::Vec<u8>,
}

impl std::fmt::Debug for Payload {
    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
        if self.data.len() > 64 {
            let mut windows = self.data.as_slice().windows(32);
            write!(
                f,
                "[{}..{}]",
                BASE64_STANDARD.encode(windows.next().unwrap_or_default()),
                BASE64_STANDARD.encode(windows.next_back().unwrap_or_default())
            )
        } else {
            write!(f, "[{}]", BASE64_STANDARD.encode(&self.data))
        }
    }
}
```
4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
