### PR TITLE
Upgrade quinn-proto version to fix security vulnerability

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,6 +52,7 @@ pin-project = "1.0"
 prometheus = "0.13"
 prost = { workspace = true }
 prost-types = { version = "0.6", package = "prost-wkt-types" }
+quinn = { version = "0.11.5" }
 rand = "0.8.3"
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], default-features = false, optional = true }
 ringbuf = "0.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ pin-project = "1.0"
 prometheus = "0.13"
 prost = { workspace = true }
 prost-types = { version = "0.6", package = "prost-wkt-types" }
-quinn = { version = "0.11.5" }
+quinn-proto = { version = "0.11.7" }
 rand = "0.8.3"
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], default-features = false, optional = true }
 ringbuf = "0.4"


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added a `quinn-proto` version requirement of 0.11.7. This ends up adding v0.11.8 to Cargo.lock.

## Why?
<!-- Tell your future self why have you made these changes -->
This security issue was flagged from the python SDK, https://github.com/temporalio/sdk-python/issues/642, 
