### PR TITLE
Make activity resolution payload methods return a reference

### DIFF
--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -212,18 +212,19 @@ pub mod coresdk {
         impl ActivityResolution {
             /// Extract an activity's payload if it completed successfully, or return an error for all
             /// other outcomes.
-            pub fn success_payload_or_error(self) -> Result<Option<Payload>, anyhow::Error> {
-                let Some(status) = self.status else {
+            pub fn success_payload_or_error(&self) -> Result<Option<&Payload>, anyhow::Error> {
+                let Some(ref status) = self.status else {
                     return Err(anyhow!("Activity completed without a status"));
                 };
 
-                match status {
-                    activity_resolution::Status::Completed(success) => Ok(success.result),
-                    e => Err(anyhow!("Activity was not successful: {e:?}")),
+                if let activity_resolution::Status::Completed(Success { ref result }) = status {
+                    return Ok(result.as_ref());
                 }
+
+                Err(anyhow!("Activity was not successful: {status:?}"))
             }
 
-            pub fn unwrap_ok_payload(self) -> Payload {
+            pub fn unwrap_ok_payload(&self) -> &Payload {
                 self.success_payload_or_error().unwrap().unwrap()
             }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Changes the interface provided in #814 to return a `Payload` reference, as suggested in [this Slack message](https://temporalio.slack.com/archives/C02MTL0GEKH/p1726556289848919?thread_ts=1726162017.262599&cid=C02MTL0GEKH).

## Why?

Provides slightly more informative error messages and makes the methods no longer require ownership of `ActivityResolution`, which is generally an ergonomic win in Rust.

## Checklist
<!--- add/delete as needed --->

1. Closes no issues (it's a small change so I opted not to create an issue first)

2. How was this tested: the standard battery of CI tests

3. Any docs updates needed? I don't believe so
