### PR TITLE
Move user metadata to command from variant

### DIFF
--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -189,7 +189,7 @@ struct UseCtx<'a, SK: SlotKind> {
     permit: &'a SlotSupplierPermit,
 }
 
-impl<'a, SK: SlotKind> SlotMarkUsedContext for UseCtx<'a, SK> {
+impl<SK: SlotKind> SlotMarkUsedContext for UseCtx<'_, SK> {
     type SlotKind = SK;
 
     fn permit(&self) -> &SlotSupplierPermit {

--- a/core/src/core_tests/updates.rs
+++ b/core/src/core_tests/updates.rs
@@ -291,7 +291,6 @@ async fn replay_with_signal_and_update_same_task() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
-                summary: None,
             }
             .into(),
             UpdateResponse {

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -45,7 +45,6 @@ async fn after_shutdown_of_worker_get_shutdown_err() {
                 workflow_command::Variant::StartTimer(StartTimer {
                     seq: 1,
                     start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
-                    summary: None,
                 }),
             ))
             .await
@@ -349,7 +348,6 @@ async fn worker_shutdown_api(#[case] use_cache: bool, #[case] api_success: bool)
                 workflow_command::Variant::StartTimer(StartTimer {
                     seq: 1,
                     start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
-                    summary: None,
                 }),
             ))
             .await

--- a/core/src/telemetry/log_export.rs
+++ b/core/src/telemetry/log_export.rs
@@ -168,7 +168,7 @@ impl fmt::Debug for CoreLogStreamConsumer {
 
 struct JsonVisitor<'a>(&'a mut HashMap<String, serde_json::Value>);
 
-impl<'a> tracing::field::Visit for JsonVisitor<'a> {
+impl tracing::field::Visit for JsonVisitor<'_> {
     fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
         self.0
             .insert(field.name().to_string(), serde_json::json!(value));

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -276,11 +276,13 @@ where
     }
 }
 
