### PR TITLE
Respect gRPC timeouts on get wf execution history

### DIFF
--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -360,9 +360,9 @@ impl AttachMetricLabels {
 }
 
 /// A request extension that, when set, should make the [RetryClient] consider this call to be a
-/// long poll
+/// [super::retry::CallType::UserLongPoll]
 #[derive(Copy, Clone, Debug)]
-pub(super) struct ForceConsiderLongPoll;
+pub(super) struct IsUserLongPoll;
 
 // Blanket impl the trait for all raw-client-like things. Since the trait default-implements
 // everything, there's nothing to actually implement.
@@ -610,7 +610,7 @@ proxier! {
             let labels = namespaced_request!(r);
             r.extensions_mut().insert(labels);
             if r.get_ref().wait_new_event {
-                r.extensions_mut().insert(ForceConsiderLongPoll);
+                r.extensions_mut().insert(IsUserLongPoll);
             }
             if r.get_ref().wait_new_event {
                 r.set_default_timeout(LONG_POLL_TIMEOUT);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Differentiated user-initiated long polls from task long polls to continue respecting timeouts in those cases

## Why?
We don't want to ignore a gRPC timeout for a user made call

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Upgraded test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
