### PR TITLE
Fix legacy query failure replying

### DIFF
--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -307,7 +307,11 @@ async fn query_failure_because_nondeterminism(#[values(true, false)] legacy: boo
         pr
     }];
     let mut mock = MockPollCfg::from_resp_batches(wfid, t, tasks, mock_workflow_client());
-    mock.num_expected_fails = 1;
+    if legacy {
+        mock.num_expected_legacy_query_resps = 1;
+    } else {
+        mock.num_expected_fails = 1;
+    }
     let mut mock = build_mock_pollers(mock);
     mock.worker_cfg(|wc| {
         wc.max_cached_workflows = 10;

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -876,11 +876,13 @@ impl ManagedRun {
             // If we've requested an eviction because of failure related reasons then we want to
             // delete any pending queries, since handling them no longer makes sense. Evictions
             // because the cache is full should get a chance to finish processing properly.
-            if !matches!(info.reason, EvictionReason::CacheFull) {
+            if !matches!(info.reason, EvictionReason::CacheFull)
+                // If the wft was just a legacy query, still reply, otherwise we might try to
+                // reply to the task as if it were a task rather than a query.
+                && !self.pending_work_is_legacy_query()
+            {
                 if let Some(wft) = self.wft.as_mut() {
                     wft.pending_queries.clear();
-                    // We don't reply to legacy queries, because after we fail the task they
-                    // are likely to get retired in the next one, and may pass.
                 }
             }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make sure we still reply to legacy queries in specific failure scenarios

## Why?
Could cause timeouts where they were not necessary

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
