### PR TITLE
add id_conflict_policy to client::WorkflowOptions

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -58,7 +58,7 @@ use temporal_sdk_core_protos::{
     temporal::api::{
         cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
         common::v1::{Header, Payload, Payloads, RetryPolicy, WorkflowExecution, WorkflowType},
-        enums::v1::{TaskQueueKind, WorkflowIdReusePolicy},
+        enums::v1::{TaskQueueKind, WorkflowIdConflictPolicy, WorkflowIdReusePolicy},
         failure::v1::Failure,
         operatorservice::v1::operator_service_client::OperatorServiceClient,
         query::v1::WorkflowQuery,
@@ -1060,6 +1060,10 @@ pub struct WorkflowOptions {
     /// Set the policy for reusing the workflow id
     pub id_reuse_policy: WorkflowIdReusePolicy,
 
+    /// Set the policy for how to resolve conflicts with running policies.
+    /// NOTE: This is ignored for child workflows.
+    pub id_conflict_policy: WorkflowIdConflictPolicy,
+
     /// Optionally set the execution timeout for the workflow
     /// <https://docs.temporal.io/workflows/#workflow-execution-timeout>
     pub execution_timeout: Option<Duration>,
@@ -1111,6 +1115,7 @@ impl WorkflowClientTrait for Client {
                 }),
                 request_id: request_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
                 workflow_id_reuse_policy: options.id_reuse_policy as i32,
+                workflow_id_conflict_policy: options.id_conflict_policy as i32,
                 workflow_execution_timeout: options
                     .execution_timeout
                     .and_then(|d| d.try_into().ok()),
@@ -1276,6 +1281,7 @@ impl WorkflowClientTrait for Client {
                     .request_id
                     .unwrap_or_else(|| Uuid::new_v4().to_string()),
                 workflow_id_reuse_policy: workflow_options.id_reuse_policy as i32,
+                workflow_id_conflict_policy: workflow_options.id_conflict_policy as i32,
                 workflow_execution_timeout: workflow_options
                     .execution_timeout
                     .and_then(|d| d.try_into().ok()),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added the WorkflowOptions::id_conflict_policy property.

## Why?
<!-- Tell your future self why have you made these changes -->

I have a need to use this feature of temporal when (unofficially) using the Rust client library.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No issue

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested this locally (i.e. used this feature from code on my machine).
Happy to add automated tests if you think there should be some... If you're open to this change and think so, could point me to a reasonable place to add a test and/or another similar test to follow?

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Don't think so.