### PR TITLE
Custom metric buckets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license-file = "LICENSE.txt"
 [workspace.dependencies]
 derive_builder = "0.20"
 derive_more = { version = "1.0", features = ["constructor", "display", "from", "into", "debug"] }
+thiserror = "2"
 tonic = "0.12"
 tonic-build = "0.12"
 opentelemetry = { version = "0.24", features = ["metrics"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -30,7 +30,7 @@ opentelemetry = { workspace = true, features = ["metrics"], optional = true }
 parking_lot = "0.12"
 prost-types = { workspace = true }
 slotmap = "1.0"
-thiserror = "1.0"
+thiserror = { workspace = true }
 tokio = "1.1"
 tonic = { workspace = true, features = ["tls", "tls-roots"] }
 tower = { version = "0.5", features = ["util"] }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -18,6 +18,7 @@ pub use crate::{
     proxy::HttpConnectProxyOptions,
     retry::{CallType, RetryClient, RETRYABLE_ERROR_CODES},
 };
+pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use raw::{CloudService, HealthService, OperatorService, TestService, WorkflowService};
 pub use temporal_sdk_core_protos::temporal::api::{
     enums::v1::ArchivalState,
@@ -42,13 +43,12 @@ use crate::{
 use backoff::{exponential, ExponentialBackoff, SystemClock};
 use http::{uri::InvalidUri, Uri};
 use parking_lot::RwLock;
-use std::sync::OnceLock;
 use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 use temporal_sdk_core_api::telemetry::metrics::TemporalMeter;

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -12,6 +12,11 @@ use temporal_sdk_core_api::telemetry::metrics::{
 use tonic::{body::BoxBody, transport::Channel, Code};
 use tower::Service;
 
+/// The string name (which may be prefixed) for this metric
+pub static REQUEST_LATENCY_HISTOGRAM_NAME: &str = "request_latency";
+/// The string name (which may be prefixed) for this metric
+pub static LONG_REQUEST_LATENCY_HISTOGRAM_NAME: &str = "long_request_latency";
+
 /// Used to track context associated with metrics, and record/update them
 // Possible improvement: make generic over some type tag so that methods are only exposed if the
 // appropriate k/vs have already been set.
@@ -58,12 +63,12 @@ impl MetricsContext {
                 unit: "".into(),
             }),
             svc_request_latency: meter.histogram_duration(MetricParameters {
-                name: "request_latency".into(),
+                name: REQUEST_LATENCY_HISTOGRAM_NAME.into(),
                 unit: "duration".into(),
                 description: "Histogram of client request latencies".into(),
             }),
             long_svc_request_latency: meter.histogram_duration(MetricParameters {
-                name: "long_request_latency".into(),
+                name: LONG_REQUEST_LATENCY_HISTOGRAM_NAME.into(),
                 unit: "duration".into(),
                 description: "Histogram of client long-poll request latencies".into(),
             }),

--- a/core-api/Cargo.toml
+++ b/core-api/Cargo.toml
@@ -23,7 +23,7 @@ opentelemetry = { workspace = true, optional = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 serde_json = "1.0"
-thiserror = "1.0"
+thiserror = { workspace = true }
 tonic = { workspace = true }
 tracing-core = "0.1"
 url = "2.3"

--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -81,11 +81,11 @@ pub struct PrometheusExporterOptions {
     #[builder(default)]
     pub global_tags: HashMap<String, String>,
     /// If set true, all counters will include a "_total" suffix
-    #[builder(default = "false")]
+    #[builder(default)]
     pub counters_total_suffix: bool,
     /// If set true, all histograms will include the unit in their name as a suffix.
     /// Ex: "_milliseconds".
-    #[builder(default = "false")]
+    #[builder(default)]
     pub unit_suffix: bool,
     /// If set to true, use f64 seconds for durations instead of u64 milliseconds
     #[builder(default)]

--- a/core-api/src/telemetry.rs
+++ b/core-api/src/telemetry.rs
@@ -68,6 +68,9 @@ pub struct OtelCollectorOptions {
     /// If set to true, use f64 seconds for durations instead of u64 milliseconds
     #[builder(default)]
     pub use_seconds_for_durations: bool,
+    /// Overrides for histogram buckets. Units depend on the value of `use_seconds_for_durations`.
+    #[builder(default)]
+    pub histogram_bucket_overrides: HistogramBucketOverrides,
 }
 
 /// Options for exporting metrics to Prometheus
@@ -87,6 +90,24 @@ pub struct PrometheusExporterOptions {
     /// If set to true, use f64 seconds for durations instead of u64 milliseconds
     #[builder(default)]
     pub use_seconds_for_durations: bool,
+    /// Overrides for histogram buckets. Units depend on the value of `use_seconds_for_durations`.
+    #[builder(default)]
+    pub histogram_bucket_overrides: HistogramBucketOverrides,
+}
+
+/// Allows overriding the buckets used by histogram metrics
+#[derive(Debug, Clone, Default)]
+pub struct HistogramBucketOverrides {
+    /// Overrides where the key is the metric name and the value is the list of bucket boundaries.
+    /// The metric name will apply regardless of name prefixing, if any. IE: the name acts like
+    /// `*metric_name`.
+    ///
+    /// The string names of core's built-in histogram metrics are publicly available on the
+    /// `core::telemetry` module and the `client` crate.
+    ///
+    /// See [here](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/enum.Aggregation.html#variant.ExplicitBucketHistogram.field.boundaries)
+    /// for the exact meaning of boundaries.
+    pub overrides: HashMap<&'static str, Vec<f64>>,
 }
 
 /// Control where logs go
@@ -102,7 +123,8 @@ pub enum Logger {
         /// An [EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html) filter string.
         filter: String,
     },
-    // Push logs to Lang. Can used with temporal_sdk_core::telemetry::CoreLogBufferedConsumer to buffer.
+    /// Push logs to Lang. Can be used with
+    /// temporal_sdk_core::telemetry::log_export::CoreLogBufferedConsumer to buffer.
     Push {
         /// An [EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html) filter string.
         filter: String,

--- a/core-api/src/telemetry/metrics.rs
+++ b/core-api/src/telemetry/metrics.rs
@@ -377,6 +377,32 @@ mod otel_impls {
         }
     }
 
+    impl Gauge for metrics::Gauge<u64> {
+        fn record(&self, value: u64, attributes: &MetricAttributes) {
+            if let MetricAttributes::OTel { kvs } = attributes {
+                self.record(value, kvs);
+            } else {
+                debug_assert!(
+                    false,
+                    "Must use OTel attributes with an OTel metric implementation"
+                );
+            }
+        }
+    }
+
+    impl GaugeF64 for metrics::Gauge<f64> {
+        fn record(&self, value: f64, attributes: &MetricAttributes) {
+            if let MetricAttributes::OTel { kvs } = attributes {
+                self.record(value, kvs);
+            } else {
+                debug_assert!(
+                    false,
+                    "Must use OTel attributes with an OTel metric implementation"
+                );
+            }
+        }
+    }
+
     impl Histogram for metrics::Histogram<u64> {
         fn record(&self, value: u64, attributes: &MetricAttributes) {
             if let MetricAttributes::OTel { kvs } = attributes {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,7 +61,7 @@ siphasher = "1.0"
 slotmap = "1.0"
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 tar = { version = "0.4", optional = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 tokio = { version = "1.37", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs", "process"] }
 tokio-util = { version = "0.7", features = ["io", "io-util"] }
 tokio-stream = "0.1"

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -292,7 +292,7 @@ impl Instruments {
                 unit: "".into(),
             }),
             wf_e2e_latency: meter.histogram_duration(MetricParameters {
-                name: WF_E2E_LATENCY_NAME.into(),
+                name: WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME.into(),
                 unit: "duration".into(),
                 description: "Histogram of total workflow execution latencies".into(),
             }),
@@ -312,17 +312,17 @@ impl Instruments {
                 unit: "".into(),
             }),
             wf_task_sched_to_start_latency: meter.histogram_duration(MetricParameters {
-                name: WF_TASK_SCHED_TO_START_LATENCY_NAME.into(),
+                name: WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME.into(),
                 unit: "duration".into(),
                 description: "Histogram of workflow task schedule-to-start latencies".into(),
             }),
             wf_task_replay_latency: meter.histogram_duration(MetricParameters {
-                name: WF_TASK_REPLAY_LATENCY_NAME.into(),
+                name: WORKFLOW_TASK_REPLAY_LATENCY_HISTOGRAM_NAME.into(),
                 unit: "duration".into(),
                 description: "Histogram of workflow task replay latencies".into(),
             }),
             wf_task_execution_latency: meter.histogram_duration(MetricParameters {
-                name: WF_TASK_EXECUTION_LATENCY_NAME.into(),
+                name: WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME.into(),
                 unit: "duration".into(),
                 description: "Histogram of workflow task execution (not replay) latencies".into(),
             }),
@@ -342,12 +342,12 @@ impl Instruments {
                 unit: "".into(),
             }),
             act_sched_to_start_latency: meter.histogram_duration(MetricParameters {
-                name: ACT_SCHED_TO_START_LATENCY_NAME.into(),
+                name: ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME.into(),
                 unit: "duration".into(),
                 description: "Histogram of activity schedule-to-start latencies".into(),
             }),
             act_exec_latency: meter.histogram_duration(MetricParameters {
-                name: ACT_EXEC_LATENCY_NAME.into(),
+                name: ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME.into(),
                 unit: "duration".into(),
                 description: "Histogram of activity execution latencies".into(),
             }),
@@ -496,13 +496,20 @@ pub(crate) fn failure_reason(reason: FailureReason) -> MetricKeyValue {
     MetricKeyValue::new(KEY_TASK_FAILURE_TYPE, reason.to_string())
 }
 
-pub(super) const WF_E2E_LATENCY_NAME: &str = "workflow_endtoend_latency";
-pub(super) const WF_TASK_SCHED_TO_START_LATENCY_NAME: &str =
+/// The string name (which may be prefixed) for this metric
+pub const WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME: &str = "workflow_endtoend_latency";
+/// The string name (which may be prefixed) for this metric
+pub const WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME: &str =
     "workflow_task_schedule_to_start_latency";
-pub(super) const WF_TASK_REPLAY_LATENCY_NAME: &str = "workflow_task_replay_latency";
-pub(super) const WF_TASK_EXECUTION_LATENCY_NAME: &str = "workflow_task_execution_latency";
-pub(super) const ACT_SCHED_TO_START_LATENCY_NAME: &str = "activity_schedule_to_start_latency";
-pub(super) const ACT_EXEC_LATENCY_NAME: &str = "activity_execution_latency";
+/// The string name (which may be prefixed) for this metric
+pub const WORKFLOW_TASK_REPLAY_LATENCY_HISTOGRAM_NAME: &str = "workflow_task_replay_latency";
+/// The string name (which may be prefixed) for this metric
+pub const WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME: &str = "workflow_task_execution_latency";
+/// The string name (which may be prefixed) for this metric
+pub const ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME: &str =
+    "activity_schedule_to_start_latency";
+/// The string name (which may be prefixed) for this metric
+pub const ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME: &str = "activity_execution_latency";
 pub(super) const NUM_POLLERS_NAME: &str = "num_pollers";
 pub(super) const TASK_SLOTS_AVAILABLE_NAME: &str = "worker_task_slots_available";
 pub(super) const TASK_SLOTS_USED_NAME: &str = "worker_task_slots_used";
@@ -533,7 +540,7 @@ macro_rules! define_latency_buckets {
 
 define_latency_buckets!(
     (
-        WF_E2E_LATENCY_NAME,
+        WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME,
         WF_LATENCY_MS_BUCKETS,
         WF_LATENCY_S_BUCKETS,
         [
@@ -556,19 +563,21 @@ define_latency_buckets!(
         ]
     ),
     (
-        WF_TASK_EXECUTION_LATENCY_NAME | WF_TASK_REPLAY_LATENCY_NAME,
+        WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME
+            | WORKFLOW_TASK_REPLAY_LATENCY_HISTOGRAM_NAME,
         WF_TASK_MS_BUCKETS,
         WF_TASK_S_BUCKETS,
         [1., 10., 20., 50., 100., 200., 500., 1000.]
     ),
     (
-        ACT_EXEC_LATENCY_NAME,
+        ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME,
         ACT_EXE_MS_BUCKETS,
         ACT_EXE_S_BUCKETS,
         [50., 100., 500., 1000., 5000., 10_000., 60_000.]
     ),
     (
-        WF_TASK_SCHED_TO_START_LATENCY_NAME | ACT_SCHED_TO_START_LATENCY_NAME,
+        WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME
+            | ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
         TASK_SCHED_TO_START_MS_BUCKETS,
         TASK_SCHED_TO_START_S_BUCKETS,
         [100., 500., 1000., 5000., 10_000., 100_000., 1_000_000.]

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -9,7 +9,12 @@ mod otel;
 mod prometheus_server;
 
 #[cfg(feature = "otel")]
-pub use metrics::{default_buckets_for, MetricsCallBuffer};
+pub use metrics::{
+    default_buckets_for, MetricsCallBuffer, ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME,
+    ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME, WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME,
+    WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME, WORKFLOW_TASK_REPLAY_LATENCY_HISTOGRAM_NAME,
+    WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
+};
 #[cfg(feature = "otel")]
 pub use otel::{build_otlp_metric_exporter, start_prometheus_metric_exporter};
 

--- a/core/src/telemetry/otel.rs
+++ b/core/src/telemetry/otel.rs
@@ -1,9 +1,11 @@
 use super::{
     default_buckets_for,
     metrics::{
-        ACT_EXEC_LATENCY_NAME, ACT_SCHED_TO_START_LATENCY_NAME, DEFAULT_MS_BUCKETS,
-        WF_E2E_LATENCY_NAME, WF_TASK_EXECUTION_LATENCY_NAME, WF_TASK_REPLAY_LATENCY_NAME,
-        WF_TASK_SCHED_TO_START_LATENCY_NAME,
+        ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME, ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
+        DEFAULT_MS_BUCKETS, WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME,
+        WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME,
+        WORKFLOW_TASK_REPLAY_LATENCY_HISTOGRAM_NAME,
+        WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
     },
     prometheus_server::PromServer,
     TELEM_SERVICE_NAME,
@@ -92,15 +94,30 @@ pub(super) fn augment_meter_provider_with_defaults(
     // Some histograms are actually gauges, but we have to use histograms otherwise they forget
     // their value between collections since we don't use callbacks.
     Ok(mpb
-        .with_view(histo_view(WF_E2E_LATENCY_NAME, use_seconds)?)
-        .with_view(histo_view(WF_TASK_EXECUTION_LATENCY_NAME, use_seconds)?)
-        .with_view(histo_view(WF_TASK_REPLAY_LATENCY_NAME, use_seconds)?)
         .with_view(histo_view(
-            WF_TASK_SCHED_TO_START_LATENCY_NAME,
+            WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME,
             use_seconds,
         )?)
-        .with_view(histo_view(ACT_SCHED_TO_START_LATENCY_NAME, use_seconds)?)
-        .with_view(histo_view(ACT_EXEC_LATENCY_NAME, use_seconds)?)
+        .with_view(histo_view(
+            WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME,
+            use_seconds,
+        )?)
+        .with_view(histo_view(
+            WORKFLOW_TASK_REPLAY_LATENCY_HISTOGRAM_NAME,
+            use_seconds,
+        )?)
+        .with_view(histo_view(
+            WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
+            use_seconds,
+        )?)
+        .with_view(histo_view(
+            ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
+            use_seconds,
+        )?)
+        .with_view(histo_view(
+            ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME,
+            use_seconds,
+        )?)
         .with_resource(default_resource(global_tags)))
 }
 

--- a/sdk-core-protos/Cargo.toml
+++ b/sdk-core-protos/Cargo.toml
@@ -25,7 +25,7 @@ prost-wkt-types = "0.6"
 rand = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
+thiserror = { workspace = true }
 tonic = { workspace = true }
 uuid = { version = "1.1", features = ["v4"], optional = true }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 
 [dependencies]
 async-trait = "0.1"
-thiserror = "1.0"
+thiserror = { workspace = true }
 anyhow = "1.0"
 derive_more = { workspace = true }
 futures-util = { version = "0.3", default-features = false }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -30,7 +30,7 @@ temporal-client = { path = "../client" }
 temporal-sdk = { path = "../sdk" }
 temporal-sdk-core = { path = "../core" }
 temporal-sdk-core-api = { path = "../core-api" }
-thiserror = "1.0"
+thiserror = { workspace = true }
 tokio = "1.1"
 tokio-util = { version = "0.7" }
 tracing = "0.1"

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -129,18 +129,16 @@ async fn prometheus_metrics_exported(
             "temporal_request_latency_bucket{\
              operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\",le=\"1337\"}"
         ));
-    } else {
-        if use_seconds_latency {
-            assert!(body.contains(
-                "temporal_request_latency_bucket{\
+    } else if use_seconds_latency {
+        assert!(body.contains(
+            "temporal_request_latency_bucket{\
              operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\",le=\"0.05\"}"
-            ));
-        } else {
-            assert!(body.contains(
-                "temporal_request_latency_bucket{\
+        ));
+    } else {
+        assert!(body.contains(
+            "temporal_request_latency_bucket{\
              operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\",le=\"50\"}"
-            ));
-        }
+        ));
     }
     // Verify counter names are appropriate (don't end w/ '_total')
     assert!(body.contains("temporal_request{"));

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -1,7 +1,9 @@
 use anyhow::anyhow;
 use assert_matches::assert_matches;
-use std::{env, net::SocketAddr, sync::Arc, time::Duration};
-use temporal_client::{WorkflowClientTrait, WorkflowOptions, WorkflowService};
+use std::{collections::HashMap, env, net::SocketAddr, sync::Arc, time::Duration};
+use temporal_client::{
+    WorkflowClientTrait, WorkflowOptions, WorkflowService, REQUEST_LATENCY_HISTOGRAM_NAME,
+};
 use temporal_sdk::{
     ActContext, ActivityError, ActivityOptions, CancellableFuture, LocalActivityOptions, WfContext,
 };
@@ -13,8 +15,8 @@ use temporal_sdk_core::{
 use temporal_sdk_core_api::{
     telemetry::{
         metrics::{CoreMeter, MetricAttributes, MetricParameters},
-        OtelCollectorOptionsBuilder, PrometheusExporterOptionsBuilder, TelemetryOptions,
-        TelemetryOptionsBuilder,
+        HistogramBucketOverrides, OtelCollectorOptionsBuilder, PrometheusExporterOptions,
+        PrometheusExporterOptionsBuilder, TelemetryOptions, TelemetryOptionsBuilder,
     },
     worker::WorkerConfigBuilder,
     Worker,
@@ -62,19 +64,16 @@ impl Drop for AbortOnDrop {
 }
 
 pub(crate) fn prom_metrics(
-    use_seconds: bool,
-    show_units: bool,
+    options_override: Option<PrometheusExporterOptions>,
 ) -> (TelemetryOptions, SocketAddr, AbortOnDrop) {
-    let mut telemopts = get_integ_telem_options();
-    let prom_info = start_prometheus_metric_exporter(
+    let prom_exp_opts = options_override.unwrap_or_else(|| {
         PrometheusExporterOptionsBuilder::default()
             .socket_addr(ANY_PORT.parse().unwrap())
-            .use_seconds_for_durations(use_seconds)
-            .unit_suffix(show_units)
             .build()
-            .unwrap(),
-    )
-    .unwrap();
+            .unwrap()
+    });
+    let mut telemopts = get_integ_telem_options();
+    let prom_info = start_prometheus_metric_exporter(prom_exp_opts).unwrap();
     telemopts.metrics = Some(prom_info.meter as Arc<dyn CoreMeter>);
     (
         telemopts,
@@ -87,8 +86,24 @@ pub(crate) fn prom_metrics(
 
 #[rstest::rstest]
 #[tokio::test]
-async fn prometheus_metrics_exported(#[values(true, false)] use_seconds_latency: bool) {
-    let (telemopts, addr, _aborter) = prom_metrics(use_seconds_latency, false);
+async fn prometheus_metrics_exported(
+    #[values(true, false)] use_seconds_latency: bool,
+    #[values(true, false)] custom_buckets: bool,
+) {
+    let mut opts_builder = PrometheusExporterOptionsBuilder::default();
+    opts_builder
+        .socket_addr(ANY_PORT.parse().unwrap())
+        .use_seconds_for_durations(use_seconds_latency);
+    if custom_buckets {
+        opts_builder.histogram_bucket_overrides(HistogramBucketOverrides {
+            overrides: {
+                let mut hm = HashMap::new();
+                hm.insert(REQUEST_LATENCY_HISTOGRAM_NAME, vec![1337.0]);
+                hm
+            },
+        });
+    }
+    let (telemopts, addr, _aborter) = prom_metrics(Some(opts_builder.build().unwrap()));
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
     let opts = get_integ_server_options();
     let mut raw_client = opts
@@ -109,16 +124,23 @@ async fn prometheus_metrics_exported(#[values(true, false)] use_seconds_latency:
     assert!(body.contains(
         "temporal_request_latency_count{operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\"} 1"
     ));
-    if use_seconds_latency {
+    if custom_buckets {
         assert!(body.contains(
             "temporal_request_latency_bucket{\
-             operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\",le=\"0.05\"}"
+             operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\",le=\"1337\"}"
         ));
     } else {
-        assert!(body.contains(
-            "temporal_request_latency_bucket{\
+        if use_seconds_latency {
+            assert!(body.contains(
+                "temporal_request_latency_bucket{\
+             operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\",le=\"0.05\"}"
+            ));
+        } else {
+            assert!(body.contains(
+                "temporal_request_latency_bucket{\
              operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\",le=\"50\"}"
-        ));
+            ));
+        }
     }
     // Verify counter names are appropriate (don't end w/ '_total')
     assert!(body.contains("temporal_request{"));
@@ -132,12 +154,13 @@ async fn prometheus_metrics_exported(#[values(true, false)] use_seconds_latency:
         },
     );
     let body = get_text(format!("http://{addr}/metrics")).await;
+    println!("{}", &body);
     assert!(body.contains("\nmygauge 42"));
 }
 
 #[tokio::test]
 async fn one_slot_worker_reports_available_slot() {
-    let (telemopts, addr, _aborter) = prom_metrics(false, false);
+    let (telemopts, addr, _aborter) = prom_metrics(None);
     let tq = "one_slot_worker_tq";
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
 
@@ -373,7 +396,7 @@ async fn query_of_closed_workflow_doesnt_tick_terminal_metric(
     )]
     completion: workflow_command::Variant,
 ) {
-    let (telemopts, addr, _aborter) = prom_metrics(false, false);
+    let (telemopts, addr, _aborter) = prom_metrics(None);
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
     let mut starter =
         CoreWfStarter::new_with_runtime("query_of_closed_workflow_doesnt_tick_terminal_metric", rt);
@@ -500,7 +523,7 @@ fn runtime_new() {
         CoreRuntime::new(get_integ_telem_options(), TokioRuntimeBuilder::default()).unwrap();
     let handle = rt.tokio_handle();
     let _rt = handle.enter();
-    let (telemopts, addr, _aborter) = prom_metrics(false, false);
+    let (telemopts, addr, _aborter) = prom_metrics(None);
     rt.telemetry_mut()
         .attach_late_init_metrics(telemopts.metrics.unwrap());
     let opts = get_integ_server_options();
@@ -525,7 +548,14 @@ async fn latency_metrics(
     #[values(true, false)] use_seconds_latency: bool,
     #[values(true, false)] show_units: bool,
 ) {
-    let (telemopts, addr, _aborter) = prom_metrics(use_seconds_latency, show_units);
+    let (telemopts, addr, _aborter) = prom_metrics(Some(
+        PrometheusExporterOptionsBuilder::default()
+            .socket_addr(ANY_PORT.parse().unwrap())
+            .use_seconds_for_durations(use_seconds_latency)
+            .unit_suffix(show_units)
+            .build()
+            .unwrap(),
+    ));
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime("latency_metrics", rt);
     let worker = starter.get_worker().await;
@@ -561,7 +591,7 @@ async fn latency_metrics(
 
 #[tokio::test]
 async fn request_fail_codes() {
-    let (telemopts, addr, _aborter) = prom_metrics(false, false);
+    let (telemopts, addr, _aborter) = prom_metrics(None);
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
     let opts = get_integ_server_options();
     let mut client = opts
@@ -625,7 +655,7 @@ async fn request_fail_codes_otel() {
 
 #[tokio::test]
 async fn activity_metrics() {
-    let (telemopts, addr, _aborter) = prom_metrics(false, false);
+    let (telemopts, addr, _aborter) = prom_metrics(None);
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
     let wf_name = "activity_metrics";
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -753,7 +753,7 @@ async fn build_id_correct_in_wf_info() {
 async fn nondeterminism_errors_fail_workflow_when_configured_to(
     #[values(true, false)] whole_worker: bool,
 ) {
-    let (telemopts, addr, _aborter) = metrics_tests::prom_metrics(false, false);
+    let (telemopts, addr, _aborter) = metrics_tests::prom_metrics(None);
     let rt = CoreRuntime::new_assume_tokio(telemopts).unwrap();
     let wf_name = "nondeterminism_errors_fail_workflow_when_configured_to";
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Allow configuring custom buckets for histogram metrics

## Why?
Oft-requested feature

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/459

2. How was this tested:
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


I'm looking at passing buckets in with user-created histograms, but my initial inclination is that that may not actually make sense since the otel API separates how aggregation happens from the instrument definition, so we would need to do some odd contortions to take the buckets from the histogram definition and somehow apply that to the overall meter provider definition.

Ultimately, it's pretty easy for the user to just use a constant for their histogram name, and then register the buckets for that in the telemetry options.