### PR TITLE
Attempt to address unusal rpc cancellation error

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -34,7 +34,7 @@ slotmap = "1.0"
 thiserror = "1.0"
 tokio = "1.1"
 tonic = { workspace = true, features = ["tls", "tls-roots"] }
-tower = "0.4"
+tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 url = "2.2"
 uuid = { version = "1.1", features = ["v4"] }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -206,7 +206,7 @@ impl Default for ClientKeepAliveConfig {
 }
 
 /// Configuration for retrying requests to the server
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RetryConfig {
     /// initial wait time before the first retry.
     pub initial_interval: Duration,

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -149,12 +149,12 @@ where
         F: FnMut(&mut Self, Request<Req>) -> BoxFuture<'static, Result<Response<Resp>, Status>>,
         F: Send + Sync + Unpin + 'static,
     {
-        let rtc = self.get_retry_config(call_name);
+        let info = self.get_call_info(call_name, Some(&req));
         let fact = || {
             let req_clone = req_cloner(&req);
             callfn(self, req_clone)
         };
-        let res = Self::make_future_retry(rtc, fact, call_name);
+        let res = Self::make_future_retry(info, fact);
         res.map_err(|(e, _attempt)| e).map_ok(|x| x.0).await
     }
 }
@@ -318,7 +318,6 @@ impl RawClientLike for Client {
 }
 
 /// Helper for cloning a tonic request as long as the inner message may be cloned.
-/// We drop extensions, so, lang bridges can't pass those in :shrug:
 fn req_cloner<T: Clone>(cloneme: &Request<T>) -> Request<T> {
     let msg = cloneme.get_ref().clone();
     let mut new_req = Request::new(msg);
@@ -333,6 +332,7 @@ fn req_cloner<T: Clone>(cloneme: &Request<T>) -> Request<T> {
             }
         }
     }
+    *new_req.extensions_mut() = cloneme.extensions().clone();
     new_req
 }
 
@@ -358,6 +358,11 @@ impl AttachMetricLabels {
         self
     }
 }
+
+/// A request extension that, when set, should make the [RetryClient] consider this call to be a
+/// long poll
+#[derive(Copy, Clone, Debug)]
+pub(super) struct ForceConsiderLongPoll;
 
 // Blanket impl the trait for all raw-client-like things. Since the trait default-implements
 // everything, there's nothing to actually implement.
@@ -413,6 +418,15 @@ where
 }
 
 /// Helps re-declare gRPC client methods
