### PR TITLE
Rust / Packages upgrade

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.84.0
+          toolchain: 1.85.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.84.0
+          toolchain: 1.85.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.84.0
+          toolchain: 1.85.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.84.0
+          toolchain: 1.85.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license-file = "LICENSE.txt"
 
 [workspace.dependencies]
 derive_builder = "0.20"
-derive_more = { version = "1.0", features = ["constructor", "display", "from", "into", "debug"] }
+derive_more = { version = "2.0", features = ["constructor", "display", "from", "into", "debug"] }
 thiserror = "2"
 tonic = "0.12"
 tonic-build = "0.12"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,7 +28,6 @@ hyper = { version = "1.4.1" }
 hyper-util = "0.1.6"
 opentelemetry = { workspace = true, features = ["metrics"], optional = true }
 parking_lot = "0.12"
-prost-types = { workspace = true }
 slotmap = "1.0"
 thiserror = { workspace = true }
 tokio = "1.1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temporal-client"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Spencer Judge <spencer@temporal.io>"]
 license-file = { workspace = true }
 description = "Clients for interacting with Temporal Clusters"

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -1,5 +1,5 @@
 use crate::{AttachMetricLabels, CallType};
-use futures_util::{future::BoxFuture, FutureExt};
+use futures_util::{FutureExt, future::BoxFuture};
 use std::{
     sync::Arc,
     task::{Context, Poll},
@@ -9,7 +9,7 @@ use temporal_sdk_core_api::telemetry::metrics::{
     CoreMeter, Counter, HistogramDuration, MetricAttributes, MetricKeyValue, MetricParameters,
     TemporalMeter,
 };
-use tonic::{body::BoxBody, transport::Channel, Code};
+use tonic::{Code, body::BoxBody, transport::Channel};
 use tower::Service;
 
 /// The string name (which may be prefixed) for this metric

--- a/client/src/proxy.rs
+++ b/client/src/proxy.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use tokio::net::TcpStream;
 use tonic::transport::{Channel, Endpoint};
-use tower::{service_fn, Service};
+use tower::{Service, service_fn};
 
 /// Options for HTTP CONNECT proxy.
 #[derive(Clone, Debug)]

--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -3,13 +3,13 @@
 //! happen.
 
 use crate::{
+    Client, ConfiguredClient, InterceptedMetricsSvc, LONG_POLL_TIMEOUT, RequestExt, RetryClient,
+    TEMPORAL_NAMESPACE_HEADER_KEY, TemporalServiceClient,
     metrics::{namespace_kv, task_queue_kv},
     raw::sealed::RawClientLike,
     worker_registry::{Slot, SlotManager},
-    Client, ConfiguredClient, InterceptedMetricsSvc, RequestExt, RetryClient,
-    TemporalServiceClient, LONG_POLL_TIMEOUT, TEMPORAL_NAMESPACE_HEADER_KEY,
 };
-use futures_util::{future::BoxFuture, FutureExt, TryFutureExt};
+use futures_util::{FutureExt, TryFutureExt, future::BoxFuture};
 use std::sync::Arc;
 use temporal_sdk_core_api::telemetry::metrics::MetricKeyValue;
 use temporal_sdk_core_protos::{
@@ -23,10 +23,10 @@ use temporal_sdk_core_protos::{
     },
 };
 use tonic::{
+    Request, Response, Status,
     body::BoxBody,
     client::GrpcService,
     metadata::{AsciiMetadataValue, KeyAndValueRef},
-    Request, Response, Status,
 };
 
 pub(super) mod sealed {
@@ -1411,29 +1411,33 @@ mod tests {
     #[test]
     fn verify_all_workflow_service_methods_implemented() {
         // This is less work than trying to hook into the codegen process
-        let proto_def =
-            include_str!("../../sdk-core-protos/protos/api_upstream/temporal/api/workflowservice/v1/service.proto");
+        let proto_def = include_str!(
+            "../../sdk-core-protos/protos/api_upstream/temporal/api/workflowservice/v1/service.proto"
+        );
         verify_methods(proto_def, ALL_IMPLEMENTED_WORKFLOW_SERVICE_RPCS);
     }
 
     #[test]
     fn verify_all_operator_service_methods_implemented() {
-        let proto_def =
-            include_str!("../../sdk-core-protos/protos/api_upstream/temporal/api/operatorservice/v1/service.proto");
+        let proto_def = include_str!(
+            "../../sdk-core-protos/protos/api_upstream/temporal/api/operatorservice/v1/service.proto"
+        );
         verify_methods(proto_def, ALL_IMPLEMENTED_OPERATOR_SERVICE_RPCS);
     }
 
     #[test]
     fn verify_all_cloud_service_methods_implemented() {
-        let proto_def =
-            include_str!("../../sdk-core-protos/protos/api_cloud_upstream/temporal/api/cloud/cloudservice/v1/service.proto");
+        let proto_def = include_str!(
+            "../../sdk-core-protos/protos/api_cloud_upstream/temporal/api/cloud/cloudservice/v1/service.proto"
+        );
         verify_methods(proto_def, ALL_IMPLEMENTED_CLOUD_SERVICE_RPCS);
     }
 
     #[test]
     fn verify_all_test_service_methods_implemented() {
-        let proto_def =
-            include_str!("../../sdk-core-protos/protos/testsrv_upstream/temporal/api/testservice/v1/service.proto");
+        let proto_def = include_str!(
+            "../../sdk-core-protos/protos/testsrv_upstream/temporal/api/testservice/v1/service.proto"
+        );
         verify_methods(proto_def, ALL_IMPLEMENTED_TEST_SERVICE_RPCS);
     }
 

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -1,7 +1,7 @@
 use crate::{
-    raw::IsUserLongPoll, Client, IsWorkerTaskLongPoll, NamespacedClient, Result, RetryConfig,
+    Client, IsWorkerTaskLongPoll, NamespacedClient, Result, RetryConfig, raw::IsUserLongPoll,
 };
-use backoff::{backoff::Backoff, exponential::ExponentialBackoff, Clock, SystemClock};
+use backoff::{Clock, SystemClock, backoff::Backoff, exponential::ExponentialBackoff};
 use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
 use std::{error::Error, fmt::Debug, future::Future, sync::Arc, time::Duration};
 use tonic::{Code, Request};

--- a/client/src/worker_registry/mod.rs
+++ b/client/src/worker_registry/mod.rs
@@ -4,7 +4,7 @@
 
 use parking_lot::RwLock;
 use slotmap::SlotMap;
-use std::collections::{hash_map::Entry::Vacant, HashMap};
+use std::collections::{HashMap, hash_map::Entry::Vacant};
 
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse;
 

--- a/core-api/Cargo.toml
+++ b/core-api/Cargo.toml
@@ -21,7 +21,6 @@ derive_builder = { workspace = true }
 derive_more = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 prost = { workspace = true }
-prost-types = { workspace = true }
 serde_json = "1.0"
 thiserror = { workspace = true }
 tonic = { workspace = true }

--- a/core-api/Cargo.toml
+++ b/core-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temporal-sdk-core-api"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Spencer Judge <spencer@temporal.io>"]
 license-file = { workspace = true }
 description = "Interface definitions for the Temporal Core SDK"

--- a/core-api/src/lib.rs
+++ b/core-api/src/lib.rs
@@ -10,11 +10,11 @@ use crate::{
     worker::WorkerConfig,
 };
 use temporal_sdk_core_protos::coresdk::{
+    ActivityHeartbeat, ActivityTaskCompletion,
     activity_task::ActivityTask,
     nexus::{NexusTask, NexusTaskCompletion},
     workflow_activation::WorkflowActivation,
     workflow_completion::WorkflowActivationCompletion,
-    ActivityHeartbeat, ActivityTaskCompletion,
 };
 
 /// This trait is the primary way by which language specific SDKs interact with the core SDK.

--- a/core-api/src/telemetry/metrics.rs
+++ b/core-api/src/telemetry/metrics.rs
@@ -345,7 +345,7 @@ impl CustomMetricAttributes for NoOpAttributes {
 #[cfg(feature = "otel_impls")]
 mod otel_impls {
     use super::*;
-    use opentelemetry::{metrics, KeyValue};
+    use opentelemetry::{KeyValue, metrics};
 
     impl From<MetricKeyValue> for KeyValue {
         fn from(kv: MetricKeyValue) -> Self {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "temporal-sdk-core"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>", "Vitaly Arbuzov <vitaly@temporal.io>"]
-edition = "2021"
+edition = "2024"
 license-file = { workspace = true }
 description = "Library for building new Temporal SDKs"
 homepage = "https://temporal.io/"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,12 +35,12 @@ enum-iterator = "2"
 flate2 = { version = "1.0", optional = true }
 futures-util = { version = "0.3", default-features = false }
 futures-channel = { version = "0.3", default-features = false, features = ["std"] }
-governor = "0.7"
+governor = "0.8"
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.2", optional = true }
 hyper-util = { version = "0.1", features = ["server", "http1", "http2", "tokio"], optional = true }
-itertools = "0.13"
-lru = "0.12"
+itertools = "0.14"
+lru = "0.13"
 mockall = "0.13"
 opentelemetry = { workspace = true, features = ["metrics"], optional = true }
 opentelemetry_sdk = { version = "0.26", features = ["rt-tokio", "metrics"], optional = true }
@@ -52,14 +52,14 @@ pin-project = "1.0"
 prometheus = "0.13"
 prost = { workspace = true }
 prost-types = { version = "0.6", package = "prost-wkt-types" }
-rand = "0.8.3"
+rand = "0.9"
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls-native-roots"], default-features = false, optional = true }
 ringbuf = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 siphasher = "1.0"
 slotmap = "1.0"
-sysinfo = { version = "0.32", default-features = false, features = ["system"] }
+sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 tar = { version = "0.4", optional = true }
 thiserror = { workspace = true }
 tokio = { version = "1.37", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs", "process"] }

--- a/core/benches/workflow_replay.rs
+++ b/core/benches/workflow_replay.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use futures_util::StreamExt;
 use std::time::Duration;
 use temporal_sdk::{WfContext, WorkflowFunction};

--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -6,8 +6,8 @@ use crate::MetricsContext;
 use std::{
     fmt::{Debug, Formatter},
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 use temporal_sdk_core_api::worker::{

--- a/core/src/core_tests/child_workflows.rs
+++ b/core/src/core_tests/child_workflows.rs
@@ -1,8 +1,8 @@
 use crate::{
     replay::DEFAULT_WORKFLOW_TYPE,
     test_help::{
-        build_fake_sdk, canned_histories, mock_sdk, mock_sdk_cfg, mock_worker, single_hist_mock_sg,
-        MockPollCfg, ResponseType,
+        MockPollCfg, ResponseType, build_fake_sdk, canned_histories, mock_sdk, mock_sdk_cfg,
+        mock_worker, single_hist_mock_sg,
     },
     worker::client::mocks::mock_workflow_client,
 };
@@ -11,8 +11,8 @@ use temporal_sdk::{ChildWorkflowOptions, Signal, WfContext, WorkflowResult};
 use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::{
     coresdk::{
-        child_workflow::{child_workflow_result, ChildWorkflowCancellationType},
-        workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        child_workflow::{ChildWorkflowCancellationType, child_workflow_result},
+        workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_commands::{
             CancelChildWorkflowExecution, CompleteWorkflowExecution, StartChildWorkflowExecution,
         },

--- a/core/src/core_tests/determinism.rs
+++ b/core/src/core_tests/determinism.rs
@@ -1,7 +1,7 @@
 use crate::{
     internal_flags::CoreInternalFlags,
     replay::DEFAULT_WORKFLOW_TYPE,
-    test_help::{canned_histories, mock_sdk, mock_sdk_cfg, MockPollCfg, ResponseType},
+    test_help::{MockPollCfg, ResponseType, canned_histories, mock_sdk, mock_sdk_cfg},
     worker::client::mocks::mock_workflow_client,
 };
 use std::{
@@ -13,11 +13,11 @@ use temporal_sdk::{
     ActivityOptions, ChildWorkflowOptions, LocalActivityOptions, WfContext, WorkflowResult,
 };
 use temporal_sdk_core_protos::{
+    DEFAULT_ACTIVITY_TYPE, TestHistoryBuilder,
     temporal::api::{
         enums::v1::{EventType, WorkflowTaskFailedCause},
         failure::v1::Failure,
     },
-    TestHistoryBuilder, DEFAULT_ACTIVITY_TYPE,
 };
 
 static DID_FAIL: AtomicBool = AtomicBool::new(false);

--- a/core/src/core_tests/local_activities.rs
+++ b/core/src/core_tests/local_activities.rs
@@ -1,21 +1,21 @@
 use crate::{
     prost_dur,
-    replay::{default_wes_attribs, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE},
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, default_wes_attribs},
     test_help::{
-        build_mock_pollers, hist_to_poll_resp, mock_sdk, mock_sdk_cfg, mock_worker,
-        single_hist_mock_sg, MockPollCfg, ResponseType, WorkerExt,
+        MockPollCfg, ResponseType, WorkerExt, build_mock_pollers, hist_to_poll_resp, mock_sdk,
+        mock_sdk_cfg, mock_worker, single_hist_mock_sg,
     },
-    worker::{client::mocks::mock_workflow_client, LEGACY_QUERY_ID},
+    worker::{LEGACY_QUERY_ID, client::mocks::mock_workflow_client},
 };
 use anyhow::anyhow;
 use crossbeam_queue::SegQueue;
-use futures_util::{future::join_all, FutureExt};
+use futures_util::{FutureExt, future::join_all};
 use std::{
     collections::HashMap,
     ops::Sub,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     time::{Duration, Instant, SystemTime},
 };
@@ -23,25 +23,25 @@ use temporal_client::WorkflowOptions;
 use temporal_sdk::{
     ActContext, ActivityError, LocalActivityOptions, WfContext, WorkflowFunction, WorkflowResult,
 };
-use temporal_sdk_core_api::{errors::PollError, Worker};
+use temporal_sdk_core_api::{Worker, errors::PollError};
 use temporal_sdk_core_protos::{
+    DEFAULT_ACTIVITY_TYPE,
     coresdk::{
+        ActivityTaskCompletion, AsJsonPayloadExt,
         activity_result::ActivityExecutionResult,
-        workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_commands::{ActivityCancellationType, ScheduleLocalActivity},
         workflow_completion::WorkflowActivationCompletion,
-        ActivityTaskCompletion, AsJsonPayloadExt,
     },
     temporal::api::{
         common::v1::RetryPolicy,
         enums::v1::{CommandType, EventType, TimeoutType, WorkflowTaskFailedCause},
-        failure::v1::{failure::FailureInfo, Failure},
+        failure::v1::{Failure, failure::FailureInfo},
         query::v1::WorkflowQuery,
     },
-    DEFAULT_ACTIVITY_TYPE,
 };
 use temporal_sdk_core_test_utils::{
-    query_ok, schedule_local_activity_cmd, start_timer_cmd, WorkerTestHelpers,
+    WorkerTestHelpers, query_ok, schedule_local_activity_cmd, start_timer_cmd,
 };
 use tokio::{join, select, sync::Barrier};
 

--- a/core/src/core_tests/mod.rs
+++ b/core/src/core_tests/mod.rs
@@ -10,10 +10,10 @@ mod workflow_cancels;
 mod workflow_tasks;
 
 use crate::{
-    errors::PollError,
-    test_help::{build_mock_pollers, canned_histories, mock_worker, test_worker_cfg, MockPollCfg},
-    worker::client::mocks::{mock_manual_workflow_client, mock_workflow_client},
     Worker,
+    errors::PollError,
+    test_help::{MockPollCfg, build_mock_pollers, canned_histories, mock_worker, test_worker_cfg},
+    worker::client::mocks::{mock_manual_workflow_client, mock_workflow_client},
 };
 use futures_util::FutureExt;
 use std::{sync::LazyLock, time::Duration};

--- a/core/src/core_tests/queries.rs
+++ b/core/src/core_tests/queries.rs
@@ -1,9 +1,9 @@
 use crate::{
     test_help::{
-        build_mock_pollers, canned_histories, hist_to_poll_resp, mock_worker, single_hist_mock_sg,
-        MockPollCfg, MocksHolder, ResponseType, WorkerExt,
+        MockPollCfg, MocksHolder, ResponseType, WorkerExt, build_mock_pollers, canned_histories,
+        hist_to_poll_resp, mock_worker, single_hist_mock_sg,
     },
-    worker::{client::mocks::mock_workflow_client, LEGACY_QUERY_ID},
+    worker::{LEGACY_QUERY_ID, client::mocks::mock_workflow_client},
 };
 use futures_util::stream;
 use std::{
@@ -12,13 +12,14 @@ use std::{
 };
 use temporal_sdk_core_api::Worker as WorkerTrait;
 use temporal_sdk_core_protos::{
+    TestHistoryBuilder,
     coresdk::{
         workflow_activation::{
-            remove_from_cache::EvictionReason, workflow_activation_job, WorkflowActivationJob,
+            WorkflowActivationJob, remove_from_cache::EvictionReason, workflow_activation_job,
         },
         workflow_commands::{
-            query_result, ActivityCancellationType, CompleteWorkflowExecution,
-            ContinueAsNewWorkflowExecution, QueryResult, RequestCancelActivity,
+            ActivityCancellationType, CompleteWorkflowExecution, ContinueAsNewWorkflowExecution,
+            QueryResult, RequestCancelActivity, query_result,
         },
         workflow_completion::WorkflowActivationCompletion,
     },
@@ -26,16 +27,15 @@ use temporal_sdk_core_protos::{
         common::v1::Payload,
         enums::v1::{CommandType, EventType},
         failure::v1::Failure,
-        history::v1::{history_event, ActivityTaskCancelRequestedEventAttributes, History},
+        history::v1::{ActivityTaskCancelRequestedEventAttributes, History, history_event},
         query::v1::WorkflowQuery,
         workflowservice::v1::{
             GetWorkflowExecutionHistoryResponse, RespondWorkflowTaskCompletedResponse,
         },
     },
-    TestHistoryBuilder,
 };
 use temporal_sdk_core_test_utils::{
-    query_ok, schedule_activity_cmd, start_timer_cmd, WorkerTestHelpers,
+    WorkerTestHelpers, query_ok, schedule_activity_cmd, start_timer_cmd,
 };
 
 #[rstest::rstest]
@@ -826,7 +826,7 @@ async fn legacy_query_combined_with_timer_fire_repro() {
     assert_matches!(
         task.jobs.as_slice(),
         [WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::QueryWorkflow(ref q)),
+            variant: Some(workflow_activation_job::Variant::QueryWorkflow(q)),
         }]
         if q.query_id == "the-query"
     );
@@ -844,7 +844,7 @@ async fn legacy_query_combined_with_timer_fire_repro() {
     assert_matches!(
         task.jobs.as_slice(),
         [WorkflowActivationJob {
-            variant: Some(workflow_activation_job::Variant::QueryWorkflow(ref q)),
+            variant: Some(workflow_activation_job::Variant::QueryWorkflow(q)),
         }]
         if q.query_id == LEGACY_QUERY_ID
     );

--- a/core/src/core_tests/replay_flag.rs
+++ b/core/src/core_tests/replay_flag.rs
@@ -1,21 +1,21 @@
 use crate::{
     test_help::{
-        build_fake_sdk, build_mock_pollers, canned_histories, hist_to_poll_resp, mock_worker,
-        MockPollCfg, ResponseType,
+        MockPollCfg, ResponseType, build_fake_sdk, build_mock_pollers, canned_histories,
+        hist_to_poll_resp, mock_worker,
     },
-    worker::{client::mocks::mock_workflow_client, LEGACY_QUERY_ID},
+    worker::{LEGACY_QUERY_ID, client::mocks::mock_workflow_client},
 };
 use rstest::{fixture, rstest};
 use std::{collections::VecDeque, time::Duration};
 use temporal_sdk::{WfContext, Worker, WorkflowFunction};
 use temporal_sdk_core_api::Worker as CoreWorker;
 use temporal_sdk_core_protos::{
+    DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder,
     coresdk::{
-        workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_completion::WorkflowActivationCompletion,
     },
     temporal::api::{enums::v1::EventType, query::v1::WorkflowQuery},
-    TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE,
 };
 use temporal_sdk_core_test_utils::{
     interceptors::ActivationAssertionsInterceptor, query_ok, start_timer_cmd,

--- a/core/src/core_tests/updates.rs
+++ b/core/src/core_tests/updates.rs
@@ -1,18 +1,19 @@
 use crate::{
     prost_dur,
     test_help::{
-        build_mock_pollers, hist_to_poll_resp, mock_worker, MockPollCfg, PollWFTRespExt,
-        ResponseType,
+        MockPollCfg, PollWFTRespExt, ResponseType, build_mock_pollers, hist_to_poll_resp,
+        mock_worker,
     },
     worker::client::mocks::mock_workflow_client,
 };
 use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::{
+    DEFAULT_ACTIVITY_TYPE, TestHistoryBuilder,
     coresdk::{
-        workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_commands::{
-            update_response::Response, CompleteWorkflowExecution, ScheduleActivity, StartTimer,
-            UpdateResponse,
+            CompleteWorkflowExecution, ScheduleActivity, StartTimer, UpdateResponse,
+            update_response::Response,
         },
         workflow_completion::WorkflowActivationCompletion,
     },
@@ -22,7 +23,6 @@ use temporal_sdk_core_protos::{
         update::v1::{Acceptance, Rejection},
         workflowservice::v1::RespondWorkflowTaskCompletedResponse,
     },
-    TestHistoryBuilder, DEFAULT_ACTIVITY_TYPE,
 };
 use temporal_sdk_core_test_utils::WorkerTestHelpers;
 

--- a/core/src/core_tests/workers.rs
+++ b/core/src/core_tests/workers.rs
@@ -1,17 +1,16 @@
 use crate::{
-    prost_dur,
+    PollError, prost_dur,
     test_help::{
-        build_fake_worker, build_mock_pollers, canned_histories, mock_worker, test_worker_cfg,
-        MockPollCfg, MockWorkerInputs, MocksHolder, ResponseType, WorkerExt,
+        MockPollCfg, MockWorkerInputs, MocksHolder, ResponseType, WorkerExt, build_fake_worker,
+        build_mock_pollers, canned_histories, mock_worker, test_worker_cfg,
     },
     worker::{
         self,
         client::{
-            mocks::{mock_workflow_client, DEFAULT_TEST_CAPABILITIES, DEFAULT_WORKERS_REGISTRY},
             MockWorkerClient,
+            mocks::{DEFAULT_TEST_CAPABILITIES, DEFAULT_WORKERS_REGISTRY, mock_workflow_client},
         },
     },
-    PollError,
 };
 use futures_util::{stream, stream::StreamExt};
 use std::{cell::RefCell, time::Duration};
@@ -19,15 +18,15 @@ use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::{
     coresdk::{
         workflow_activation::workflow_activation_job,
-        workflow_commands::{workflow_command, CompleteWorkflowExecution, StartTimer},
+        workflow_commands::{CompleteWorkflowExecution, StartTimer, workflow_command},
         workflow_completion::WorkflowActivationCompletion,
     },
     temporal::api::workflowservice::v1::{
         PollWorkflowTaskQueueResponse, RespondWorkflowTaskCompletedResponse, ShutdownWorkerResponse,
     },
 };
-use temporal_sdk_core_test_utils::{start_timer_cmd, WorkerTestHelpers};
-use tokio::sync::{watch, Barrier};
+use temporal_sdk_core_test_utils::{WorkerTestHelpers, start_timer_cmd};
+use tokio::sync::{Barrier, watch};
 
 #[tokio::test]
 async fn after_shutdown_of_worker_get_shutdown_err() {

--- a/core/src/core_tests/workflow_cancels.rs
+++ b/core/src/core_tests/workflow_cancels.rs
@@ -1,14 +1,14 @@
 use crate::{
     job_assert,
     test_help::{
-        build_fake_worker, canned_histories, gen_assert_and_reply, poll_and_reply, ResponseType,
-        WorkflowCachingPolicy::NonSticky,
+        ResponseType, WorkflowCachingPolicy::NonSticky, build_fake_worker, canned_histories,
+        gen_assert_and_reply, poll_and_reply,
     },
 };
 use rstest::rstest;
 use std::time::Duration;
 use temporal_sdk_core_protos::coresdk::{
-    workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+    workflow_activation::{WorkflowActivationJob, workflow_activation_job},
     workflow_commands::{
         CancelWorkflowExecution, CompleteWorkflowExecution, FailWorkflowExecution,
     },

--- a/core/src/ephemeral_server/mod.rs
+++ b/core/src/ephemeral_server/mod.rs
@@ -13,7 +13,7 @@ use std::{
 use temporal_client::ClientOptionsBuilder;
 use tokio::{
     task::spawn_blocking,
-    time::{sleep, Duration},
+    time::{Duration, sleep},
 };
 use tokio_util::io::{StreamReader, SyncIoBridge};
 use url::Url;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -50,8 +50,8 @@ pub use worker::{
 use crate::{
     replay::{HistoryForReplay, ReplayWorkerInput},
     telemetry::{
-        metrics::MetricsContext, remove_trace_subscriber_for_current_thread,
-        set_trace_subscriber_for_current_thread, telemetry_init, TelemetryInstance,
+        TelemetryInstance, metrics::MetricsContext, remove_trace_subscriber_for_current_thread,
+        set_trace_subscriber_for_current_thread, telemetry_init,
     },
     worker::client::WorkerClientBag,
 };
@@ -60,9 +60,9 @@ use futures_util::Stream;
 use std::sync::Arc;
 use temporal_client::{ConfiguredClient, NamespacedClient, TemporalServiceClientWithMetrics};
 use temporal_sdk_core_api::{
+    Worker as WorkerTrait,
     errors::{CompleteActivityError, PollError},
     telemetry::TelemetryOptions,
-    Worker as WorkerTrait,
 };
 use temporal_sdk_core_protos::coresdk::ActivityHeartbeat;
 

--- a/core/src/pollers/mod.rs
+++ b/core/src/pollers/mod.rs
@@ -1,7 +1,7 @@
 mod poll_buffer;
 
 pub(crate) use poll_buffer::{
-    new_activity_task_buffer, new_nexus_task_buffer, new_workflow_task_buffer, WorkflowTaskPoller,
+    WorkflowTaskPoller, new_activity_task_buffer, new_nexus_task_buffer, new_workflow_task_buffer,
 };
 pub use temporal_client::{
     Client, ClientOptions, ClientOptionsBuilder, ClientTlsConfig, RetryClient, RetryConfig,
@@ -13,7 +13,7 @@ use crate::{
     telemetry::metrics::MetricsContext,
 };
 use anyhow::{anyhow, bail};
-use futures_util::{stream, Stream};
+use futures_util::{Stream, stream};
 use std::{fmt::Debug, marker::PhantomData};
 use temporal_sdk_core_api::worker::{ActivitySlotKind, NexusSlotKind, SlotKind, WorkflowSlotKind};
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::{

--- a/core/src/pollers/poll_buffer.rs
+++ b/core/src/pollers/poll_buffer.rs
@@ -1,16 +1,16 @@
 use crate::{
-    abstractions::{dbg_panic, MeteredPermitDealer, OwnedMeteredSemPermit},
+    abstractions::{MeteredPermitDealer, OwnedMeteredSemPermit, dbg_panic},
     pollers::{self, Poller},
     worker::client::WorkerClient,
 };
-use futures_util::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
 use governor::{Quota, RateLimiter};
 use std::{
     fmt::Debug,
     future::Future,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -23,9 +23,8 @@ use temporal_sdk_core_protos::temporal::api::{
 };
 use tokio::{
     sync::{
-        broadcast,
-        mpsc::{unbounded_channel, UnboundedReceiver},
-        Mutex,
+        Mutex, broadcast,
+        mpsc::{UnboundedReceiver, unbounded_channel},
     },
     task::JoinHandle,
 };

--- a/core/src/protosext/mod.rs
+++ b/core/src/protosext/mod.rs
@@ -1,9 +1,9 @@
 pub(crate) mod protocol_messages;
 
 use crate::{
-    protosext::protocol_messages::IncomingProtocolMessage,
-    worker::{LocalActivityExecutionResult, LEGACY_QUERY_ID},
     CompleteActivityError, TaskToken,
+    protosext::protocol_messages::IncomingProtocolMessage,
+    worker::{LEGACY_QUERY_ID, LocalActivityExecutionResult},
 };
 use anyhow::anyhow;
 use itertools::Itertools;
@@ -23,11 +23,11 @@ use temporal_sdk_core_protos::{
         },
         external_data::LocalActivityMarkerData,
         workflow_activation::{
-            query_to_job, workflow_activation_job, QueryWorkflow, WorkflowActivation,
-            WorkflowActivationJob,
+            QueryWorkflow, WorkflowActivation, WorkflowActivationJob, query_to_job,
+            workflow_activation_job,
         },
         workflow_commands::{
-            query_result, ActivityCancellationType, QueryResult, ScheduleLocalActivity,
+            ActivityCancellationType, QueryResult, ScheduleLocalActivity, query_result,
         },
         workflow_completion,
     },
@@ -35,7 +35,7 @@ use temporal_sdk_core_protos::{
         common::v1::{Payload, RetryPolicy, WorkflowExecution},
         enums::v1::EventType,
         failure::v1::Failure,
-        history::v1::{history_event, History, HistoryEvent, MarkerRecordedEventAttributes},
+        history::v1::{History, HistoryEvent, MarkerRecordedEventAttributes, history_event},
         query::v1::WorkflowQuery,
         workflowservice::v1::PollWorkflowTaskQueueResponse,
     },
@@ -400,7 +400,7 @@ impl ValidScheduleLA {
                 return Err(anyhow!(
                     "One or both of schedule_to_close or start_to_close timeouts must be set for \
                      local activities"
-                ))
+                ));
             }
         };
         let retry_policy = v.retry_policy.unwrap_or_default();

--- a/core/src/protosext/protocol_messages.rs
+++ b/core/src/protosext/protocol_messages.rs
@@ -2,8 +2,8 @@ use anyhow::{anyhow, bail};
 use std::collections::HashMap;
 use temporal_sdk_core_protos::temporal::api::{
     common::v1::Payload,
-    history::v1::{history_event, HistoryEvent},
-    protocol::v1::{message::SequencingId, Message},
+    history::v1::{HistoryEvent, history_event},
+    protocol::v1::{Message, message::SequencingId},
     update,
 };
 

--- a/core/src/replay/mod.rs
+++ b/core/src/replay/mod.rs
@@ -3,21 +3,23 @@
 //! users during testing.
 
 use crate::{
-    worker::{
-        client::mocks::{mock_manual_workflow_client, MockManualWorkerClient},
-        PostActivateHookData,
-    },
     Worker,
+    worker::{
+        PostActivateHookData,
+        client::mocks::{MockManualWorkerClient, mock_manual_workflow_client},
+    },
 };
 use futures_util::{FutureExt, Stream, StreamExt};
 use parking_lot::Mutex;
-use std::sync::OnceLock;
 use std::{
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     task::{Context, Poll},
 };
 use temporal_sdk_core_api::worker::WorkerConfig;
+pub use temporal_sdk_core_protos::{
+    DEFAULT_WORKFLOW_TYPE, HistoryInfo, TestHistoryBuilder, default_wes_attribs,
+};
 use temporal_sdk_core_protos::{
     coresdk::workflow_activation::remove_from_cache::EvictionReason,
     temporal::api::{
@@ -28,10 +30,7 @@ use temporal_sdk_core_protos::{
         },
     },
 };
-pub use temporal_sdk_core_protos::{
-    default_wes_attribs, HistoryInfo, TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE,
-};
-use tokio::sync::{mpsc, mpsc::UnboundedSender, Mutex as TokioMutex};
+use tokio::sync::{Mutex as TokioMutex, mpsc, mpsc::UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 
@@ -202,7 +201,7 @@ impl Historator {
     /// we're ready to replay the next history, or whatever else.
     pub(crate) fn get_post_activate_hook(
         &self,
-    ) -> impl Fn(&Worker, PostActivateHookData) + Send + Sync {
+    ) -> impl Fn(&Worker, PostActivateHookData) + Send + Sync + use<> {
         let done_tx = self.replay_done_tx.clone();
         move |worker, data| {
             if !data.replaying {

--- a/core/src/retry_logic.rs
+++ b/core/src/retry_logic.rs
@@ -169,8 +169,8 @@ mod tests {
             maximum_attempts: 10,
             non_retryable_error_types: vec!["no retry".to_string()],
         };
-        assert!(rp
-            .should_retry(
+        assert!(
+            rp.should_retry(
                 1,
                 Some(&ApplicationFailureInfo {
                     r#type: "no retry".to_string(),
@@ -178,7 +178,8 @@ mod tests {
                     ..Default::default()
                 })
             )
-            .is_none());
+            .is_none()
+        );
     }
 
     #[test]
@@ -190,8 +191,8 @@ mod tests {
             maximum_attempts: 10,
             non_retryable_error_types: vec![],
         };
-        assert!(rp
-            .should_retry(
+        assert!(
+            rp.should_retry(
                 1,
                 Some(&ApplicationFailureInfo {
                     r#type: "".to_string(),
@@ -199,7 +200,8 @@ mod tests {
                     ..Default::default()
                 })
             )
-            .is_none());
+            .is_none()
+        );
     }
 
     #[test]

--- a/core/src/telemetry/log_export.rs
+++ b/core/src/telemetry/log_export.rs
@@ -1,6 +1,6 @@
-use futures_channel::mpsc::{channel, Receiver, Sender};
+use futures_channel::mpsc::{Receiver, Sender, channel};
 use parking_lot::Mutex;
-use ringbuf::{consumer::Consumer, producer::Producer, traits::Split, HeapRb};
+use ringbuf::{HeapRb, consumer::Consumer, producer::Producer, traits::Split};
 use std::{collections::HashMap, fmt, sync::Arc, time::SystemTime};
 use temporal_sdk_core_api::telemetry::{CoreLog, CoreLogConsumer};
 use tracing_subscriber::Layer;
@@ -216,7 +216,7 @@ impl tracing::field::Visit for JsonVisitor<'_> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        telemetry::{construct_filter_string, CoreLogStreamConsumer},
+        telemetry::{CoreLogStreamConsumer, construct_filter_string},
         telemetry_init,
     };
     use futures_util::stream::StreamExt;

--- a/core/src/telemetry/metrics.rs
+++ b/core/src/telemetry/metrics.rs
@@ -904,8 +904,8 @@ mod tests {
     use super::*;
     use std::any::Any;
     use temporal_sdk_core_api::telemetry::{
-        metrics::{BufferInstrumentRef, CustomMetricAttributes},
         METRIC_PREFIX,
+        metrics::{BufferInstrumentRef, CustomMetricAttributes},
     };
     use tracing::subscriber::NoSubscriber;
 

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -10,10 +10,10 @@ mod prometheus_server;
 
 #[cfg(feature = "otel")]
 pub use metrics::{
-    default_buckets_for, MetricsCallBuffer, ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME,
-    ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME, WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME,
+    ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME, ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
+    MetricsCallBuffer, WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME,
     WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME, WORKFLOW_TASK_REPLAY_LATENCY_HISTOGRAM_NAME,
-    WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
+    WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME, default_buckets_for,
 };
 #[cfg(feature = "otel")]
 pub use otel::{build_otlp_metric_exporter, start_prometheus_metric_exporter};
@@ -28,16 +28,16 @@ use std::{
     collections::VecDeque,
     env,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
 use temporal_sdk_core_api::telemetry::{
-    metrics::{CoreMeter, MetricKeyValue, NewAttributes, TemporalMeter},
     CoreLog, CoreTelemetry, Logger, TelemetryOptions,
+    metrics::{CoreMeter, MetricKeyValue, NewAttributes, TemporalMeter},
 };
 use tracing::{Level, Subscriber};
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt};
 
 const TELEM_SERVICE_NAME: &str = "temporal-core-sdk";
 

--- a/core/src/telemetry/otel.rs
+++ b/core/src/telemetry/otel.rs
@@ -1,5 +1,5 @@
 use super::{
-    default_buckets_for,
+    TELEM_SERVICE_NAME, default_buckets_for,
     metrics::{
         ACTIVITY_EXEC_LATENCY_HISTOGRAM_NAME, ACTIVITY_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
         DEFAULT_MS_BUCKETS, WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME,
@@ -8,30 +8,29 @@ use super::{
         WORKFLOW_TASK_SCHED_TO_START_LATENCY_HISTOGRAM_NAME,
     },
     prometheus_server::PromServer,
-    TELEM_SERVICE_NAME,
 };
 use crate::{abstractions::dbg_panic, telemetry::metrics::DEFAULT_S_BUCKETS};
 use opentelemetry::{
-    self, global,
+    self, Key, KeyValue, Value, global,
     metrics::{Meter, MeterProvider as MeterProviderT},
-    Key, KeyValue, Value,
 };
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
+    Resource,
     metrics::{
-        data::Temporality, new_view, reader::TemporalitySelector, Aggregation, Instrument,
-        InstrumentKind, MeterProviderBuilder, PeriodicReader, SdkMeterProvider, View,
+        Aggregation, Instrument, InstrumentKind, MeterProviderBuilder, PeriodicReader,
+        SdkMeterProvider, View, data::Temporality, new_view, reader::TemporalitySelector,
     },
-    runtime, Resource,
+    runtime,
 };
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use temporal_sdk_core_api::telemetry::{
+    HistogramBucketOverrides, MetricTemporality, OtelCollectorOptions, OtlpProtocol,
+    PrometheusExporterOptions,
     metrics::{
         CoreMeter, Counter, Gauge, GaugeF64, Histogram, HistogramDuration, HistogramF64,
         MetricAttributes, MetricParameters, NewAttributes,
     },
-    HistogramBucketOverrides, MetricTemporality, OtelCollectorOptions, OtlpProtocol,
-    PrometheusExporterOptions,
 };
 use tokio::task::AbortHandle;
 use tonic::{metadata::MetadataMap, transport::ClientTlsConfig};

--- a/core/src/telemetry/prometheus_server.rs
+++ b/core/src/telemetry/prometheus_server.rs
@@ -1,5 +1,5 @@
 use http_body_util::Full;
-use hyper::{body::Bytes, header::CONTENT_TYPE, service::service_fn, Method, Request, Response};
+use hyper::{Method, Request, Response, body::Bytes, header::CONTENT_TYPE, service::service_fn};
 use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto,

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -1,21 +1,21 @@
 pub(crate) use temporal_sdk_core_test_utils::canned_histories;
 
 use crate::{
+    TaskToken, Worker, WorkerConfig, WorkerConfigBuilder,
     pollers::{BoxedPoller, MockManualPoller, MockPoller},
     protosext::ValidPollWFTQResponse,
     replay::TestHistoryBuilder,
     sticky_q_name_for_worker,
     worker::{
-        client::{
-            mocks::mock_workflow_client, MockWorkerClient, WorkerClient, WorkflowTaskCompletion,
-        },
         TaskPollers,
+        client::{
+            MockWorkerClient, WorkerClient, WorkflowTaskCompletion, mocks::mock_workflow_client,
+        },
     },
-    TaskToken, Worker, WorkerConfig, WorkerConfigBuilder,
 };
 use async_trait::async_trait;
 use bimap::BiMap;
-use futures_util::{future::BoxFuture, stream, stream::BoxStream, FutureExt, Stream, StreamExt};
+use futures_util::{FutureExt, Stream, StreamExt, future::BoxFuture, stream, stream::BoxStream};
 use mockall::TimesRange;
 use parking_lot::RwLock;
 use std::{
@@ -24,19 +24,19 @@ use std::{
     ops::{Deref, DerefMut},
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     task::{Context, Poll},
     time::Duration,
 };
 use temporal_sdk::interceptors::FailOnNondeterminismInterceptor;
-use temporal_sdk_core_api::{errors::PollError, Worker as WorkerTrait};
+use temporal_sdk_core_api::{Worker as WorkerTrait, errors::PollError};
 use temporal_sdk_core_protos::{
     coresdk::{
-        workflow_activation::{workflow_activation_job, WorkflowActivation},
+        workflow_activation::{WorkflowActivation, workflow_activation_job},
         workflow_commands::workflow_command,
-        workflow_completion::{self, workflow_activation_completion, WorkflowActivationCompletion},
+        workflow_completion::{self, WorkflowActivationCompletion, workflow_activation_completion},
     },
     temporal::api::{
         common::v1::WorkflowExecution,
@@ -52,8 +52,8 @@ use temporal_sdk_core_protos::{
     },
     utilities::pack_any,
 };
-use temporal_sdk_core_test_utils::{TestWorker, NAMESPACE};
-use tokio::sync::{mpsc::unbounded_channel, Notify};
+use temporal_sdk_core_test_utils::{NAMESPACE, TestWorker};
+use tokio::sync::{Notify, mpsc::unbounded_channel};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 pub(crate) const TEST_Q: &str = "q";
@@ -825,7 +825,7 @@ pub(crate) fn hist_to_poll_resp(
             return QueueResponse {
                 resp: r,
                 delay_until: None,
-            }
+            };
         }
         ResponseType::UntilResolved(fut, tn) => {
             delay_until = Some(fut);
@@ -835,7 +835,7 @@ pub(crate) fn hist_to_poll_resp(
             return QueueResponse {
                 resp: r,
                 delay_until: Some(fut),
-            }
+            };
         }
     };
     let mut resp = hist_info.as_poll_wft_response();

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -352,7 +352,7 @@ impl WorkerActivityTasks {
                     aer::Status::Failed(ar::Failure { failure }) => {
                         act_metrics.act_execution_failed();
                         client
-                            .fail_activity_task(task_token.clone(), failure.map(Into::into))
+                            .fail_activity_task(task_token.clone(), failure)
                             .await
                             .err()
                     }
@@ -387,7 +387,7 @@ impl WorkerActivityTasks {
                                 None
                             };
                             client
-                                .cancel_activity_task(task_token.clone(), details.map(Into::into))
+                                .cancel_activity_task(task_token.clone(), details)
                                 .await
                                 .err()
                         }

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -7,50 +7,49 @@ pub(crate) use local_activities::{
 };
 
 use crate::{
+    PollError, TaskToken,
     abstractions::{
         ClosableMeteredPermitDealer, MeteredPermitDealer, TrackedOwnedMeteredSemPermit,
         UsedMeteredSemPermit,
     },
-    pollers::{new_activity_task_poller, BoxedActPoller, PermittedTqResp, TrackedPermittedTqResp},
-    telemetry::metrics::{activity_type, eager, workflow_type, MetricsContext},
+    pollers::{BoxedActPoller, PermittedTqResp, TrackedPermittedTqResp, new_activity_task_poller},
+    telemetry::metrics::{MetricsContext, activity_type, eager, workflow_type},
     worker::{
         activities::activity_heartbeat_manager::ActivityHeartbeatError, client::WorkerClient,
     },
-    PollError, TaskToken,
 };
 use activity_heartbeat_manager::ActivityHeartbeatManager;
 use dashmap::DashMap;
 use futures_util::{
-    stream,
+    Stream, StreamExt, stream,
     stream::{BoxStream, PollNext},
-    Stream, StreamExt,
 };
 use std::{
     convert::TryInto,
     future,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     time::{Duration, Instant, SystemTime},
 };
 use temporal_sdk_core_api::worker::ActivitySlotKind;
 use temporal_sdk_core_protos::{
     coresdk::{
+        ActivityHeartbeat, ActivitySlotInfo,
         activity_result::{self as ar, activity_execution_result as aer},
         activity_task::{ActivityCancelReason, ActivityTask},
-        ActivityHeartbeat, ActivitySlotInfo,
     },
     temporal::api::{
-        failure::v1::{failure::FailureInfo, ApplicationFailureInfo, CanceledFailureInfo, Failure},
+        failure::v1::{ApplicationFailureInfo, CanceledFailureInfo, Failure, failure::FailureInfo},
         workflowservice::v1::PollActivityTaskQueueResponse,
     },
 };
 use tokio::{
     join,
     sync::{
-        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
         Mutex, Notify,
+        mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     },
     task::JoinHandle,
 };

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -1,24 +1,24 @@
 use crate::{
+    TaskToken,
     abstractions::take_cell::TakeCell,
     worker::{activities::PendingActivityCancel, client::WorkerClient},
-    TaskToken,
 };
 use futures_util::StreamExt;
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     sync::Arc,
     time::{Duration, Instant},
 };
 use temporal_sdk_core_protos::{
-    coresdk::{activity_task::ActivityCancelReason, ActivityHeartbeat, IntoPayloadsExt},
+    coresdk::{ActivityHeartbeat, IntoPayloadsExt, activity_task::ActivityCancelReason},
     temporal::api::{
         common::v1::Payload, workflowservice::v1::RecordActivityTaskHeartbeatResponse,
     },
 };
 use tokio::{
     sync::{
-        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
         Notify,
+        mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     },
     task::JoinHandle,
 };
@@ -67,7 +67,9 @@ enum HeartbeatExecutorAction {
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum ActivityHeartbeatError {
     /// Heartbeat referenced an activity that we don't think exists. It may have completed already.
-    #[error("Heartbeat has been sent for activity that either completed or never started on this worker.")]
+    #[error(
+        "Heartbeat has been sent for activity that either completed or never started on this worker."
+    )]
     UnknownActivity,
     /// There was a set heartbeat timeout, but it was not parseable. A valid timeout is requried
     /// to heartbeat.

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -1,17 +1,17 @@
 use crate::{
-    abstractions::{dbg_panic, MeteredPermitDealer, OwnedMeteredSemPermit, UsedMeteredSemPermit},
+    MetricsContext, TaskToken,
+    abstractions::{MeteredPermitDealer, OwnedMeteredSemPermit, UsedMeteredSemPermit, dbg_panic},
     protosext::ValidScheduleLA,
     retry_logic::RetryPolicyExt,
     telemetry::metrics::{activity_type, workflow_type},
     worker::workflow::HeartbeatTimeoutMsg,
-    MetricsContext, TaskToken,
 };
 use futures_util::{
-    future, future::AbortRegistration, stream, stream::BoxStream, Stream, StreamExt,
+    Stream, StreamExt, future, future::AbortRegistration, stream, stream::BoxStream,
 };
 use parking_lot::{Mutex, MutexGuard};
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     fmt::{Debug, Formatter},
     pin::Pin,
     task::{Context, Poll},
@@ -20,20 +20,20 @@ use std::{
 use temporal_sdk_core_api::worker::LocalActivitySlotKind;
 use temporal_sdk_core_protos::{
     coresdk::{
-        activity_result::{Cancellation, Failure as ActFail, Success},
-        activity_task::{activity_task, ActivityCancelReason, ActivityTask, Cancel, Start},
         LocalActivitySlotInfo,
+        activity_result::{Cancellation, Failure as ActFail, Success},
+        activity_task::{ActivityCancelReason, ActivityTask, Cancel, Start, activity_task},
     },
     temporal::api::{
         common::v1::WorkflowExecution,
         enums::v1::TimeoutType,
-        failure::v1::{failure, Failure as APIFailure, TimeoutFailureInfo},
+        failure::v1::{Failure as APIFailure, TimeoutFailureInfo, failure},
     },
 };
 use tokio::{
     sync::{
-        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
         Notify,
+        mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     },
     task::JoinHandle,
     time::sleep,
@@ -973,7 +973,7 @@ mod tests {
     use futures_util::FutureExt;
     use temporal_sdk_core_protos::temporal::api::{
         common::v1::RetryPolicy,
-        failure::v1::{failure::FailureInfo, ApplicationFailureInfo, Failure},
+        failure::v1::{ApplicationFailureInfo, Failure, failure::FailureInfo},
     };
     use tokio::task::yield_now;
 

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -8,6 +8,7 @@ use temporal_client::{
     WorkflowService,
 };
 use temporal_sdk_core_protos::{
+    TaskToken,
     coresdk::workflow_commands::QueryResult,
     temporal::api::{
         command::v1::Command,
@@ -24,7 +25,6 @@ use temporal_sdk_core_protos::{
         taskqueue::v1::{StickyExecutionAttributes, TaskQueue, TaskQueueMetadata},
         workflowservice::v1::{get_system_info_response::Capabilities, *},
     },
-    TaskToken,
 };
 use tonic::IntoRequest;
 

--- a/core/src/worker/tuner/resource_based.rs
+++ b/core/src/worker/tuner/resource_based.rs
@@ -3,8 +3,8 @@ use parking_lot::Mutex;
 use std::{
     marker::PhantomData,
     sync::{
-        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc, OnceLock,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -546,8 +546,8 @@ mod tests {
     use super::*;
     use crate::{abstractions::MeteredPermitDealer, telemetry::metrics::MetricsContext};
     use std::sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     };
     use temporal_sdk_core_api::worker::WorkflowSlotKind;
 

--- a/core/src/worker/workflow/driven_workflow.rs
+++ b/core/src/worker/workflow/driven_workflow.rs
@@ -8,7 +8,7 @@ use std::{
     sync::mpsc::{self, Receiver, Sender},
 };
 use temporal_sdk_core_protos::{
-    coresdk::workflow_activation::{start_workflow_from_attribs, WorkflowActivationJob},
+    coresdk::workflow_activation::{WorkflowActivationJob, start_workflow_from_attribs},
     temporal::api::{common::v1::Payload, history::v1::WorkflowExecutionStartedEventAttributes},
     utilities::TryIntoOrNone,
 };

--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -5,7 +5,7 @@ use crate::{
         workflow::{CacheMissFetchReq, PermittedWFT, PreparedWFT},
     },
 };
-use futures_util::{future::BoxFuture, FutureExt, Stream, TryFutureExt};
+use futures_util::{FutureExt, Stream, TryFutureExt, future::BoxFuture};
 use itertools::Itertools;
 use std::{
     collections::VecDeque,
@@ -20,8 +20,7 @@ use std::{
 use temporal_sdk_core_protos::temporal::api::{
     enums::v1::EventType,
     history::v1::{
-        history_event, history_event::Attributes, History, HistoryEvent,
-        WorkflowTaskCompletedEventAttributes,
+        History, HistoryEvent, WorkflowTaskCompletedEventAttributes, history_event::Attributes,
     },
 };
 use tracing::Instrument;
@@ -651,9 +650,7 @@ impl HistoryUpdate {
             .iter()
             .skip_while(|e| e.event_id < from_id)
             .find_map(|e| match &e.attributes {
-                Some(history_event::Attributes::WorkflowTaskCompletedEventAttributes(ref a)) => {
-                    Some(a)
-                }
+                Some(Attributes::WorkflowTaskCompletedEventAttributes(a)) => Some(a),
                 _ => None,
             })
     }
@@ -794,7 +791,7 @@ mod tests {
     use super::*;
     use crate::{
         replay::{HistoryInfo, TestHistoryBuilder},
-        test_help::{canned_histories, hist_to_poll_resp, mock_sdk_cfg, MockPollCfg, ResponseType},
+        test_help::{MockPollCfg, ResponseType, canned_histories, hist_to_poll_resp, mock_sdk_cfg},
         worker::client::mocks::mock_workflow_client,
     };
     use futures_util::{StreamExt, TryStreamExt};
@@ -802,11 +799,11 @@ mod tests {
     use temporal_client::WorkflowOptions;
     use temporal_sdk::WfContext;
     use temporal_sdk_core_protos::{
+        DEFAULT_WORKFLOW_TYPE,
         temporal::api::{
             common::v1::WorkflowExecution, enums::v1::WorkflowTaskFailedCause,
             workflowservice::v1::GetWorkflowExecutionHistoryResponse,
         },
-        DEFAULT_WORKFLOW_TYPE,
     };
 
     impl From<HistoryInfo> for HistoryUpdate {

--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -1,34 +1,33 @@
 #![allow(clippy::large_enum_variant)]
 
 use super::{
-    workflow_machines::MachineResponse, EventInfo, NewMachineWithCommand, OnEventWrapper,
-    WFMachinesAdapter, WFMachinesError,
+    EventInfo, NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
+    workflow_machines::MachineResponse,
 };
 use crate::{
     abstractions::dbg_panic,
     internal_flags::CoreInternalFlags,
-    worker::workflow::{machines::HistEventData, InternalFlagsRef},
+    worker::workflow::{InternalFlagsRef, machines::HistEventData},
 };
-use rustfsm::{fsm, MachineError, StateMachine, TransitionResult};
+use rustfsm::{MachineError, StateMachine, TransitionResult, fsm};
 use std::convert::{TryFrom, TryInto};
 use temporal_sdk_core_protos::{
     coresdk::{
-        activity_result::{self as ar, activity_resolution, ActivityResolution, Cancellation},
+        activity_result::{self as ar, ActivityResolution, Cancellation, activity_resolution},
         workflow_activation::ResolveActivity,
         workflow_commands::{ActivityCancellationType, ScheduleActivity},
     },
     temporal::api::{
         command::v1::{
-            command, schedule_activity_cmd_to_api, Command,
-            RequestCancelActivityTaskCommandAttributes,
+            Command, RequestCancelActivityTaskCommandAttributes, command,
+            schedule_activity_cmd_to_api,
         },
         common::v1::{ActivityType, Payload, Payloads},
         enums::v1::{CommandType, EventType, RetryState},
-        failure::v1::{failure::FailureInfo, ActivityFailureInfo, CanceledFailureInfo, Failure},
+        failure::v1::{ActivityFailureInfo, CanceledFailureInfo, Failure, failure::FailureInfo},
         history::v1::{
-            history_event, ActivityTaskCanceledEventAttributes,
-            ActivityTaskCompletedEventAttributes, ActivityTaskFailedEventAttributes,
-            ActivityTaskTimedOutEventAttributes,
+            ActivityTaskCanceledEventAttributes, ActivityTaskCompletedEventAttributes,
+            ActivityTaskFailedEventAttributes, ActivityTaskTimedOutEventAttributes, history_event,
         },
     },
 };
@@ -279,7 +278,7 @@ impl TryFrom<HistEventData> for ActivityMachineEvents {
             _ => {
                 return Err(WFMachinesError::Nondeterminism(format!(
                     "Activity machine does not handle this event: {e}"
-                )))
+                )));
             }
         })
     }
@@ -293,28 +292,32 @@ impl WFMachinesAdapter for ActivityMachine {
     ) -> Result<Vec<MachineResponse>, WFMachinesError> {
         Ok(match my_command {
             ActivityMachineCommand::Complete(result) => {
-                vec![ResolveActivity {
-                    seq: self.shared_state.attrs.seq,
-                    result: Some(ActivityResolution {
-                        status: Some(activity_resolution::Status::Completed(ar::Success {
-                            result: convert_payloads(event_info, result)?,
-                        })),
-                    }),
-                    is_local: false,
-                }
-                .into()]
+                vec![
+                    ResolveActivity {
+                        seq: self.shared_state.attrs.seq,
+                        result: Some(ActivityResolution {
+                            status: Some(activity_resolution::Status::Completed(ar::Success {
+                                result: convert_payloads(event_info, result)?,
+                            })),
+                        }),
+                        is_local: false,
+                    }
+                    .into(),
+                ]
             }
             ActivityMachineCommand::Fail(failure) => {
-                vec![ResolveActivity {
-                    seq: self.shared_state.attrs.seq,
-                    result: Some(ActivityResolution {
-                        status: Some(activity_resolution::Status::Failed(ar::Failure {
-                            failure: Some(failure),
-                        })),
-                    }),
-                    is_local: false,
-                }
-                .into()]
+                vec![
+                    ResolveActivity {
+                        seq: self.shared_state.attrs.seq,
+                        result: Some(ActivityResolution {
+                            status: Some(activity_resolution::Status::Failed(ar::Failure {
+                                failure: Some(failure),
+                            })),
+                        }),
+                        is_local: false,
+                    }
+                    .into(),
+                ]
             }
             ActivityMachineCommand::RequestCancellation(c) => {
                 self.machine_responses_from_cancel_request(c)
@@ -801,14 +804,14 @@ mod test {
     use crate::{
         internal_flags::InternalFlags,
         replay::TestHistoryBuilder,
-        test_help::{build_fake_sdk, MockPollCfg, ResponseType},
-        worker::workflow::{machines::Machines, OutgoingJob},
+        test_help::{MockPollCfg, ResponseType, build_fake_sdk},
+        worker::workflow::{OutgoingJob, machines::Machines},
     };
     use std::{cell::RefCell, mem::discriminant, rc::Rc};
     use temporal_sdk::{ActivityOptions, CancellableFuture, WfContext, WorkflowFunction};
     use temporal_sdk_core_protos::{
-        coresdk::workflow_activation::{workflow_activation_job, WorkflowActivationJob},
         DEFAULT_WORKFLOW_TYPE,
+        coresdk::workflow_activation::{WorkflowActivationJob, workflow_activation_job},
     };
     use temporal_sdk_core_test_utils::interceptors::ActivationAssertionsInterceptor;
 

--- a/core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/activity_state_machine.rs
@@ -750,7 +750,7 @@ fn new_cancel_failure(dat: &SharedState, attrs: ActivityTaskCanceledEventAttribu
         message: "Activity cancelled".to_string(),
         cause: Some(Box::from(Failure {
             failure_info: Some(FailureInfo::CanceledFailureInfo(CanceledFailureInfo {
-                details: attrs.details.map(Into::into),
+                details: attrs.details,
             })),
             ..Default::default()
         })),

--- a/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/cancel_workflow_state_machine.rs
@@ -1,9 +1,9 @@
 use super::{
-    workflow_machines::MachineResponse, EventInfo, NewMachineWithCommand, OnEventWrapper,
-    WFMachinesAdapter, WFMachinesError,
+    EventInfo, NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
+    workflow_machines::MachineResponse,
 };
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{StateMachine, TransitionResult, fsm};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::CancelWorkflowExecution,
@@ -70,7 +70,7 @@ impl TryFrom<HistEventData> for CancelWorkflowMachineEvents {
             _ => {
                 return Err(WFMachinesError::Nondeterminism(format!(
                     "Cancel workflow machine does not handle this event: {e}"
-                )))
+                )));
             }
         })
     }
@@ -100,12 +100,12 @@ impl WFMachinesAdapter for CancelWorkflowMachine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_help::{build_fake_sdk, canned_histories, MockPollCfg};
+    use crate::test_help::{MockPollCfg, build_fake_sdk, canned_histories};
     use std::time::Duration;
     use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
     use temporal_sdk_core_protos::{
-        coresdk::workflow_activation::{workflow_activation_job, WorkflowActivationJob},
         DEFAULT_WORKFLOW_TYPE,
+        coresdk::workflow_activation::{WorkflowActivationJob, workflow_activation_job},
     };
     use temporal_sdk_core_test_utils::interceptors::ActivationAssertionsInterceptor;
 

--- a/core/src/worker/workflow/machines/complete_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/complete_workflow_state_machine.rs
@@ -1,9 +1,9 @@
 use super::{
-    workflow_machines::MachineResponse, EventInfo, NewMachineWithCommand, OnEventWrapper,
-    WFMachinesAdapter, WFMachinesError,
+    EventInfo, NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
+    workflow_machines::MachineResponse,
 };
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{StateMachine, TransitionResult, fsm};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::CompleteWorkflowExecution,
@@ -60,7 +60,7 @@ impl TryFrom<HistEventData> for CompleteWorkflowMachineEvents {
             _ => {
                 return Err(WFMachinesError::Nondeterminism(format!(
                     "Complete workflow machine does not handle this event: {e}"
-                )))
+                )));
             }
         })
     }

--- a/core/src/worker/workflow/machines/continue_as_new_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/continue_as_new_workflow_state_machine.rs
@@ -3,7 +3,7 @@ use super::{
     WFMachinesError,
 };
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{StateMachine, TransitionResult, fsm};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::ContinueAsNewWorkflowExecution,
@@ -76,7 +76,7 @@ impl TryFrom<HistEventData> for ContinueAsNewWorkflowMachineEvents {
             _ => {
                 return Err(WFMachinesError::Nondeterminism(format!(
                     "Continue as new workflow machine does not handle this event: {e}"
-                )))
+                )));
             }
         })
     }
@@ -108,7 +108,7 @@ impl WFMachinesAdapter for ContinueAsNewWorkflowMachine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_help::{build_fake_sdk, canned_histories, MockPollCfg};
+    use crate::test_help::{MockPollCfg, build_fake_sdk, canned_histories};
     use std::time::Duration;
     use temporal_sdk::{WfContext, WfExitValue, WorkflowResult};
     use temporal_sdk_core_protos::DEFAULT_WORKFLOW_TYPE;

--- a/core/src/worker/workflow/machines/fail_workflow_state_machine.rs
+++ b/core/src/worker/workflow/machines/fail_workflow_state_machine.rs
@@ -1,9 +1,9 @@
 use super::{
-    workflow_machines::MachineResponse, EventInfo, NewMachineWithCommand, OnEventWrapper,
-    WFMachinesAdapter, WFMachinesError,
+    EventInfo, NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
+    workflow_machines::MachineResponse,
 };
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{StateMachine, TransitionResult, fsm};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::FailWorkflowExecution,
@@ -87,7 +87,7 @@ impl TryFrom<HistEventData> for FailWorkflowMachineEvents {
             _ => {
                 return Err(WFMachinesError::Nondeterminism(format!(
                     "Fail workflow machine does not handle this event: {e}"
-                )))
+                )));
             }
         })
     }

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -1,20 +1,20 @@
 use super::{
-    workflow_machines::MachineResponse, EventInfo, OnEventWrapper, WFMachinesAdapter,
-    WFMachinesError,
+    EventInfo, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
+    workflow_machines::MachineResponse,
 };
 use crate::{
     internal_flags::CoreInternalFlags,
     protosext::{CompleteLocalActivityData, HistoryEventExt, ValidScheduleLA},
     worker::{
-        workflow::{
-            machines::{activity_state_machine::activity_fail_info, HistEventData},
-            InternalFlagsRef,
-        },
         LocalActivityExecutionResult,
+        workflow::{
+            InternalFlagsRef,
+            machines::{HistEventData, activity_state_machine::activity_fail_info},
+        },
     },
 };
 use itertools::Itertools;
-use rustfsm::{fsm, MachineError, StateMachine, TransitionResult};
+use rustfsm::{MachineError, StateMachine, TransitionResult, fsm};
 use std::{
     convert::TryFrom,
     time::{Duration, SystemTime},
@@ -31,9 +31,9 @@ use temporal_sdk_core_protos::{
         workflow_commands::ActivityCancellationType,
     },
     temporal::api::{
-        command::v1::{command, RecordMarkerCommandAttributes},
+        command::v1::{RecordMarkerCommandAttributes, command},
         enums::v1::{CommandType, EventType, RetryState},
-        failure::v1::{failure::FailureInfo, Failure},
+        failure::v1::{Failure, failure::FailureInfo},
     },
     utilities::TryIntoOrNone,
 };
@@ -866,7 +866,7 @@ mod tests {
     use super::*;
     use crate::{
         replay::TestHistoryBuilder,
-        test_help::{build_fake_sdk, canned_histories, MockPollCfg, ResponseType},
+        test_help::{MockPollCfg, ResponseType, build_fake_sdk, canned_histories},
     };
     use anyhow::anyhow;
     use rstest::rstest;
@@ -879,14 +879,14 @@ mod tests {
         WorkflowResult,
     };
     use temporal_sdk_core_protos::{
+        DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE,
         coresdk::{
-            workflow_activation::{workflow_activation_job, WorkflowActivationJob},
             AsJsonPayloadExt,
+            workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         },
         temporal::api::{
             common::v1::RetryPolicy, enums::v1::WorkflowTaskFailedCause, failure::v1::Failure,
         },
-        DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE,
     };
     use temporal_sdk_core_test_utils::interceptors::ActivationAssertionsInterceptor;
     use tokio_util::sync::CancellationToken;

--- a/core/src/worker/workflow/machines/modify_workflow_properties_state_machine.rs
+++ b/core/src/worker/workflow/machines/modify_workflow_properties_state_machine.rs
@@ -1,9 +1,9 @@
-use super::{workflow_machines::MachineResponse, NewMachineWithCommand};
+use super::{NewMachineWithCommand, workflow_machines::MachineResponse};
 use crate::worker::workflow::{
-    machines::{EventInfo, HistEventData, WFMachinesAdapter},
     WFMachinesError,
+    machines::{EventInfo, HistEventData, WFMachinesAdapter},
 };
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{StateMachine, TransitionResult, fsm};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::ModifyWorkflowProperties,
     temporal::api::enums::v1::{CommandType, EventType},
@@ -105,15 +105,15 @@ mod tests {
     use super::*;
     use crate::{
         replay::TestHistoryBuilder,
-        test_help::{build_fake_sdk, MockPollCfg},
+        test_help::{MockPollCfg, build_fake_sdk},
     };
     use temporal_sdk::WfContext;
     use temporal_sdk_core_protos::{
+        DEFAULT_WORKFLOW_TYPE,
         temporal::api::{
-            command::v1::{command, Command},
+            command::v1::{Command, command},
             common::v1::Payload,
         },
-        DEFAULT_WORKFLOW_TYPE,
     };
 
     #[tokio::test]

--- a/core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/core/src/worker/workflow/machines/patch_state_machine.rs
@@ -18,28 +18,28 @@
 //! | replaying, no marker         | deprecate_patch | Call allowed                                                                       |
 
 use super::{
-    workflow_machines::MachineResponse, EventInfo, NewMachineWithCommand, OnEventWrapper,
-    WFMachinesAdapter, WFMachinesError,
+    EventInfo, NewMachineWithCommand, OnEventWrapper, WFMachinesAdapter, WFMachinesError,
+    workflow_machines::MachineResponse,
 };
 use crate::{
     internal_flags::CoreInternalFlags,
     protosext::HistoryEventExt,
     worker::workflow::{
-        machines::{
-            upsert_search_attributes_state_machine::MAX_SEARCH_ATTR_PAYLOAD_SIZE, HistEventData,
-        },
         InternalFlagsRef,
+        machines::{
+            HistEventData, upsert_search_attributes_state_machine::MAX_SEARCH_ATTR_PAYLOAD_SIZE,
+        },
     },
 };
 use anyhow::Context;
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{StateMachine, TransitionResult, fsm};
 use std::{
     collections::{BTreeSet, HashMap},
     convert::TryFrom,
 };
 use temporal_sdk_core_protos::{
     constants::PATCH_MARKER_NAME,
-    coresdk::{common::build_has_change_marker_details, AsJsonPayloadExt},
+    coresdk::{AsJsonPayloadExt, common::build_has_change_marker_details},
     temporal::api::{
         command::v1::{
             RecordMarkerCommandAttributes, UpsertWorkflowSearchAttributesCommandAttributes,
@@ -270,27 +270,27 @@ mod tests {
     use crate::{
         internal_flags::CoreInternalFlags,
         replay::TestHistoryBuilder,
-        test_help::{build_fake_sdk, MockPollCfg, ResponseType},
+        test_help::{MockPollCfg, ResponseType, build_fake_sdk},
         worker::workflow::machines::patch_state_machine::VERSION_SEARCH_ATTR_KEY,
     };
     use rstest::rstest;
     use std::{
-        collections::{hash_map::RandomState, HashSet, VecDeque},
+        collections::{HashSet, VecDeque, hash_map::RandomState},
         time::Duration,
     };
     use temporal_sdk::{ActivityOptions, WfContext};
     use temporal_sdk_core_protos::{
+        DEFAULT_WORKFLOW_TYPE,
         constants::PATCH_MARKER_NAME,
         coresdk::{
-            common::decode_change_marker_details,
-            workflow_activation::{workflow_activation_job, NotifyHasPatch, WorkflowActivationJob},
             AsJsonPayloadExt, FromJsonPayloadExt,
+            common::decode_change_marker_details,
+            workflow_activation::{NotifyHasPatch, WorkflowActivationJob, workflow_activation_job},
         },
         temporal::api::{
             command::v1::{
-                command::Attributes, RecordMarkerCommandAttributes,
-                ScheduleActivityTaskCommandAttributes,
-                UpsertWorkflowSearchAttributesCommandAttributes,
+                RecordMarkerCommandAttributes, ScheduleActivityTaskCommandAttributes,
+                UpsertWorkflowSearchAttributesCommandAttributes, command::Attributes,
             },
             common::v1::ActivityType,
             enums::v1::{CommandType, EventType},
@@ -299,7 +299,6 @@ mod tests {
                 ActivityTaskStartedEventAttributes, TimerFiredEventAttributes,
             },
         },
-        DEFAULT_WORKFLOW_TYPE,
     };
     use temporal_sdk_core_test_utils::interceptors::ActivationAssertionsInterceptor;
 

--- a/core/src/worker/workflow/machines/transition_coverage.rs
+++ b/core/src/worker/workflow/machines/transition_coverage.rs
@@ -3,13 +3,13 @@
 //! in stable Rust. Don't do the things in here. They're bad. This is test only code, and should
 //! never ever be removed from behind `#[cfg(test)]` compilation.
 
-use dashmap::{mapref::entry::Entry, DashMap, DashSet};
+use dashmap::{DashMap, DashSet, mapref::entry::Entry};
 use std::sync::LazyLock;
 use std::{
     path::PathBuf,
     sync::{
-        mpsc::{sync_channel, SyncSender},
         Mutex,
+        mpsc::{SyncSender, sync_channel},
     },
     thread::JoinHandle,
     time::Duration,

--- a/core/src/worker/workflow/machines/update_state_machine.rs
+++ b/core/src/worker/workflow/machines/update_state_machine.rs
@@ -1,25 +1,25 @@
-use super::{workflow_machines::MachineResponse, EventInfo, WFMachinesAdapter, WFMachinesError};
+use super::{EventInfo, WFMachinesAdapter, WFMachinesError, workflow_machines::MachineResponse};
 use crate::{
     protosext::protocol_messages::UpdateRequest,
     worker::workflow::machines::{HistEventData, NewMachineWithResponse},
 };
 use itertools::Itertools;
 use prost::EncodeError;
-use rustfsm::{fsm, MachineError, StateMachine, TransitionResult};
+use rustfsm::{MachineError, StateMachine, TransitionResult, fsm};
 use std::convert::TryFrom;
 use temporal_sdk_core_protos::{
     coresdk::{
         workflow_activation::DoUpdate,
-        workflow_commands::{update_response, UpdateResponse},
+        workflow_commands::{UpdateResponse, update_response},
     },
     temporal::api::{
-        command::v1::{command, ProtocolMessageCommandAttributes},
+        command::v1::{ProtocolMessageCommandAttributes, command},
         common::v1::Payload,
         enums::v1::{CommandType, EventType},
         failure::v1::Failure,
         protocol::v1::Message as ProtocolMessage,
         update,
-        update::v1::{outcome, Acceptance, Outcome, Rejection, Response},
+        update::v1::{Acceptance, Outcome, Rejection, Response, outcome},
     },
     utilities::pack_any,
 };
@@ -122,7 +122,7 @@ impl UpdateMachine {
                 return Err(WFMachinesError::Fatal(format!(
                     "Update response for update {} had an empty result, this is a lang layer bug.",
                     &self.shared_state.meta.update_id
-                )))
+                )));
             }
             Some(update_response::Response::Accepted(_)) => {
                 self.on_event(UpdateMachineEvents::Accept)
@@ -223,7 +223,7 @@ impl TryFrom<HistEventData> for UpdateMachineEvents {
             _ => {
                 return Err(WFMachinesError::Nondeterminism(format!(
                     "Update machine does not handle this event: {e}"
-                )))
+                )));
             }
         })
     }

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -1,19 +1,19 @@
-use super::{workflow_machines::MachineResponse, NewMachineWithCommand};
+use super::{NewMachineWithCommand, workflow_machines::MachineResponse};
 use crate::{
     internal_flags::CoreInternalFlags,
     worker::workflow::{
-        machines::{
-            patch_state_machine::VERSION_SEARCH_ATTR_KEY, EventInfo, HistEventData,
-            WFMachinesAdapter,
-        },
         InternalFlagsRef, WFMachinesError,
+        machines::{
+            EventInfo, HistEventData, WFMachinesAdapter,
+            patch_state_machine::VERSION_SEARCH_ATTR_KEY,
+        },
     },
 };
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{StateMachine, TransitionResult, fsm};
 use temporal_sdk_core_protos::{
     coresdk::workflow_commands::UpsertWorkflowSearchAttributes,
     temporal::api::{
-        command::v1::{command, UpsertWorkflowSearchAttributesCommandAttributes},
+        command::v1::{UpsertWorkflowSearchAttributesCommandAttributes, command},
         common::v1::SearchAttributes,
         enums::v1::CommandType,
         history::v1::history_event,
@@ -181,7 +181,7 @@ mod tests {
     use super::{super::OnEventWrapper, *};
     use crate::{
         replay::TestHistoryBuilder,
-        test_help::{build_fake_sdk, build_mock_pollers, mock_worker, MockPollCfg, ResponseType},
+        test_help::{MockPollCfg, ResponseType, build_fake_sdk, build_mock_pollers, mock_worker},
         worker::{
             client::mocks::mock_workflow_client,
             workflow::machines::patch_state_machine::VERSION_SEARCH_ATTR_KEY,
@@ -192,19 +192,19 @@ mod tests {
     use temporal_sdk::WfContext;
     use temporal_sdk_core_api::Worker;
     use temporal_sdk_core_protos::{
+        DEFAULT_WORKFLOW_TYPE,
         coresdk::{
-            workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+            AsJsonPayloadExt,
+            workflow_activation::{WorkflowActivationJob, workflow_activation_job},
             workflow_commands::SetPatchMarker,
             workflow_completion::WorkflowActivationCompletion,
-            AsJsonPayloadExt,
         },
         temporal::api::{
-            command::v1::{command::Attributes, Command},
+            command::v1::{Command, command::Attributes},
             common::v1::Payload,
             enums::v1::EventType,
             history::v1::{HistoryEvent, UpsertWorkflowSearchAttributesEventAttributes},
         },
-        DEFAULT_WORKFLOW_TYPE,
     };
     use temporal_sdk_core_test_utils::WorkerTestHelpers;
 
@@ -361,11 +361,13 @@ mod tests {
         );
         let act = core.poll_workflow_activation().await.unwrap();
         let mut cmds = if with_patched_cmd {
-            vec![SetPatchMarker {
-                patch_id,
-                deprecated: false,
-            }
-            .into()]
+            vec![
+                SetPatchMarker {
+                    patch_id,
+                    deprecated: false,
+                }
+                .into(),
+            ]
         } else {
             vec![]
         };

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1029,7 +1029,7 @@ impl WorkflowMachines {
     }
 
     fn set_current_time(&mut self, time: SystemTime) -> SystemTime {
-        if self.current_wf_time.map_or(true, |t| t < time) {
+        if self.current_wf_time.is_none_or(|t| t < time) {
             self.current_wf_time = Some(time);
         }
         self.current_wf_time

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1,6 +1,7 @@
 mod local_acts;
 
 use super::{
+    Machines, NewMachineWithCommand, TemporalStateMachine,
     cancel_external_state_machine::new_external_cancel,
     cancel_workflow_state_machine::cancel_workflow,
     complete_workflow_state_machine::complete_workflow,
@@ -9,34 +10,32 @@ use super::{
     patch_state_machine::has_change, signal_external_state_machine::new_external_signal,
     timer_state_machine::new_timer, upsert_search_attributes_state_machine::upsert_search_attrs,
     workflow_machines::local_acts::LocalActivityData,
-    workflow_task_state_machine::WorkflowTaskMachine, Machines, NewMachineWithCommand,
-    TemporalStateMachine,
+    workflow_task_state_machine::WorkflowTaskMachine,
 };
 use crate::{
     abstractions::dbg_panic,
     internal_flags::{CoreInternalFlags, InternalFlags},
     protosext::{
-        protocol_messages::{IncomingProtocolMessage, IncomingProtocolMessageBody},
         CompleteLocalActivityData, HistoryEventExt, ValidScheduleLA,
+        protocol_messages::{IncomingProtocolMessage, IncomingProtocolMessageBody},
     },
-    telemetry::{metrics::MetricsContext, VecDisplayer},
+    telemetry::{VecDisplayer, metrics::MetricsContext},
     worker::{
+        ExecutingLAId, LocalActRequest, LocalActivityExecutionResult, LocalActivityResolution,
         workflow::{
+            CommandID, DrivenWorkflow, HistoryUpdate, InternalFlagsRef, LocalResolution,
+            OutgoingJob, RunBasics, WFCommand, WFCommandVariant, WFMachinesError,
+            WorkflowStartedInfo,
             history_update::NextWFT,
             machines::{
-                activity_state_machine::ActivityMachine,
+                HistEventData, activity_state_machine::ActivityMachine,
                 child_workflow_state_machine::ChildWorkflowMachine,
                 modify_workflow_properties_state_machine::modify_workflow_properties,
                 nexus_operation_state_machine::NexusOperationMachine,
                 patch_state_machine::VERSION_SEARCH_ATTR_KEY, update_state_machine::UpdateMachine,
                 upsert_search_attributes_state_machine::upsert_search_attrs_internal,
-                HistEventData,
             },
-            CommandID, DrivenWorkflow, HistoryUpdate, InternalFlagsRef, LocalResolution,
-            OutgoingJob, RunBasics, WFCommand, WFCommandVariant, WFMachinesError,
-            WorkflowStartedInfo,
         },
-        ExecutingLAId, LocalActRequest, LocalActivityExecutionResult, LocalActivityResolution,
     },
 };
 use anyhow::Context;
@@ -58,17 +57,17 @@ use temporal_sdk_core_protos::{
         common::{NamespacedWorkflowExecution, VersioningIntent},
         workflow_activation,
         workflow_activation::{
-            workflow_activation_job, NotifyHasPatch, UpdateRandomSeed, WorkflowActivation,
+            NotifyHasPatch, UpdateRandomSeed, WorkflowActivation, workflow_activation_job,
         },
         workflow_commands::ContinueAsNewWorkflowExecution,
     },
     temporal::api::{
         command::v1::{
-            command::Attributes as ProtoCmdAttrs, Command as ProtoCommand, CommandAttributesExt,
+            Command as ProtoCommand, CommandAttributesExt, command::Attributes as ProtoCmdAttrs,
         },
         enums::v1::EventType,
-        history::v1::{history_event, HistoryEvent},
-        protocol::v1::{message::SequencingId, Message as ProtocolMessage},
+        history::v1::{HistoryEvent, history_event},
+        protocol::v1::{Message as ProtocolMessage, message::SequencingId},
         sdk::v1::{UserMetadata, WorkflowTaskCompletedMetadata},
     },
 };
@@ -241,7 +240,7 @@ where
 macro_rules! cancel_machine {
     ($self:expr, $cmd_id:expr, $machine_variant:ident, $cancel_method:ident $(, $args:expr )* $(,)?) => {{
         let m_key = $self.get_machine_key($cmd_id)?;
-        let machine = if let Machines::$machine_variant(ref mut m) = $self.machine_mut(m_key) {
+        let machine = if let Machines::$machine_variant(m) = $self.machine_mut(m_key) {
             m
         } else {
             return Err(WFMachinesError::Nondeterminism(format!(
@@ -1190,8 +1189,8 @@ impl WorkflowMachines {
                     }
                     c => {
                         return Err(WFMachinesError::Fatal(format!(
-                        "A machine requested to create a new command of an unsupported type: {c:?}"
-                    )))
+                            "A machine requested to create a new command of an unsupported type: {c:?}"
+                        )));
                     }
                 },
                 MachineResponse::IssueFakeLocalActivityMarker(seq) => {
@@ -1213,7 +1212,9 @@ impl WorkflowMachines {
                             let more_responses = lam.try_resolve_with_dat(preres)?;
                             self.process_machine_responses(smk, more_responses)?;
                         } else {
-                            panic!("A non local-activity machine returned a request cancel LA response");
+                            panic!(
+                                "A non local-activity machine returned a request cancel LA response"
+                            );
                         }
                     }
                     // If it's in the request queue, just rip it out.
@@ -1231,7 +1232,9 @@ impl WorkflowMachines {
                             )?;
                             self.process_machine_responses(smk, more_responses)?;
                         } else {
-                            panic!("A non local-activity machine returned a request cancel LA response");
+                            panic!(
+                                "A non local-activity machine returned a request cancel LA response"
+                            );
                         }
                     } else {
                         // Finally, if we know about the LA at all, it's currently running, so

--- a/core/src/worker/workflow/machines/workflow_task_state_machine.rs
+++ b/core/src/worker/workflow/machines/workflow_task_state_machine.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::enum_variant_names)]
 
-use super::{workflow_machines::MachineResponse, EventInfo, WFMachinesAdapter, WFMachinesError};
+use super::{EventInfo, WFMachinesAdapter, WFMachinesError, workflow_machines::MachineResponse};
 use crate::worker::workflow::machines::HistEventData;
-use rustfsm::{fsm, StateMachine, TransitionResult};
+use rustfsm::{StateMachine, TransitionResult, fsm};
 use std::{
     convert::{TryFrom, TryInto},
     time::SystemTime,
@@ -103,7 +103,7 @@ impl TryFrom<HistEventData> for WorkflowTaskMachineEvents {
                             return Err(WFMachinesError::Fatal(
                                 "Workflow task started event timestamp was inconvertible"
                                     .to_string(),
-                            ))
+                            ));
                         }
                     }
                 } else {
@@ -143,7 +143,7 @@ impl TryFrom<HistEventData> for WorkflowTaskMachineEvents {
             _ => {
                 return Err(WFMachinesError::Nondeterminism(format!(
                     "Event does not apply to a wf task machine: {e}"
-                )))
+                )));
             }
         })
     }

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -1,23 +1,23 @@
 use crate::{
+    MetricsContext,
     abstractions::dbg_panic,
     internal_flags::CoreInternalFlags,
-    protosext::{protocol_messages::IncomingProtocolMessage, WorkflowActivationExt},
+    protosext::{WorkflowActivationExt, protocol_messages::IncomingProtocolMessage},
     telemetry::metrics,
     worker::{
+        LEGACY_QUERY_ID, LocalActRequest,
         workflow::{
-            history_update::HistoryPaginator,
-            machines::{MachinesWFTResponseContent, WorkflowMachines},
             ActivationAction, ActivationCompleteOutcome, ActivationCompleteResult,
             ActivationOrAuto, BufferedTasks, DrivenWorkflow, EvictionRequestResult,
             FailedActivationWFTReport, HeartbeatTimeoutMsg, HistoryUpdate,
             LocalActivityRequestSink, LocalResolution, NextPageReq, OutstandingActivation,
             OutstandingTask, PermittedWFT, RequestEvictMsg, RunBasics,
             ServerCommandsWithWorkflowInfo, WFCommand, WFCommandVariant, WFMachinesError,
-            WFTReportStatus, WorkflowTaskInfo, WFT_HEARTBEAT_TIMEOUT_FRACTION,
+            WFT_HEARTBEAT_TIMEOUT_FRACTION, WFTReportStatus, WorkflowTaskInfo,
+            history_update::HistoryPaginator,
+            machines::{MachinesWFTResponseContent, WorkflowMachines},
         },
-        LocalActRequest, LEGACY_QUERY_ID,
     },
-    MetricsContext,
 };
 use futures_util::future::AbortHandle;
 use std::{
@@ -25,15 +25,16 @@ use std::{
     mem,
     ops::Add,
     rc::Rc,
-    sync::{mpsc::Sender, Arc},
+    sync::{Arc, mpsc::Sender},
     time::{Duration, Instant},
 };
 use temporal_sdk_core_api::{errors::WorkflowErrorType, worker::WorkerConfig};
 use temporal_sdk_core_protos::{
+    TaskToken,
     coresdk::{
         workflow_activation::{
-            create_evict_activation, query_to_job, remove_from_cache::EvictionReason,
-            workflow_activation_job, WorkflowActivation,
+            WorkflowActivation, create_evict_activation, query_to_job,
+            remove_from_cache::EvictionReason, workflow_activation_job,
         },
         workflow_commands::{FailWorkflowExecution, QueryResult},
         workflow_completion,
@@ -42,7 +43,6 @@ use temporal_sdk_core_protos::{
         command::v1::command::Attributes as CmdAttribs, enums::v1::WorkflowTaskFailedCause,
         failure::v1::Failure,
     },
-    TaskToken,
 };
 use tokio::sync::oneshot;
 use tracing::Span;
@@ -1507,7 +1507,7 @@ impl From<WFMachinesError> for RunUpdateErr {
 #[cfg(test)]
 mod tests {
     use crate::worker::workflow::{WFCommand, WFCommandVariant};
-    use std::mem::{discriminant, Discriminant};
+    use std::mem::{Discriminant, discriminant};
 
     use command_utils::*;
 

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -429,7 +429,7 @@ impl Workflows {
                     warn!(run_id=%run_id, failure=?failure, "Failing workflow task");
                     self.handle_wft_reporting_errs(&run_id, || async {
                         self.client
-                            .fail_workflow_task(tt, cause, failure.failure.map(Into::into))
+                            .fail_workflow_task(tt, cause, failure.failure)
                             .await
                     })
                     .await;

--- a/core/src/worker/workflow/run_cache.rs
+++ b/core/src/worker/workflow/run_cache.rs
@@ -1,10 +1,10 @@
 use crate::{
+    MetricsContext,
     telemetry::metrics::workflow_type,
     worker::workflow::{
-        managed_run::{ManagedRun, RunUpdateAct},
         HistoryUpdate, LocalActivityRequestSink, PermittedWFT, RequestEvictMsg, RunBasics,
+        managed_run::{ManagedRun, RunUpdateAct},
     },
-    MetricsContext,
 };
 use lru::LruCache;
 use std::{num::NonZeroUsize, rc::Rc, sync::Arc};

--- a/core/src/worker/workflow/wft_extraction.rs
+++ b/core/src/worker/workflow/wft_extraction.rs
@@ -4,15 +4,15 @@ use crate::{
     worker::{
         client::WorkerClient,
         workflow::{
-            history_update::HistoryPaginator, CacheMissFetchReq, HistoryUpdate, NextPageReq,
-            PermittedWFT,
+            CacheMissFetchReq, HistoryUpdate, NextPageReq, PermittedWFT,
+            history_update::HistoryPaginator,
         },
     },
 };
-use futures_util::{stream, stream::PollNext, FutureExt, Stream, StreamExt};
+use futures_util::{FutureExt, Stream, StreamExt, stream, stream::PollNext};
 use std::{future, sync::Arc};
 use temporal_sdk_core_api::worker::WorkflowSlotKind;
-use temporal_sdk_core_protos::{coresdk::WorkflowSlotInfo, TaskToken};
+use temporal_sdk_core_protos::{TaskToken, coresdk::WorkflowSlotInfo};
 use tracing::Span;
 
 /// Transforms incoming validated WFTs and history fetching requests into [PermittedWFT]s ready

--- a/core/src/worker/workflow/wft_poller.rs
+++ b/core/src/worker/workflow/wft_poller.rs
@@ -1,10 +1,10 @@
 use crate::{
+    MetricsContext,
     abstractions::OwnedMeteredSemPermit,
     pollers::{BoxedWFPoller, Poller},
     protosext::ValidPollWFTQResponse,
-    MetricsContext,
 };
-use futures_util::{stream, Stream};
+use futures_util::{Stream, stream};
 use temporal_sdk_core_api::worker::WorkflowSlotKind;
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse;
 
@@ -78,7 +78,7 @@ mod tests {
         abstractions::tests::fixed_size_permit_dealer, pollers::MockPermittedPollBuffer,
         test_help::mock_poller,
     };
-    use futures_util::{pin_mut, StreamExt};
+    use futures_util::{StreamExt, pin_mut};
     use std::sync::Arc;
     use temporal_sdk_core_api::worker::WorkflowSlotKind;
 

--- a/core/src/worker/workflow/workflow_stream.rs
+++ b/core/src/worker/workflow/workflow_stream.rs
@@ -1,4 +1,5 @@
 use crate::{
+    MetricsContext,
     abstractions::dbg_panic,
     worker::workflow::{
         managed_run::RunUpdateAct,
@@ -6,9 +7,8 @@ use crate::{
         wft_extraction::{HistfetchRC, HistoryFetchReq, WFTExtractorOutput},
         *,
     },
-    MetricsContext,
 };
-use futures_util::{stream, stream::PollNext, Stream, StreamExt};
+use futures_util::{Stream, StreamExt, stream, stream::PollNext};
 use std::{collections::VecDeque, fmt::Debug, future, sync::Arc};
 use temporal_sdk_core_api::errors::PollError;
 use temporal_sdk_core_protos::coresdk::workflow_activation::remove_from_cache::EvictionReason;

--- a/fsm/Cargo.toml
+++ b/fsm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustfsm"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>"]
-edition = "2021"
+edition = "2024"
 license-file = "LICENSE.txt"
 description = "Define state machines that can accept events and produce commands"
 homepage = "https://temporal.io/"

--- a/fsm/rustfsm_procmacro/Cargo.toml
+++ b/fsm/rustfsm_procmacro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustfsm_procmacro"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>"]
-edition = "2021"
+edition = "2024"
 license-file = "LICENSE.txt"
 description = "Procmacro sub-crate of the `rustfsm` crate"
 

--- a/fsm/rustfsm_procmacro/src/lib.rs
+++ b/fsm/rustfsm_procmacro/src/lib.rs
@@ -1,12 +1,11 @@
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map::Entry};
 use syn::{
-    parenthesized,
+    Error, Fields, Ident, Token, Type, Variant, Visibility, parenthesized,
     parse::{Parse, ParseStream, Result},
     parse_macro_input,
     spanned::Spanned,
-    Error, Fields, Ident, Token, Type, Variant, Visibility,
 };
 
 /// Parses a DSL for defining finite state machines, and produces code implementing the
@@ -287,7 +286,7 @@ impl Parse for Transition {
                 return Err(Error::new(
                     event.span(),
                     "Struct variants are not supported for events",
-                ))
+                ));
             }
             Fields::Unnamed(uf) => {
                 if uf.unnamed.len() != 1 {

--- a/fsm/rustfsm_trait/Cargo.toml
+++ b/fsm/rustfsm_trait/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustfsm_trait"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>"]
-edition = "2021"
+edition = "2024"
 license-file = "LICENSE.txt"
 description = "Trait sub-crate of the `rustfsm` crate"
 

--- a/sdk-core-protos/Cargo.toml
+++ b/sdk-core-protos/Cargo.toml
@@ -19,10 +19,9 @@ anyhow = "1.0"
 base64 = "0.22"
 derive_more = { workspace = true }
 prost = { workspace = true }
-prost-types = { workspace = true }
 prost-wkt = "0.6"
 prost-wkt-types = "0.6"
-rand = { version = "0.8", optional = true }
+rand = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { workspace = true }

--- a/sdk-core-protos/Cargo.toml
+++ b/sdk-core-protos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temporal-sdk-core-protos"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Spencer Judge <spencer@temporal.io>"]
 license-file = { workspace = true }
 description = "Protobuf definitions for Temporal SDKs Core/Lang interface"

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -1,26 +1,26 @@
 use crate::{
+    HistoryInfo,
     constants::{LOCAL_ACTIVITY_MARKER_NAME, PATCH_MARKER_NAME},
     coresdk::{
+        AsJsonPayloadExt, IntoPayloadsExt,
         common::{
-            build_has_change_marker_details, build_local_activity_marker_details,
-            NamespacedWorkflowExecution,
+            NamespacedWorkflowExecution, build_has_change_marker_details,
+            build_local_activity_marker_details,
         },
         external_data::LocalActivityMarkerData,
         workflow_commands::ScheduleActivity,
-        AsJsonPayloadExt, IntoPayloadsExt,
     },
     temporal::api::{
         common::v1::{
             ActivityType, Payload, Payloads, SearchAttributes, WorkflowExecution, WorkflowType,
         },
         enums::v1::{EventType, TaskQueueKind, WorkflowTaskFailedCause},
-        failure::v1::{failure, CanceledFailureInfo, Failure},
+        failure::v1::{CanceledFailureInfo, Failure, failure},
         history::v1::{history_event::Attributes, *},
         taskqueue::v1::TaskQueue,
         update,
         update::v1::outcome,
     },
-    HistoryInfo,
 };
 use anyhow::bail;
 use prost_wkt_types::Timestamp;

--- a/sdk-core-protos/src/history_info.rs
+++ b/sdk-core-protos/src/history_info.rs
@@ -1,7 +1,7 @@
 use crate::temporal::api::{
     common::v1::WorkflowType,
     enums::v1::{EventType, TaskQueueKind},
-    history::v1::{history_event, History, HistoryEvent, WorkflowExecutionStartedEventAttributes},
+    history::v1::{History, HistoryEvent, WorkflowExecutionStartedEventAttributes, history_event},
     taskqueue::v1::TaskQueue,
     workflowservice::v1::{GetWorkflowExecutionHistoryResponse, PollWorkflowTaskQueueResponse},
 };
@@ -207,7 +207,7 @@ impl From<HistoryInfo> for GetWorkflowExecutionHistoryResponse {
 
 #[cfg(test)]
 mod tests {
-    use crate::{temporal::api::enums::v1::EventType, TestHistoryBuilder};
+    use crate::{TestHistoryBuilder, temporal::api::enums::v1::EventType};
 
     fn single_timer(timer_id: &str) -> TestHistoryBuilder {
         let mut t = TestHistoryBuilder::default();

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -13,8 +13,8 @@ mod task_token;
 
 #[cfg(feature = "history_builders")]
 pub use history_builder::{
-    default_act_sched, default_wes_attribs, TestHistoryBuilder, DEFAULT_ACTIVITY_TYPE,
-    DEFAULT_WORKFLOW_TYPE,
+    DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, default_act_sched,
+    default_wes_attribs,
 };
 #[cfg(feature = "history_builders")]
 pub use history_info::HistoryInfo;
@@ -37,16 +37,16 @@ pub mod coresdk {
     tonic::include_proto!("coresdk");
 
     use crate::{
+        ENCODING_PAYLOAD_KEY, JSON_ENCODING_VAL,
         temporal::api::{
             common::v1::{Payload, Payloads, WorkflowExecution},
             enums::v1::{TimeoutType, WorkflowTaskFailedCause},
             failure::v1::{
-                failure::FailureInfo, ActivityFailureInfo, ApplicationFailureInfo, Failure,
-                TimeoutFailureInfo,
+                ActivityFailureInfo, ApplicationFailureInfo, Failure, TimeoutFailureInfo,
+                failure::FailureInfo,
             },
             workflowservice::v1::PollActivityTaskQueueResponse,
         },
-        ENCODING_PAYLOAD_KEY, JSON_ENCODING_VAL,
     };
     use activity_task::ActivityTask;
     use serde::{Deserialize, Serialize};
@@ -56,9 +56,9 @@ pub mod coresdk {
         fmt::{Display, Formatter},
         iter::FromIterator,
     };
-    use workflow_activation::{workflow_activation_job, WorkflowActivationJob};
-    use workflow_commands::{workflow_command, workflow_command::Variant, WorkflowCommand};
-    use workflow_completion::{workflow_activation_completion, WorkflowActivationCompletion};
+    use workflow_activation::{WorkflowActivationJob, workflow_activation_job};
+    use workflow_commands::{WorkflowCommand, workflow_command, workflow_command::Variant};
+    use workflow_completion::{WorkflowActivationCompletion, workflow_activation_completion};
 
     #[allow(clippy::module_inception)]
     pub mod activity_task {
@@ -107,7 +107,7 @@ pub mod coresdk {
         tonic::include_proto!("coresdk.activity_result");
         use super::super::temporal::api::{
             common::v1::Payload,
-            failure::v1::{failure, CanceledFailureInfo, Failure as APIFailure},
+            failure::v1::{CanceledFailureInfo, Failure as APIFailure, failure},
         };
         use crate::{
             coresdk::activity_result::activity_resolution::Status,
@@ -287,12 +287,12 @@ pub mod coresdk {
         tonic::include_proto!("coresdk.common");
         use super::external_data::LocalActivityMarkerData;
         use crate::{
+            PATCHED_MARKER_DETAILS_KEY,
             coresdk::{
-                external_data::PatchedMarkerData, AsJsonPayloadExt, FromJsonPayloadExt,
-                IntoPayloadsExt,
+                AsJsonPayloadExt, FromJsonPayloadExt, IntoPayloadsExt,
+                external_data::PatchedMarkerData,
             },
             temporal::api::common::v1::{Payload, Payloads},
-            PATCHED_MARKER_DETAILS_KEY,
         };
         use std::collections::HashMap;
 
@@ -450,10 +450,10 @@ pub mod coresdk {
     pub mod workflow_activation {
         use crate::{
             coresdk::{
-                activity_result::{activity_resolution, ActivityResolution},
+                FromPayloadsExt,
+                activity_result::{ActivityResolution, activity_resolution},
                 common::NamespacedWorkflowExecution,
                 workflow_activation::remove_from_cache::EvictionReason,
-                FromPayloadsExt,
             },
             temporal::api::{
                 enums::v1::WorkflowTaskFailedCause,
@@ -1563,7 +1563,7 @@ pub mod temporal {
                 tonic::include_proto!("temporal.api.command.v1");
 
                 use crate::{
-                    coresdk::{workflow_commands, IntoPayloadsExt},
+                    coresdk::{IntoPayloadsExt, workflow_commands},
                     temporal::api::{
                         common::v1::{ActivityType, WorkflowType},
                         enums::v1::CommandType,
@@ -1934,7 +1934,7 @@ pub mod temporal {
         pub mod common {
             pub mod v1 {
                 use crate::{ENCODING_PAYLOAD_KEY, JSON_ENCODING_VAL};
-                use base64::{prelude::BASE64_STANDARD, Engine};
+                use base64::{Engine, prelude::BASE64_STANDARD};
                 use std::{
                     collections::HashMap,
                     fmt::{Display, Formatter},
@@ -2401,7 +2401,7 @@ pub mod temporal {
             pub mod v1 {
                 use crate::temporal::api::{
                     common,
-                    common::v1::link::{workflow_event, WorkflowEvent},
+                    common::v1::link::{WorkflowEvent, workflow_event},
                     enums::v1::EventType,
                 };
                 use anyhow::{anyhow, bail};

--- a/sdk-core-protos/src/lib.rs
+++ b/sdk-core-protos/src/lib.rs
@@ -1263,7 +1263,7 @@ pub mod coresdk {
                         schedule_to_close_timeout: r.schedule_to_close_timeout,
                         start_to_close_timeout: r.start_to_close_timeout,
                         heartbeat_timeout: r.heartbeat_timeout,
-                        retry_policy: r.retry_policy.map(Into::into),
+                        retry_policy: r.retry_policy,
                         is_local: false,
                     },
                 )),
@@ -1424,7 +1424,7 @@ pub mod coresdk {
         fn from_payloads(p: Option<Payloads>) -> Self {
             match p {
                 None => std::iter::empty().collect(),
-                Some(p) => p.payloads.into_iter().map(Into::into).collect(),
+                Some(p) => p.payloads.into_iter().collect(),
             }
         }
     }
@@ -1442,7 +1442,7 @@ pub mod coresdk {
                 None
             } else {
                 Some(Payloads {
-                    payloads: iterd.map(Into::into).collect(),
+                    payloads: iterd.collect(),
                 })
             }
         }

--- a/sdk-core-protos/src/task_token.rs
+++ b/sdk-core-protos/src/task_token.rs
@@ -1,4 +1,4 @@
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 use std::{
     borrow::Borrow,
     fmt::{Debug, Display, Formatter},

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["development-tools"]
 
 [dependencies]
 async-trait = "0.1"
-thiserror = { workspace = true }
 anyhow = "1.0"
 derive_more = { workspace = true }
 futures-util = { version = "0.3", default-features = false }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "temporal-sdk"
 version = "0.1.0-alpha.1"
-edition = "2021"
+edition = "2024"
 authors = ["Spencer Judge <spencer@temporal.io>"]
 license-file = { workspace = true }
 description = "Temporal Rust SDK"

--- a/sdk/src/activity_context.rs
+++ b/sdk/src/activity_context.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::{
-    coresdk::{activity_task, ActivityHeartbeat},
+    coresdk::{ActivityHeartbeat, activity_task},
     temporal::api::common::v1::{Payload, RetryPolicy, WorkflowExecution},
     utilities::TryIntoOrNone,
 };

--- a/sdk/src/interceptors.rs
+++ b/sdk/src/interceptors.rs
@@ -3,7 +3,7 @@
 use crate::Worker;
 use anyhow::bail;
 use temporal_sdk_core_protos::coresdk::{
-    workflow_activation::{remove_from_cache::EvictionReason, WorkflowActivation},
+    workflow_activation::{WorkflowActivation, remove_from_cache::EvictionReason},
     workflow_completion::WorkflowActivationCompletion,
 };
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -17,25 +17,17 @@ ephemeral-server = ["temporal-sdk-core/ephemeral-server"]
 anyhow = "1.0"
 assert_matches = "1"
 async-trait = "0.1"
-base64 = "0.22"
-bytes = "1.3"
 futures-util = { version = "0.3", default-features = false }
 parking_lot = "0.12"
 prost = { workspace = true }
-prost-types = { workspace = true }
-rand = "0.8"
-rmp-serde = "1.1"
-serde_json = "1.0"
+rand = "0.9"
 temporal-client = { path = "../client" }
 temporal-sdk = { path = "../sdk" }
 temporal-sdk-core = { path = "../core" }
 temporal-sdk-core-api = { path = "../core-api" }
-thiserror = { workspace = true }
 tokio = "1.1"
-tokio-util = { version = "0.7" }
 tracing = "0.1"
 url = "2.2"
-uuid = "1.1"
 
 [dependencies.temporal-sdk-core-protos]
 path = "../sdk-core-protos"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "temporal-sdk-core-test-utils"
 version = "0.1.0"
 authors = ["Spencer Judge <spencer@temporal.io>"]
-edition = "2021"
+edition = "2024"
 license-file = { workspace = true }
 
 [[bin]]

--- a/test-utils/src/canned_histories.rs
+++ b/test-utils/src/canned_histories.rs
@@ -767,7 +767,7 @@ pub fn lots_of_big_signals(num_tasks: usize) -> TestHistoryBuilder {
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 1..=num_tasks {
         let mut dat = [0_u8; 1024 * 1000];
         for _ in 1..=5 {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -16,7 +16,7 @@ use assert_matches::assert_matches;
 use futures_util::{StreamExt, future, stream, stream::FuturesUnordered};
 use parking_lot::Mutex;
 use prost::Message;
-use rand::{Rng, distributions};
+use rand::Rng;
 use std::{
     convert::TryFrom, env, future::Future, net::SocketAddr, path::PathBuf, sync::Arc,
     time::Duration,
@@ -874,8 +874,8 @@ pub async fn drain_pollers_and_shutdown(worker: &Arc<dyn CoreWorker>) {
 }
 
 pub fn rand_6_chars() -> String {
-    rand::thread_rng()
-        .sample_iter(&distributions::Alphanumeric)
+    rand::rng()
+        .sample_iter(&rand::distr::Alphanumeric)
         .take(6)
         .map(char::from)
         .collect()

--- a/tests/fuzzy_workflow.rs
+++ b/tests/fuzzy_workflow.rs
@@ -21,7 +21,7 @@ enum FuzzyWfAction {
 struct FuzzyWfActionSampler;
 impl Distribution<FuzzyWfAction> for FuzzyWfActionSampler {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> FuzzyWfAction {
-        let v: u8 = rng.gen_range(1..=2);
+        let v: u8 = rng.random_range(1..=2);
         match v {
             1 => FuzzyWfAction::DoAct,
             2 => FuzzyWfAction::DoLocalAct,

--- a/tests/fuzzy_workflow.rs
+++ b/tests/fuzzy_workflow.rs
@@ -1,5 +1,5 @@
-use futures_util::{sink, stream::FuturesUnordered, FutureExt, StreamExt};
-use rand::{prelude::Distribution, rngs::SmallRng, Rng, SeedableRng};
+use futures_util::{FutureExt, StreamExt, sink, stream::FuturesUnordered};
+use rand::{Rng, SeedableRng, prelude::Distribution, rngs::SmallRng};
 use std::{future, time::Duration};
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{

--- a/tests/heavy_tests.rs
+++ b/tests/heavy_tests.rs
@@ -1,4 +1,4 @@
-use futures_util::{future::join_all, sink, stream::FuturesUnordered, StreamExt};
+use futures_util::{StreamExt, future::join_all, sink, stream::FuturesUnordered};
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -7,10 +7,10 @@ use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{ActContext, ActivityOptions, WfContext, WorkflowResult};
 use temporal_sdk_core::{ResourceBasedTuner, ResourceSlotOptions};
 use temporal_sdk_core_protos::{
-    coresdk::{workflow_commands::ActivityCancellationType, AsJsonPayloadExt},
+    coresdk::{AsJsonPayloadExt, workflow_commands::ActivityCancellationType},
     temporal::api::enums::v1::WorkflowIdReusePolicy,
 };
-use temporal_sdk_core_test_utils::{workflows::la_problem_workflow, CoreWfStarter};
+use temporal_sdk_core_test_utils::{CoreWfStarter, workflows::la_problem_workflow};
 
 mod fuzzy_workflow;
 

--- a/tests/integ_tests/client_tests.rs
+++ b/tests/integ_tests/client_tests.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use futures_util::{future::BoxFuture, FutureExt};
+use futures_util::{FutureExt, future::BoxFuture};
 use http_body_util::BodyExt;
 use prost::Message;
 use std::{
@@ -7,14 +7,14 @@ use std::{
     convert::Infallible,
     env,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     task::{Context, Poll},
     time::Duration,
 };
 use temporal_client::{
-    Namespace, RetryConfig, WorkflowClientTrait, WorkflowService, RETRYABLE_ERROR_CODES,
+    Namespace, RETRYABLE_ERROR_CODES, RetryConfig, WorkflowClientTrait, WorkflowService,
 };
 use temporal_sdk_core_protos::temporal::api::{
     cloud::cloudservice::v1::GetNamespaceRequest,
@@ -23,17 +23,17 @@ use temporal_sdk_core_protos::temporal::api::{
         RespondActivityTaskCanceledResponse,
     },
 };
-use temporal_sdk_core_test_utils::{get_integ_server_options, CoreWfStarter, NAMESPACE};
+use temporal_sdk_core_test_utils::{CoreWfStarter, NAMESPACE, get_integ_server_options};
 use tokio::{
     net::TcpListener,
     sync::{mpsc::UnboundedSender, oneshot},
 };
 use tonic::{
+    Code, Request, Status,
     body::BoxBody,
-    codegen::{http::Response, Service},
+    codegen::{Service, http::Response},
     server::NamedService,
     transport::Server,
-    Code, Request, Status,
 };
 use tracing::info;
 

--- a/tests/integ_tests/ephemeral_server_tests.rs
+++ b/tests/integ_tests/ephemeral_server_tests.rs
@@ -1,4 +1,4 @@
-use futures_util::{stream, TryStreamExt};
+use futures_util::{TryStreamExt, stream};
 use std::time::{SystemTime, UNIX_EPOCH};
 use temporal_client::{ClientOptionsBuilder, TestService, WorkflowService};
 use temporal_sdk_core::ephemeral_server::{
@@ -6,7 +6,7 @@ use temporal_sdk_core::ephemeral_server::{
     TestServerConfigBuilder,
 };
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::DescribeNamespaceRequest;
-use temporal_sdk_core_test_utils::{default_cached_download, NAMESPACE};
+use temporal_sdk_core_test_utils::{NAMESPACE, default_cached_download};
 use url::Url;
 
 #[tokio::test]

--- a/tests/integ_tests/heartbeat_tests.rs
+++ b/tests/integ_tests/heartbeat_tests.rs
@@ -3,25 +3,25 @@ use std::time::Duration;
 use temporal_client::{WfClientExt, WorkflowOptions};
 use temporal_sdk::{ActContext, ActivityOptions, WfContext};
 use temporal_sdk_core_protos::{
+    DEFAULT_ACTIVITY_TYPE,
     coresdk::{
+        ActivityHeartbeat, ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
         activity_result::{
-            self, activity_resolution as act_res, ActivityExecutionResult, ActivityResolution,
+            self, ActivityExecutionResult, ActivityResolution, activity_resolution as act_res,
         },
         activity_task::activity_task,
-        workflow_activation::{workflow_activation_job, ResolveActivity, WorkflowActivationJob},
+        workflow_activation::{ResolveActivity, WorkflowActivationJob, workflow_activation_job},
         workflow_commands::{ActivityCancellationType, ScheduleActivity},
         workflow_completion::WorkflowActivationCompletion,
-        ActivityHeartbeat, ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
     },
     temporal::api::{
         common::v1::{Payload, RetryPolicy},
         enums::v1::TimeoutType,
     },
-    DEFAULT_ACTIVITY_TYPE,
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, init_core_and_create_wf, schedule_activity_cmd, CoreWfStarter,
-    WorkerTestHelpers,
+    CoreWfStarter, WorkerTestHelpers, drain_pollers_and_shutdown, init_core_and_create_wf,
+    schedule_activity_cmd,
 };
 use tokio::time::sleep;
 

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -2,19 +2,19 @@ use assert_matches::assert_matches;
 use std::{sync::Arc, time::Duration};
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk_core::{
-    ephemeral_server::TemporalDevServerConfigBuilder, init_worker, ClientOptionsBuilder,
+    ClientOptionsBuilder, ephemeral_server::TemporalDevServerConfigBuilder, init_worker,
 };
 use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::coresdk::{
+    IntoCompletion,
     activity_task::activity_task as act_task,
-    workflow_activation::{workflow_activation_job, FireTimer, WorkflowActivationJob},
+    workflow_activation::{FireTimer, WorkflowActivationJob, workflow_activation_job},
     workflow_commands::{ActivityCancellationType, RequestCancelActivity, StartTimer},
     workflow_completion::WorkflowActivationCompletion,
-    IntoCompletion,
 };
 use temporal_sdk_core_test_utils::{
-    default_cached_download, drain_pollers_and_shutdown, init_core_and_create_wf, init_integ_telem,
-    integ_worker_config, schedule_activity_cmd, WorkerTestHelpers,
+    WorkerTestHelpers, default_cached_download, drain_pollers_and_shutdown,
+    init_core_and_create_wf, init_integ_telem, integ_worker_config, schedule_activity_cmd,
 };
 use tokio::time::timeout;
 use tracing::info;

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -1,17 +1,17 @@
 use assert_matches::assert_matches;
-use futures_util::{future::join_all, stream::FuturesUnordered, FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt, future::join_all, stream::FuturesUnordered};
 use std::time::{Duration, Instant};
 use temporal_client::WorkflowClientTrait;
 use temporal_sdk_core_protos::{
     coresdk::{
-        workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_commands::{QueryResult, QuerySuccess, StartTimer},
         workflow_completion::WorkflowActivationCompletion,
     },
     temporal::api::{failure::v1::Failure, query::v1::WorkflowQuery},
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, init_core_and_create_wf, CoreWfStarter, WorkerTestHelpers,
+    CoreWfStarter, WorkerTestHelpers, drain_pollers_and_shutdown, init_core_and_create_wf,
 };
 use tokio::join;
 
@@ -125,9 +125,11 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
 
             // When we see the query, handle it.
             if go_until_query {
-                if let [WorkflowActivationJob {
-                    variant: Some(workflow_activation_job::Variant::QueryWorkflow(query)),
-                }] = task.jobs.as_slice()
+                if let [
+                    WorkflowActivationJob {
+                        variant: Some(workflow_activation_job::Variant::QueryWorkflow(query)),
+                    },
+                ] = task.jobs.as_slice()
                 {
                     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
                         task.run_id,

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -1,10 +1,10 @@
 use anyhow::anyhow;
 use assert_matches::assert_matches;
-use futures_util::{future, future::join_all, StreamExt};
+use futures_util::{StreamExt, future, future::join_all};
 use std::{
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, LazyLock,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -16,15 +16,15 @@ use temporal_sdk_core::replay::HistoryForReplay;
 use temporal_sdk_core_api::Worker;
 use temporal_sdk_core_protos::{
     coresdk::{
+        ActivityTaskCompletion, AsJsonPayloadExt, IntoPayloadsExt,
         activity_result::ActivityExecutionResult,
         workflow_activation::{
-            remove_from_cache::EvictionReason, workflow_activation_job, WorkflowActivationJob,
+            WorkflowActivationJob, remove_from_cache::EvictionReason, workflow_activation_job,
         },
         workflow_commands::{
-            update_response, CompleteWorkflowExecution, ScheduleLocalActivity, UpdateResponse,
+            CompleteWorkflowExecution, ScheduleLocalActivity, UpdateResponse, update_response,
         },
         workflow_completion::WorkflowActivationCompletion,
-        ActivityTaskCompletion, AsJsonPayloadExt, IntoPayloadsExt,
     },
     temporal::api::{
         common::v1::WorkflowExecution,
@@ -34,8 +34,8 @@ use temporal_sdk_core_protos::{
     },
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, init_core_and_create_wf, init_core_replay_preloaded,
-    start_timer_cmd, CoreWfStarter, WorkerTestHelpers, WorkflowHandleExt,
+    CoreWfStarter, WorkerTestHelpers, WorkflowHandleExt, drain_pollers_and_shutdown,
+    init_core_and_create_wf, init_core_replay_preloaded, start_timer_cmd,
 };
 use tokio::{join, sync::Barrier};
 use uuid::Uuid;
@@ -614,11 +614,13 @@ async fn update_speculative_wft() {
         // Reject the update
         core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
             res.run_id,
-            vec![UpdateResponse {
-                protocol_instance_id: pid.to_string(),
-                response: Some(update_response::Response::Rejected("nope!".into())),
-            }
-            .into()],
+            vec![
+                UpdateResponse {
+                    protocol_instance_id: pid.to_string(),
+                    response: Some(update_response::Response::Rejected("nope!".into())),
+                }
+                .into(),
+            ],
         ))
         .await
         .unwrap();

--- a/tests/integ_tests/visibility_tests.rs
+++ b/tests/integ_tests/visibility_tests.rs
@@ -5,11 +5,11 @@ use temporal_client::{
     WorkflowClientTrait, WorkflowExecutionFilter,
 };
 use temporal_sdk_core_protos::coresdk::workflow_activation::{
-    workflow_activation_job, WorkflowActivationJob,
+    WorkflowActivationJob, workflow_activation_job,
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, get_integ_server_options, CoreWfStarter, WorkerTestHelpers,
-    NAMESPACE,
+    CoreWfStarter, NAMESPACE, WorkerTestHelpers, drain_pollers_and_shutdown,
+    get_integ_server_options,
 };
 use tokio::time::sleep;
 

--- a/tests/integ_tests/worker_tests.rs
+++ b/tests/integ_tests/worker_tests.rs
@@ -1,17 +1,17 @@
 use assert_matches::assert_matches;
 use std::{cell::Cell, sync::Arc, time::Duration};
 use temporal_client::WorkflowOptions;
-use temporal_sdk::{interceptors::WorkerInterceptor, WfContext};
-use temporal_sdk_core::{init_worker, CoreRuntime, ResourceBasedTuner, ResourceSlotOptions};
-use temporal_sdk_core_api::{errors::WorkerValidationError, worker::WorkerConfigBuilder, Worker};
+use temporal_sdk::{WfContext, interceptors::WorkerInterceptor};
+use temporal_sdk_core::{CoreRuntime, ResourceBasedTuner, ResourceSlotOptions, init_worker};
+use temporal_sdk_core_api::{Worker, errors::WorkerValidationError, worker::WorkerConfigBuilder};
 use temporal_sdk_core_protos::{
     coresdk::workflow_completion::{
-        workflow_activation_completion::Status, Failure, WorkflowActivationCompletion,
+        Failure, WorkflowActivationCompletion, workflow_activation_completion::Status,
     },
     temporal::api::failure::v1::Failure as InnerFailure,
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, get_integ_server_options, get_integ_telem_options, CoreWfStarter,
+    CoreWfStarter, drain_pollers_and_shutdown, get_integ_server_options, get_integ_telem_options,
 };
 use tokio::sync::Notify;
 use uuid::Uuid;

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -26,20 +26,20 @@ use std::{
 };
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowExecutionResult, WorkflowOptions};
 use temporal_sdk::{
-    interceptors::WorkerInterceptor, ActivityOptions, LocalActivityOptions, WfContext,
-    WorkflowResult,
+    ActivityOptions, LocalActivityOptions, WfContext, WorkflowResult,
+    interceptors::WorkerInterceptor,
 };
-use temporal_sdk_core::{replay::HistoryForReplay, CoreRuntime};
+use temporal_sdk_core::{CoreRuntime, replay::HistoryForReplay};
 use temporal_sdk_core_api::errors::{PollError, WorkflowErrorType};
 use temporal_sdk_core_protos::{
     coresdk::{
+        ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
         activity_result::ActivityExecutionResult,
-        workflow_activation::{workflow_activation_job, WorkflowActivationJob},
+        workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_commands::{
             ActivityCancellationType, FailWorkflowExecution, QueryResult, QuerySuccess, StartTimer,
         },
         workflow_completion::WorkflowActivationCompletion,
-        ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
     },
     temporal::api::{
         enums::v1::EventType, failure::v1::Failure, history::v1::history_event,
@@ -47,8 +47,8 @@ use temporal_sdk_core_protos::{
     },
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, history_from_proto_binary, init_core_and_create_wf,
-    init_core_replay_preloaded, schedule_activity_cmd, CoreWfStarter, WorkerTestHelpers,
+    CoreWfStarter, WorkerTestHelpers, drain_pollers_and_shutdown, history_from_proto_binary,
+    init_core_and_create_wf, init_core_replay_preloaded, schedule_activity_cmd,
 };
 use tokio::{join, sync::Notify, time::sleep};
 use uuid::Uuid;
@@ -200,11 +200,13 @@ async fn fail_wf_task(#[values(true, false)] replay: bool) {
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
-        vec![StartTimer {
-            seq: 0,
-            start_to_fire_timeout: Some(prost_dur!(from_millis(200))),
-        }
-        .into()],
+        vec![
+            StartTimer {
+                seq: 0,
+                start_to_fire_timeout: Some(prost_dur!(from_millis(200))),
+            }
+            .into(),
+        ],
     ))
     .await
     .unwrap();
@@ -224,10 +226,12 @@ async fn fail_workflow_execution() {
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
-        vec![FailWorkflowExecution {
-            failure: Some(Failure::application_failure("I'm ded".to_string(), false)),
-        }
-        .into()],
+        vec![
+            FailWorkflowExecution {
+                failure: Some(Failure::application_failure("I'm ded".to_string(), false)),
+            }
+            .into(),
+        ],
     ))
     .await
     .unwrap();
@@ -324,11 +328,13 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
         // Task is completed with a timer
         core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
             res.run_id,
-            vec![StartTimer {
-                seq: 0,
-                start_to_fire_timeout: Some(prost_dur!(from_millis(10))),
-            }
-            .into()],
+            vec![
+                StartTimer {
+                    seq: 0,
+                    start_to_fire_timeout: Some(prost_dur!(from_millis(10))),
+                }
+                .into(),
+            ],
         ))
         .await
         .unwrap();

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -12,31 +12,31 @@ use temporal_sdk::{
     WfExitValue, WorkflowResult,
 };
 use temporal_sdk_core_protos::{
+    DEFAULT_ACTIVITY_TYPE, TaskToken,
     coresdk::{
+        ActivityHeartbeat, ActivityTaskCompletion, AsJsonPayloadExt, FromJsonPayloadExt,
+        IntoCompletion,
         activity_result::{
-            self, activity_resolution as act_res, ActivityExecutionResult, ActivityResolution,
+            self, ActivityExecutionResult, ActivityResolution, activity_resolution as act_res,
         },
         activity_task::activity_task as act_task,
         workflow_activation::{
-            workflow_activation_job, FireTimer, ResolveActivity, WorkflowActivationJob,
+            FireTimer, ResolveActivity, WorkflowActivationJob, workflow_activation_job,
         },
         workflow_commands::{
             ActivityCancellationType, RequestCancelActivity, ScheduleActivity, StartTimer,
         },
         workflow_completion::WorkflowActivationCompletion,
-        ActivityHeartbeat, ActivityTaskCompletion, AsJsonPayloadExt, FromJsonPayloadExt,
-        IntoCompletion,
     },
     temporal::api::{
         common::v1::{ActivityType, Payload, Payloads, RetryPolicy},
         enums::v1::RetryState,
-        failure::v1::{failure::FailureInfo, ActivityFailureInfo, Failure},
+        failure::v1::{ActivityFailureInfo, Failure, failure::FailureInfo},
     },
-    TaskToken, DEFAULT_ACTIVITY_TYPE,
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, init_core_and_create_wf, schedule_activity_cmd, CoreWfStarter,
-    WorkerTestHelpers,
+    CoreWfStarter, WorkerTestHelpers, drain_pollers_and_shutdown, init_core_and_create_wf,
+    schedule_activity_cmd,
 };
 use tokio::{join, sync::Semaphore, time::sleep};
 
@@ -458,11 +458,13 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     // another short timer
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
-        vec![StartTimer {
-            seq: 2,
-            start_to_fire_timeout: Some(prost_dur!(from_millis(100))),
-        }
-        .into()],
+        vec![
+            StartTimer {
+                seq: 2,
+                start_to_fire_timeout: Some(prost_dur!(from_millis(100))),
+            }
+            .into(),
+        ],
     ))
     .await
     .unwrap();

--- a/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -1,6 +1,6 @@
 use temporal_client::{GetWorkflowResultOpts, WfClientExt, WorkflowOptions};
 use temporal_sdk::{WfContext, WorkflowResult};
-use temporal_sdk_core_protos::coresdk::{common::NamespacedWorkflowExecution, FromJsonPayloadExt};
+use temporal_sdk_core_protos::coresdk::{FromJsonPayloadExt, common::NamespacedWorkflowExecution};
 use temporal_sdk_core_test_utils::CoreWfStarter;
 
 const RECEIVER_WFID: &str = "sends-cancel-receiver";

--- a/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -5,8 +5,8 @@ use temporal_client::{WorkflowClientTrait, WorkflowOptions};
 use temporal_sdk::{ChildWorkflowOptions, WfContext, WfExitValue, WorkflowResult};
 use temporal_sdk_core_protos::{
     coresdk::{
-        child_workflow::{child_workflow_result, ChildWorkflowCancellationType, Success},
         AsJsonPayloadExt,
+        child_workflow::{ChildWorkflowCancellationType, Success, child_workflow_result},
     },
     temporal::api::enums::v1::ParentClosePolicy,
 };

--- a/tests/integ_tests/workflow_tests/eager.rs
+++ b/tests/integ_tests/workflow_tests/eager.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use temporal_client::WorkflowClientTrait;
 use temporal_sdk::{WfContext, WorkflowResult};
-use temporal_sdk_core_test_utils::{get_integ_server_options, CoreWfStarter, NAMESPACE};
+use temporal_sdk_core_test_utils::{CoreWfStarter, NAMESPACE, get_integ_server_options};
 
 pub(crate) async fn eager_wf(_context: WfContext) -> WorkflowResult<()> {
     Ok(().into())

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -7,23 +7,23 @@ use std::{
 };
 use temporal_client::{WfClientExt, WorkflowOptions};
 use temporal_sdk::{
-    interceptors::WorkerInterceptor, ActContext, ActivityError, ActivityOptions, CancellableFuture,
-    LocalActivityOptions, WfContext, WorkflowResult,
+    ActContext, ActivityError, ActivityOptions, CancellableFuture, LocalActivityOptions, WfContext,
+    WorkflowResult, interceptors::WorkerInterceptor,
 };
 use temporal_sdk_core::replay::HistoryForReplay;
 use temporal_sdk_core_protos::{
+    TestHistoryBuilder,
     coresdk::{
-        workflow_commands::{workflow_command::Variant, ActivityCancellationType},
-        workflow_completion,
-        workflow_completion::{workflow_activation_completion, WorkflowActivationCompletion},
         AsJsonPayloadExt,
+        workflow_commands::{ActivityCancellationType, workflow_command::Variant},
+        workflow_completion,
+        workflow_completion::{WorkflowActivationCompletion, workflow_activation_completion},
     },
     temporal::api::{common::v1::RetryPolicy, enums::v1::TimeoutType},
-    TestHistoryBuilder,
 };
 use temporal_sdk_core_test_utils::{
-    history_from_proto_binary, replay_sdk_worker, workflows::la_problem_workflow, CoreWfStarter,
-    WorkflowHandleExt,
+    CoreWfStarter, WorkflowHandleExt, history_from_proto_binary, replay_sdk_worker,
+    workflows::la_problem_workflow,
 };
 use tokio_util::sync::CancellationToken;
 

--- a/tests/integ_tests/workflow_tests/nexus.rs
+++ b/tests/integ_tests/workflow_tests/nexus.rs
@@ -7,23 +7,23 @@ use temporal_sdk::{CancellableFuture, NexusOperationOptions, WfContext, WfExitVa
 use temporal_sdk_core_api::errors::PollError;
 use temporal_sdk_core_protos::{
     coresdk::{
-        nexus::{
-            nexus_operation_result, nexus_task, nexus_task_completion, NexusOperationResult,
-            NexusTaskCancelReason, NexusTaskCompletion,
-        },
         FromJsonPayloadExt,
+        nexus::{
+            NexusOperationResult, NexusTaskCancelReason, NexusTaskCompletion,
+            nexus_operation_result, nexus_task, nexus_task_completion,
+        },
     },
     temporal::api::{
-        common::v1::{callback, Callback},
+        common::v1::{Callback, callback},
         failure::v1::failure::FailureInfo,
         nexus,
         nexus::v1::{
-            request, start_operation_response, workflow_event_link_from_nexus,
-            CancelOperationResponse, HandlerError, StartOperationResponse,
+            CancelOperationResponse, HandlerError, StartOperationResponse, request,
+            start_operation_response, workflow_event_link_from_nexus,
         },
     },
 };
-use temporal_sdk_core_test_utils::{rand_6_chars, CoreWfStarter};
+use temporal_sdk_core_test_utils::{CoreWfStarter, rand_6_chars};
 use tokio::{join, sync::mpsc};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/tests/integ_tests/workflow_tests/patches.rs
+++ b/tests/integ_tests/workflow_tests/patches.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };

--- a/tests/integ_tests/workflow_tests/replay.rs
+++ b/tests/integ_tests/workflow_tests/replay.rs
@@ -2,21 +2,21 @@ use crate::integ_tests::workflow_tests::patches::changes_wf;
 use assert_matches::assert_matches;
 use parking_lot::Mutex;
 use std::{collections::HashSet, sync::Arc, time::Duration};
-use temporal_sdk::{interceptors::WorkerInterceptor, WfContext, Worker, WorkflowFunction};
+use temporal_sdk::{WfContext, Worker, WorkflowFunction, interceptors::WorkerInterceptor};
 use temporal_sdk_core::replay::{HistoryFeeder, HistoryForReplay};
 use temporal_sdk_core_api::errors::PollError;
 use temporal_sdk_core_protos::{
+    DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder,
     coresdk::{
         workflow_activation::remove_from_cache::EvictionReason,
         workflow_commands::{ScheduleActivity, StartTimer},
         workflow_completion::WorkflowActivationCompletion,
     },
     temporal::api::enums::v1::EventType,
-    TestHistoryBuilder, DEFAULT_WORKFLOW_TYPE,
 };
 use temporal_sdk_core_test_utils::{
-    canned_histories, history_from_proto_binary, init_core_replay_preloaded, replay_sdk_worker,
-    replay_sdk_worker_stream, WorkerTestHelpers,
+    WorkerTestHelpers, canned_histories, history_from_proto_binary, init_core_replay_preloaded,
+    replay_sdk_worker, replay_sdk_worker_stream,
 };
 use tokio::join;
 
@@ -39,11 +39,13 @@ async fn timer_workflow_replay() {
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
-        vec![StartTimer {
-            seq: 0,
-            start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
-        }
-        .into()],
+        vec![
+            StartTimer {
+                seq: 0,
+                start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
+            }
+            .into(),
+        ],
     ))
     .await
     .unwrap();
@@ -94,13 +96,15 @@ async fn workflow_nondeterministic_replay() {
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
-        vec![ScheduleActivity {
-            seq: 0,
-            activity_id: "0".to_string(),
-            activity_type: "fake_act".to_string(),
-            ..Default::default()
-        }
-        .into()],
+        vec![
+            ScheduleActivity {
+                seq: 0,
+                activity_id: "0".to_string(),
+                activity_type: "fake_act".to_string(),
+                ..Default::default()
+            }
+            .into(),
+        ],
     ))
     .await
     .unwrap();
@@ -261,13 +265,15 @@ async fn replay_ends_with_empty_wft() {
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
-        vec![ScheduleActivity {
-            seq: 1,
-            activity_id: "1".to_string(),
-            activity_type: "say_hello".to_string(),
-            ..Default::default()
-        }
-        .into()],
+        vec![
+            ScheduleActivity {
+                seq: 1,
+                activity_id: "1".to_string(),
+                activity_type: "say_hello".to_string(),
+                ..Default::default()
+            }
+            .into(),
+        ],
     ))
     .await
     .unwrap();

--- a/tests/integ_tests/workflow_tests/resets.rs
+++ b/tests/integ_tests/workflow_tests/resets.rs
@@ -2,8 +2,8 @@ use crate::integ_tests::activity_functions::echo;
 use futures_util::StreamExt;
 use std::{
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Duration,
 };

--- a/tests/integ_tests/workflow_tests/timers.rs
+++ b/tests/integ_tests/workflow_tests/timers.rs
@@ -6,8 +6,8 @@ use temporal_sdk_core_protos::coresdk::{
     workflow_completion::WorkflowActivationCompletion,
 };
 use temporal_sdk_core_test_utils::{
-    drain_pollers_and_shutdown, init_core_and_create_wf, start_timer_cmd, CoreWfStarter,
-    WorkerTestHelpers,
+    CoreWfStarter, WorkerTestHelpers, drain_pollers_and_shutdown, init_core_and_create_wf,
+    start_timer_cmd,
 };
 
 pub(crate) async fn timer_wf(command_sink: WfContext) -> WorkflowResult<()> {
@@ -35,11 +35,13 @@ async fn timer_workflow_manual() {
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
-        vec![StartTimer {
-            seq: 0,
-            start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
-        }
-        .into()],
+        vec![
+            StartTimer {
+                seq: 0,
+                start_to_fire_timeout: Some(prost_dur!(from_secs(1))),
+            }
+            .into(),
+        ],
     ))
     .await
     .unwrap();

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -22,17 +22,17 @@ mod integ_tests {
     use std::{env, str::FromStr, time::Duration};
     use temporal_client::{NamespacedClient, WorkflowService};
     use temporal_sdk_core::{
-        init_worker, ClientOptionsBuilder, ClientTlsConfig, CoreRuntime, TlsConfig,
-        WorkflowClientTrait,
+        ClientOptionsBuilder, ClientTlsConfig, CoreRuntime, TlsConfig, WorkflowClientTrait,
+        init_worker,
     };
     use temporal_sdk_core_api::worker::WorkerConfigBuilder;
     use temporal_sdk_core_protos::temporal::api::{
-        nexus::v1::{endpoint_target, EndpointSpec, EndpointTarget},
+        nexus::v1::{EndpointSpec, EndpointTarget, endpoint_target},
         operatorservice::v1::CreateNexusEndpointRequest,
         workflowservice::v1::ListNamespacesRequest,
     };
     use temporal_sdk_core_test_utils::{
-        get_integ_server_options, get_integ_telem_options, rand_6_chars, CoreWfStarter,
+        CoreWfStarter, get_integ_server_options, get_integ_telem_options, rand_6_chars,
     };
     use url::Url;
 

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -9,8 +9,8 @@ use temporal_sdk_core::ephemeral_server::{
     TemporalDevServerConfigBuilder, TestServerConfigBuilder,
 };
 use temporal_sdk_core_test_utils::{
-    default_cached_download, INTEG_SERVER_TARGET_ENV_VAR, INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR,
-    INTEG_TEST_SERVER_USED_ENV_VAR, SEARCH_ATTR_INT, SEARCH_ATTR_TXT,
+    INTEG_SERVER_TARGET_ENV_VAR, INTEG_TEMPORAL_DEV_SERVER_USED_ENV_VAR,
+    INTEG_TEST_SERVER_USED_ENV_VAR, SEARCH_ATTR_INT, SEARCH_ATTR_TXT, default_cached_download,
 };
 use tokio::{self, process::Command};
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Upgrade rust, and crates, ~and Otel (maybe)~

Problem is Otel has managed to break something. In this case, error logging (they also are logging some uninteresting junk at INFO level). AFAICT errors simply aren't logged while trying to export metrics. This happens in a new thread now and after wasting a bunch of time on this I gave up trying to figure out exactly why. I opened an [issue](https://github.com/open-telemetry/opentelemetry-rust/issues/2697) for them.

We can simply not upgrade otel for now, but we'll be stuck on that git revision of the prom exporter.

## Why?
Updates good.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/879

2. How was this tested:
Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
