### PR TITLE
Use mpsc instead crossbeam-channel

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["development-tools"]
 async-trait = "0.1"
 thiserror = "1.0"
 anyhow = "1.0"
-crossbeam-channel = "0.5"
 derive_more = { workspace = true }
 futures = "0.3"
 parking_lot = { version = "0.12", features = ["send_guard"] }

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -11,7 +11,7 @@ use crate::{
     IntoUpdateValidatorFunc, RustWfCmd, SignalExternalWfResult, TimerResult, UnblockEvent,
     Unblockable, UpdateFunctions,
 };
-use crossbeam_channel::{Receiver, Sender};
+use std::sync::mpsc::{Receiver, Sender};
 use futures::{task::Context, FutureExt, Stream, StreamExt};
 use parking_lot::{RwLock, RwLockReadGuard};
 use std::{
@@ -71,8 +71,8 @@ impl WfContext {
         args: Vec<Payload>,
         am_cancelled: watch::Receiver<bool>,
     ) -> (Self, Receiver<RustWfCmd>) {
-        // We need to use a normal std channel since our receiving side is non-async
-        let (chan, rx) = crossbeam_channel::unbounded();
+        // The receiving side is non-async
+        let (chan, rx) = std::sync::mpsc::channel();
         (
             Self {
                 namespace,

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -11,9 +11,9 @@ use crate::{
     IntoUpdateValidatorFunc, RustWfCmd, SignalExternalWfResult, TimerResult, UnblockEvent,
     Unblockable, UpdateFunctions,
 };
-use std::sync::mpsc::{Receiver, Sender};
 use futures_util::{task::Context, FutureExt, Stream, StreamExt};
 use parking_lot::{RwLock, RwLockReadGuard};
+use std::sync::mpsc::{Receiver, Sender};
 use std::{
     collections::HashMap,
     future::Future,

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -4,7 +4,7 @@ use crate::{
     WorkflowResult,
 };
 use anyhow::{anyhow, bail, Context as AnyhowContext, Error};
-use crossbeam_channel::Receiver;
+use std::sync::mpsc::Receiver;
 use futures::{future::BoxFuture, FutureExt};
 use std::{
     collections::{hash_map::Entry, HashMap},

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -4,8 +4,8 @@ use crate::{
     WorkflowResult,
 };
 use anyhow::{anyhow, bail, Context as AnyhowContext, Error};
-use std::sync::mpsc::Receiver;
 use futures_util::{future::BoxFuture, FutureExt};
+use std::sync::mpsc::Receiver;
 use std::{
     collections::{hash_map::Entry, HashMap},
     future::Future,


### PR DESCRIPTION
## What was changed
Replaced `crossbeam-channel` crate with `std::sync::mpsc`

## Why?
Noticed that `crossbeam-channel` is being used unnecessarily.

## Checklist

1. How was this tested:
Run `cargo test`
