### PR TITLE
Activity pause interrupt heartbeat

### DIFF
--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -1339,7 +1339,7 @@ async fn heartbeat_response_can_be_paused() {
             task_token == &vec![1] &&
             *reason == ActivityCancelReason::Paused as i32 &&
             details.as_ref().is_some_and(|d| d.is_paused) &&
-            details.as_ref().is_some_and(|d| d.is_cancelled == false)
+            details.as_ref().is_some_and(|d| !d.is_cancelled)
     );
     core.complete_activity_task(ActivityTaskCompletion {
         task_token: act.task_token,
@@ -1364,7 +1364,7 @@ async fn heartbeat_response_can_be_paused() {
         } if
             task_token == &vec![2] &&
             *reason == ActivityCancelReason::Cancelled as i32 &&
-            details.as_ref().is_some_and(|d| d.is_paused == false) &&
+            details.as_ref().is_some_and(|d| !d.is_paused) &&
             details.as_ref().is_some_and(|d| d.is_cancelled)
     );
     core.complete_activity_task(ActivityTaskCompletion {

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -1307,6 +1307,20 @@ async fn heartbeat_response_can_be_paused() {
         ],
     ));
 
+    // The general testing pattern for each of these cases is:
+    // 1. Poll for activity task
+    // 2. Record activity heartbeat, get mocked heartbeat response
+    // 3. Sleep for 10ms (waiting for heartbeat request to be flushed)
+    // (i.e. sleep enough for the heartbeat flush interval to have elapsed)
+    // 4. Poll for activity task.
+    // We expect a cancellation activity task as they are prioritized (i.e. ordered before)
+    // regular activity tasks.
+    // 5. Assert that the received activity task is indeed a cancellation, with the reason
+    // we expect.
+    // 6. Complete the activity with a cancellation result.
+    //
+    // Repeat for subsequent test case(s).
+
     // Test pause only
     let act = core.poll_activity_task().await.unwrap();
     core.record_activity_heartbeat(ActivityHeartbeat {

--- a/core/src/core_tests/activity_tasks.rs
+++ b/core/src/core_tests/activity_tasks.rs
@@ -1335,8 +1335,8 @@ async fn heartbeat_response_can_be_paused() {
             task_token,
             variant: Some(activity_task::Variant::Cancel(Cancel { reason })),
             ..
-        } => { 
-            task_token == &vec![1] && 
+        } => {
+            task_token == &vec![1] &&
             *reason == ActivityCancelReason::Paused as i32
         }
     );
@@ -1361,8 +1361,8 @@ async fn heartbeat_response_can_be_paused() {
             task_token,
             variant: Some(activity_task::Variant::Cancel(Cancel { reason })),
             ..
-        } => { 
-            task_token == &vec![2] && 
+        } => {
+            task_token == &vec![2] &&
             *reason == ActivityCancelReason::Cancelled as i32
         }
     );
@@ -1387,8 +1387,8 @@ async fn heartbeat_response_can_be_paused() {
             task_token,
             variant: Some(activity_task::Variant::Cancel(Cancel { reason })),
             ..
-        } => { 
-            task_token == &vec![3] && 
+        } => {
+            task_token == &vec![3] &&
             *reason == ActivityCancelReason::Cancelled as i32
         }
     );

--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -40,7 +40,7 @@ use temporal_sdk_core_protos::{
     coresdk::{
         ActivityHeartbeat, ActivitySlotInfo,
         activity_result::{self as ar, activity_execution_result as aer},
-        activity_task::{ActivityCancelReason, ActivityTask},
+        activity_task::{ActivityCancelReason, ActivityCancellationDetails, ActivityTask},
     },
     temporal::api::{
         failure::v1::{ApplicationFailureInfo, CanceledFailureInfo, Failure, failure::FailureInfo},
@@ -65,16 +65,19 @@ type OutstandingActMap = Arc<DashMap<TaskToken, RemoteInFlightActInfo>>;
 struct PendingActivityCancel {
     task_token: TaskToken,
     reason: ActivityCancelReason,
-    /// Set true if we should assume the server has already forgotten about this activity
-    consider_not_found: bool,
+    details: ActivityCancellationDetails,
 }
 
 impl PendingActivityCancel {
-    fn new(task_token: TaskToken, reason: ActivityCancelReason) -> Self {
+    fn new(
+        task_token: TaskToken,
+        reason: ActivityCancelReason,
+        details: ActivityCancellationDetails,
+    ) -> Self {
         Self {
             task_token,
             reason,
-            consider_not_found: false,
+            details,
         }
     }
 }
@@ -508,13 +511,14 @@ where
                             } else {
                                 details.issued_cancel_to_lang = Some(next_pc.reason);
                                 if next_pc.reason == ActivityCancelReason::NotFound
-                                    || next_pc.consider_not_found
+                                    || next_pc.details.is_not_found
                                 {
                                     details.known_not_found = true;
                                 }
                                 Some(Ok(ActivityTask::cancel_from_ids(
                                     next_pc.task_token.0,
                                     next_pc.reason,
+                                    next_pc.details,
                                 )))
                             }
                         } else {
@@ -566,6 +570,9 @@ where
                                 let _ = cancels_tx.send(PendingActivityCancel::new(
                                     tt,
                                     ActivityCancelReason::WorkerShutdown,
+                                    ActivityTask::primary_reason_to_cancellation_details(
+                                        ActivityCancelReason::WorkerShutdown,
+                                    ),
                                 ));
                             } else {
                                 // Fire off task to keep track of local timeouts. We do this so that
@@ -611,11 +618,15 @@ where
                                                 "Timing out activity due to elapsed local \
                                                  {timeout_type} timer"
                                             );
-                                            let _ = cancel_tx.send(PendingActivityCancel {
-                                                task_token: tt,
-                                                reason: ActivityCancelReason::TimedOut,
-                                                consider_not_found: true,
-                                            });
+                                            let _ = cancel_tx.send(PendingActivityCancel::new(
+                                                tt,
+                                                ActivityCancelReason::TimedOut,
+                                                ActivityCancellationDetails {
+                                                    is_not_found: true,
+                                                    is_timed_out: true,
+                                                    ..Default::default()
+                                                },
+                                            ));
                                         }));
                                     outstanding_info.timeout_resetter = resetter;
                                 }
