### PR TITLE
Avoid CLI overflowing UI port

### DIFF
--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -37,10 +37,13 @@ pub struct TemporalDevServerConfig {
     /// Port to use or obtains a free one if none given.
     #[builder(default)]
     pub port: Option<u16>,
+    /// Port to use for the UI server or obtains a free one if none given.
+    #[builder(default)]
+    pub ui_port: Option<u16>,
     /// Sqlite DB filename if persisting or non-persistent if none.
     #[builder(default)]
     pub db_filename: Option<String>,
-    /// Whether to enable the UI.
+    /// Whether to enable the UI. If ui_port is set, assumes true.
     #[builder(default)]
     pub ui: bool,
     /// Log format and level
@@ -101,7 +104,15 @@ impl TemporalDevServerConfig {
             args.push("--filename".to_owned());
             args.push(db_filename.clone());
         }
-        if !self.ui {
+        if let Some(ui_port) = self.ui_port {
+            args.push("--ui-port".to_owned());
+            args.push(ui_port.to_string());
+        } else if self.ui {
+            // Caps at u16 max which is also max port value
+            let port = port.saturating_add(1000);
+            args.push("--ui-port".to_owned());
+            args.push(port.to_string());
+        } else {
             args.push("--headless".to_owned());
         }
         args.extend(self.extra_args.clone());


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
CLI can overflow UI port (should fix this there too). Avoid that.

## Why?
Big port bad

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/767

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
