### PR TITLE
Evict workflows when they complete

### DIFF
--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -83,15 +83,7 @@ async fn legacy_query(#[case] include_history: bool) {
             .unwrap();
     };
     let clear_eviction = || async {
-        let t = worker.poll_workflow_activation().await.unwrap();
-        assert_matches!(
-            t.jobs[0].variant,
-            Some(workflow_activation_job::Variant::RemoveFromCache(_))
-        );
-        worker
-            .complete_workflow_activation(WorkflowActivationCompletion::empty(t.run_id))
-            .await
-            .unwrap();
+        worker.handle_eviction().await;
     };
 
     first_wft().await;
@@ -324,15 +316,7 @@ async fn query_failure_because_nondeterminism(#[values(true, false)] legacy: boo
     core.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
         .await
         .unwrap();
-    let task = core.poll_workflow_activation().await.unwrap();
-    assert_matches!(
-        task.jobs[0].variant,
-        Some(workflow_activation_job::Variant::RemoveFromCache(_))
-    );
-    core.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
-        .await
-        .unwrap();
-
+    core.handle_eviction().await;
     core.shutdown().await;
 }
 

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -26,7 +26,7 @@ use temporal_sdk_core_protos::{
         PollWorkflowTaskQueueResponse, RespondWorkflowTaskCompletedResponse, ShutdownWorkerResponse,
     },
 };
-use temporal_sdk_core_test_utils::start_timer_cmd;
+use temporal_sdk_core_test_utils::{start_timer_cmd, WorkerTestHelpers};
 use tokio::sync::{watch, Barrier};
 
 #[tokio::test]
@@ -259,11 +259,7 @@ async fn worker_does_not_panic_on_retry_exhaustion_of_nonfatal_net_err() {
     .await
     .unwrap();
     // We should see an eviction
-    let res = core.poll_workflow_activation().await.unwrap();
-    assert_matches!(
-        res.jobs[0].variant,
-        Some(workflow_activation_job::Variant::RemoveFromCache(_))
-    );
+    core.handle_eviction().await;
 }
 
 #[rstest::rstest]

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2485,7 +2485,6 @@ async fn core_internal_flags() {
     core.shutdown().await;
 }
 
