### PR TITLE
Replace futures with future-util

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ backoff = "0.4"
 base64 = "0.22"
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 futures-retry = "0.6.0"
 http = "1.1.0"
 http-body-util = "0.1"

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -1,5 +1,5 @@
 use crate::{AttachMetricLabels, LONG_POLL_METHOD_NAMES};
-use futures::{future::BoxFuture, FutureExt};
+use futures_util::{future::BoxFuture, FutureExt};
 use std::{
     sync::Arc,
     task::{Context, Poll},

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -9,7 +9,7 @@ use crate::{
     Client, ConfiguredClient, InterceptedMetricsSvc, RequestExt, RetryClient,
     TemporalServiceClient, LONG_POLL_TIMEOUT, TEMPORAL_NAMESPACE_HEADER_KEY,
 };
-use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use futures_util::{future::BoxFuture, FutureExt, TryFutureExt};
 use std::sync::Arc;
 use temporal_sdk_core_api::telemetry::metrics::MetricKeyValue;
 use temporal_sdk_core_protos::{

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,8 +32,8 @@ derive_more = { workspace = true }
 enum_dispatch = "0.3"
 enum-iterator = "2"
 flate2 = { version = "1.0", optional = true }
-futures = "0.3"
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false }
+futures-channel = { version = "0.3", default-features = false }
 governor = "0.6"
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.2", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ enum_dispatch = "0.3"
 enum-iterator = "2"
 flate2 = { version = "1.0", optional = true }
 futures-util = { version = "0.3", default-features = false }
-futures-channel = { version = "0.3", default-features = false }
+futures-channel = { version = "0.3", default-features = false, features = ["std"]}
 governor = "0.6"
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.2", optional = true }

--- a/core/benches/workflow_replay.rs
+++ b/core/benches/workflow_replay.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::time::Duration;
 use temporal_sdk::{WfContext, WorkflowFunction};
 use temporal_sdk_core::replay::HistoryForReplay;

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -9,7 +9,7 @@ use crate::{
     worker::client::mocks::{mock_manual_workflow_client, mock_workflow_client},
     ActivityHeartbeat, Worker,
 };
-use futures::FutureExt;
+use futures_util::FutureExt;
 use itertools::Itertools;
 use std::{
     cell::RefCell,
@@ -674,7 +674,7 @@ async fn no_eager_activities_requested_when_worker_options_disable_remote_activi
     let mut mock_poller = mock_manual_poller();
     mock_poller
         .expect_poll()
-        .returning(|| futures::future::pending().boxed());
+        .returning(|| futures_util::future::pending().boxed());
     mock.set_act_poller(Box::new(mock_poller));
     mock.worker_cfg(|wc| {
         wc.max_cached_workflows = 2;

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use crossbeam_queue::SegQueue;
-use futures::{future::join_all, FutureExt};
+use futures_util::{future::join_all, FutureExt};
 use std::{
     collections::HashMap,
     ops::Sub,

--- a/core/src/core_tests/mod.rs
+++ b/core/src/core_tests/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     worker::client::mocks::{mock_manual_workflow_client, mock_workflow_client},
     Worker,
 };
-use futures::FutureExt;
+use futures_util::FutureExt;
 use once_cell::sync::Lazy;
 use std::time::Duration;
 use temporal_sdk_core_api::Worker as WorkerTrait;

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     Worker,
 };
-use futures::{stream, FutureExt};
+use futures_util::{stream, FutureExt};
 use mockall::TimesRange;
 use rstest::{fixture, rstest};
 use std::{

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -3,7 +3,7 @@
 
 use anyhow::anyhow;
 use flate2::read::GzDecoder;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use serde::Deserialize;
 use std::{
     fs::OpenOptions,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,7 +54,7 @@ use crate::{
     worker::client::WorkerClientBag,
 };
 use anyhow::bail;
-use futures::Stream;
+use futures_util::Stream;
 use std::sync::Arc;
 use temporal_client::{ConfiguredClient, TemporalServiceClientWithMetrics};
 use temporal_sdk_core_api::{

--- a/core/src/pollers/mod.rs
+++ b/core/src/pollers/mod.rs
@@ -14,7 +14,7 @@ use temporal_sdk_core_protos::temporal::api::workflowservice::v1::{
 };
 
 #[cfg(test)]
-use futures::Future;
+use futures_util::Future;
 #[cfg(test)]
 pub(crate) use poll_buffer::MockPermittedPollBuffer;
 use temporal_sdk_core_api::worker::{ActivitySlotKind, WorkflowSlotKind};

--- a/core/src/pollers/poll_buffer.rs
+++ b/core/src/pollers/poll_buffer.rs
@@ -3,8 +3,8 @@ use crate::{
     pollers::{self, Poller},
     worker::client::WorkerClient,
 };
-use futures::{prelude::stream::FuturesUnordered, StreamExt};
 use futures_util::{future::BoxFuture, FutureExt};
+use futures_util::{stream::FuturesUnordered, StreamExt};
 use governor::{Quota, RateLimiter};
 use std::{
     fmt::Debug,
@@ -337,7 +337,7 @@ mod tests {
         abstractions::tests::fixed_size_permit_dealer,
         worker::client::mocks::mock_manual_workflow_client,
     };
-    use futures::FutureExt;
+    use futures_util::FutureExt;
     use std::time::Duration;
     use temporal_sdk_core_protos::temporal::api::enums::v1::TaskQueueKind;
     use tokio::{select, sync::mpsc::channel};

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     Worker,
 };
-use futures::{FutureExt, Stream, StreamExt};
+use futures_util::{FutureExt, Stream, StreamExt};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use std::{

--- a/core/src/telemetry/log_export.rs
+++ b/core/src/telemetry/log_export.rs
@@ -1,4 +1,4 @@
-use futures::channel::mpsc::{channel, Receiver, Sender};
+use futures_channel::mpsc::{channel, Receiver, Sender};
 use parking_lot::Mutex;
 use ringbuf::{consumer::Consumer, producer::Producer, traits::Split, HeapRb};
 use std::{collections::HashMap, fmt, sync::Arc, time::SystemTime};
@@ -219,7 +219,7 @@ mod tests {
         telemetry::{construct_filter_string, CoreLogStreamConsumer},
         telemetry_init,
     };
-    use futures::stream::StreamExt;
+    use futures_util::stream::StreamExt;
     use std::{
         fmt,
         sync::{Arc, Mutex},

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use bimap::BiMap;
-use futures::{future::BoxFuture, stream, stream::BoxStream, FutureExt, Stream, StreamExt};
+use futures_util::{future::BoxFuture, stream, stream::BoxStream, FutureExt, Stream, StreamExt};
 use mockall::TimesRange;
 use parking_lot::RwLock;
 use std::{
@@ -1014,9 +1014,9 @@ macro_rules! job_assert {
 #[macro_export]
 macro_rules! advance_fut {
     ($fut:ident) => {
-        ::futures::pin_mut!($fut);
+        ::futures_util::pin_mut!($fut);
         {
-            let waker = ::futures::task::noop_waker();
+            let waker = ::futures_util::task::noop_waker();
             let mut cx = core::task::Context::from_waker(&waker);
             for _ in 0..10 {
                 assert_matches!($fut.poll_unpin(&mut cx), core::task::Poll::Pending);

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use activity_heartbeat_manager::ActivityHeartbeatManager;
 use dashmap::DashMap;
-use futures::{
+use futures_util::{
     stream,
     stream::{BoxStream, PollNext},
     Stream, StreamExt,
@@ -279,7 +279,7 @@ impl WorkerActivityTasks {
         // Prefer eager activities over polling the server
         stream::select_with_strategy(non_poll_stream, poller_stream, |_: &mut ()| PollNext::Left)
             .map(|res| Some(res.map_err(Into::into)))
-            .chain(futures::stream::once(async move {
+            .chain(futures_util::stream::once(async move {
                 on_complete_token.cancel();
                 None
             }))

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -3,7 +3,7 @@ use crate::{
     worker::{activities::PendingActivityCancel, client::WorkerClient},
     TaskToken,
 };
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Arc,
@@ -94,7 +94,7 @@ impl ActivityHeartbeatManager {
             // The stream of incoming heartbeats uses unfold to carry state across each item in the
             // stream. The closure checks if, for any given activity, we should heartbeat or not
             // depending on its delay and when we last issued a heartbeat for it.
-            futures::stream::unfold(heartbeat_stream_state, move |mut hb_states| {
+            futures_util::stream::unfold(heartbeat_stream_state, move |mut hb_states| {
                 async move {
                     let hb = tokio::select! {
                         biased;

--- a/core/src/worker/activities/activity_task_poller_stream.rs
+++ b/core/src/worker/activities/activity_task_poller_stream.rs
@@ -1,5 +1,5 @@
 use crate::{pollers::BoxedActPoller, worker::activities::PermittedTqResp, MetricsContext};
-use futures::{stream, Stream};
+use futures_util::{stream, Stream};
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::PollActivityTaskQueueResponse;
 use tokio::select;
 use tokio_util::sync::CancellationToken;

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -6,8 +6,8 @@ use crate::{
     worker::workflow::HeartbeatTimeoutMsg,
     MetricsContext, TaskToken,
 };
-use futures::{stream::BoxStream, Stream};
 use futures_util::{future, future::AbortRegistration, stream, StreamExt};
+use futures_util::{stream::BoxStream, Stream};
 use parking_lot::{Mutex, MutexGuard};
 use std::{
     collections::{hash_map::Entry, HashMap},

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -1,5 +1,5 @@
 use super::*;
-use futures::Future;
+use futures_util::Future;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
 use temporal_client::SlotManager;

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -77,7 +77,7 @@ use {
         pollers::{BoxedPoller, MockPermittedPollBuffer},
         protosext::ValidPollWFTQResponse,
     },
-    futures::stream::BoxStream,
+    futures_util::stream::BoxStream,
     temporal_sdk_core_protos::temporal::api::workflowservice::v1::PollActivityTaskQueueResponse,
 };
 
@@ -750,7 +750,7 @@ mod tests {
     use crate::{
         advance_fut, test_help::test_worker_cfg, worker::client::mocks::mock_workflow_client,
     };
-    use futures::FutureExt;
+    use futures_util::FutureExt;
 
     use temporal_sdk_core_protos::temporal::api::workflowservice::v1::PollActivityTaskQueueResponse;
 

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -5,7 +5,7 @@ use crate::{
         workflow::{CacheMissFetchReq, PermittedWFT, PreparedWFT},
     },
 };
-use futures::{future::BoxFuture, FutureExt, Stream, TryFutureExt};
+use futures_util::{future::BoxFuture, FutureExt, Stream, TryFutureExt};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use std::{
@@ -766,7 +766,7 @@ mod tests {
         test_help::{canned_histories, hist_to_poll_resp, mock_sdk_cfg, MockPollCfg, ResponseType},
         worker::client::mocks::mock_workflow_client,
     };
-    use futures::StreamExt;
+    use futures_util::StreamExt;
     use futures_util::TryStreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use temporal_client::WorkflowOptions;

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -38,8 +38,8 @@ use crate::{
     MetricsContext,
 };
 use anyhow::anyhow;
-use futures::{stream::BoxStream, Stream, StreamExt};
 use futures_util::{future::abortable, stream};
+use futures_util::{stream::BoxStream, Stream, StreamExt};
 use itertools::Itertools;
 use prost_types::TimestampError;
 use std::{

--- a/core/src/worker/workflow/wft_extraction.rs
+++ b/core/src/worker/workflow/wft_extraction.rs
@@ -9,7 +9,7 @@ use crate::{
         },
     },
 };
-use futures::Stream;
+use futures_util::Stream;
 use futures_util::{stream, stream::PollNext, FutureExt, StreamExt};
 use std::{future, sync::Arc};
 use temporal_sdk_core_api::worker::{WorkflowSlotInfo, WorkflowSlotKind};

--- a/core/src/worker/workflow/wft_poller.rs
+++ b/core/src/worker/workflow/wft_poller.rs
@@ -4,7 +4,7 @@ use crate::{
     protosext::ValidPollWFTQResponse,
     MetricsContext,
 };
-use futures::{stream, Stream};
+use futures_util::{stream, Stream};
 use temporal_sdk_core_api::worker::WorkflowSlotKind;
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse;
 
@@ -78,7 +78,7 @@ mod tests {
         abstractions::tests::fixed_size_permit_dealer, pollers::MockPermittedPollBuffer,
         test_help::mock_poller,
     };
-    use futures::{pin_mut, StreamExt};
+    use futures_util::{pin_mut, StreamExt};
     use std::sync::Arc;
     use temporal_sdk_core_api::worker::WorkflowSlotKind;
 

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     MetricsContext,
 };
-use futures::{stream, stream::PollNext, Stream, StreamExt};
+use futures_util::{stream, stream::PollNext, Stream, StreamExt};
 use std::{collections::VecDeque, fmt::Debug, future, sync::Arc};
 use temporal_sdk_core_api::errors::PollWfError;
 use temporal_sdk_core_protos::coresdk::workflow_activation::remove_from_cache::EvictionReason;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 crossbeam-channel = "0.5"
 derive_more = { workspace = true }
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 parking_lot = { version = "0.12", features = ["send_guard"] }
 prost-types = { version = "0.6", package = "prost-wkt-types" }
 serde = "1.0"

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -63,7 +63,7 @@ pub use workflow_context::{
 use crate::{interceptors::WorkerInterceptor, workflow_context::ChildWfCommon};
 use anyhow::{anyhow, bail, Context};
 use app_data::AppData;
-use futures::{future::BoxFuture, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use futures_util::{future::BoxFuture, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use serde::Serialize;
 use std::{
     any::{Any, TypeId},

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -12,7 +12,7 @@ use crate::{
     Unblockable, UpdateFunctions,
 };
 use crossbeam_channel::{Receiver, Sender};
-use futures::{task::Context, FutureExt, Stream, StreamExt};
+use futures_util::{task::Context, FutureExt, Stream, StreamExt};
 use parking_lot::{RwLock, RwLockReadGuard};
 use std::{
     collections::HashMap,

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Context as AnyhowContext, Error};
 use crossbeam_channel::Receiver;
-use futures::{future::BoxFuture, FutureExt};
+use futures_util::{future::BoxFuture, FutureExt};
 use std::{
     collections::{hash_map::Entry, HashMap},
     future::Future,

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1.3"
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 log = "0.4"
 once_cell = { workspace = true }
 parking_lot = "0.12"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -13,7 +13,7 @@ pub use temporal_sdk_core::replay::HistoryForReplay;
 use crate::stream::{Stream, TryStreamExt};
 use anyhow::{Context, Error};
 use base64::{prelude::BASE64_STANDARD, Engine};
-use futures::{future, stream, stream::FuturesUnordered, StreamExt};
+use futures_util::{future, stream, stream::FuturesUnordered, StreamExt};
 use parking_lot::Mutex;
 use prost::Message;
 use rand::{distributions::Standard, Rng};

--- a/tests/heavy_tests.rs
+++ b/tests/heavy_tests.rs
@@ -1,4 +1,4 @@
-use futures::{future::join_all, sink, stream::FuturesUnordered, StreamExt};
+use futures_util::{future::join_all, sink, stream::FuturesUnordered, StreamExt};
 use std::{
     sync::Arc,
     time::{Duration, Instant},

--- a/tests/integ_tests/ephemeral_server_tests.rs
+++ b/tests/integ_tests/ephemeral_server_tests.rs
@@ -1,5 +1,5 @@
-use futures::stream;
-use futures::TryStreamExt;
+use futures_util::stream;
+use futures_util::TryStreamExt;
 use std::time::{SystemTime, UNIX_EPOCH};
 use temporal_client::{ClientOptionsBuilder, TestService, WorkflowService};
 use temporal_sdk_core::ephemeral_server::{

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
-use futures::{prelude::stream::FuturesUnordered, FutureExt, StreamExt};
 use futures_util::future::join_all;
+use futures_util::{stream::FuturesUnordered, FutureExt, StreamExt};
 use std::time::{Duration, Instant};
 use temporal_client::WorkflowClientTrait;
 use temporal_sdk_core_protos::{

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -18,7 +18,7 @@ mod upsert_search_attrs;
 
 use crate::integ_tests::{activity_functions::echo, metrics_tests};
 use assert_matches::assert_matches;
-use futures::{channel::mpsc::UnboundedReceiver, future, SinkExt, StreamExt};
+use futures_util::{channel::mpsc::UnboundedReceiver, future, SinkExt, StreamExt};
 use std::{
     collections::{HashMap, HashSet},
     sync::{
@@ -92,7 +92,7 @@ async fn parallel_workflows_same_queue() {
     let handles: Vec<_> = run_ids
         .iter()
         .map(|run_id| {
-            let (tx, rx) = futures::channel::mpsc::unbounded();
+            let (tx, rx) = futures_util::channel::mpsc::unbounded();
             send_chans.insert(run_id.clone(), tx);
             tokio::spawn(wf_task(core.clone(), rx))
         })

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -18,7 +18,8 @@ mod upsert_search_attrs;
 
 use crate::integ_tests::{activity_functions::echo, metrics_tests};
 use assert_matches::assert_matches;
-use futures_util::{channel::mpsc::UnboundedReceiver, future, SinkExt, StreamExt};
+use futures_channel::mpsc::UnboundedReceiver;
+use futures_util::{future, SinkExt, StreamExt};
 use std::{
     collections::{HashMap, HashSet},
     sync::{
@@ -92,7 +93,7 @@ async fn parallel_workflows_same_queue() {
     let handles: Vec<_> = run_ids
         .iter()
         .map(|run_id| {
-            let (tx, rx) = futures_util::channel::mpsc::unbounded();
+            let (tx, rx) = futures_channel::mpsc::unbounded();
             send_chans.insert(run_id.clone(), tx);
             tokio::spawn(wf_task(core.clone(), rx))
         })

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -1,6 +1,6 @@
 use crate::integ_tests::activity_functions::echo;
 use anyhow::anyhow;
-use futures::future::join_all;
+use futures_util::future::join_all;
 use std::{
     sync::atomic::{AtomicU8, Ordering},
     time::Duration,

--- a/tests/integ_tests/workflow_tests/resets.rs
+++ b/tests/integ_tests/workflow_tests/resets.rs
@@ -1,5 +1,5 @@
 use crate::integ_tests::activity_functions::echo;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::{
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},

--- a/tests/integ_tests/workflow_tests/signals.rs
+++ b/tests/integ_tests/workflow_tests/signals.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use temporal_client::{SignalWithStartOptions, WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{
     ChildWorkflowOptions, Signal, SignalWorkflowOptions, WfContext, WorkflowResult,


### PR DESCRIPTION
## What was changed
Replaced `futures` crate with its direct dependencies

## Why?
It's much easier to control small dependencies instead of one big one. Most of the functions from `futures` crate are not used.

## Checklist

1. How was this tested:
Run `cargo test`