### PR TITLE
Replace once_cell with std::sync::{OnceLock,LazyLock}

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.77.0
+          toolchain: 1.80.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.77.0
+          toolchain: 1.80.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.77.0
+          toolchain: 1.80.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ license-file = "LICENSE.txt"
 [workspace.dependencies]
 derive_builder = "0.20"
 derive_more = { version = "1.0", features = ["constructor", "display", "from", "into", "debug"] }
-once_cell = "1.16"
 tonic = "0.12"
 tonic-build = "0.12"
 opentelemetry = { version = "0.24", features = ["metrics"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,7 +26,6 @@ http = "1.1.0"
 http-body-util = "0.1"
 hyper = { version = "1.4.1" }
 hyper-util = "0.1.6"
-once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"], optional = true }
 parking_lot = "0.12"
 prost-types = { workspace = true }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -41,8 +41,8 @@ use crate::{
 };
 use backoff::{exponential, ExponentialBackoff, SystemClock};
 use http::{uri::InvalidUri, Uri};
-use std::sync::OnceLock;
 use parking_lot::RwLock;
+use std::sync::OnceLock;
 use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 use backoff::{exponential, ExponentialBackoff, SystemClock};
 use http::{uri::InvalidUri, Uri};
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 use parking_lot::RwLock;
 use std::{
     collections::HashMap,
@@ -546,17 +546,17 @@ impl Interceptor for ServiceCallInterceptor {
 #[derive(Debug, Clone)]
 pub struct TemporalServiceClient<T> {
     svc: T,
-    workflow_svc_client: OnceCell<WorkflowServiceClient<T>>,
-    operator_svc_client: OnceCell<OperatorServiceClient<T>>,
-    cloud_svc_client: OnceCell<CloudServiceClient<T>>,
-    test_svc_client: OnceCell<TestServiceClient<T>>,
-    health_svc_client: OnceCell<HealthClient<T>>,
+    workflow_svc_client: OnceLock<WorkflowServiceClient<T>>,
+    operator_svc_client: OnceLock<OperatorServiceClient<T>>,
+    cloud_svc_client: OnceLock<CloudServiceClient<T>>,
+    test_svc_client: OnceLock<TestServiceClient<T>>,
+    health_svc_client: OnceLock<HealthClient<T>>,
 }
 
 /// We up the limit on incoming messages from server from the 4Mb default to 128Mb. If for
 /// whatever reason this needs to be changed by the user, we support overriding it via env var.
 fn get_decode_max_size() -> usize {
-    static _DECODE_MAX_SIZE: OnceCell<usize> = OnceCell::new();
+    static _DECODE_MAX_SIZE: OnceLock<usize> = OnceLock::new();
     *_DECODE_MAX_SIZE.get_or_init(|| {
         std::env::var("TEMPORAL_MAX_INCOMING_GRPC_BYTES")
             .ok()
@@ -576,11 +576,11 @@ where
     fn new(svc: T) -> Self {
         Self {
             svc,
-            workflow_svc_client: OnceCell::new(),
-            operator_svc_client: OnceCell::new(),
-            cloud_svc_client: OnceCell::new(),
-            test_svc_client: OnceCell::new(),
-            health_svc_client: OnceCell::new(),
+            workflow_svc_client: OnceLock::new(),
+            operator_svc_client: OnceLock::new(),
+            cloud_svc_client: OnceLock::new(),
+            test_svc_client: OnceLock::new(),
+            health_svc_client: OnceLock::new(),
         }
     }
     /// Get the underlying workflow service client

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,7 +41,6 @@ hyper-util = { version = "0.1", features = ["server", "http1", "http2", "tokio"]
 itertools = "0.13"
 lru = "0.12"
 mockall = "0.13"
-once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"], optional = true }
 opentelemetry_sdk = { version = "0.24", features = ["rt-tokio", "metrics"], optional = true }
 opentelemetry-otlp = { version = "0.17", features = ["tokio", "metrics", "tls"], optional = true }

--- a/core/src/abstractions/take_cell.rs
+++ b/core/src/abstractions/take_cell.rs
@@ -1,7 +1,7 @@
 use parking_lot::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// Implements something a bit like a `OnceCell`, but starts already initialized and allows you
+/// Implements something a bit like a `OnceLock`, but starts already initialized and allows you
 /// to take everything out of it only once in a thread-safe way. This isn't optimized for super
 /// fast-path usage.
 pub(crate) struct TakeCell<T> {

--- a/core/src/core_tests/mod.rs
+++ b/core/src/core_tests/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     Worker,
 };
 use futures::FutureExt;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::time::Duration;
 use temporal_sdk_core_api::Worker as WorkerTrait;
 use temporal_sdk_core_protos::coresdk::workflow_completion::WorkflowActivationCompletion;
@@ -46,7 +46,7 @@ async fn after_shutdown_server_is_not_polled() {
 }
 
 // Better than cloning a billion arcs...
-static BARR: Lazy<Barrier> = Lazy::new(|| Barrier::new(3));
+static BARR: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(3));
 
 #[tokio::test]
 async fn shutdown_interrupts_both_polls() {

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -10,8 +10,8 @@ use crate::{
     Worker,
 };
 use futures::{FutureExt, Stream, StreamExt};
-use std::sync::OnceLock;
 use parking_lot::Mutex;
+use std::sync::OnceLock;
 use std::{
     pin::Pin,
     sync::Arc,

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     Worker,
 };
 use futures::{FutureExt, Stream, StreamExt};
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 use parking_lot::Mutex;
 use std::{
     pin::Pin,
@@ -179,7 +179,7 @@ impl Stream for HistoryFeederStream {
 pub(crate) struct Historator {
     iter: Pin<Box<dyn Stream<Item = HistoryForReplay> + Send>>,
     allow_stream: UnboundedReceiverStream<String>,
-    worker_closer: Arc<OnceCell<CancellationToken>>,
+    worker_closer: Arc<OnceLock<CancellationToken>>,
     dat: Arc<Mutex<HistoratorDat>>,
     replay_done_tx: UnboundedSender<String>,
 }
@@ -192,7 +192,7 @@ impl Historator {
         Self {
             iter: Box::pin(histories.fuse()),
             allow_stream: UnboundedReceiverStream::new(replay_done_rx),
-            worker_closer: Arc::new(OnceCell::new()),
+            worker_closer: Arc::new(OnceLock::new()),
             dat,
             replay_done_tx,
         }

--- a/core/src/telemetry/otel.rs
+++ b/core/src/telemetry/otel.rs
@@ -335,9 +335,9 @@ impl GaugeF64 for MemoryGauge<f64> {
 }
 
 fn default_resource_instance() -> &'static Resource {
-    use once_cell::sync::OnceCell;
+    use std::sync::OnceLock;
 
-    static INSTANCE: OnceCell<Resource> = OnceCell::new();
+    static INSTANCE: OnceLock<Resource> = OnceLock::new();
     INSTANCE.get_or_init(|| {
         let resource = Resource::default();
         if resource.get(Key::from("service.name")) == Some(Value::from("unknown_service")) {

--- a/core/src/worker/client/mocks.rs
+++ b/core/src/worker/client/mocks.rs
@@ -1,11 +1,11 @@
 use super::*;
 use futures::Future;
-use once_cell::sync::Lazy;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use temporal_client::SlotManager;
 
-static DEFAULT_WORKERS_REGISTRY: Lazy<Arc<SlotManager>> =
-    Lazy::new(|| Arc::new(SlotManager::new()));
+static DEFAULT_WORKERS_REGISTRY: LazyLock<Arc<SlotManager>> =
+    LazyLock::new(|| Arc::new(SlotManager::new()));
 
 pub(crate) static DEFAULT_TEST_CAPABILITIES: &Capabilities = &Capabilities {
     signal_and_query_header: true,

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use futures::{future::BoxFuture, FutureExt, Stream, TryFutureExt};
 use itertools::Itertools;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::{
     collections::VecDeque,
     fmt::Debug,
@@ -24,9 +24,9 @@ use temporal_sdk_core_protos::temporal::api::{
 };
 use tracing::Instrument;
 
-static EMPTY_FETCH_ERR: Lazy<tonic::Status> =
-    Lazy::new(|| tonic::Status::unknown("Fetched empty history page"));
-static EMPTY_TASK_ERR: Lazy<tonic::Status> = Lazy::new(|| {
+static EMPTY_FETCH_ERR: LazyLock<tonic::Status> =
+    LazyLock::new(|| tonic::Status::unknown("Fetched empty history page"));
+static EMPTY_TASK_ERR: LazyLock<tonic::Status> = LazyLock::new(|| {
     tonic::Status::unknown("Received an empty workflow task with no queries or history")
 });
 

--- a/core/src/worker/workflow/machines/transition_coverage.rs
+++ b/core/src/worker/workflow/machines/transition_coverage.rs
@@ -4,7 +4,7 @@
 //! never ever be removed from behind `#[cfg(test)]` compilation.
 
 use dashmap::{mapref::entry::Entry, DashMap, DashSet};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::{
     path::PathBuf,
     sync::{
@@ -16,11 +16,11 @@ use std::{
 };
 
 // During test we want to know about which transitions we've covered in state machines
-static COVERED_TRANSITIONS: Lazy<DashMap<String, DashSet<CoveredTransition>>> =
-    Lazy::new(DashMap::new);
-static COVERAGE_SENDER: Lazy<SyncSender<(String, CoveredTransition)>> =
-    Lazy::new(spawn_save_coverage_at_end);
-static THREAD_HANDLE: Lazy<Mutex<Option<JoinHandle<()>>>> = Lazy::new(|| Mutex::new(None));
+static COVERED_TRANSITIONS: LazyLock<DashMap<String, DashSet<CoveredTransition>>> =
+    LazyLock::new(DashMap::new);
+static COVERAGE_SENDER: LazyLock<SyncSender<(String, CoveredTransition)>> =
+    LazyLock::new(spawn_save_coverage_at_end);
+static THREAD_HANDLE: LazyLock<Mutex<Option<JoinHandle<()>>>> = LazyLock::new(|| Mutex::new(None));
 
 #[derive(Eq, PartialEq, Hash, Debug)]
 struct CoveredTransition {

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -20,7 +20,6 @@ base64 = "0.22"
 bytes = "1.3"
 futures = "0.3"
 log = "0.4"
-once_cell = { workspace = true }
 parking_lot = "0.12"
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -154,7 +154,7 @@ pub async fn history_from_proto_binary(path_from_root: &str) -> Result<History, 
     Ok(History::decode(&*bytes)?)
 }
 
-static INTEG_TESTS_RT: once_cell::sync::OnceCell<CoreRuntime> = once_cell::sync::OnceCell::new();
+static INTEG_TESTS_RT: std::sync::OnceLock<CoreRuntime> = std::sync::OnceLock::new();
 pub fn init_integ_telem() -> &'static CoreRuntime {
     INTEG_TESTS_RT.get_or_init(|| {
         let telemetry_options = get_integ_telem_options();

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use assert_matches::assert_matches;
 use futures_util::{future, future::join_all, StreamExt};
-use once_cell::sync::Lazy;
+use std::sync::OnceLock;
 use std::{
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -957,7 +957,7 @@ async fn worker_restarted_in_middle_of_update() {
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
 
-    static BARR: Lazy<Barrier> = Lazy::new(|| Barrier::new(2));
+    static BARR: OnceLock<Barrier> = Lazy::new(|| Barrier::new(2));
     static ACT_RAN: AtomicBool = AtomicBool::new(false);
     worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
         ctx.update_handler(

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use assert_matches::assert_matches;
 use futures_util::{future, future::join_all, StreamExt};
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 use std::{
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -957,7 +957,7 @@ async fn worker_restarted_in_middle_of_update() {
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
 
-    static BARR: OnceLock<Barrier> = Lazy::new(|| Barrier::new(2));
+    static BARR: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(2));
     static ACT_RAN: AtomicBool = AtomicBool::new(false);
     worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
         ctx.update_handler(


### PR DESCRIPTION
## What was changed
Replaced `once_cell` with `std::sync`

## Why?
Since you can already directly use `OnceLock` and `LazyLock` from std without an additional crate. However, this would require raising MSVR to 1.80 because of `LazyLock`, but `OnceLock` can be used from 1.70 onwards.

Considering that the current approximate MSVR is `1.77` (based on GitHub Workflow) I think it won't be a big deal to raise it to `1.80`.

## Checklist

1. How was this tested:
Run `cargo test`

