### PR TITLE
Support user metadata in child workflow, timer, and activity

### DIFF
--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -2,9 +2,9 @@ use crate::{
     advance_fut, job_assert, prost_dur,
     test_help::{
         build_fake_worker, build_mock_pollers, canned_histories, gen_assert_and_reply,
-        mock_manual_poller, mock_poller, mock_poller_from_resps, mock_worker, poll_and_reply,
-        single_hist_mock_sg, test_worker_cfg, MockPollCfg, MockWorkerInputs, MocksHolder,
-        QueueResponse, ResponseType, WorkerExt, WorkflowCachingPolicy, TEST_Q,
+        mock_manual_poller, mock_poller, mock_poller_from_resps, mock_sdk_cfg, mock_worker,
+        poll_and_reply, single_hist_mock_sg, test_worker_cfg, MockPollCfg, MockWorkerInputs,
+        MocksHolder, QueueResponse, ResponseType, WorkerExt, WorkflowCachingPolicy, TEST_Q,
     },
     worker::client::mocks::{mock_manual_workflow_client, mock_workflow_client},
     ActivityHeartbeat, Worker,
@@ -45,17 +45,18 @@ use temporal_sdk_core_protos::{
     },
     temporal::api::{
         command::v1::{command::Attributes, ScheduleActivityTaskCommandAttributes},
-        enums::v1::EventType,
+        enums::v1::{CommandType, EventType},
         history::v1::{
             history_event::Attributes as EventAttributes, ActivityTaskScheduledEventAttributes,
         },
+        sdk::v1::UserMetadata,
         workflowservice::v1::{
             PollActivityTaskQueueResponse, RecordActivityTaskHeartbeatResponse,
             RespondActivityTaskCanceledResponse, RespondActivityTaskCompletedResponse,
             RespondActivityTaskFailedResponse, RespondWorkflowTaskCompletedResponse,
         },
     },
-    TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE,
+    TestHistoryBuilder, DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE,
 };
 use temporal_sdk_core_test_utils::{fanout_tasks, start_timer_cmd, TestWorker};
 use tokio::{join, sync::Barrier, time::sleep};
@@ -1186,4 +1187,56 @@ async fn activities_must_be_flushed_to_server_on_shutdown(#[values(true, false)]
             .unwrap();
     };
     join!(shutdown_task, complete_task);
+}
+
+#[tokio::test]
+async fn pass_activity_summary_to_metadata() {
+    crate::telemetry::test_telem_console();
+    let t = canned_histories::single_activity("1");
+    let mut mock_cfg = MockPollCfg::from_hist_builder(t);
+    let wf_id = mock_cfg.hists[0].wf_id.clone();
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let expected_user_metadata = Some(UserMetadata {
+        summary: Some(b"activity summary".into()),
+        details: None,
+    });
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::ScheduleActivityTask
+                );
+                assert_eq!(wft.commands[0].user_metadata, expected_user_metadata)
+            })
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+            });
+    });
+
+    let mut worker = mock_sdk_cfg(mock_cfg, |_| {});
+    worker.register_wf(wf_type, |ctx: WfContext| async move {
+        ctx.activity(ActivityOptions {
+            activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
+            summary: Some("activity summary".to_string()),
+            ..Default::default()
+        })
+        .await;
+        Ok(().into())
+    });
+    worker
+        .submit_wf(
+            wf_id.to_owned(),
+            wf_type.to_owned(),
+            vec![],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
 }

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -1191,7 +1191,6 @@ async fn activities_must_be_flushed_to_server_on_shutdown(#[values(true, false)]
 
 #[tokio::test]
 async fn pass_activity_summary_to_metadata() {
-    crate::telemetry::test_telem_console();
     let t = canned_histories::single_activity("1");
     let mut mock_cfg = MockPollCfg::from_hist_builder(t);
     let wf_id = mock_cfg.hists[0].wf_id.clone();

--- a/core/src/core_tests/updates.rs
+++ b/core/src/core_tests/updates.rs
@@ -291,6 +291,7 @@ async fn replay_with_signal_and_update_same_task() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
+                summary: None,
             }
             .into(),
             UpdateResponse {

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -45,6 +45,7 @@ async fn after_shutdown_of_worker_get_shutdown_err() {
                 workflow_command::Variant::StartTimer(StartTimer {
                     seq: 1,
                     start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
+                    summary: None,
                 }),
             ))
             .await
@@ -352,6 +353,7 @@ async fn worker_shutdown_api(#[case] use_cache: bool, #[case] api_success: bool)
                 workflow_command::Variant::StartTimer(StartTimer {
                     seq: 1,
                     start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
+                    summary: None,
                 }),
             ))
             .await

