### PR TITLE
Ensure resource tuner won't get WFTs stuck

### DIFF
--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -301,6 +301,9 @@ pub trait SlotSupplier {
 pub trait SlotReservationContext: Send + Sync {
     /// Returns the number of currently outstanding slot permits, whether used or un-used.
     fn num_issued_slots(&self) -> usize;
+
+    /// Returns true iff this is a sticky poll for a workflow task
+    fn is_sticky(&self) -> bool;
 }
 
 #[derive(Default)]
@@ -325,46 +328,59 @@ impl SlotSupplierPermit {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct WorkflowSlotInfo<'a> {
     pub workflow_type: &'a str,
     // etc...
 }
-
+#[derive(Debug, Clone)]
 pub struct ActivitySlotInfo<'a> {
     pub activity_type: &'a str,
     // etc...
 }
+#[derive(Debug, Clone)]
 pub struct LocalActivitySlotInfo<'a> {
     pub activity_type: &'a str,
     // etc...
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, derive_more::Display)]
+pub enum SlotKindType {
+    Workflow,
+    Activity,
+    LocalActivity,
+}
+
+#[derive(Debug, Copy, Clone)]
 pub struct WorkflowSlotKind {}
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct ActivitySlotKind {}
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct LocalActivitySlotKind {}
+
 pub trait SlotKind {
     type Info<'a>;
-    fn kind_name() -> &'static str;
+
+    fn kind() -> SlotKindType;
 }
 impl SlotKind for WorkflowSlotKind {
     type Info<'a> = WorkflowSlotInfo<'a>;
 
-    fn kind_name() -> &'static str {
-        "workflow"
+    fn kind() -> SlotKindType {
+        SlotKindType::Workflow
     }
 }
 impl SlotKind for ActivitySlotKind {
     type Info<'a> = ActivitySlotInfo<'a>;
-    fn kind_name() -> &'static str {
-        "activity"
+
+    fn kind() -> SlotKindType {
+        SlotKindType::Activity
     }
 }
 impl SlotKind for LocalActivitySlotKind {
     type Info<'a> = LocalActivitySlotInfo<'a>;
-    fn kind_name() -> &'static str {
-        "local_activity"
+
+    fn kind() -> SlotKindType {
+        SlotKindType::LocalActivity
     }
 }

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -350,7 +350,7 @@ pub struct LocalActivitySlotInfo {
     pub activity_type: String,
 }
 
