### PR TITLE
Fix possible NDEs caused by LAs & immediate cancels resolving in different order upon replay

### DIFF
--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -125,10 +125,10 @@ async fn single_timer(#[case] worker: Worker, #[case] evict: WorkflowCachingPoli
 }
 
 #[rstest(worker,
-case::incremental(single_activity_setup(&[1, 2])),
-case::incremental_activity_failure(single_activity_failure_setup(&[1, 2])),
-case::replay(single_activity_setup(&[2])),
-case::replay_activity_failure(single_activity_failure_setup(&[2]))
+    case::incremental(single_activity_setup(&[1, 2])),
+    case::incremental_activity_failure(single_activity_failure_setup(&[1, 2])),
+    case::replay(single_activity_setup(&[2])),
+    case::replay_activity_failure(single_activity_failure_setup(&[2]))
 )]
 #[tokio::test]
 async fn single_activity_completion(worker: Worker) {
@@ -319,7 +319,7 @@ async fn scheduled_activity_timeout(hist_batches: &'static [usize]) {
                                         status: Some(activity_resolution::Status::Failed(ar::Failure {
                                             failure: Some(failure)
                                         })),
-                                    })
+                                    }), ..
                                 }
                             )),
                         }
@@ -361,7 +361,7 @@ async fn started_activity_timeout(hist_batches: &'static [usize]) {
             // Activity is getting resolved right away as it has been timed out.
             gen_assert_and_reply(
                 &|res| {
-                assert_matches!(
+                    assert_matches!(
                     res.jobs.as_slice(),
                     [
                         WorkflowActivationJob {
@@ -372,7 +372,7 @@ async fn started_activity_timeout(hist_batches: &'static [usize]) {
                                         status: Some(activity_resolution::Status::Failed(ar::Failure {
                                             failure: Some(failure)
                                         })),
-                                    })
+                                    }), ..
                                 }
                             )),
                         }
@@ -421,10 +421,10 @@ async fn cancelled_activity_timeout(hist_batches: &'static [usize]) {
             gen_assert_and_reply(
                 &job_assert!(workflow_activation_job::Variant::ResolveActivity(
                     ResolveActivity {
-                        seq: _,
                         result: Some(ActivityResolution {
                             status: Some(activity_resolution::Status::Cancelled(..)),
-                        })
+                        }),
+                        ..
                     }
                 )),
                 vec![CompleteWorkflowExecution { result: None }.into()],
@@ -574,10 +574,10 @@ async fn verify_activity_cancellation(
             gen_assert_and_reply(
                 &job_assert!(workflow_activation_job::Variant::ResolveActivity(
                     ResolveActivity {
-                        seq: _,
                         result: Some(ActivityResolution {
                             status: Some(activity_resolution::Status::Cancelled(..)),
-                        })
+                        }),
+                        ..
                     }
                 )),
                 vec![CompleteWorkflowExecution { result: None }.into()],