--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -30,6 +30,7 @@ use temporal_sdk_core_protos::{
             ActivityTaskCompletedEventAttributes, ActivityTaskFailedEventAttributes,
             ActivityTaskTimedOutEventAttributes,
         },
+        sdk::v1::UserMetadata,
     },
 };
 
@@ -114,6 +115,10 @@ impl ActivityMachine {
         internal_flags: InternalFlagsRef,
         use_compatible_version: bool,
     ) -> NewMachineWithCommand {
+        let user_metadata = attrs.summary.clone().map(|x| UserMetadata {
+            summary: Some(x),
+            details: None,
+        });
         let mut s = Self::from_parts(
             Created {}.into(),
             SharedState {
@@ -134,7 +139,7 @@ impl ActivityMachine {
                 s.shared_state().attrs.clone(),
                 use_compatible_version,
             )),
-            user_metadata: Default::default(),
+            user_metadata,
         };
         NewMachineWithCommand {
             command,

--- a/core/src/worker/workflow/machines/child_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/child_workflow_state_machine.rs
@@ -450,15 +450,17 @@ impl ChildWorkflowMachine {
                 cancelled_before_sent: false,
             },
         );
+        let mut attribs = attribs;
         let user_metadata = if attribs.static_summary.is_some() || attribs.static_details.is_some()
         {
             Some(UserMetadata {
-                summary: attribs.static_summary.clone(),
-                details: attribs.static_details.clone(),
+                summary: attribs.static_summary.take(),
+                details: attribs.static_details.take(),
             })
         } else {
             None
         };
+        let attribs = attribs;
         OnEventWrapper::on_event_mut(&mut s, ChildWorkflowMachineEvents::Schedule)
             .expect("Scheduling child workflows doesn't fail");
         let cmd = Command {

--- a/core/src/worker/workflow/machines/child_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/child_workflow_state_machine.rs
@@ -41,6 +41,7 @@ use temporal_sdk_core_protos::{
             ChildWorkflowExecutionStartedEventAttributes,
             StartChildWorkflowExecutionFailedEventAttributes,
         },
+        sdk::v1::UserMetadata,
     },
 };
 
@@ -449,6 +450,15 @@ impl ChildWorkflowMachine {
                 cancelled_before_sent: false,
             },
         );
+        let user_metadata = if attribs.static_summary.is_some() || attribs.static_details.is_some()
+        {
+            Some(UserMetadata {
+                summary: attribs.static_summary.clone(),
+                details: attribs.static_details.clone(),
+            })
+        } else {
+            None
+        };
         OnEventWrapper::on_event_mut(&mut s, ChildWorkflowMachineEvents::Schedule)
             .expect("Scheduling child workflows doesn't fail");
         let cmd = Command {
@@ -457,7 +467,7 @@ impl ChildWorkflowMachine {
                 attribs,
                 use_compatible_version,
             )),