+///
+/// There are two forms:
+///
+/// * The first takes a closure that can modify the request. This is only called once, before the
+///   actual rpc call is made, and before determinations are made about the kind of call (long poll
+///   or not) and retry policy.
+/// * The second takes three closures. The first can modify the request like in the first form.
+///   The second can modify the request and return a value, and is called right before every call
+///   (including on retries). The third is called with the response to the call after it resolves.
 macro_rules! proxy {
     ($client_type:tt, $client_meth:ident, $method:ident, $req:ty, $resp:ty $(, $closure:expr)?) => {
         #[doc = concat!("See [", stringify!($client_type), "::", stringify!($method), "]")]
@@ -421,21 +435,26 @@ macro_rules! proxy {
             request: impl tonic::IntoRequest<$req>,
         ) -> BoxFuture<Result<tonic::Response<$resp>, tonic::Status>> {
             #[allow(unused_mut)]
+            let mut as_req = request.into_request();
+            $( type_closure_arg(&mut as_req, $closure); )*
+            #[allow(unused_mut)]
             let fact = |c: &mut Self, mut req: tonic::Request<$req>| {
-                $( type_closure_arg(&mut req, $closure); )*
                 let mut c = c.$client_meth().clone();
                 async move { c.$method(req).await }.boxed()
             };
-            self.call(stringify!($method), fact, request.into_request())
+            self.call(stringify!($method), fact, as_req)
         }
     };
     ($client_type:tt, $client_meth:ident, $method:ident, $req:ty, $resp:ty,
-     $closure_before:expr, $closure_after:expr) => {
+     $closure_request:expr, $closure_before:expr, $closure_after:expr) => {
         #[doc = concat!("See [", stringify!($client_type), "::", stringify!($method), "]")]
         fn $method(
             &mut self,
             request: impl tonic::IntoRequest<$req>,
         ) -> BoxFuture<Result<tonic::Response<$resp>, tonic::Status>> {
+            #[allow(unused_mut)]
+            let mut as_req = request.into_request();
+            type_closure_arg(&mut as_req, $closure_request);
             #[allow(unused_mut)]
             let fact = |c: &mut Self, mut req: tonic::Request<$req>| {
                 let data = type_closure_two_arg(&mut req, c.get_workers_info().unwrap(),
@@ -445,13 +464,14 @@ macro_rules! proxy {
                     type_closure_two_arg(c.$method(req).await, data, $closure_after)
                 }.boxed()
             };
-            self.call(stringify!($method), fact, request.into_request())
+            self.call(stringify!($method), fact, as_req)
         }
     };
 }
 macro_rules! proxier {
     ( $trait_name:ident; $impl_list_name:ident; $client_type:tt; $client_meth:ident;
-      $(($method:ident, $req:ty, $resp:ty $(, $closure:expr $(, $closure_after:expr)?)? );)* ) => {
+      $(($method:ident, $req:ty, $resp:ty
+         $(, $closure:expr $(, $closure_before:expr, $closure_after:expr)?)? );)* ) => {
         #[cfg(test)]
         const $impl_list_name: &'static [&'static str] = &[$(stringify!($method)),*];
         /// Trait version of the generated client with modifications to attach appropriate metric
@@ -470,7 +490,7 @@ macro_rules! proxier {
         {
             $(
                proxy!($client_type, $client_meth, $method, $req, $resp
-                      $(,$closure $(,$closure_after)*)*);
+                      $(,$closure $(,$closure_before, $closure_after)*)*);
             )*
         }
     };
@@ -548,15 +568,18 @@ proxier! {
         start_workflow_execution,
         StartWorkflowExecutionRequest,
         StartWorkflowExecutionResponse,
-        |r, workers| {
-            let mut slot: Option<Box<dyn Slot + Send>> = None;
+        |r| {
             let mut labels = namespaced_request!(r);
             labels.task_q(r.get_ref().task_queue.clone());
             r.extensions_mut().insert(labels);
+        },
+        |r, workers| {
+            let mut slot: Option<Box<dyn Slot + Send>> = None;
             let req_mut = r.get_mut();
             if req_mut.request_eager_execution {
                 let namespace = req_mut.namespace.clone();
-                let task_queue = req_mut.task_queue.clone().unwrap().name.clone();
+                let task_queue = req_mut.task_queue.as_ref()
+                                    .map(|tq| tq.name.clone()).unwrap_or_default();
                 match workers.try_reserve_wft_slot(namespace, task_queue) {
                     Some(s) => slot = Some(s),
                     None => req_mut.request_eager_execution = false
@@ -586,6 +609,9 @@ proxier! {
         |r| {
             let labels = namespaced_request!(r);
             r.extensions_mut().insert(labels);
+            if r.get_ref().wait_new_event {
+                r.extensions_mut().insert(ForceConsiderLongPoll);
+            }
             if r.get_ref().wait_new_event {
                 r.set_default_timeout(LONG_POLL_TIMEOUT);
             }
@@ -981,7 +1007,7 @@ proxier! {
         GetWorkerTaskReachabilityRequest,
         GetWorkerTaskReachabilityResponse,
         |r| {
-            let mut labels = namespaced_request!(r);
+            let labels = namespaced_request!(r);
             r.extensions_mut().insert(labels);
         }
     );

--- a/client/src/workflow_handle/mod.rs
+++ b/client/src/workflow_handle/mod.rs
@@ -1,4 +1,4 @@
-use crate::{InterceptedMetricsSvc, RawClientLike};
+use crate::{InterceptedMetricsSvc, RawClientLike, WorkflowService};
 use anyhow::{anyhow, bail};
 use std::marker::PhantomData;
 use temporal_sdk_core_protos::{
@@ -107,7 +107,6 @@ where
             let server_res = self
                 .client
                 .clone()
-                .workflow_client_mut()
                 .get_workflow_execution_history(GetWorkflowExecutionHistoryRequest {
                     namespace: self.info.namespace.to_string(),
                     execution: Some(WorkflowExecution {

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -631,9 +631,6 @@ impl Cancellable for LocalActivityMachine {
     }
 }
 
-#[derive(Default, Clone)]
-pub(super) struct Abandoned {}
-
 impl WFMachinesAdapter for LocalActivityMachine {
     fn adapt_response(
         &self,

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -1063,6 +1063,7 @@ async fn activity_can_be_cancelled_by_local_timeout() {
 }
 
 #[tokio::test]
+#[ignore] // Runs forever, used to manually attempt to repro spurious activity completion rpc errs
 async fn long_activity_timeout_repro() {
     let wf_name = "long_activity_timeout_repro";
     let mut starter = CoreWfStarter::new(wf_name);
@@ -1089,10 +1090,9 @@ async fn long_activity_timeout_repro() {
             ctx.timer(Duration::from_secs(60 * 3)).await;
             iter += 1;
             if iter > 5000 {
-                return Ok(WfExitValue::continue_as_new(Default::default()));
+                return Ok(WfExitValue::<()>::continue_as_new(Default::default()));
             }
         }
-        Ok(().into())
     });
     worker.register_activity("echo_activity", echo);
 

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -9,7 +9,7 @@ use std::{
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowExecutionResult, WorkflowOptions};
 use temporal_sdk::{
     ActContext, ActExitValue, ActivityError, ActivityOptions, CancellableFuture, WfContext,
-    WorkflowResult,
+    WfExitValue, WorkflowResult,
 };
 use temporal_sdk_core_protos::{
     coresdk::{
@@ -52,7 +52,7 @@ pub(crate) async fn one_activity_wf(ctx: WfContext) -> WorkflowResult<()> {
 }
 
 #[tokio::test]
-async fn one_activity() {
+async fn one_activity_only() {
     let wf_name = "one_activity";
     let mut starter = CoreWfStarter::new(wf_name);
     let mut worker = starter.worker().await;
@@ -1060,4 +1060,42 @@ async fn activity_can_be_cancelled_by_local_timeout() {
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
     assert!(WAS_CANCELLED.load(Ordering::Relaxed));
+}
+
+#[tokio::test]
+async fn long_activity_timeout_repro() {
+    let wf_name = "long_activity_timeout_repro";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .worker_config
+        .local_timeout_buffer_for_activities(Duration::from_secs(0));
+    let mut worker = starter.worker().await;
+    worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
+        let mut iter = 1;
+        loop {
+            let res = ctx
+                .activity(ActivityOptions {
+                    activity_type: "echo_activity".to_string(),
+                    start_to_close_timeout: Some(Duration::from_secs(1)),
+                    input: "hi!".as_json_payload().expect("serializes fine"),
+                    retry_policy: Some(RetryPolicy {
+                        maximum_attempts: 1,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+                .await;
+            assert!(res.completed_ok());
+            ctx.timer(Duration::from_secs(60 * 3)).await;
+            iter += 1;
+            if iter > 5000 {
+                return Ok(WfExitValue::continue_as_new(Default::default()));
+            }
+        }
+        Ok(().into())
+    });
+    worker.register_activity("echo_activity", echo);
+
+    starter.start_with_worker(wf_name, &mut worker).await;
+    worker.run_until_done().await.unwrap();
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* Fixed get workflow history not being considered a long-poll call (discovered while trying to repro)
* Retry at most once the specific error users have seen occasionally during activity completions

## Why?
Avoid spurious rpc failures due to goaways

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/807

2. How was this tested:
Could not repro the exact case, but, by analysis this should allow that situation to retry at most once.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