@@ -647,10 +647,10 @@ async fn verify_activity_cancellation_wait_for_cancellation(activity_id: u32, wo
             gen_assert_and_reply(
                 &job_assert!(workflow_activation_job::Variant::ResolveActivity(
                     ResolveActivity {
-                        seq: _,
                         result: Some(ActivityResolution {
                             status: Some(activity_resolution::Status::Cancelled(..)),
-                        })
+                        }),
+                        ..
                     }
                 )),
                 vec![CompleteWorkflowExecution { result: None }.into()],

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -506,7 +506,7 @@ where
                                 )))
                             }
                         } else {
-                            debug!(task_token = ?next_pc.task_token,
+                            debug!(task_token = %next_pc.task_token,
                                    "Unknown activity task when issuing cancel");
                             // If we can't find the activity here, it's already been completed,
                             // in which case issuing a cancel again is pointless.

--- a/core/src/worker/activities/activity_task_poller_stream.rs
+++ b/core/src/worker/activities/activity_task_poller_stream.rs
@@ -28,15 +28,15 @@ pub(crate) fn new_activity_task_poller(
                 loop {
                     return match state.poller.poll().await {
                         Some(Ok((resp, permit))) => {
-                            if let Some(reason) = validate_activity_task(&resp) {
-                                warn!("Received invalid activity task ({}): {:?}", reason, &resp);
-                                continue;
-                            }
                             if resp == PollActivityTaskQueueResponse::default() {
                                 // We get the default proto in the event that the long poll times
                                 // out.
                                 debug!("Poll activity task timeout");
                                 state.metrics.act_poll_timeout();
+                                continue;
+                            }
+                            if let Some(reason) = validate_activity_task(&resp) {
+                                warn!("Received invalid activity task ({}): {:?}", reason, &resp);
                                 continue;
                             }
                             Some(Ok(PermittedTqResp { permit, resp }))

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -587,16 +587,16 @@ impl Worker {
     /// Attempt to record an activity heartbeat
     pub(crate) fn record_heartbeat(&self, details: ActivityHeartbeat) {
         if let Some(at_mgr) = self.at_task_mgr.as_ref() {
-            let tt = details.task_token.clone();
+            let tt = TaskToken(details.task_token.clone());
             if let Err(e) = at_mgr.record_heartbeat(details) {
-                warn!(task_token = ?tt, details = ?e, "Activity heartbeat failed.");
+                warn!(task_token = %tt, details = ?e, "Activity heartbeat failed.");
             }
         }
     }
 
     #[instrument(skip(self, task_token, status),
-                 fields(task_token=%&task_token, status=%&status,
-                        task_queue=%self.config.task_queue, workflow_id, run_id))]
+        fields(task_token=%&task_token, status=%&status,
+               task_queue=%self.config.task_queue, workflow_id, run_id))]
     pub(crate) async fn complete_activity(
         &self,
         task_token: TaskToken,
@@ -637,8 +637,8 @@ impl Worker {
     }
 
     #[instrument(skip(self, completion),
-                 fields(completion=%&completion, run_id=%completion.run_id, workflow_id,
-                        task_queue=%self.config.task_queue))]
+        fields(completion=%&completion, run_id=%completion.run_id, workflow_id,
+               task_queue=%self.config.task_queue))]
     pub(crate) async fn complete_workflow_activation(
         &self,
         completion: WorkflowActivationCompletion,

--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -166,6 +166,7 @@ impl ActivityMachine {
                     failure: Some(new_cancel_failure(&self.shared_state, attrs)),
                 })),
             }),
+            is_local: false,
         }
     }
 }
@@ -265,6 +266,7 @@ impl WFMachinesAdapter for ActivityMachine {
                             result: convert_payloads(event_info, result)?,
                         })),
                     }),
+                    is_local: false,
                 }
                 .into()]
             }
@@ -276,6 +278,7 @@ impl WFMachinesAdapter for ActivityMachine {
                             failure: Some(failure),
                         })),
                     }),