-// TODO: Flakes sometimes
 #[tokio::test]
 async fn post_terminal_commands_are_retained_when_not_replaying() {
     // History contains a non-terminal command (N) followed by the terminal
@@ -2581,6 +2580,7 @@ async fn _do_post_terminal_commands_test(
 
     let act = core.poll_workflow_activation().await.unwrap();
 
+    core.initiate_shutdown();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         act.run_id,
         commands_sent_by_lang,
@@ -2588,7 +2588,6 @@ async fn _do_post_terminal_commands_test(
     .await
     .unwrap();
 
-    core.initiate_shutdown();
     let act = core.poll_workflow_activation().await;
     assert_matches!(act.unwrap_err(), PollWfError::ShutDown);
     core.shutdown().await;

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -1329,17 +1329,7 @@ async fn fail_wft_then_recover() {
     .await
     .unwrap();
     // We must handle an eviction now
-    let evict_act = core.poll_workflow_activation().await.unwrap();
-    assert_eq!(evict_act.run_id, act.run_id);
-    assert_matches!(
-        evict_act.jobs.as_slice(),
-        [WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
-        }]
-    );
-    core.complete_workflow_activation(WorkflowActivationCompletion::empty(evict_act.run_id))
-        .await
-        .unwrap();
+    core.handle_eviction().await;
 
     // Workflow starting over, this time issue the right command
     let act = core.poll_workflow_activation().await.unwrap();
@@ -1530,6 +1520,7 @@ async fn failing_wft_doesnt_eat_permit_forever() {
     // row because we purposefully time out rather than spamming.
     for _ in 1..=2 {
         let activation = worker.poll_workflow_activation().await.unwrap();
+        run_id.clone_from(&activation.run_id);
         // Issue a nonsense completion that will trigger a WFT failure
         worker
             .complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
@@ -1538,18 +1529,7 @@ async fn failing_wft_doesnt_eat_permit_forever() {
             ))
             .await
             .unwrap();
-        let activation = worker.poll_workflow_activation().await.unwrap();
-        assert_matches!(
-            activation.jobs.as_slice(),
-            [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
-            },]
-        );
-        run_id.clone_from(&activation.run_id);
-        worker
-            .complete_workflow_activation(WorkflowActivationCompletion::empty(activation.run_id))
-            .await
-            .unwrap();
+        worker.handle_eviction().await;
     }
     assert_eq!(worker.outstanding_workflow_tasks().await, 0);
     // We should be "out of work" because the mock service thinks we didn't complete the last task,
@@ -2505,6 +2485,7 @@ async fn core_internal_flags() {
     core.shutdown().await;
 }
 
+// TODO: Flakes sometimes
 #[tokio::test]
 async fn post_terminal_commands_are_retained_when_not_replaying() {
     // History contains a non-terminal command (N) followed by the terminal

--- a/core/src/core_tests/workflow_tasks.rs
+++ b/core/src/core_tests/workflow_tasks.rs
@@ -2607,6 +2607,7 @@ async fn _do_post_terminal_commands_test(
     .await
     .unwrap();
 
+    core.initiate_shutdown();
     let act = core.poll_workflow_activation().await;
     assert_matches!(act.unwrap_err(), PollWfError::ShutDown);
     core.shutdown().await;

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -262,6 +262,7 @@ impl MetricsContext {
         self.instruments.sticky_cache_size.record(size, &self.kvs);
     }
 
+    // TODO: Not on normal completion
     /// Count a workflow being evicted from the cache
     pub(crate) fn cache_eviction(&self) {
         self.instruments.sticky_cache_evictions.add(1, &self.kvs);

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -656,7 +656,7 @@ pub(crate) fn build_mock_pollers(mut cfg: MockPollCfg) -> MocksHolder {
                 tokio::select! {
                     _ = outstanding_wakeup.notified() => {}
                     _ = tokio::time::sleep(Duration::from_secs(60)) => {}
-                };
+                }
             }
         }
     });

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -508,7 +508,12 @@ impl Worker {
         if let Some(name) = self.workflows.get_sticky_queue_name() {
             // This is a best effort call and we can still shutdown the worker if it fails
             match self.client.shutdown_worker(name).await {
-                Err(err) if err.code() != tonic::Code::Unavailable => {
+                Err(err)
+                    if !matches!(
+                        err.code(),
+                        tonic::Code::Unimplemented | tonic::Code::Unavailable
+                    ) =>
+                {
                     warn!("Failed to shutdown sticky queue  {:?}", err);
                 }
                 _ => {}

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -142,6 +142,10 @@ impl ManagedRun {
         self.wfm.machines.have_seen_terminal_event
     }
 
+    pub(super) fn workflow_is_finished(&self) -> bool {
+        self.wfm.machines.workflow_is_finished()
+    }
+
     /// Returns a ref to info about the currently tracked workflow task, if any.
     pub(super) fn wft(&self) -> Option<&OutstandingTask> {
         self.wft.as_ref()
@@ -876,7 +880,7 @@ impl ManagedRun {
             // If we've requested an eviction because of failure related reasons then we want to
             // delete any pending queries, since handling them no longer makes sense. Evictions
             // because the cache is full should get a chance to finish processing properly.
-            if !matches!(info.reason, EvictionReason::CacheFull)
+            if !matches!(info.reason, EvictionReason::CacheFull | EvictionReason::WorkflowExecutionEnding)
                 // If the wft was just a legacy query, still reply, otherwise we might try to
                 // reply to the task as if it were a task rather than a query.
                 && !self.pending_work_is_legacy_query()

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -156,9 +156,9 @@ impl ManagedRun {
         self.activation.as_ref()
     }
 
-    /// Returns true if this run has already been told it will be evicted.
-    pub(super) fn is_trying_to_evict(&self) -> bool {
-        self.trying_to_evict.is_some()
+    /// Returns this run's eviction reason if it is going to be evicted
+    pub(super) fn trying_to_evict(&self) -> Option<&RequestEvictMsg> {
+        self.trying_to_evict.as_ref()
     }
 
     /// Called whenever a new workflow task is obtained for this run

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -318,6 +318,7 @@ impl Workflows {
         post_activate_hook: Option<impl Fn(PostActivateHookData)>,
     ) -> Result<(), CompleteWfError> {
         let is_empty_completion = completion.is_empty();
+        // let does_end_execution = completion.has_execution_ending();
         let completion = validate_completion(completion, is_autocomplete)?;
         let run_id = completion.run_id().to_string();
         let (tx, rx) = oneshot::channel();
@@ -404,6 +405,14 @@ impl Workflows {
                         Ok(())
                     })
                     .await;
+                    // Successful completions that finish the workflow should queue up an eviction
+                    // if does_end_execution {
+                    //     self.request_eviction(
+                    //         &run_id,
+                    //         "Workflow completed",
+                    //         EvictionReason::WorkflowExecutionEnding,
+                    //     );
+                    // }
                     WFTReportStatus::Reported {
                         reset_last_started_to,
                     }

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -505,7 +505,7 @@ impl WFStream {
         let num_existing_evictions = self
             .runs
             .runs_lru_order()
-            .filter(|(_, h)| h.is_trying_to_evict())
+            .filter(|(_, h)| h.trying_to_evict().is_some())
             .count();
         let mut num_evicts_needed = num_in_buff.saturating_sub(num_existing_evictions);
         for (rid, handle) in self.runs.runs_lru_order() {
@@ -559,7 +559,7 @@ impl WFStream {
         if let Some(r) = self.runs.peek(run_id) {
             info!(run_id, wft=?r.wft(), activation=?r.activation(),
                   buffered_wft=r.has_buffered_wft(),
-                  trying_to_evict=r.is_trying_to_evict(), more_work=r.more_pending_work());
+                  trying_to_evict=r.trying_to_evict().is_some(), more_work=r.more_pending_work());
         } else {
             info!(run_id, "Run not found");
         }

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -343,6 +343,9 @@ message RemoveFromCache {
         FATAL = 8;
         // Something went wrong attempting to fetch more history events.
         PAGINATION_OR_HISTORY_FETCH = 9;
+        // The workflow is being completed with a terminal command and we sent the WFT completion
+        // to server successfully.
+        WORKFLOW_EXECUTION_ENDING = 10;
     }
     EvictionReason reason = 2;
 }

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -39,8 +39,11 @@ pub mod coresdk {
     use crate::{
         temporal::api::{
             common::v1::{Payload, Payloads, WorkflowExecution},
-            enums::v1::WorkflowTaskFailedCause,
-            failure::v1::{failure::FailureInfo, ApplicationFailureInfo, Failure},
+            enums::v1::{TimeoutType, WorkflowTaskFailedCause},
+            failure::v1::{
+                failure::FailureInfo, ActivityFailureInfo, ApplicationFailureInfo, Failure,
+                TimeoutFailureInfo,
+            },
             workflowservice::v1::PollActivityTaskQueueResponse,
         },
         ENCODING_PAYLOAD_KEY, JSON_ENCODING_VAL,
@@ -1240,6 +1243,24 @@ pub mod coresdk {
                         })
                     })
                     .unwrap_or_default()
+            }
+        }
+
+        pub fn timeout(timeout_type: TimeoutType) -> Self {
+            Self {
+                message: "Activity timed out".to_string(),
+                cause: Some(Box::new(Failure {
+                    message: "Activity timed out".to_string(),
+                    failure_info: Some(FailureInfo::TimeoutFailureInfo(TimeoutFailureInfo {
+                        timeout_type: timeout_type.into(),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                })),
+                failure_info: Some(FailureInfo::ActivityFailureInfo(
+                    ActivityFailureInfo::default(),
+                )),
+                ..Default::default()
             }
         }
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -15,6 +15,7 @@ ephemeral-server = ["temporal-sdk-core/ephemeral-server"]
 
 [dependencies]
 anyhow = "1.0"
+assert_matches = "1"
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1.3"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -796,12 +796,9 @@ where
                 variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
             }]
         );
-        self.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
-            task.run_id,
-            vec![],
-        ))
-        .await
-        .unwrap();
+        self.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
+            .await
+            .unwrap();
     }
 }
 

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -171,6 +171,7 @@ async fn many_act_fails_with_heartbeats() {
         },]
     );
     core.complete_execution(&task.run_id).await;