+/// Helpers for test initialization
 #[cfg(test)]
 pub mod test_initters {
     use super::*;
     use temporal_sdk_core_api::telemetry::TelemetryOptionsBuilder;
 
+    /// Turn on logging to the console
     #[allow(dead_code)] // Not always used, called to enable for debugging when needed
     pub fn test_telem_console() {
         telemetry_init_global(

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -1026,6 +1026,7 @@ macro_rules! advance_fut {
     };
 }
 
+/// Helps easily construct prost proto durations from stdlib duration constructors
 #[macro_export]
 macro_rules! prost_dur {
     ($dur_call:ident $args:tt) => {

--- a/core/src/worker/workflow/driven_workflow.rs
+++ b/core/src/worker/workflow/driven_workflow.rs
@@ -1,6 +1,6 @@
 use crate::{
     telemetry::VecDisplayer,
-    worker::workflow::{OutgoingJob, WFCommand, WorkflowStartedInfo},
+    worker::workflow::{OutgoingJob, WFCommand, WFCommandVariant, WorkflowStartedInfo},
 };
 use prost_types::Timestamp;
 use std::{
@@ -86,7 +86,12 @@ impl DrivenWorkflow {
     /// from a buffer that the language side sinks into when it calls [crate::Core::complete_task]
     pub(super) fn fetch_workflow_iteration_output(&mut self) -> Vec<WFCommand> {
         let in_cmds = self.incoming_commands.try_recv();
-        let in_cmds = in_cmds.unwrap_or_else(|_| vec![WFCommand::NoCommandsFromLang]);
+        let in_cmds = in_cmds.unwrap_or_else(|_| {
+            vec![WFCommand {
+                variant: WFCommandVariant::NoCommandsFromLang,
+                metadata: None,
+            }]
+        });
         debug!(in_cmds = %in_cmds.display(), "wf bridge iteration fetch");
         in_cmds
     }

--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -30,7 +30,6 @@ use temporal_sdk_core_protos::{
             ActivityTaskCompletedEventAttributes, ActivityTaskFailedEventAttributes,
             ActivityTaskTimedOutEventAttributes,
         },
-        sdk::v1::UserMetadata,
     },
 };
 
@@ -115,10 +114,6 @@ impl ActivityMachine {
         internal_flags: InternalFlagsRef,
         use_compatible_version: bool,
     ) -> NewMachineWithCommand {
-        let user_metadata = attrs.summary.clone().map(|x| UserMetadata {
-            summary: Some(x),
-            details: None,
-        });
         let mut s = Self::from_parts(
             Created {}.into(),
             SharedState {
@@ -133,16 +128,11 @@ impl ActivityMachine {
         );
         OnEventWrapper::on_event_mut(&mut s, ActivityMachineEvents::Schedule)
             .expect("Scheduling activities doesn't fail");
-        let command = Command {
-            command_type: CommandType::ScheduleActivityTask as i32,
-            attributes: Some(schedule_activity_cmd_to_api(
+        NewMachineWithCommand {
+            command: schedule_activity_cmd_to_api(
                 s.shared_state().attrs.clone(),
                 use_compatible_version,
-            )),
-            user_metadata,
-        };
-        NewMachineWithCommand {
-            command,
+            ),
             machine: s.into(),
         }
     }

--- a/core/src/worker/workflow/machines/cancel_external_state_machine.rs
+++ b/core/src/worker/workflow/machines/cancel_external_state_machine.rs
@@ -11,7 +11,7 @@ use temporal_sdk_core_protos::{
         workflow_activation::ResolveRequestCancelExternalWorkflow,
     },
     temporal::api::{
-        command::v1::{command, Command, RequestCancelExternalWorkflowExecutionCommandAttributes},
+        command::v1::{command, RequestCancelExternalWorkflowExecutionCommandAttributes},
         enums::v1::{CancelExternalWorkflowExecutionFailedCause, CommandType, EventType},
         failure::v1::{failure::FailureInfo, ApplicationFailureInfo, Failure},
         history::v1::history_event,
@@ -75,13 +75,8 @@ pub(super) fn new_external_cancel(
             reason,
         },
     );
-    let cmd = Command {
-        command_type: CommandType::RequestCancelExternalWorkflowExecution as i32,
-        attributes: Some(cmd_attrs),
-        user_metadata: Default::default(),
-    };
     NewMachineWithCommand {
-        command: cmd,
+        command: cmd_attrs,
         machine: s.into(),
     }
 }

--- a/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
@@ -7,10 +7,7 @@ use rustfsm::{fsm, StateMachine, TransitionResult};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::CancelWorkflowExecution,
-    temporal::api::{
-        command::v1::Command,
-        enums::v1::{CommandType, EventType},
-    },
+    temporal::api::enums::v1::{CommandType, EventType},
 };
 
 fsm! {
@@ -34,13 +31,8 @@ pub(super) fn cancel_workflow(attribs: CancelWorkflowExecution) -> NewMachineWit
     let mut machine = CancelWorkflowMachine::from_parts(Created {}.into(), ());
     OnEventWrapper::on_event_mut(&mut machine, CancelWorkflowMachineEvents::Schedule)
         .expect("Scheduling continue as new machine doesn't fail");
-    let command = Command {
-        command_type: CommandType::CancelWorkflowExecution as i32,
-        attributes: Some(attribs.into()),
-        user_metadata: Default::default(),
-    };
     NewMachineWithCommand {
-        command,
+        command: attribs.into(),
         machine: machine.into(),
     }
 }

--- a/core/src/worker/workflow/machines/child_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/child_workflow_state_machine.rs
@@ -27,7 +27,7 @@ use temporal_sdk_core_protos::{
     },
     temporal::api::{
         command::v1::{
-            start_child_workflow_cmd_to_api, Command,
+            start_child_workflow_cmd_to_api,
             RequestCancelExternalWorkflowExecutionCommandAttributes,
         },
         common::v1::{Payload, Payloads, WorkflowExecution, WorkflowType},
@@ -41,7 +41,6 @@ use temporal_sdk_core_protos::{
             ChildWorkflowExecutionStartedEventAttributes,
             StartChildWorkflowExecutionFailedEventAttributes,
         },
-        sdk::v1::UserMetadata,
     },
 };
 
@@ -450,29 +449,10 @@ impl ChildWorkflowMachine {
                 cancelled_before_sent: false,
             },
         );
-        let mut attribs = attribs;
-        let user_metadata = if attribs.static_summary.is_some() || attribs.static_details.is_some()
-        {
-            Some(UserMetadata {
-                summary: attribs.static_summary.take(),
-                details: attribs.static_details.take(),
-            })
-        } else {
-            None
-        };
-        let attribs = attribs;
         OnEventWrapper::on_event_mut(&mut s, ChildWorkflowMachineEvents::Schedule)
             .expect("Scheduling child workflows doesn't fail");
-        let cmd = Command {
-            command_type: CommandType::StartChildWorkflowExecution as i32,
-            attributes: Some(start_child_workflow_cmd_to_api(
-                attribs,
-                use_compatible_version,
-            )),
-            user_metadata,
-        };
         NewMachineWithCommand {
-            command: cmd,
+            command: start_child_workflow_cmd_to_api(attribs, use_compatible_version),
             machine: s.into(),
         }
     }

--- a/core/src/worker/workflow/machines/continue_as_new_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/continue_as_new_workflow_state_machine.rs
@@ -8,7 +8,7 @@ use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::ContinueAsNewWorkflowExecution,
     temporal::api::{
-        command::v1::{continue_as_new_cmd_to_api, Command},
+        command::v1::continue_as_new_cmd_to_api,
         enums::v1::{CommandType, EventType},
     },
 };
@@ -37,13 +37,8 @@ pub(super) fn continue_as_new(
     let mut machine = ContinueAsNewWorkflowMachine::from_parts(Created {}.into(), ());
     OnEventWrapper::on_event_mut(&mut machine, ContinueAsNewWorkflowMachineEvents::Schedule)
         .expect("Scheduling continue as new machine doesn't fail");
-    let command = Command {
-        command_type: CommandType::ContinueAsNewWorkflowExecution as i32,
-        attributes: Some(continue_as_new_cmd_to_api(attribs, use_compatible_version)),
-        user_metadata: Default::default(),
-    };
     NewMachineWithCommand {
-        command,
+        command: continue_as_new_cmd_to_api(attribs, use_compatible_version),
         machine: machine.into(),
     }
 }

--- a/core/src/worker/workflow/machines/mod.rs
+++ b/core/src/worker/workflow/machines/mod.rs
@@ -42,7 +42,6 @@ use std::{
     fmt::{Debug, Display},
 };
 use temporal_sdk_core_protos::temporal::api::{
-    command::v1::Command as ProtoCommand,
     enums::v1::{CommandType, EventType},
     history::v1::HistoryEvent,
 };
@@ -310,7 +309,7 @@ where
 }
 
 struct NewMachineWithCommand {
-    command: ProtoCommand,
+    command: temporal_sdk_core_protos::temporal::api::command::v1::command::Attributes,
     machine: Machines,
 }
 

