### PR TITLE
disable tracing-log feature for tracing-subscriber

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,7 +67,7 @@ tokio-util = { version = "0.7", features = ["io", "io-util"] }
 tokio-stream = "0.1"
 tonic = { workspace = true, features = ["tls", "tls-roots"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["parking_lot", "env-filter", "registry"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["parking_lot", "env-filter", "registry", "ansi"] }
 url = "2.2"
 uuid = { version = "1.1", features = ["v4"] }
 zip = { version = "2.0", optional = true }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -20,7 +20,6 @@ async-trait = "0.1"
 base64 = "0.22"
 bytes = "1.3"
 futures-util = { version = "0.3", default-features = false }
-log = "0.4"
 parking_lot = "0.12"
 prost = { workspace = true }
 prost-types = { workspace = true }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Disable the `tracing-log` feature for `tracing-subscriber` by turning off [default features](https://github.com/tokio-rs/tracing/blob/master/tracing-subscriber/Cargo.toml#L27). The `ansi` feature was explicitly listed because it's used in the code.

## Why?
I am trying to use `core` crate from Temporal SDK in a Rust application that already uses `tracing-subscriber`. However, it fails to initialize the subscriber because `core` depends on `tracing-subscriber` with `tracing-log` feature enabled. This behavior is documented [here](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/util/trait.SubscriberInitExt.html#method.try_init):

> This method panics if a global default subscriber has already been set, or if a log logger has already been set (when the “tracing-log” feature is enabled).

In a perfect world, `core` would not depend on `tracing-subscribers` since it is a [library](https://github.com/tokio-rs/tracing?tab=readme-ov-file#in-libraries), but I propose this as an immediate fix.