+    core.handle_eviction().await;
     drain_pollers_and_shutdown(&core).await;
 }
 

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -179,6 +179,7 @@ async fn switching_worker_client_changes_poll() {
     let act1 = worker.poll_workflow_activation().await.unwrap();
     assert_eq!(wf1.run_id, act1.run_id);
     worker.complete_execution(&act1.run_id).await;
+    worker.handle_eviction().await;
     info!("Waiting on first workflow complete");
     client1
         .get_untyped_workflow_handle("my-workflow-1", wf1.run_id)
@@ -192,6 +193,7 @@ async fn switching_worker_client_changes_poll() {
     let act2 = worker.poll_workflow_activation().await.unwrap();
     assert_eq!(wf2.run_id, act2.run_id);
     worker.complete_execution(&act2.run_id).await;
+    worker.handle_eviction().await;
     info!("Waiting on second workflow complete");
     client2
         .get_untyped_workflow_handle("my-workflow-2", wf2.run_id)

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -1,6 +1,5 @@
 use assert_matches::assert_matches;
-use futures_util::future::join_all;
-use futures_util::{stream::FuturesUnordered, FutureExt, StreamExt};
+use futures_util::{future::join_all, stream::FuturesUnordered, FutureExt, StreamExt};
 use std::time::{Duration, Instant};
 use temporal_client::WorkflowClientTrait;
 use temporal_sdk_core_protos::{
@@ -224,6 +223,7 @@ async fn fail_legacy_query() {
     // Queries are *always* legacy on closed workflows, so that's the easiest way to ensure that
     // path is used.
     core.complete_execution(&task.run_id).await;
+    core.handle_eviction().await;
     let query_fut = async {
         starter
             .get_client()
@@ -241,6 +241,9 @@ async fn fail_legacy_query() {
             .unwrap_err()
     };
     let query_responder = async {
+        // Have to replay first since we've evicted
+        let task = core.poll_workflow_activation().await.unwrap();
+        core.complete_execution(&task.run_id).await;
         let task = core.poll_workflow_activation().await.unwrap();
         assert_matches!(
             task.jobs.as_slice(),
@@ -428,6 +431,7 @@ async fn queries_handled_before_next_wft() {
             }]
         );
         core.complete_execution(&task.run_id).await;
+        core.handle_eviction().await;
     };
     join!(join_all(query_futs), complete_fut);
     drain_pollers_and_shutdown(&core).await;

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -472,17 +472,8 @@ async fn query_should_not_be_sent_if_wft_about_to_fail() {
         ))
         .await
         .unwrap();
-        let task = core.poll_workflow_activation().await.unwrap();
         // Should *not* get a query here. If the bug wasn't fixed, this job would have a query.
-        assert_matches!(
-            task.jobs.as_slice(),
-            [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
-            }]
-        );
-        core.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
-            .await
-            .unwrap();
+        core.handle_eviction().await;
 
         // We can still service the query by trying again
         let task = core.poll_workflow_activation().await.unwrap();

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -183,12 +183,6 @@ async fn reapplied_updates_due_to_reset() {
     )
     .await;
 
-    // This is a replay worker and there is a remaining activation containing a RemoveFromCache job.
-    let act = replay_worker.poll_workflow_activation().await.unwrap();
-    replay_worker
-        .complete_workflow_activation(WorkflowActivationCompletion::empty(act.run_id))
-        .await
-        .unwrap();
     drain_pollers_and_shutdown(&replay_worker).await;
 }
 
@@ -292,6 +286,9 @@ async fn handle_update(
     ))
     .await
     .unwrap();