-            user_metadata: Default::default(),
+            user_metadata,
         };
         NewMachineWithCommand {
             command: cmd,

--- a/core/src/worker/workflow/machines/timer_state_machine.rs
+++ b/core/src/worker/workflow/machines/timer_state_machine.rs
@@ -74,10 +74,12 @@ pub(super) fn new_timer(attribs: StartTimer) -> NewMachineWithCommand {
 impl TimerMachine {
     /// Create a new timer and immediately schedule it
     fn new_scheduled(attribs: StartTimer) -> (Self, Command) {
-        let user_metadata = attribs.summary.clone().map(|x| UserMetadata {
+        let mut attribs = attribs;
+        let user_metadata = attribs.summary.take().map(|x| UserMetadata {
             summary: Some(x),
             details: None,
         });
+        let attribs = attribs;
         let mut s = Self::new(attribs);
         OnEventWrapper::on_event_mut(&mut s, TimerMachineEvents::Schedule)
             .expect("Scheduling timers doesn't fail");

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -46,6 +46,8 @@ message StartTimer {
     // Lang's incremental sequence number, used as the operation identifier
     uint32 seq = 1;
     google.protobuf.Duration start_to_fire_timeout = 2;
+    // Summary that is stored as user_metadata
+    temporal.api.common.v1.Payload summary = 3;
 }
 
 message CancelTimer {
@@ -88,6 +90,8 @@ message ScheduleActivity {
     bool do_not_eagerly_execute = 14;
     // Whether this activity should run on a worker with a compatible build id or not.
     coresdk.common.VersioningIntent versioning_intent = 15;
+    // Summary that is stored as user_metadata
+    temporal.api.common.v1.Payload summary = 16;
 }
 
 message ScheduleLocalActivity {
@@ -253,6 +257,10 @@ message StartChildWorkflowExecution {
     child_workflow.ChildWorkflowCancellationType cancellation_type = 18;
     // Whether this child should run on a worker with a compatible build id or not.
     coresdk.common.VersioningIntent versioning_intent = 19;
+    // Static summary of the child workflow
+    temporal.api.common.v1.Payload static_summary = 20;
+    // Static details of the child workflow
+    temporal.api.common.v1.Payload static_details = 21;
 }
 
 // Cancel a child workflow

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -57,7 +57,7 @@ use tracing::{field, Instrument, Span};
 pub use workflow_context::{
     ActivityOptions, CancellableFuture, ChildWorkflow, ChildWorkflowOptions, LocalActivityOptions,
     PendingChildWorkflow, Signal, SignalData, SignalWorkflowOptions, StartedChildWorkflow,
-    WfContext,
+    TimerOptions, WfContext,
 };
 
 use crate::{interceptors::WorkerInterceptor, workflow_context::ChildWfCommon};

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -1,5 +1,6 @@
 mod options;
 
+use options::TimerOptions;
 pub use options::{
     ActivityOptions, ChildWorkflowOptions, LocalActivityOptions, Signal, SignalData,
     SignalWorkflowOptions,
@@ -148,6 +149,15 @@ impl WfContext {
 
     /// Request to create a timer
     pub fn timer(&self, duration: Duration) -> impl CancellableFuture<TimerResult> {
+        self.timer_with_options(duration, TimerOptions::default())
+    }
+
+    /// Request to create a timer with optioons
+    pub fn timer_with_options(
+        &self,
+        duration: Duration,
+        opts: TimerOptions,
+    ) -> impl CancellableFuture<TimerResult> {
         let seq = self.seq_nums.write().next_timer_seq();
         let (cmd, unblocker) = CancellableWFCommandFut::new(CancellableID::Timer(seq));
         self.send(
@@ -159,6 +169,7 @@ impl WfContext {
                             .try_into()
                             .expect("Durations must fit into 64 bits"),
                     ),
+                    summary: opts.summary.map(|x| x.as_bytes().into()),
                 }
                 .into(),
                 unblocker,

--- a/sdk/src/workflow_context/options.rs
+++ b/sdk/src/workflow_context/options.rs
@@ -68,6 +68,9 @@ pub struct ActivityOptions {
     pub cancellation_type: ActivityCancellationType,
     /// Activity retry policy
     pub retry_policy: Option<RetryPolicy>,
+    /// Summary of the activity
+    /// NOTE: Experimental
+    pub summary: Option<String>,
 }
 
 impl IntoWorkflowCommand for ActivityOptions {
@@ -192,6 +195,12 @@ pub struct ChildWorkflowOptions {
     pub options: WorkflowOptions,
     /// How to respond to parent workflow ending
     pub parent_close_policy: ParentClosePolicy,
+    /// Static summary of the child workflow
+    /// NOTE: Experimental
+    pub static_summary: Option<String>,
+    /// Static details of the child workflow
+    /// NOTE: Experimental
+    pub static_details: Option<String>,
 }
 
 impl IntoWorkflowCommand for ChildWorkflowOptions {
@@ -306,4 +315,12 @@ impl SignalData {
         self.headers.insert(key.into(), payload.into());
         self
     }
+}
+
+/// Options for timer
+#[derive(Default, Debug, Clone)]
+pub struct TimerOptions {
+    /// Summary of the timer
+    /// NOTE: Experimental
+    pub summary: Option<String>,
 }

--- a/sdk/src/workflow_context/options.rs
+++ b/sdk/src/workflow_context/options.rs
@@ -69,7 +69,6 @@ pub struct ActivityOptions {
     /// Activity retry policy
     pub retry_policy: Option<RetryPolicy>,
     /// Summary of the activity
-    /// NOTE: Experimental
     pub summary: Option<String>,
 }
 
@@ -197,10 +196,8 @@ pub struct ChildWorkflowOptions {
     /// How to respond to parent workflow ending
     pub parent_close_policy: ParentClosePolicy,
     /// Static summary of the child workflow
-    /// NOTE: Experimental
     pub static_summary: Option<String>,
     /// Static details of the child workflow
-    /// NOTE: Experimental
     pub static_details: Option<String>,
 }
 
@@ -326,7 +323,6 @@ pub struct TimerOptions {
     /// Duration for the timer
     pub duration: Duration,
     /// Summary of the timer
-    /// NOTE: Experimental
     pub summary: Option<String>,
 }
 

--- a/sdk/src/workflow_context/options.rs
+++ b/sdk/src/workflow_context/options.rs
@@ -95,6 +95,7 @@ impl IntoWorkflowCommand for ActivityOptions {
             cancellation_type: self.cancellation_type as i32,
             arguments: vec![self.input],
             retry_policy: self.retry_policy,
+            summary: self.summary.map(Into::into),
             ..Default::default()
         }
     }
@@ -226,6 +227,8 @@ impl IntoWorkflowCommand for ChildWorkflowOptions {
             search_attributes: self.options.search_attributes.unwrap_or_default(),
             cron_schedule: self.options.cron_schedule.unwrap_or_default(),
             parent_close_policy: self.parent_close_policy as i32,
+            static_summary: self.static_summary.map(Into::into),
+            static_details: self.static_details.map(Into::into),
             ..Default::default()
         }
     }
@@ -320,7 +323,18 @@ impl SignalData {
 /// Options for timer
 #[derive(Default, Debug, Clone)]
 pub struct TimerOptions {
+    /// Duration for the timer
+    pub duration: Duration,
     /// Summary of the timer
     /// NOTE: Experimental
     pub summary: Option<String>,
+}
+
+impl From<Duration> for TimerOptions {
+    fn from(duration: Duration) -> Self {
+        TimerOptions {
+            duration,
+            ..Default::default()
+        }
+    }
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -716,6 +716,7 @@ pub fn start_timer_cmd(seq: u32, duration: Duration) -> workflow_command::Varian
     StartTimer {
         seq,
         start_to_fire_timeout: Some(duration.try_into().expect("duration fits")),
+        summary: None,
     }
     .into()
 }
@@ -779,6 +780,7 @@ where
             vec![StartTimer {
                 seq,
                 start_to_fire_timeout: Some(duration.try_into().expect("duration fits")),
+                summary: None,
             }
             .into()],
         ))

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -41,6 +41,7 @@ async fn out_of_order_completion_doesnt_hang() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
+                summary: None,
             }
             .into(),
         ]

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -29,11 +29,13 @@ async fn simple_query_legacy() {
             StartTimer {
                 seq: 0,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(500))),
+                summary: None,
             }
             .into(),
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_secs(3))),
+                summary: None,
             }
             .into(),
         ],

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -248,6 +248,7 @@ async fn fail_wf_task(#[values(true, false)] replay: bool) {
         vec![StartTimer {
             seq: 0,
             start_to_fire_timeout: Some(prost_dur!(from_millis(200))),
+            summary: None,
         }
         .into()],
     ))
@@ -372,6 +373,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
             vec![StartTimer {
                 seq: 0,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(10))),
+                summary: None,
             }
             .into()],
         ))

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -360,6 +360,7 @@ async fn activity_cancellation_try_cancel() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
+                summary: None,
             }
             .into(),
         ]
