### PR TITLE
Add "Internal" to Ruby package for Core protos

### DIFF
--- a/sdk-core-protos/protos/local/temporal/sdk/core/activity_result/activity_result.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/activity_result/activity_result.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.activity_result;
-option ruby_package = "Temporalio::Bridge::Api::ActivityResult";
+option ruby_package = "Temporalio::Internal::Bridge::Api::ActivityResult";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/sdk-core-protos/protos/local/temporal/sdk/core/activity_task/activity_task.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/activity_task/activity_task.proto
@@ -4,7 +4,7 @@ syntax = "proto3";
  * Definitions of the different activity tasks returned from [crate::Core::poll_task].
  */
 package coresdk.activity_task;
-option ruby_package = "Temporalio::Bridge::Api::ActivityTask";
+option ruby_package = "Temporalio::Internal::Bridge::Api::ActivityTask";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/sdk-core-protos/protos/local/temporal/sdk/core/child_workflow/child_workflow.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/child_workflow/child_workflow.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.child_workflow;
-option ruby_package = "Temporalio::Bridge::Api::ChildWorkflow";
+option ruby_package = "Temporalio::Internal::Bridge::Api::ChildWorkflow";
 
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";

--- a/sdk-core-protos/protos/local/temporal/sdk/core/common/common.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/common/common.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.common;
-option ruby_package = "Temporalio::Bridge::Api::Common";
+option ruby_package = "Temporalio::Internal::Bridge::Api::Common";
 
 import "google/protobuf/duration.proto";
 

--- a/sdk-core-protos/protos/local/temporal/sdk/core/core_interface.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/core_interface.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk;
-option ruby_package = "Temporalio::Bridge::Api::CoreInterface";
+option ruby_package = "Temporalio::Internal::Bridge::Api::CoreInterface";
 
 // Note: Intellij will think the Google imports don't work because of the slightly odd nature of
 // the include paths. You can make it work by going to the "Protobuf Support" settings section

--- a/sdk-core-protos/protos/local/temporal/sdk/core/external_data/external_data.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/external_data/external_data.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.external_data;
-option ruby_package = "Temporalio::Bridge::Api::ExternalData";
+option ruby_package = "Temporalio::Internal::Bridge::Api::ExternalData";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
  * lang SDK applies these activation jobs to drive workflows.
  */
 package coresdk.workflow_activation;
-option ruby_package = "Temporalio::Bridge::Api::WorkflowActivation";
+option ruby_package = "Temporalio::Internal::Bridge::Api::WorkflowActivation";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
  * activation.
  */
 package coresdk.workflow_commands;
-option ruby_package = "Temporalio::Bridge::Api::WorkflowCommands";
+option ruby_package = "Temporalio::Internal::Bridge::Api::WorkflowCommands";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_completion/workflow_completion.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_completion/workflow_completion.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package coresdk.workflow_completion;
-option ruby_package = "Temporalio::Bridge::Api::WorkflowCompletion";
+option ruby_package = "Temporalio::Internal::Bridge::Api::WorkflowCompletion";
 
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/enums/v1/failed_cause.proto";


### PR DESCRIPTION
## What was changed

Need `Temporalio::Bridge::Api` to be `Temporalio::Internal::Bridge::Api`