@@ -639,6 +650,9 @@ where
                             let _ = self.cancels_tx.send(PendingActivityCancel::new(
                                 mapref.key().clone(),
                                 ActivityCancelReason::WorkerShutdown,
+                                ActivityTask::primary_reason_to_cancellation_details(
+                                    ActivityCancelReason::WorkerShutdown,
+                                ),
                             ));
                         }
                     }

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -148,7 +148,11 @@ impl ActivityHeartbeatManager {
                                     Ok(RecordActivityTaskHeartbeatResponse { cancel_requested, activity_paused }) => {
                                         if cancel_requested || activity_paused {
                                             // Prioritize Cancel over Pause
-                                            let reason = if cancel_requested { ActivityCancelReason::Cancelled } else { ActivityCancelReason::Paused};
+                                            let reason = if cancel_requested {
+                                                ActivityCancelReason::Cancelled
+                                            } else {
+                                                ActivityCancelReason::Paused
+                                            };
                                             cancels_tx
                                                 .send(PendingActivityCancel::new(
                                                     tt.clone(),

--- a/core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/core/src/worker/activities/activity_heartbeat_manager.rs
@@ -142,12 +142,13 @@ impl ActivityHeartbeatManager {
                                     .record_activity_heartbeat(tt.clone(), details.into_payloads())
                                     .await
                                 {
-                                    Ok(RecordActivityTaskHeartbeatResponse { cancel_requested, activity_paused: _ }) => {
-                                        if cancel_requested {
+                                    Ok(RecordActivityTaskHeartbeatResponse { cancel_requested, activity_paused }) => {
+                                        if cancel_requested || activity_paused {
+                                            let reason = if cancel_requested { ActivityCancelReason::Cancelled } else { ActivityCancelReason::Paused};
                                             cancels_tx
                                                 .send(PendingActivityCancel::new(
                                                     tt.clone(),
-                                                    ActivityCancelReason::Cancelled,
+                                                    reason,
                                                 ))
                                                 .expect(
                                                     "Receive half of heartbeat cancels not blocked",

--- a/sdk-core-protos/protos/local/temporal/sdk/core/activity_task/activity_task.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/activity_task/activity_task.proto
@@ -79,6 +79,8 @@ enum ActivityCancelReason {
     TIMED_OUT = 2;
     // Core is shutting down and the graceful timeout has elapsed
     WORKER_SHUTDOWN = 3;
+    // Activity was paused
+    PAUSED = 4;
 }
 
 

--- a/sdk-core-protos/protos/local/temporal/sdk/core/activity_task/activity_task.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/activity_task/activity_task.proto
@@ -67,7 +67,18 @@ message Start {
 
 // Attempt to cancel a running activity
 message Cancel {
+    // Primary cancellation reason
     ActivityCancelReason reason = 1;
+    // Activity cancellation details, surfaces all cancellation reasons.
+    ActivityCancellationDetails details = 2;
+}
+
+message ActivityCancellationDetails {
+    bool is_not_found = 1;
+    bool is_cancelled = 2;
+    bool is_paused = 3;
+    bool is_timed_out = 4;
+    bool is_worker_shutdown = 5;
 }
 
 enum ActivityCancelReason {


### PR DESCRIPTION
## What was changed
Add `Pause` as a reason for activity cancellations.

## Why?
Provide visibility to consuming lang-SDKs to discern whether the activity has been paused.

Note that if both the cancellation and activity flags are set, the activity will be *cancelled*, **not** paused. This follows the same priority as Java.

1. Closes #895

2. How was this tested:
Unit test

3. Any docs updates needed?
Nope
