### PR TITLE
Account for cgroup memory limits

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,7 +34,7 @@ enum_dispatch = "0.3"
 enum-iterator = "2"
 flate2 = { version = "1.0", optional = true }
 futures-util = { version = "0.3", default-features = false }
-futures-channel = { version = "0.3", default-features = false, features = ["std"]}
+futures-channel = { version = "0.3", default-features = false, features = ["std"] }
 governor = "0.6"
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.2", optional = true }
@@ -59,7 +59,7 @@ serde = "1.0"
 serde_json = "1.0"
 siphasher = "1.0"
 slotmap = "1.0"
-sysinfo = { version = "0.31", default-features = false, features = ["system"] }
+sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 tar = { version = "0.4", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.37", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs", "process"] }


### PR DESCRIPTION
Factor in cgroup memory limits to resource based tuner.

The crate doesn't have support at the moment for CPU limits. I tried to parse it semi-manually like we did in the Go SDK, but even then I don't have the right metric (elapsed cpu microseconds) to make the calculation - and even then, setting CPU limits is an [ill-advised thing to do anyway](https://home.robusta.dev/blog/stop-using-cpu-limits?nocache=234) so missing this feature is unlikely to bother anyone.

Tested w/ omes