-#[derive(Debug, Copy, Clone, derive_more::Display)]
+#[derive(Debug, Copy, Clone, derive_more::Display, Eq, PartialEq)]
 pub enum SlotKindType {
     Workflow,
     Activity,

--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -142,7 +142,7 @@ where
 }
 
 impl MeteredPermitDealer<WorkflowSlotKind> {
-    pub(crate) fn as_sticky(mut self) -> Self {
+    pub(crate) fn into_sticky(mut self) -> Self {
         self.is_sticky_poller = true;
         self
     }
@@ -284,6 +284,7 @@ pub(crate) struct OwnedMeteredSemPermit<SK: SlotKind> {
     release_ctx: ReleaseCtx<SK>,
     #[allow(clippy::type_complexity)] // not really tho, bud
     use_fn: Box<dyn Fn(&SK::Info) + Send + Sync>,
+    #[allow(clippy::type_complexity)] // not really tho, bud
     release_fn: Box<dyn Fn(&ReleaseCtx<SK>) + Send + Sync>,
 }
 impl<SK: SlotKind> Drop for OwnedMeteredSemPermit<SK> {

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -33,7 +33,8 @@ use temporal_sdk::{ActivityOptions, CancellableFuture, WfContext};
 use temporal_sdk_core_api::{
     errors::PollWfError,
     worker::{
-        SlotKind, SlotReservationContext, SlotSupplier, SlotSupplierPermit, WorkflowSlotKind,
+        SlotKind, SlotReleaseContext, SlotReservationContext, SlotSupplier, SlotSupplierPermit,
+        WorkflowSlotKind,
     },
     Worker as WorkerTrait,
 };
@@ -3028,8 +3029,8 @@ async fn slot_provider_cant_hand_out_more_permits_than_cache_size() {
         fn try_reserve_slot(&self, _: &dyn SlotReservationContext) -> Option<SlotSupplierPermit> {
             Some(SlotSupplierPermit::default())
         }
-        fn mark_slot_used(&self, _: <Self::SlotKind as SlotKind>::Info<'_>) {}
-        fn release_slot(&self) {}
+        fn mark_slot_used(&self, _: &<Self::SlotKind as SlotKind>::Info) {}
+        fn release_slot(&self, _: &dyn SlotReleaseContext<SlotKind = Self::SlotKind>) {}
         fn available_slots(&self) -> Option<usize> {
             None
         }

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -182,7 +182,7 @@ enum ActivityTaskSource {
 impl WorkerActivityTasks {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        semaphore: Arc<MeteredPermitDealer<ActivitySlotKind>>,
+        semaphore: MeteredPermitDealer<ActivitySlotKind>,
         poller: BoxedActPoller,
         client: Arc<dyn WorkerClient>,
         metrics: MetricsContext,
@@ -196,7 +196,7 @@ impl WorkerActivityTasks {
         let server_poller_stream =
             new_activity_task_poller(poller, metrics.clone(), shutdown_initiated_token.clone());
         let (eager_activities_tx, eager_activities_rx) = unbounded_channel();
-        let eager_activities_semaphore = ClosableMeteredPermitDealer::new_arc(semaphore);
+        let eager_activities_semaphore = ClosableMeteredPermitDealer::new_arc(Arc::new(semaphore));
 
         let start_tasks_stream_complete = CancellationToken::new();
         let starts_stream = Self::merge_start_task_sources(
@@ -750,7 +750,7 @@ mod tests {
             .times(2)
             .returning(|_, _| Ok(Default::default()));
         let mock_client = Arc::new(mock_client);
-        let sem = Arc::new(fixed_size_permit_dealer(10));
+        let sem = fixed_size_permit_dealer(10);
         let shutdown_token = CancellationToken::new();
         let ap = new_activity_task_buffer(
             mock_client.clone(),
@@ -839,7 +839,7 @@ mod tests {
                 })
             });
         let mock_client = Arc::new(mock_client);
-        let sem = Arc::new(fixed_size_permit_dealer(1));
+        let sem = fixed_size_permit_dealer(1);
         let shutdown_token = CancellationToken::new();
         let ap = new_activity_task_buffer(
             mock_client.clone(),
@@ -910,7 +910,7 @@ mod tests {
             .times(2)
             .returning(|_, _| Ok(Default::default()));
         let mock_client = Arc::new(mock_client);
-        let sem = Arc::new(fixed_size_permit_dealer(1));
+        let sem = fixed_size_permit_dealer(1);
         let shutdown_token = CancellationToken::new();
         let ap = new_activity_task_buffer(
             mock_client.clone(),

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -553,7 +553,7 @@ where
                                 outstanding_entry.insert(RemoteInFlightActInfo::new(
                                     &task.resp,
                                     task.permit.into_used(ActivitySlotInfo {
-                                        activity_type: activity_type_name,
+                                        activity_type: activity_type_name.to_string(),
                                     }),
                                 ));
                             // If we have already waited the grace period and issued cancels,

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -6,8 +6,9 @@ use crate::{
     worker::workflow::HeartbeatTimeoutMsg,
     MetricsContext, TaskToken,
 };
-use futures_util::{future, future::AbortRegistration, stream, StreamExt};
-use futures_util::{stream::BoxStream, Stream};
+use futures_util::{
+    future, future::AbortRegistration, stream, stream::BoxStream, Stream, StreamExt,
+};
 use parking_lot::{Mutex, MutexGuard};
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -482,7 +483,7 @@ impl LocalActivityManager {
                 dispatch_time: Instant::now(),
                 attempt,
                 _permit: permit.into_used(LocalActivitySlotInfo {
-                    activity_type: new_la.workflow_type.as_str(),
+                    activity_type: new_la.workflow_type.clone(),
                 }),
             },
         );

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -320,7 +320,7 @@ impl Worker {
                             normal_name: config.task_queue.clone(),
                         },
                         max_sticky_polls,
-                        wft_slots.clone().as_sticky(),
+                        wft_slots.clone().into_sticky(),
                         shutdown_token.child_token(),
                         Some(move |np| {
                             sticky_metrics.record_num_pollers(np);

--- a/core/src/worker/tuner/fixed_size.rs
+++ b/core/src/worker/tuner/fixed_size.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, sync::Arc};
 use temporal_sdk_core_api::worker::{
-    SlotKind, SlotReservationContext, SlotSupplier, SlotSupplierPermit,
+    SlotKind, SlotReleaseContext, SlotReservationContext, SlotSupplier, SlotSupplierPermit,
 };
 use tokio::sync::Semaphore;
 
@@ -42,9 +42,9 @@ where
         perm.ok().map(SlotSupplierPermit::with_user_data)
     }
 
-    fn mark_slot_used(&self, _info: SK::Info<'_>) {}
+    fn mark_slot_used(&self, _info: &SK::Info) {}
 
-    fn release_slot(&self) {}
+    fn release_slot(&self, _ctx: &dyn SlotReleaseContext<SlotKind = Self::SlotKind>) {}
 
     fn available_slots(&self) -> Option<usize> {
         Some(self.sem.available_permits())

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -38,8 +38,7 @@ use crate::{
     MetricsContext,
 };
 use anyhow::anyhow;
-use futures_util::{future::abortable, stream};
-use futures_util::{stream::BoxStream, Stream, StreamExt};
+use futures_util::{future::abortable, stream, stream::BoxStream, Stream, StreamExt};
 use itertools::Itertools;
 use prost_types::TimestampError;
 use std::{
@@ -121,7 +120,7 @@ pub(crate) struct Workflows {
     /// If set, can be used to reserve activity task slots for eager-return of new activity tasks.
     activity_tasks_handle: Option<ActivitiesFromWFTsHandle>,
     /// Ensures we stay at or below this worker's maximum concurrent workflow task limit
-    wft_semaphore: Arc<MeteredPermitDealer<WorkflowSlotKind>>,
+    wft_semaphore: MeteredPermitDealer<WorkflowSlotKind>,
     local_act_mgr: Arc<LocalActivityManager>,
     ever_polled: AtomicBool,
 }
@@ -149,7 +148,7 @@ impl Workflows {
         basics: WorkflowBasics,
         sticky_attrs: Option<StickyExecutionAttributes>,
         client: Arc<dyn WorkerClient>,
-        wft_semaphore: Arc<MeteredPermitDealer<WorkflowSlotKind>>,
+        wft_semaphore: MeteredPermitDealer<WorkflowSlotKind>,
         wft_stream: impl Stream<Item = WFTStreamIn> + Send + 'static,
         local_activity_request_sink: impl LocalActivityRequestSink,
         local_act_mgr: Arc<LocalActivityManager>,

--- a/core/src/worker/workflow/wft_extraction.rs
+++ b/core/src/worker/workflow/wft_extraction.rs
@@ -9,8 +9,7 @@ use crate::{
         },
     },
 };
-use futures_util::Stream;
-use futures_util::{stream, stream::PollNext, FutureExt, StreamExt};
+use futures_util::{stream, stream::PollNext, FutureExt, Stream, StreamExt};
 use std::{future, sync::Arc};
 use temporal_sdk_core_api::worker::{WorkflowSlotInfo, WorkflowSlotKind};
 use temporal_sdk_core_protos::TaskToken;
@@ -76,7 +75,7 @@ impl WFTExtractor {
                             Ok(match HistoryPaginator::from_poll(wft, client).await {
                                 Ok((pag, prep)) => WFTExtractorOutput::NewWFT(PermittedWFT {
                                     permit: permit.into_used(WorkflowSlotInfo {
-                                        workflow_type: prep.workflow_type.as_str(),
+                                        workflow_type: prep.workflow_type.clone(),
                                     }),
                                     work: prep,
                                     paginator: pag,

--- a/tests/integ_tests/worker_tests.rs
+++ b/tests/integ_tests/worker_tests.rs
@@ -119,6 +119,7 @@ async fn resource_based_few_pollers_guarantees_non_sticky_poll() {
     starter
         .worker_config
         .clear_max_outstanding_opts()
+        .no_remote_activities(true)
         // 3 pollers so the minimum slots of 2 can both be handed out to a sticky poller
         .max_concurrent_wft_polls(3_usize);
     // Set the limits to zero so it's essentially unwilling to hand out slots


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make sure the resource tuner is always willing to hand out a minimum of 1 slot for sticky and non-sticky WFT polls

## Why?
Avoids a scenario where the sticky pollers can hog all the slots, starving normal poller.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/775

2. How was this tested:
Added IT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