+                    is_local: false,
                 }
                 .into()]
             }

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -8,7 +8,7 @@ use crate::{
     worker::{
         workflow::{
             machines::{activity_state_machine::activity_fail_info, HistEventData},
-            InternalFlagsRef, OutgoingJob,
+            InternalFlagsRef,
         },
         LocalActivityExecutionResult,
     },
@@ -737,14 +737,12 @@ impl WFMachinesAdapter for LocalActivityMachine {
                 };
 
                 let mut responses = vec![
-                    MachineResponse::PushWFJob(OutgoingJob {
-                        variant: ResolveActivity {
-                            seq: self.shared_state.attrs.seq,
-                            result: Some(resolution),
-                        }
-                        .into(),
-                        is_la_resolution: true,
-                    }),
+                    ResolveActivity {
+                        seq: self.shared_state.attrs.seq,
+                        result: Some(resolution),
+                        is_local: true,
+                    }
+                    .into(),
                     MachineResponse::UpdateWFTime(complete_time),
                 ];
 

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -449,7 +449,7 @@ impl WorkflowMachines {
         self.drive_me
             .peek_pending_jobs()
             .iter()
-            .any(|v| v.is_la_resolution)
+            .any(|v| v.variant.is_local_activity_resolution())
     }
 
     pub(crate) fn get_metadata_for_wft_complete(&mut self) -> WorkflowTaskCompletedMetadata {
@@ -1160,11 +1160,9 @@ impl WorkflowMachines {
                             CommandIdKind::NeverResolves,
                         );
                     }
-                    c => {
-                        return Err(WFMachinesError::Fatal(format!(
+                    c => return Err(WFMachinesError::Fatal(format!(
                         "A machine requested to create a new command of an unsupported type: {c:?}"
-                    )))
-                    }
+                    ))),
                 },
                 MachineResponse::IssueFakeLocalActivityMarker(seq) => {
                     self.current_wf_task_commands.push_back(CommandAndMachine {

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -23,22 +23,38 @@ import "temporal/sdk/core/common/common.proto";
 // ## Job ordering guarantees and semantics
 //
 // Core will, by default, order jobs within the activation as follows:
-// `init-workflow -> patches -> random-seed-updates -> signals/updates -> other -> queries -> evictions`
+// 1. init workflow
+// 2. patches
+// 3. random-seed-updates
+// 4. signals/updates
+// 5. all others
+// 6. local activity resolutions
+// 7. queries
+// 8. evictions
 //
 // This is because:
 // * Patches are expected to apply to the entire activation
 // * Signal and update handlers should be invoked before workflow routines are iterated. That is to
 //   say before the users' main workflow function and anything spawned by it is allowed to continue.
+// * Local activities resolutions go after other normal jobs because while *not* replaying, they
+//   will always take longer than anything else that produces an immediate job (which is
+//   effectively instant). When *replaying* we need to scan ahead for LA markers so that we can
+//   resolve them in the same activation that they completed in when not replaying. However, doing
+//   so would, by default, put those resolutions *before* any other immediate jobs that happened
+//   in that same activation (prime example: cancelling not-wait-for-cancel activities). So, we do
+//   this to ensure the LA resolution happens after that cancel (or whatever else it may be) as it
+//   normally would have when executing.
 // * Queries always go last (and, in fact, always come in their own activation)
 // * Evictions also always come in their own activation
 //
-// The downside of this reordering is that a signal or update handler may not observe that some
-// other event had already happened (ex: an activity completed) when it is first invoked, though it
-// will subsequently when workflow routines are driven. Core only does this reordering to make life
-// easier for languages that cannot explicitly control when workflow routines are iterated.
-// Languages that can explicitly control such iteration should prefer to apply all the jobs to state
-// (by resolving promises/futures, invoking handlers, etc as they iterate over the jobs) and then
-// only *after* that is done, drive the workflow routines.
+// Core does this reordering to ensure that langs observe jobs in the same order during replay as
+// they would have during execution. However, in principle, this ordering is not necessary
+// (excepting queries/evictions, which definitely must come last) if lang layers apply all jobs to
+// state *first* (by resolving promises/futures, marking handlers to be invoked, etc as they iterate
+// over the jobs) and then only *after* that is done, drive coroutines/threads/whatever. If
+// execution works this way, then determinism is only impacted by the order routines are driven in
+// (which must be stable based on lang implementation or convention), rather than the order jobs are
+// processed.
 //
 // ## Evictions
 //
@@ -175,6 +191,9 @@ message ResolveActivity {
     // Sequence number as provided by lang in the corresponding ScheduleActivity command
     uint32 seq = 1;
     activity_result.ActivityResolution result = 2;
+    // Set to true if the resolution is for a local activity. This is used internally by Core and
+    // lang does not need to care about it.
+    bool is_local = 3;
 }
 
 // Notify a workflow that a start child workflow execution request has succeeded, failed or was

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -513,6 +513,12 @@ pub mod coresdk {
             }
         }
 
+        impl workflow_activation_job::Variant {
+            pub fn is_local_activity_resolution(&self) -> bool {
+                matches!(self, workflow_activation_job::Variant::ResolveActivity(ra) if ra.is_local)
+            }
+        }
+
         impl Display for EvictionReason {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{self:?}")
@@ -1994,60 +2000,60 @@ pub mod temporal {
                     pub fn event_type(&self) -> EventType {
                         // I just absolutely _love_ this
                         match self {
-                            Attributes::WorkflowExecutionStartedEventAttributes(_) => {EventType::WorkflowExecutionStarted}
-                            Attributes::WorkflowExecutionCompletedEventAttributes(_) => {EventType::WorkflowExecutionCompleted}
-                            Attributes::WorkflowExecutionFailedEventAttributes(_) => {EventType::WorkflowExecutionFailed}
-                            Attributes::WorkflowExecutionTimedOutEventAttributes(_) => {EventType::WorkflowExecutionTimedOut}
-                            Attributes::WorkflowTaskScheduledEventAttributes(_) => {EventType::WorkflowTaskScheduled}
-                            Attributes::WorkflowTaskStartedEventAttributes(_) => {EventType::WorkflowTaskStarted}
-                            Attributes::WorkflowTaskCompletedEventAttributes(_) => {EventType::WorkflowTaskCompleted}
-                            Attributes::WorkflowTaskTimedOutEventAttributes(_) => {EventType::WorkflowTaskTimedOut}
-                            Attributes::WorkflowTaskFailedEventAttributes(_) => {EventType::WorkflowTaskFailed}
-                            Attributes::ActivityTaskScheduledEventAttributes(_) => {EventType::ActivityTaskScheduled}
-                            Attributes::ActivityTaskStartedEventAttributes(_) => {EventType::ActivityTaskStarted}
-                            Attributes::ActivityTaskCompletedEventAttributes(_) => {EventType::ActivityTaskCompleted}
-                            Attributes::ActivityTaskFailedEventAttributes(_) => {EventType::ActivityTaskFailed}
-                            Attributes::ActivityTaskTimedOutEventAttributes(_) => {EventType::ActivityTaskTimedOut}
-                            Attributes::TimerStartedEventAttributes(_) => {EventType::TimerStarted}
-                            Attributes::TimerFiredEventAttributes(_) => {EventType::TimerFired}
-                            Attributes::ActivityTaskCancelRequestedEventAttributes(_) => {EventType::ActivityTaskCancelRequested}
-                            Attributes::ActivityTaskCanceledEventAttributes(_) => {EventType::ActivityTaskCanceled}
-                            Attributes::TimerCanceledEventAttributes(_) => {EventType::TimerCanceled}
-                            Attributes::MarkerRecordedEventAttributes(_) => {EventType::MarkerRecorded}
-                            Attributes::WorkflowExecutionSignaledEventAttributes(_) => {EventType::WorkflowExecutionSignaled}
-                            Attributes::WorkflowExecutionTerminatedEventAttributes(_) => {EventType::WorkflowExecutionTerminated}
-                            Attributes::WorkflowExecutionCancelRequestedEventAttributes(_) => {EventType::WorkflowExecutionCancelRequested}
-                            Attributes::WorkflowExecutionCanceledEventAttributes(_) => {EventType::WorkflowExecutionCanceled}
-                            Attributes::RequestCancelExternalWorkflowExecutionInitiatedEventAttributes(_) => {EventType::RequestCancelExternalWorkflowExecutionInitiated}
-                            Attributes::RequestCancelExternalWorkflowExecutionFailedEventAttributes(_) => {EventType::RequestCancelExternalWorkflowExecutionFailed}
-                            Attributes::ExternalWorkflowExecutionCancelRequestedEventAttributes(_) => {EventType::ExternalWorkflowExecutionCancelRequested}
-                            Attributes::WorkflowExecutionContinuedAsNewEventAttributes(_) => {EventType::WorkflowExecutionContinuedAsNew}
-                            Attributes::StartChildWorkflowExecutionInitiatedEventAttributes(_) => {EventType::StartChildWorkflowExecutionInitiated}
-                            Attributes::StartChildWorkflowExecutionFailedEventAttributes(_) => {EventType::StartChildWorkflowExecutionFailed}
-                            Attributes::ChildWorkflowExecutionStartedEventAttributes(_) => {EventType::ChildWorkflowExecutionStarted}
-                            Attributes::ChildWorkflowExecutionCompletedEventAttributes(_) => {EventType::ChildWorkflowExecutionCompleted}
-                            Attributes::ChildWorkflowExecutionFailedEventAttributes(_) => {EventType::ChildWorkflowExecutionFailed}
-                            Attributes::ChildWorkflowExecutionCanceledEventAttributes(_) => {EventType::ChildWorkflowExecutionCanceled}
-                            Attributes::ChildWorkflowExecutionTimedOutEventAttributes(_) => {EventType::ChildWorkflowExecutionTimedOut}
-                            Attributes::ChildWorkflowExecutionTerminatedEventAttributes(_) => {EventType::ChildWorkflowExecutionTerminated}
-                            Attributes::SignalExternalWorkflowExecutionInitiatedEventAttributes(_) => {EventType::SignalExternalWorkflowExecutionInitiated}
-                            Attributes::SignalExternalWorkflowExecutionFailedEventAttributes(_) => {EventType::SignalExternalWorkflowExecutionFailed}
-                            Attributes::ExternalWorkflowExecutionSignaledEventAttributes(_) => {EventType::ExternalWorkflowExecutionSignaled}
-                            Attributes::UpsertWorkflowSearchAttributesEventAttributes(_) => {EventType::UpsertWorkflowSearchAttributes}
-                            Attributes::WorkflowExecutionUpdateAdmittedEventAttributes(_) => {EventType::WorkflowExecutionUpdateAdmitted}
-                            Attributes::WorkflowExecutionUpdateRejectedEventAttributes(_) => {EventType::WorkflowExecutionUpdateRejected}
-                            Attributes::WorkflowExecutionUpdateAcceptedEventAttributes(_) => {EventType::WorkflowExecutionUpdateAccepted}
-                            Attributes::WorkflowExecutionUpdateCompletedEventAttributes(_) => {EventType::WorkflowExecutionUpdateCompleted}
-                            Attributes::WorkflowPropertiesModifiedExternallyEventAttributes(_) => {EventType::WorkflowPropertiesModifiedExternally}
-                            Attributes::ActivityPropertiesModifiedExternallyEventAttributes(_) => {EventType::ActivityPropertiesModifiedExternally}
-                            Attributes::WorkflowPropertiesModifiedEventAttributes(_) => {EventType::WorkflowPropertiesModified}
-                            Attributes::NexusOperationScheduledEventAttributes(_) => {EventType::NexusOperationScheduled}
-                            Attributes::NexusOperationStartedEventAttributes(_) => {EventType::NexusOperationStarted}
-                            Attributes::NexusOperationCompletedEventAttributes(_) => {EventType::NexusOperationCompleted}
-                            Attributes::NexusOperationFailedEventAttributes(_) => {EventType::NexusOperationFailed}
-                            Attributes::NexusOperationCanceledEventAttributes(_) => {EventType::NexusOperationCanceled}
-                            Attributes::NexusOperationTimedOutEventAttributes(_) => {EventType::NexusOperationTimedOut}
-                            Attributes::NexusOperationCancelRequestedEventAttributes(_) => {EventType::NexusOperationCancelRequested}
+                            Attributes::WorkflowExecutionStartedEventAttributes(_) => { EventType::WorkflowExecutionStarted }
+                            Attributes::WorkflowExecutionCompletedEventAttributes(_) => { EventType::WorkflowExecutionCompleted }
+                            Attributes::WorkflowExecutionFailedEventAttributes(_) => { EventType::WorkflowExecutionFailed }
+                            Attributes::WorkflowExecutionTimedOutEventAttributes(_) => { EventType::WorkflowExecutionTimedOut }
+                            Attributes::WorkflowTaskScheduledEventAttributes(_) => { EventType::WorkflowTaskScheduled }
+                            Attributes::WorkflowTaskStartedEventAttributes(_) => { EventType::WorkflowTaskStarted }
+                            Attributes::WorkflowTaskCompletedEventAttributes(_) => { EventType::WorkflowTaskCompleted }
+                            Attributes::WorkflowTaskTimedOutEventAttributes(_) => { EventType::WorkflowTaskTimedOut }
+                            Attributes::WorkflowTaskFailedEventAttributes(_) => { EventType::WorkflowTaskFailed }
+                            Attributes::ActivityTaskScheduledEventAttributes(_) => { EventType::ActivityTaskScheduled }
+                            Attributes::ActivityTaskStartedEventAttributes(_) => { EventType::ActivityTaskStarted }
+                            Attributes::ActivityTaskCompletedEventAttributes(_) => { EventType::ActivityTaskCompleted }
+                            Attributes::ActivityTaskFailedEventAttributes(_) => { EventType::ActivityTaskFailed }
+                            Attributes::ActivityTaskTimedOutEventAttributes(_) => { EventType::ActivityTaskTimedOut }
+                            Attributes::TimerStartedEventAttributes(_) => { EventType::TimerStarted }
+                            Attributes::TimerFiredEventAttributes(_) => { EventType::TimerFired }
+                            Attributes::ActivityTaskCancelRequestedEventAttributes(_) => { EventType::ActivityTaskCancelRequested }
+                            Attributes::ActivityTaskCanceledEventAttributes(_) => { EventType::ActivityTaskCanceled }
+                            Attributes::TimerCanceledEventAttributes(_) => { EventType::TimerCanceled }
+                            Attributes::MarkerRecordedEventAttributes(_) => { EventType::MarkerRecorded }
+                            Attributes::WorkflowExecutionSignaledEventAttributes(_) => { EventType::WorkflowExecutionSignaled }
+                            Attributes::WorkflowExecutionTerminatedEventAttributes(_) => { EventType::WorkflowExecutionTerminated }
+                            Attributes::WorkflowExecutionCancelRequestedEventAttributes(_) => { EventType::WorkflowExecutionCancelRequested }
+                            Attributes::WorkflowExecutionCanceledEventAttributes(_) => { EventType::WorkflowExecutionCanceled }
+                            Attributes::RequestCancelExternalWorkflowExecutionInitiatedEventAttributes(_) => { EventType::RequestCancelExternalWorkflowExecutionInitiated }
+                            Attributes::RequestCancelExternalWorkflowExecutionFailedEventAttributes(_) => { EventType::RequestCancelExternalWorkflowExecutionFailed }
+                            Attributes::ExternalWorkflowExecutionCancelRequestedEventAttributes(_) => { EventType::ExternalWorkflowExecutionCancelRequested }
+                            Attributes::WorkflowExecutionContinuedAsNewEventAttributes(_) => { EventType::WorkflowExecutionContinuedAsNew }
+                            Attributes::StartChildWorkflowExecutionInitiatedEventAttributes(_) => { EventType::StartChildWorkflowExecutionInitiated }
+                            Attributes::StartChildWorkflowExecutionFailedEventAttributes(_) => { EventType::StartChildWorkflowExecutionFailed }
+                            Attributes::ChildWorkflowExecutionStartedEventAttributes(_) => { EventType::ChildWorkflowExecutionStarted }
+                            Attributes::ChildWorkflowExecutionCompletedEventAttributes(_) => { EventType::ChildWorkflowExecutionCompleted }
+                            Attributes::ChildWorkflowExecutionFailedEventAttributes(_) => { EventType::ChildWorkflowExecutionFailed }
+                            Attributes::ChildWorkflowExecutionCanceledEventAttributes(_) => { EventType::ChildWorkflowExecutionCanceled }
+                            Attributes::ChildWorkflowExecutionTimedOutEventAttributes(_) => { EventType::ChildWorkflowExecutionTimedOut }
+                            Attributes::ChildWorkflowExecutionTerminatedEventAttributes(_) => { EventType::ChildWorkflowExecutionTerminated }
+                            Attributes::SignalExternalWorkflowExecutionInitiatedEventAttributes(_) => { EventType::SignalExternalWorkflowExecutionInitiated }
+                            Attributes::SignalExternalWorkflowExecutionFailedEventAttributes(_) => { EventType::SignalExternalWorkflowExecutionFailed }
+                            Attributes::ExternalWorkflowExecutionSignaledEventAttributes(_) => { EventType::ExternalWorkflowExecutionSignaled }
+                            Attributes::UpsertWorkflowSearchAttributesEventAttributes(_) => { EventType::UpsertWorkflowSearchAttributes }
+                            Attributes::WorkflowExecutionUpdateAdmittedEventAttributes(_) => { EventType::WorkflowExecutionUpdateAdmitted }
+                            Attributes::WorkflowExecutionUpdateRejectedEventAttributes(_) => { EventType::WorkflowExecutionUpdateRejected }
+                            Attributes::WorkflowExecutionUpdateAcceptedEventAttributes(_) => { EventType::WorkflowExecutionUpdateAccepted }
+                            Attributes::WorkflowExecutionUpdateCompletedEventAttributes(_) => { EventType::WorkflowExecutionUpdateCompleted }
+                            Attributes::WorkflowPropertiesModifiedExternallyEventAttributes(_) => { EventType::WorkflowPropertiesModifiedExternally }
+                            Attributes::ActivityPropertiesModifiedExternallyEventAttributes(_) => { EventType::ActivityPropertiesModifiedExternally }
+                            Attributes::WorkflowPropertiesModifiedEventAttributes(_) => { EventType::WorkflowPropertiesModified }
+                            Attributes::NexusOperationScheduledEventAttributes(_) => { EventType::NexusOperationScheduled }
+                            Attributes::NexusOperationStartedEventAttributes(_) => { EventType::NexusOperationStarted }
+                            Attributes::NexusOperationCompletedEventAttributes(_) => { EventType::NexusOperationCompleted }
+                            Attributes::NexusOperationFailedEventAttributes(_) => { EventType::NexusOperationFailed }
+                            Attributes::NexusOperationCanceledEventAttributes(_) => { EventType::NexusOperationCanceled }
+                            Attributes::NexusOperationTimedOutEventAttributes(_) => { EventType::NexusOperationTimedOut }
+                            Attributes::NexusOperationCancelRequestedEventAttributes(_) => { EventType::NexusOperationCancelRequested }
                         }
                     }
                 }

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -182,7 +182,7 @@ impl WorkflowFuture {
                 Variant::FireTimer(FireTimer { seq }) => {
                     self.unblock(UnblockEvent::Timer(seq, TimerResult::Fired))?
                 }
-                Variant::ResolveActivity(ResolveActivity { seq, result }) => {
+                Variant::ResolveActivity(ResolveActivity { seq, result, .. }) => {
                     self.unblock(UnblockEvent::Activity(
                         seq,
                         Box::new(result.context("Activity must have result")?),

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -85,7 +85,7 @@ async fn activity_heartbeat() {
                 variant: Some(workflow_activation_job::Variant::ResolveActivity(
                     ResolveActivity {seq, result: Some(ActivityResolution {
                     status: Some(act_res::Status::Completed(activity_result::Success{result: Some(r)})),
-                     ..})}
+                     ..}),..}
                 )),
             },
         ] => {

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -129,7 +129,7 @@ async fn activity_workflow() {
                       status: Some(
                         act_res::Status::Completed(activity_result::Success{result: Some(r)})),
                         ..
-                    })}
+                    }), ..}
                 )),
             },
         ] => {
@@ -182,7 +182,7 @@ async fn activity_non_retryable_failure() {
                     ResolveActivity {seq, result: Some(ActivityResolution{
                     status: Some(act_res::Status::Failed(activity_result::Failure{
                         failure: Some(f),
-                    }))})}
+                    }))}),..}
                 )),
             },
         ] => {
@@ -249,7 +249,7 @@ async fn activity_non_retryable_failure_with_error() {
                     ResolveActivity {seq, result: Some(ActivityResolution{
                     status: Some(act_res::Status::Failed(activity_result::Failure{
                         failure: Some(f),
-                    }))})}
+                    }))}),..}
                 )),
             },
         ] => {
@@ -328,7 +328,7 @@ async fn activity_retry() {
             WorkflowActivationJob {
                 variant: Some(workflow_activation_job::Variant::ResolveActivity(
                     ResolveActivity {seq, result: Some(ActivityResolution{
-                    status: Some(act_res::Status::Completed(activity_result::Success{result: Some(r)}))})}
+                    status: Some(act_res::Status::Completed(activity_result::Success{result: Some(r)}))}),..}
                 )),
             },
         ] => {
@@ -526,7 +526,7 @@ async fn started_activity_timeout() {
                                 )
                             ),
                             ..
-                        })
+                        }), ..
                     }
                 )),
             },
@@ -714,7 +714,7 @@ async fn async_activity_completion_workflow() {
                 variant: Some(workflow_activation_job::Variant::ResolveActivity(
                     ResolveActivity {seq, result: Some(ActivityResolution {
                     status: Some(act_res::Status::Completed(activity_result::Success{result: Some(r)})),
-                     ..})}
+                     ..}), ..}
                 )),
             },
         ] => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Always resolve LAs last within one activation

I am confident this does not need a flag for the reasons explained in the docstring for the test. If you were in this situation before, you were experiencing UB that would likely lead to an NDE. The only situation this change impacts _is_ exactly that situation. The test docstring explains why you can't force something else to happen.

However, we should still test this change in lang SDKs with the fuzzer before releasing them with it.

## Why?
Well explained by docstrings

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/803

2. How was this tested:
Added reproing test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