--- a/core/src/worker/workflow/machines/modify_workflow_properties_state_machine.rs
+++ b/core/src/worker/workflow/machines/modify_workflow_properties_state_machine.rs
@@ -6,10 +6,7 @@ use crate::worker::workflow::{
 use rustfsm::{fsm, StateMachine, TransitionResult};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::ModifyWorkflowProperties,
-    temporal::api::{
-        command::v1::Command,
-        enums::v1::{CommandType, EventType},
-    },
+    temporal::api::enums::v1::{CommandType, EventType},
 };
 
 fsm! {
@@ -28,13 +25,8 @@ pub(super) fn modify_workflow_properties(
     lang_cmd: ModifyWorkflowProperties,
 ) -> NewMachineWithCommand {
     let sm = ModifyWorkflowPropertiesMachine::from_parts(Created {}.into(), ());
-    let cmd = Command {
-        command_type: CommandType::ModifyWorkflowProperties as i32,
-        attributes: Some(lang_cmd.into()),
-        user_metadata: Default::default(),
-    };
     NewMachineWithCommand {
-        command: cmd,
+        command: lang_cmd.into(),
         machine: sm.into(),
     }
 }
@@ -119,7 +111,10 @@ mod tests {
     };
     use temporal_sdk::WfContext;
     use temporal_sdk_core_protos::{
-        temporal::api::{command::v1::command, common::v1::Payload},
+        temporal::api::{
+            command::v1::{command, Command},
+            common::v1::Payload,
+        },
         DEFAULT_WORKFLOW_TYPE,
     };
 

--- a/core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/core/src/worker/workflow/machines/patch_state_machine.rs
@@ -42,7 +42,7 @@ use temporal_sdk_core_protos::{
     coresdk::{common::build_has_change_marker_details, AsJsonPayloadExt},
     temporal::api::{
         command::v1::{
-            Command, RecordMarkerCommandAttributes, UpsertWorkflowSearchAttributesCommandAttributes,
+            RecordMarkerCommandAttributes, UpsertWorkflowSearchAttributesCommandAttributes,
         },
         common::v1::SearchAttributes,
         enums::v1::CommandType,
@@ -102,20 +102,14 @@ pub(super) fn has_change<'a>(
     } else {
         Executing {}.into()
     };
-    let command = Command {
-        command_type: CommandType::RecordMarker as i32,
-        attributes: Some(
-            RecordMarkerCommandAttributes {
-                marker_name: PATCH_MARKER_NAME.to_string(),
-                details: build_has_change_marker_details(&shared_state.patch_id, deprecated)
-                    .context("While encoding patch marker details")?,
-                header: None,
-                failure: None,
-            }
-            .into(),
-        ),
-        user_metadata: Default::default(),
-    };
+    let command = RecordMarkerCommandAttributes {
+        marker_name: PATCH_MARKER_NAME.to_string(),
+        details: build_has_change_marker_details(&shared_state.patch_id, deprecated)
+            .context("While encoding patch marker details")?,
+        header: None,
+        failure: None,
+    }
+    .into();
     let mut machine = PatchMachine::from_parts(initial_state, shared_state);
 
     OnEventWrapper::on_event_mut(&mut machine, PatchMachineEvents::Schedule)

--- a/core/src/worker/workflow/machines/signal_external_state_machine.rs
+++ b/core/src/worker/workflow/machines/signal_external_state_machine.rs
@@ -15,7 +15,7 @@ use temporal_sdk_core_protos::{
         IntoPayloadsExt,
     },
     temporal::api::{
-        command::v1::{command, Command, SignalExternalWorkflowExecutionCommandAttributes},
+        command::v1::{command, SignalExternalWorkflowExecutionCommandAttributes},
         common::v1::WorkflowExecution as UpstreamWE,
         enums::v1::{CommandType, EventType, SignalExternalWorkflowExecutionFailedCause},
         failure::v1::{failure::FailureInfo, ApplicationFailureInfo, CanceledFailureInfo, Failure},
@@ -109,13 +109,8 @@ pub(super) fn new_external_signal(
             child_workflow_only: only_child,
         },
     );
-    let cmd = Command {
-        command_type: CommandType::SignalExternalWorkflowExecution as i32,
-        attributes: Some(cmd_attrs),
-        user_metadata: Default::default(),
-    };
     Ok(NewMachineWithCommand {
-        command: cmd,
+        command: cmd_attrs,
         machine: s.into(),
     })
 }
@@ -305,6 +300,7 @@ mod tests {
     use temporal_sdk::{CancellableFuture, SignalWorkflowOptions, WfContext, WorkflowResult};
     use temporal_sdk_core_protos::{
         coresdk::workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        temporal::api::command::v1::Command,
         DEFAULT_WORKFLOW_TYPE,
     };
     use temporal_sdk_core_test_utils::interceptors::ActivationAssertionsInterceptor;

--- a/core/src/worker/workflow/machines/timer_state_machine.rs
+++ b/core/src/worker/workflow/machines/timer_state_machine.rs
@@ -76,7 +76,7 @@ impl TimerMachine {
         let mut s = Self::new(attribs);
         OnEventWrapper::on_event_mut(&mut s, TimerMachineEvents::Schedule)
             .expect("Scheduling timers doesn't fail");
-        let cmd = s.shared_state().attrs.clone().into();
+        let cmd = s.shared_state().attrs.into();
         (s, cmd)
     }
 

--- a/core/src/worker/workflow/machines/timer_state_machine.rs
+++ b/core/src/worker/workflow/machines/timer_state_machine.rs
@@ -14,10 +14,9 @@ use temporal_sdk_core_protos::{
         HistoryEventId,
     },
     temporal::api::{
-        command::v1::Command,
+        command::v1::command,
         enums::v1::{CommandType, EventType},
         history::v1::{history_event, TimerFiredEventAttributes},
-        sdk::v1::UserMetadata,
     },
 };
 
@@ -50,7 +49,7 @@ fsm! {
 #[derive(Debug, derive_more::Display)]
 pub(super) enum TimerMachineCommand {
     Complete,
-    IssueCancelCmd(Command),
+    IssueCancelCmd(command::Attributes),
     // We don't issue activations for timer cancellations. Lang SDK is expected to cancel
     // it's own timers when user calls cancel, and they cannot be cancelled by any other
     // means.
@@ -73,21 +72,11 @@ pub(super) fn new_timer(attribs: StartTimer) -> NewMachineWithCommand {
 
 impl TimerMachine {
     /// Create a new timer and immediately schedule it
-    fn new_scheduled(attribs: StartTimer) -> (Self, Command) {
-        let mut attribs = attribs;
-        let user_metadata = attribs.summary.take().map(|x| UserMetadata {
-            summary: Some(x),
-            details: None,
-        });
-        let attribs = attribs;
+    fn new_scheduled(attribs: StartTimer) -> (Self, command::Attributes) {
         let mut s = Self::new(attribs);
         OnEventWrapper::on_event_mut(&mut s, TimerMachineEvents::Schedule)
             .expect("Scheduling timers doesn't fail");
-        let cmd = Command {
-            command_type: CommandType::StartTimer as i32,
-            attributes: Some(s.shared_state().attrs.clone().into()),
-            user_metadata,
-        };
+        let cmd = s.shared_state().attrs.clone().into();
         (s, cmd)
     }
 
@@ -215,13 +204,10 @@ impl StartCommandRecorded {
         self,
         dat: &mut SharedState,
     ) -> TimerMachineTransition<CancelTimerCommandCreated> {
-        let cmd = Command {
-            command_type: CommandType::CancelTimer as i32,
-            attributes: Some(CancelTimer { seq: dat.attrs.seq }.into()),
-            user_metadata: Default::default(),
-        };
         TransitionResult::ok(
-            vec![TimerMachineCommand::IssueCancelCmd(cmd)],
+            vec![TimerMachineCommand::IssueCancelCmd(
+                CancelTimer { seq: dat.attrs.seq }.into(),
+            )],
             CancelTimerCommandCreated::default(),
         )
     }
@@ -239,7 +225,9 @@ impl WFMachinesAdapter for TimerMachine {
                 seq: self.shared_state.attrs.seq,
             }
             .into()],
-            TimerMachineCommand::IssueCancelCmd(c) => vec![MachineResponse::IssueNewCommand(c)],
+            TimerMachineCommand::IssueCancelCmd(c) => {
+                vec![MachineResponse::IssueNewCommand(c.into())]
+            }
         })
     }
 }
@@ -249,7 +237,7 @@ impl Cancellable for TimerMachine {
         Ok(
             match OnEventWrapper::on_event_mut(self, TimerMachineEvents::Cancel)?.pop() {
                 Some(TimerMachineCommand::IssueCancelCmd(cmd)) => {
-                    vec![MachineResponse::IssueNewCommand(cmd)]
+                    vec![MachineResponse::IssueNewCommand(cmd.into())]
                 }
                 None => vec![],
                 x => panic!("Invalid cancel event response {x:?}"),

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -13,7 +13,7 @@ use rustfsm::{fsm, StateMachine, TransitionResult};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::UpsertWorkflowSearchAttributes,
     temporal::api::{
-        command::v1::{command, Command, UpsertWorkflowSearchAttributesCommandAttributes},
+        command::v1::{command, UpsertWorkflowSearchAttributesCommandAttributes},
         common::v1::SearchAttributes,
         enums::v1::CommandType,
         history::v1::history_event,
@@ -77,19 +77,13 @@ pub(super) fn upsert_search_attrs_internal(
 
 fn create_new(sa_map: SearchAttributes) -> NewMachineWithCommand {
     let sm = UpsertSearchAttributesMachine::from_parts(Created {}.into(), SharedState {});
-    let cmd = Command {
-        command_type: CommandType::UpsertWorkflowSearchAttributes as i32,
-        attributes: Some(
-            command::Attributes::UpsertWorkflowSearchAttributesCommandAttributes(
-                UpsertWorkflowSearchAttributesCommandAttributes {
-                    search_attributes: Some(sa_map),
-                },
-            ),
-        ),
-        user_metadata: Default::default(),
-    };
     NewMachineWithCommand {
-        command: cmd,
+        command: command::Attributes::UpsertWorkflowSearchAttributesCommandAttributes(
+            UpsertWorkflowSearchAttributesCommandAttributes {
+                search_attributes: Some(sa_map),
+            },
+        ),
+
         machine: sm.into(),
     }
 }
@@ -207,7 +201,7 @@ mod tests {
             AsJsonPayloadExt,
         },
         temporal::api::{
-            command::v1::command::Attributes,
+            command::v1::{command::Attributes, Command},
             common::v1::Payload,
             enums::v1::EventType,
             history::v1::{HistoryEvent, UpsertWorkflowSearchAttributesEventAttributes},

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -32,7 +32,8 @@ use crate::{
                 HistEventData,
             },
             CommandID, DrivenWorkflow, HistoryUpdate, InternalFlagsRef, LocalResolution,
-            OutgoingJob, RunBasics, WFCommand, WFMachinesError, WorkflowStartedInfo,
+            OutgoingJob, RunBasics, WFCommand, WFCommandVariant, WFMachinesError,
+            WorkflowStartedInfo,
         },
         ExecutingLAId, LocalActRequest, LocalActivityExecutionResult, LocalActivityResolution,
     },
@@ -61,11 +62,13 @@ use temporal_sdk_core_protos::{
         workflow_commands::ContinueAsNewWorkflowExecution,
     },
     temporal::api::{
-        command::v1::{command::Attributes as ProtoCmdAttrs, Command as ProtoCommand},
+        command::v1::{
+            command::Attributes as ProtoCmdAttrs, Command as ProtoCommand, CommandAttributesExt,
+        },
         enums::v1::EventType,
         history::v1::{history_event, HistoryEvent},
         protocol::v1::{message::SequencingId, Message as ProtocolMessage},
-        sdk::v1::WorkflowTaskCompletedMetadata,
+        sdk::v1::{UserMetadata, WorkflowTaskCompletedMetadata},
     },
 };
 
@@ -1156,6 +1159,7 @@ impl WorkflowMachines {
                         };
                         self.add_cmd_to_wf_task(
                             new_external_cancel(0, we, attrs.child_workflow_only, attrs.reason),
+                            None,
                             CommandIdKind::CoreInternal,
                         );
                     }
@@ -1165,6 +1169,7 @@ impl WorkflowMachines {
                         // workflows by users (but rather, just for them to search with).
                         self.add_cmd_to_wf_task(
                             upsert_search_attrs_internal(attrs),
+                            None,
                             CommandIdKind::NeverResolves,
                         );
                     }
@@ -1267,12 +1272,16 @@ impl WorkflowMachines {
     /// server.
     fn handle_driven_results(&mut self, results: Vec<WFCommand>) -> Result<()> {
         for cmd in results {
-            match cmd {
-                WFCommand::AddTimer(attrs) => {
+            match cmd.variant {
+                WFCommandVariant::AddTimer(attrs) => {
                     let seq = attrs.seq;
-                    self.add_cmd_to_wf_task(new_timer(attrs), CommandID::Timer(seq).into());
+                    self.add_cmd_to_wf_task(
+                        new_timer(attrs),
+                        cmd.metadata,
+                        CommandID::Timer(seq).into(),
+                    );
                 }
-                WFCommand::UpsertSearchAttributes(attrs) => {
+                WFCommandVariant::UpsertSearchAttributes(attrs) => {
                     self.drive_me
                         .search_attributes_update(attrs.search_attributes.clone());
                     self.add_cmd_to_wf_task(
@@ -1281,13 +1290,14 @@ impl WorkflowMachines {
                             self.observed_internal_flags.clone(),
                             self.replaying,
                         ),
+                        cmd.metadata,
                         CommandIdKind::NeverResolves,
                     );
                 }
-                WFCommand::CancelTimer(attrs) => {
+                WFCommandVariant::CancelTimer(attrs) => {
                     self.process_cancellation(CommandID::Timer(attrs.seq))?;
                 }
-                WFCommand::AddActivity(attrs) => {
+                WFCommandVariant::AddActivity(attrs) => {
                     let seq = attrs.seq;
                     let use_compat = self.determine_use_compatible_flag(
                         attrs.versioning_intent(),
@@ -1299,10 +1309,11 @@ impl WorkflowMachines {
                             self.observed_internal_flags.clone(),
                             use_compat,
                         ),
+                        cmd.metadata,
                         CommandID::Activity(seq).into(),
                     );
                 }
-                WFCommand::AddLocalActivity(attrs) => {
+                WFCommandVariant::AddLocalActivity(attrs) => {
                     let seq = attrs.seq;
                     let attrs: ValidScheduleLA =
                         ValidScheduleLA::from_schedule_la(attrs).map_err(|e| {
@@ -1322,30 +1333,30 @@ impl WorkflowMachines {
                         .insert(CommandID::LocalActivity(seq), machkey);
                     self.process_machine_responses(machkey, mach_resp)?;
                 }
-                WFCommand::RequestCancelActivity(attrs) => {
+                WFCommandVariant::RequestCancelActivity(attrs) => {
                     self.process_cancellation(CommandID::Activity(attrs.seq))?;
                 }
-                WFCommand::RequestCancelLocalActivity(attrs) => {
+                WFCommandVariant::RequestCancelLocalActivity(attrs) => {
                     self.process_cancellation(CommandID::LocalActivity(attrs.seq))?;
                 }
-                WFCommand::CompleteWorkflow(attrs) => {
-                    self.add_terminal_command(complete_workflow(attrs));
+                WFCommandVariant::CompleteWorkflow(attrs) => {
+                    self.add_terminal_command(complete_workflow(attrs), cmd.metadata);
                 }
-                WFCommand::FailWorkflow(attrs) => {
-                    self.add_terminal_command(fail_workflow(attrs));
+                WFCommandVariant::FailWorkflow(attrs) => {
+                    self.add_terminal_command(fail_workflow(attrs), cmd.metadata);
                 }
-                WFCommand::ContinueAsNew(attrs) => {
+                WFCommandVariant::ContinueAsNew(attrs) => {
                     let attrs = self.augment_continue_as_new_with_current_values(attrs);
                     let use_compat = self.determine_use_compatible_flag(
                         attrs.versioning_intent(),
                         &attrs.task_queue,
                     );
-                    self.add_terminal_command(continue_as_new(attrs, use_compat));
+                    self.add_terminal_command(continue_as_new(attrs, use_compat), cmd.metadata);
                 }
-                WFCommand::CancelWorkflow(attrs) => {
-                    self.add_terminal_command(cancel_workflow(attrs));
+                WFCommandVariant::CancelWorkflow(attrs) => {
+                    self.add_terminal_command(cancel_workflow(attrs), cmd.metadata);
                 }
-                WFCommand::SetPatchMarker(attrs) => {
+                WFCommandVariant::SetPatchMarker(attrs) => {
                     // Do not create commands for change IDs that we have already created commands
                     // for.
                     let encountered_entry = self.encountered_patch_markers.get(&attrs.patch_id);
@@ -1360,8 +1371,11 @@ impl WorkflowMachines {
                             self.encountered_patch_markers.keys().map(|s| s.as_str()),
                             self.observed_internal_flags.clone(),
                         )?;
-                        let mkey =
-                            self.add_cmd_to_wf_task(patch_machine, CommandIdKind::NeverResolves);
+                        let mkey = self.add_cmd_to_wf_task(
+                            patch_machine,
+                            cmd.metadata,
+                            CommandIdKind::NeverResolves,
+                        );
                         self.process_machine_responses(mkey, other_cmds)?;
 
                         if let Some(ci) = self.encountered_patch_markers.get_mut(&attrs.patch_id) {
@@ -1376,7 +1390,7 @@ impl WorkflowMachines {
                         }
                     }
                 }
-                WFCommand::AddChildWorkflow(attrs) => {
+                WFCommandVariant::AddChildWorkflow(attrs) => {
                     let seq = attrs.seq;
                     let use_compat = self.determine_use_compatible_flag(
                         attrs.versioning_intent(),
@@ -1388,13 +1402,14 @@ impl WorkflowMachines {
                             self.observed_internal_flags.clone(),
                             use_compat,
                         ),
+                        cmd.metadata,
                         CommandID::ChildWorkflowStart(seq).into(),
                     );
                 }
-                WFCommand::CancelChild(attrs) => self.process_cancellation(
+                WFCommandVariant::CancelChild(attrs) => self.process_cancellation(
                     CommandID::ChildWorkflowStart(attrs.child_workflow_seq),
                 )?,
-                WFCommand::RequestCancelExternalWorkflow(attrs) => {
+                WFCommandVariant::RequestCancelExternalWorkflow(attrs) => {
                     let we = attrs.workflow_execution.ok_or_else(|| {
                         WFMachinesError::Fatal(
                             "Cancel external workflow command had no workflow_execution field"
@@ -1408,30 +1423,33 @@ impl WorkflowMachines {
                             false,
                             format!("Cancel requested by workflow with run id {}", self.run_id),
                         ),
+                        cmd.metadata,
                         CommandID::CancelExternal(attrs.seq).into(),
                     );
                 }
-                WFCommand::SignalExternalWorkflow(attrs) => {
+                WFCommandVariant::SignalExternalWorkflow(attrs) => {
                     let seq = attrs.seq;
                     self.add_cmd_to_wf_task(
                         new_external_signal(attrs, &self.worker_config.namespace)?,
+                        cmd.metadata,
                         CommandID::SignalExternal(seq).into(),
                     );
                 }
-                WFCommand::CancelSignalWorkflow(attrs) => {
+                WFCommandVariant::CancelSignalWorkflow(attrs) => {
                     self.process_cancellation(CommandID::SignalExternal(attrs.seq))?;
                 }
-                WFCommand::QueryResponse(_) => {
+                WFCommandVariant::QueryResponse(_) => {
                     // Nothing to do here, queries are handled above the machine level
                     unimplemented!("Query responses should not make it down into the machines")
                 }
-                WFCommand::ModifyWorkflowProperties(attrs) => {
+                WFCommandVariant::ModifyWorkflowProperties(attrs) => {
                     self.add_cmd_to_wf_task(
                         modify_workflow_properties(attrs),
+                        cmd.metadata,
                         CommandIdKind::NeverResolves,
                     );
                 }
-                WFCommand::UpdateResponse(ur) => {
+                WFCommandVariant::UpdateResponse(ur) => {
                     let m_key = self.get_machine_by_msg(&ur.protocol_instance_id)?;
                     let mach = self.machine_mut(m_key);
                     if let Machines::UpdateMachine(m) = mach {
@@ -1445,7 +1463,7 @@ impl WorkflowMachines {
                         )));
                     }
                 }
-                WFCommand::NoCommandsFromLang => (),
+                WFCommandVariant::NoCommandsFromLang => (),
             }
         }
         Ok(())
@@ -1479,8 +1497,12 @@ impl WorkflowMachines {
             })?)
     }
 
-    fn add_terminal_command(&mut self, machine: NewMachineWithCommand) {
-        let cwfm = self.add_new_command_machine(machine);
+    fn add_terminal_command(
+        &mut self,
+        machine: NewMachineWithCommand,
+        metadata: Option<UserMetadata>,
+    ) {
+        let cwfm = self.add_new_command_machine(machine, metadata);
         self.workflow_end_time = Some(SystemTime::now());
         self.current_wf_task_commands.push_back(cwfm);
         // Wipe out any pending / executing local activity data since we're about to terminate
@@ -1492,9 +1514,10 @@ impl WorkflowMachines {
     fn add_cmd_to_wf_task(
         &mut self,
         machine: NewMachineWithCommand,
+        metadata: Option<UserMetadata>,
         id: CommandIdKind,
     ) -> MachineKey {
-        let mach = self.add_new_command_machine(machine);
+        let mach = self.add_new_command_machine(machine, metadata);
         let key = mach.machine;
         if let CommandIdKind::LangIssued(id) = id {
             self.id_to_machine.insert(id, key);
@@ -1506,10 +1529,19 @@ impl WorkflowMachines {
         key
     }
 
-    fn add_new_command_machine(&mut self, machine: NewMachineWithCommand) -> CommandAndMachine {
+    fn add_new_command_machine(
+        &mut self,
+        machine: NewMachineWithCommand,
+        metadata: Option<UserMetadata>,
+    ) -> CommandAndMachine {
         let k = self.all_machines.insert(machine.machine);
+        let cmd = ProtoCommand {
+            command_type: machine.command.as_type() as i32,
+            attributes: Some(machine.command),
+            user_metadata: metadata,
+        };
         CommandAndMachine {
-            command: MachineAssociatedCommand::Real(Box::new(machine.command)),
+            command: MachineAssociatedCommand::Real(Box::new(cmd)),
             machine: k,
         }
     }

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1609,7 +1609,7 @@ pub(crate) struct MachinesWFTResponseContent<'a> {
     pub(crate) have_pending_la_resolutions: bool,
 }
 
-impl<'a> MachinesWFTResponseContent<'a> {
+impl MachinesWFTResponseContent<'_> {
     pub(crate) fn commands(&self) -> Peekable<impl Iterator<Item = ProtoCommand> + '_> {
         self.me.get_commands().peekable()
     }

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -14,10 +14,16 @@ import "google/protobuf/empty.proto";
 import "temporal/api/common/v1/message.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/failure/v1/message.proto";
+import "temporal/api/sdk/v1/user_metadata.proto";
 import "temporal/sdk/core/child_workflow/child_workflow.proto";
 import "temporal/sdk/core/common/common.proto";
 
 message WorkflowCommand {
+    // User metadata that may or may not be persisted into history depending on the command type.
+    // Lang layers are expected to expose the setting of the internals of this metadata on a
+    // per-command basis where applicable.
+    temporal.api.sdk.v1.UserMetadata user_metadata = 100;
+
     oneof variant {
         StartTimer start_timer = 1;
         ScheduleActivity schedule_activity = 2;
@@ -46,8 +52,6 @@ message StartTimer {
     // Lang's incremental sequence number, used as the operation identifier
     uint32 seq = 1;
     google.protobuf.Duration start_to_fire_timeout = 2;
-    // Summary that is stored as user_metadata
-    temporal.api.common.v1.Payload summary = 3;
 }
 
 message CancelTimer {
@@ -90,8 +94,6 @@ message ScheduleActivity {
     bool do_not_eagerly_execute = 14;
     // Whether this activity should run on a worker with a compatible build id or not.
     coresdk.common.VersioningIntent versioning_intent = 15;
-    // Summary that is stored as user_metadata
-    temporal.api.common.v1.Payload summary = 16;
 }
 
 message ScheduleLocalActivity {
@@ -257,10 +259,6 @@ message StartChildWorkflowExecution {
     child_workflow.ChildWorkflowCancellationType cancellation_type = 18;
     // Whether this child should run on a worker with a compatible build id or not.
     coresdk.common.VersioningIntent versioning_intent = 19;
-    // Static summary of the child workflow
-    temporal.api.common.v1.Payload static_summary = 20;
-    // Static details of the child workflow
-    temporal.api.common.v1.Payload static_details = 21;
 }
 
 // Cancel a child workflow

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -605,7 +605,7 @@ pub mod coresdk {
                             r.seq,
                             r.result
                                 .as_ref()
-                                .unwrap_or_else(|| &ActivityResolution { status: None })
+                                .unwrap_or(&ActivityResolution { status: None })
                         )
                     }
                     workflow_activation_job::Variant::NotifyHasPatch(_) => {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -381,6 +381,7 @@ impl Worker {
 }
 
 impl WorkflowHalf {
+    #[allow(clippy::type_complexity)]
     fn workflow_activation_handler(
         &self,
         common: &CommonWorker,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -91,7 +91,7 @@ use temporal_sdk_core_protos::{
             resolve_child_workflow_execution_start::Status as ChildWorkflowStartStatus,
             workflow_activation_job::Variant, WorkflowActivation,
         },
-        workflow_commands::{workflow_command, ContinueAsNewWorkflowExecution},
+        workflow_commands::{workflow_command, ContinueAsNewWorkflowExecution, WorkflowCommand},
         workflow_completion::WorkflowActivationCompletion,
         ActivityTaskCompletion, AsJsonPayloadExt, FromJsonPayloadExt,
     },
@@ -747,7 +747,7 @@ enum RustWfCmd {
 }
 
 struct CommandCreateRequest {
-    cmd: workflow_command::Variant,
+    cmd: WorkflowCommand,
     unblocker: oneshot::Sender<UnblockEvent>,
 }
 

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -217,7 +217,7 @@ impl WfContext {
         let (cmd, unblocker) = CancellableWFCommandFut::new(CancellableID::LocalActivity(seq));
         self.send(
             CommandCreateRequest {
-                cmd: opts.into_command(seq).into(),
+                cmd: opts.into_command(seq),
                 unblocker,
             }
             .into(),
@@ -599,8 +599,8 @@ impl<'a> LATimerBackoffFut<'a> {
         }
     }
 }
-impl<'a> Unpin for LATimerBackoffFut<'a> {}
-impl<'a> Future for LATimerBackoffFut<'a> {
+impl Unpin for LATimerBackoffFut<'_> {}
+impl Future for LATimerBackoffFut<'_> {
     type Output = ActivityResolution;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -655,7 +655,7 @@ impl<'a> Future for LATimerBackoffFut<'a> {
         poll_res
     }
 }
-impl<'a> CancellableFuture<ActivityResolution> for LATimerBackoffFut<'a> {
+impl CancellableFuture<ActivityResolution> for LATimerBackoffFut<'_> {
     fn cancel(&self, ctx: &WfContext) {
         self.did_cancel.store(true, Ordering::Release);
         if let Some(tf) = self.timer_fut.as_ref() {
@@ -737,7 +737,7 @@ impl ChildWorkflow {
             CancellableWFCommandFut::new_with_dat(CancellableID::ChildWorkflow(child_seq), common);
         cx.send(
             CommandCreateRequest {
-                cmd: self.opts.into_command(child_seq).into(),
+                cmd: self.opts.into_command(child_seq),
                 unblocker,
             }
             .into(),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -717,7 +717,6 @@ pub fn start_timer_cmd(seq: u32, duration: Duration) -> workflow_command::Varian
     StartTimer {
         seq,
         start_to_fire_timeout: Some(duration.try_into().expect("duration fits")),
-        summary: None,
     }
     .into()
 }
@@ -782,7 +781,6 @@ where
             vec![StartTimer {
                 seq,
                 start_to_fire_timeout: Some(duration.try_into().expect("duration fits")),
-                summary: None,
             }
             .into()],
         ))

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -41,7 +41,6 @@ async fn out_of_order_completion_doesnt_hang() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
-                summary: None,
             }
             .into(),
         ]

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -28,13 +28,11 @@ async fn simple_query_legacy() {
             StartTimer {
                 seq: 0,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(500))),
-                summary: None,
             }
             .into(),
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_secs(3))),
-                summary: None,
             }
             .into(),
         ],

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -200,7 +200,6 @@ async fn fail_wf_task(#[values(true, false)] replay: bool) {
         vec![StartTimer {
             seq: 0,
             start_to_fire_timeout: Some(prost_dur!(from_millis(200))),
-            summary: None,
         }
         .into()],
     ))
@@ -325,7 +324,6 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
             vec![StartTimer {
                 seq: 0,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(10))),
-                summary: None,
             }
             .into()],
         ))

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -360,7 +360,6 @@ async fn activity_cancellation_try_cancel() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
-                summary: None,
             }
             .into(),
         ]
@@ -418,7 +417,6 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
-                summary: None,
             }
             .into(),
         ]
@@ -463,7 +461,6 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
         vec![StartTimer {
             seq: 2,
             start_to_fire_timeout: Some(prost_dur!(from_millis(100))),
-            summary: None,
         }
         .into()],
     ))
@@ -562,7 +559,6 @@ async fn activity_cancellation_wait_cancellation_completed() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
-                summary: None,
             }
             .into(),
         ]
@@ -625,7 +621,6 @@ async fn activity_cancellation_abandon() {
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
-                summary: None,
             }
             .into(),
         ]

--- a/tests/integ_tests/workflow_tests/replay.rs
+++ b/tests/integ_tests/workflow_tests/replay.rs
@@ -42,7 +42,6 @@ async fn timer_workflow_replay() {
         vec![StartTimer {
             seq: 0,
             start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
-            summary: None,
         }
         .into()],
     ))

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -38,7 +38,6 @@ async fn timer_workflow_manual() {
         vec![StartTimer {
             seq: 0,
             start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
-            summary: None,
         }
         .into()],
     ))
@@ -62,13 +61,11 @@ async fn timer_cancel_workflow() {
             StartTimer {
                 seq: 0,
                 start_to_fire_timeout: Some(prost_dur!(from_millis(50))),
-                summary: None,
             }
             .into(),
             StartTimer {
                 seq: 1,
                 start_to_fire_timeout: Some(prost_dur!(from_secs(10))),
-                summary: None,
             }
             .into(),
         ],


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Moved user metadata for commands from existing on a per-variant basis to a per-command basis

## Why?
More closely matches the server, requires fewer changes in the future.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
