### PR TITLE
Fix possible replay bug with empty WFT sequences and updates

### DIFF
--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2421,9 +2421,7 @@ async fn lang_internal_flag_with_update() {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    t.set_flags_first_wft(&[1, 2], &[]);
-    t.add_full_wf_task();
-    t.set_flags_last_wft(&[], &[1]);
+    t.set_flags_last_wft(&[1, 2], &[1]);
     let updid = t.add_update_accepted("upd1", "upd");
     t.add_update_completed(updid);
     t.add_workflow_execution_completed();

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -740,9 +740,13 @@ fn find_end_index_of_next_wft_seq(
                         if next_next_event.event_type() == EventType::WorkflowTaskScheduled {
                             continue;
                         } else {
-                            // If we see some commands after WFT completed, and those commands
-                            // include update acceptance, we want to conclude the WFT sequence where
-                            // that update should have been processed.
+                            // If we see an update accepted command after WFT completed, we want to
+                            // conclude the WFT sequence where that update should have been
+                            // processed. We don't need to check for any other command types,
+                            // because the only thing that can run before an update validator is a
+                            // signal handler - but if a signal handler ran then there would have
+                            // been a previous signal event, and we would've already concluded the
+                            // previous WFT sequence.
                             if let Some(
                                 Attributes::WorkflowExecutionUpdateAcceptedEventAttributes(
                                     ref attr,

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use futures_util::{future::BoxFuture, FutureExt, Stream, TryFutureExt};
 use itertools::Itertools;
-use std::sync::LazyLock;
 use std::{
     collections::VecDeque,
     fmt::Debug,
@@ -15,12 +14,15 @@ use std::{
     mem,
     mem::transmute,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, LazyLock},
     task::{Context, Poll},
 };
 use temporal_sdk_core_protos::temporal::api::{
     enums::v1::EventType,
-    history::v1::{history_event, History, HistoryEvent, WorkflowTaskCompletedEventAttributes},
+    history::v1::{
+        history_event, history_event::Attributes, History, HistoryEvent,
+        WorkflowTaskCompletedEventAttributes,
+    },
 };
 use tracing::Instrument;
 
@@ -697,6 +699,8 @@ fn find_end_index_of_next_wft_seq(
     }
     let mut last_index = 0;
     let mut saw_any_command_event = false;
+    let mut last_wft_started = None;
+    let mut wft_started_event_id_to_index = vec![];
     for (ix, e) in events.iter().enumerate() {
         last_index = ix;
 
@@ -714,12 +718,14 @@ fn find_end_index_of_next_wft_seq(
         }
 
         if e.event_type() == EventType::WorkflowTaskStarted {
+            wft_started_event_id_to_index.push((e.event_id, ix));
+            last_wft_started = Some(e.event_id);
             if let Some(next_event) = events.get(ix + 1) {
-                let et = next_event.event_type();
+                let next_event_type = next_event.event_type();
                 // If the next event is WFT timeout or fail, or abrupt WF execution end, that
                 // doesn't conclude a WFT sequence.
                 if matches!(
-                    et,
+                    next_event_type,
                     EventType::WorkflowTaskFailed
                         | EventType::WorkflowTaskTimedOut
                         | EventType::WorkflowExecutionTimedOut
@@ -731,11 +737,34 @@ fn find_end_index_of_next_wft_seq(
                 // If we've never seen an interesting event and the next two events are a completion
                 // followed immediately again by scheduled, then this is a WFT heartbeat and also
                 // doesn't conclude the sequence.
-                else if et == EventType::WorkflowTaskCompleted {
+                else if next_event_type == EventType::WorkflowTaskCompleted {
                     if let Some(next_next_event) = events.get(ix + 2) {
                         if next_next_event.event_type() == EventType::WorkflowTaskScheduled {
                             continue;
                         } else {
+                            warn!("Complete, saw wtc w/ next command @ {}", e.event_id);
+                            // // TODO extract if works
+                            if let Some(
+                                Attributes::WorkflowExecutionUpdateAcceptedEventAttributes(
+                                    ref attr,
+                                ),
+                            ) = next_next_event.attributes
+                            {
+                                // Find index of closest WFT started before sequencing id
+                                if let Some(ret_ix) = wft_started_event_id_to_index
+                                    .iter()
+                                    .rev()
+                                    .find_map(|(eid, ix)| {
+                                        if *eid < attr.accepted_request_sequencing_event_id {
+                                            return Some(*ix);
+                                        }
+                                        None
+                                    })
+                                {
+                                    error!("returning at {ix}");
+                                    return NextWFTSeqEndIndex::Complete(ret_ix);
+                                }
+                            }
                             return NextWFTSeqEndIndex::Complete(ix);
                         }
                     } else if !has_last_wft && !saw_any_command_event {
@@ -766,8 +795,7 @@ mod tests {
         test_help::{canned_histories, hist_to_poll_resp, mock_sdk_cfg, MockPollCfg, ResponseType},
         worker::client::mocks::mock_workflow_client,
     };
-    use futures_util::StreamExt;
-    use futures_util::TryStreamExt;
+    use futures_util::{StreamExt, TryStreamExt};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use temporal_client::WorkflowOptions;
     use temporal_sdk::WfContext;

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -635,8 +635,8 @@ impl WorkflowMachines {
                 event.attributes,
                 Some(history_event::Attributes::WorkflowExecutionUpdateAdmittedEventAttributes(_)),
             ) {
-                // The server has sent a durable update admitted event: create the message that would have been sent
-                // for a non-durable update request message.
+                // The server has sent a durable update admitted event: create the message that
+                // would have been sent for a non-durable update request message.
                 let msg = IncomingProtocolMessage::try_from(&event).context(
                     "Failed to create protocol message from WorkflowExecutionUpdateAdmittedEvent",
                 )?;
@@ -745,9 +745,10 @@ impl WorkflowMachines {
                 history_event::Attributes::WorkflowExecutionUpdateAcceptedEventAttributes(ref atts),
             ) = e.attributes
             {
-                // We've encountered an UpdateAccepted event during replay: pretend that we received the message we
-                // would have when receiving an update request under not-replay. If this event was preceded by an
-                // UpdateAdmitted event, then use the message that we created when we encountered that.
+                // We've encountered an UpdateAccepted event during replay: pretend that we received
+                // the message we would have when receiving an update request under not-replay. If
+                // this event was preceded by an UpdateAdmitted event, then use the message that we
+                // created when we encountered that.
                 delayed_actions.push(DelayedAction::ProtocolMessage(
                     update_admitted_event_messages
                         .remove(&atts.protocol_instance_id)

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use futures_util::{task::Context, FutureExt, Stream, StreamExt};
 use parking_lot::{RwLock, RwLockReadGuard};
-use std::sync::mpsc::{Receiver, Sender};
 use std::{
     collections::HashMap,
     future::Future,
@@ -22,6 +21,7 @@ use std::{
     pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
+        mpsc::{Receiver, Sender},
         Arc,
     },
     task::Poll,
@@ -344,6 +344,11 @@ impl WfContext {
         ))
     }
 
+    /// Buffer a command to be sent in the activation reply
+    pub(crate) fn send(&self, c: RustWfCmd) {
+        self.chan.send(c).expect("command channel intact");
+    }
+
     fn send_signal_wf(
         &self,
         target: sig_we::Target,
@@ -372,10 +377,6 @@ impl WfContext {
     /// Cancel any cancellable operation by ID
     fn cancel(&self, cancellable_id: CancellableID) {
         self.send(RustWfCmd::Cancel(cancellable_id));
-    }
-
-    fn send(&self, c: RustWfCmd) {
-        self.chan.send(c).unwrap();
     }
 }
 

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -1062,6 +1062,7 @@ async fn worker_restarted_in_middle_of_update() {
         .unwrap();
 }
 
+#[rstest::rstest]
 #[tokio::test]
 async fn update_after_empty_wft() {
     let wf_name = "update_after_empty_wft";
@@ -1070,7 +1071,7 @@ async fn update_after_empty_wft() {
     let client = starter.get_client().await;
 
     static ACT_STARTED: AtomicBool = AtomicBool::new(false);
-    worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
+    worker.register_wf(wf_name.to_owned(), move |ctx: WfContext| async move {
         ctx.update_handler(
             "update",
             |_: &_, _: ()| Ok(()),

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -1062,7 +1062,6 @@ async fn worker_restarted_in_middle_of_update() {
         .unwrap();
 }
 
-#[rstest::rstest]
 #[tokio::test]
 async fn update_after_empty_wft() {
     let wf_name = "update_after_empty_wft";


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed a bug where an empty WFT sequence followed by an update could cause the update job to be sent before things that happened preceding the empty sequence.

## Why?
Bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-python/issues/673
2. How was this tested:
UT / IT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
