### PR TITLE
Add helper function for extracting success payload

### DIFF
--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -210,10 +210,8 @@ pub mod coresdk {
         }
 
         impl ActivityResolution {
-            /// A helper function for cases when you want to extract an activity's payload if it
-            /// completed successfully or return an error for all other outcomes. It's essentially
-            /// an alternative to [`unwrap_ok_payload`][`Self::unwrap_ok_payload`] that uses neither
-            /// `unwrap()` nor `panic!`.
+            /// Extract an activity's payload if it completed successfully, or return an error for all 
+            /// other outcomes.
             pub fn success_payload_or_error(self) -> Result<Option<Payload>, anyhow::Error> {
                 let Some(status) = self.status else {
                     return Err(anyhow!("activity completed without a status"));

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -211,8 +211,9 @@ pub mod coresdk {
 
         impl ActivityResolution {
             /// A helper function for cases when you want to extract an activity's payload if it
-            /// completed successfully or return an error for all other outcomes. It's a safer,
-            /// non-panicking alternative to [`unwrap_ok_payload`][`Self::unwrap_ok_payload`].
+            /// completed successfully or return an error for all other outcomes. It's essentially
+            /// an alternative to [`unwrap_ok_payload`][`Self::unwrap_ok_payload`] that uses neither
+            /// `unwrap()` nor `panic!`.
             pub fn success_payload_or_error(self) -> Result<Option<Payload>, anyhow::Error> {
                 let Some(status) = self.status else {
                     return Err(anyhow!("activity completed without a status"));

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -210,27 +210,21 @@ pub mod coresdk {
         }
 
         impl ActivityResolution {
-            /// Extract an activity's payload if it completed successfully, or return an error for all 
+            /// Extract an activity's payload if it completed successfully, or return an error for all
             /// other outcomes.
             pub fn success_payload_or_error(self) -> Result<Option<Payload>, anyhow::Error> {
                 let Some(status) = self.status else {
-                    return Err(anyhow!("activity completed without a status"));
+                    return Err(anyhow!("Activity completed without a status"));
                 };
 
                 match status {
                     activity_resolution::Status::Completed(success) => Ok(success.result),
-                    status => Err(anyhow!(
-                        "activity resulted in a non-completed status: {:?}",
-                        status
-                    )),
+                    e => Err(anyhow!("Activity was not successful: {e:?}")),
                 }
             }
 
             pub fn unwrap_ok_payload(self) -> Payload {
-                match self.status.unwrap() {
-                    activity_resolution::Status::Completed(c) => c.result.unwrap(),
-                    e => panic!("Activity was not successful: {e:?}"),
-                }
+                self.success_payload_or_error().unwrap().unwrap()
             }
 
             pub fn completed_ok(&self) -> bool {


### PR DESCRIPTION
## What was changed

I added a helper function to `ActivityResolution` to cover a use case of mine that may also help others (the idea to do this emerged from a discussion in the **sdk-core** Slack channel).

## Why?

I've been using this lib to create my own makeshift SDK and wanted a kind of quick-and-dirty way to extract the payload from an activity, but without any use of `unwrap()` (making `unwrap_ok_payload` a bit too "unsafe" for my liking). I have my own function along these lines but wanted to contribute it upstream.

## Checklist

1. Closes **N/A** (it's a small enough change that I opted not to create an issue).

2. How was this tested: no tests necessary beyond compilation

3. Any docs updates needed? I don't believe so