@@ -417,6 +418,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
+                summary: None,
             }
             .into(),
         ]
@@ -461,6 +463,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
         vec![StartTimer {
             seq: 2,
             start_to_fire_timeout: Some(prost_dur!(from_millis(100))),
+            summary: None,
         }
         .into()],
     ))
@@ -559,6 +562,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
+                summary: None,
             }
             .into(),
         ]
@@ -621,6 +625,7 @@ async fn activity_cancellation_abandon() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
+                summary: None,
             }
             .into(),
         ]

--- a/tests/integ_tests/workflow_tests/replay.rs
+++ b/tests/integ_tests/workflow_tests/replay.rs
@@ -42,6 +42,7 @@ async fn timer_workflow_replay() {
         vec![StartTimer {
             seq: 0,
             start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
+            summary: None,
         }
         .into()],
     ))

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -38,6 +38,7 @@ async fn timer_workflow_manual() {
         vec![StartTimer {
             seq: 0,
             start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
+            summary: None,
         }
         .into()],
     ))
@@ -60,11 +61,13 @@ async fn timer_cancel_workflow() {
             StartTimer {
                 seq: 0,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
+                summary: None,
             }
             .into(),
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_secs(10))),
+                summary: None,
             }
             .into(),
         ],


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
added `static_summary` and `static_details` to  child workflow

added `summary` to timer and activity

and plumbed all new fields to user_metadata in command sent to server. 

## Why?
<!-- Tell your future self why have you made these changes -->
This allows individual SDK languages to pass this information to the server, allowing it to show up in the UI.

## Checklist

1. Closes #830

2. How was this tested:
Wrote new tests to validate metadata is being passed to server