+    if matches!(complete_workflow, CompleteWorkflow::Yes) {
+        core.handle_eviction().await;
+    }
 }
 
 #[tokio::test]

--- a/tests/integ_tests/visibility_tests.rs
+++ b/tests/integ_tests/visibility_tests.rs
@@ -52,6 +52,7 @@ async fn client_list_open_closed_workflow_executions() {
 
     // Complete workflow
     core.complete_execution(&task.run_id).await;
+    core.handle_eviction().await;
     drain_pollers_and_shutdown(&core).await;
 
     // List above CLOSED workflow. Visibility doesn't always update immediately so we give this a

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -18,27 +18,19 @@ mod upsert_search_attrs;
 
 use crate::integ_tests::{activity_functions::echo, metrics_tests};
 use assert_matches::assert_matches;
-use futures_channel::mpsc::UnboundedReceiver;
-use futures_util::{future, SinkExt, StreamExt};
 use std::{
     collections::{HashMap, HashSet},
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{interceptors::WorkerInterceptor, ActivityOptions, WfContext, WorkflowResult};
 use temporal_sdk_core::{replay::HistoryForReplay, CoreRuntime};
-use temporal_sdk_core_api::{
-    errors::{PollWfError, WorkflowErrorType},
-    Worker,
-};
+use temporal_sdk_core_api::errors::{PollWfError, WorkflowErrorType};
 use temporal_sdk_core_protos::{
     coresdk::{
         activity_result::ActivityExecutionResult,
-        workflow_activation::{workflow_activation_job, WorkflowActivation, WorkflowActivationJob},
+        workflow_activation::{workflow_activation_job, WorkflowActivationJob},
         workflow_commands::{
             ActivityCancellationType, FailWorkflowExecution, QueryResult, QuerySuccess, StartTimer,
         },
@@ -62,57 +54,26 @@ use uuid::Uuid;
 
 #[tokio::test]
 async fn parallel_workflows_same_queue() {
-    let mut starter = CoreWfStarter::new("parallel_workflows_same_queue");
-    let core = starter.get_worker().await;
-    let num_workflows = 25usize;
+    let wf_name = "parallel_workflows_same_queue";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.worker_config.no_remote_activities(true);
+    let mut core = starter.worker().await;
 
-    let run_ids: Vec<_> = future::join_all(
-        (0..num_workflows).map(|i| starter.start_wf_with_id(format!("wf-id-{i}"))),
-    )
-    .await;
-
-    let mut send_chans = HashMap::new();
-    async fn wf_task(
-        worker: Arc<dyn Worker>,
-        mut task_chan: UnboundedReceiver<WorkflowActivation>,
-    ) {
-        let task = task_chan.next().await.unwrap();
-        assert_matches!(
-            task.jobs.as_slice(),
-            [WorkflowActivationJob {
-                variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
-            }]
-        );
-        worker
-            .complete_timer(&task.run_id, 1, Duration::from_secs(1))
-            .await;
-        let task = task_chan.next().await.unwrap();
-        worker.complete_execution(&task.run_id).await;
+    core.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
+        ctx.timer(Duration::from_secs(1)).await;
+        Ok(().into())
+    });
+    for i in 0..25 {
+        core.submit_wf(
+            format!("{}-{}", wf_name, i),
+            wf_name,
+            vec![],
+            starter.workflow_options.clone(),
+        )
+        .await
+        .unwrap();
     }
-
-    let handles: Vec<_> = run_ids
-        .iter()
-        .map(|run_id| {
-            let (tx, rx) = futures_channel::mpsc::unbounded();
-            send_chans.insert(run_id.clone(), tx);
-            tokio::spawn(wf_task(core.clone(), rx))
-        })
-        .collect();
-
-    for _ in 0..num_workflows * 2 {
-        let task = core.poll_workflow_activation().await.unwrap();
-        send_chans
-            .get(&task.run_id)
-            .unwrap()
-            .send(task)
-            .await
-            .unwrap();
-    }
-
-    for handle in handles {
-        handle.await.unwrap()
-    }
-    drain_pollers_and_shutdown(&core).await;
+    core.run_until_done().await.unwrap();
 }
 
 static RUN_CT: AtomicUsize = AtomicUsize::new(0);

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -45,6 +45,7 @@ async fn timer_workflow_manual() {
     .unwrap();
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_execution(&task.run_id).await;
+    core.handle_eviction().await;
     drain_pollers_and_shutdown(&core).await;
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Workflows now are evicted if they emit a terminal command and there is no more work to be done (no already pending queries, for example).

## Why?
Same behavior as Go/Java. Reduce memory usage for most scenarios, since not everyone queries closed workflows often.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/836

2. How was this tested:
Existing tests & new

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
