### PR TITLE
Fix DB filename argument for ephemeral server

### DIFF
--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -101,7 +101,7 @@ impl TemporalDevServerConfig {
             "frontend.enableUpdateWorkflowExecutionAsyncAccepted=true".to_owned(),
         ];
         if let Some(db_filename) = &self.db_filename {
-            args.push("--filename".to_owned());
+            args.push("--db-filename".to_owned());
             args.push(db_filename.clone());
         }
         if let Some(ui_port) = self.ui_port {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This is a relatively simple fix: the ephemeral server code isn't using the correct option name for setting the SQLite filename argument.

## Why?
I didn't check old versions of the ephemeral server, but I am at least confident that for `temporal version 1.0.0 (Server 1.24.2, UI 2.28.0)`, the current flag is incorrect.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Ran the updated SDK against our internal codebase and validated that the flag worked. I can add a regression test if y'all like, but wasn't sure if it was worth it here.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
