### PR TITLE
Add meters to custom slot supplier contexts

### DIFF
--- a/core-api/src/telemetry/metrics.rs
+++ b/core-api/src/telemetry/metrics.rs
@@ -2,6 +2,7 @@ use std::{
     any::Any,
     borrow::Cow,
     fmt::Debug,
+    ops::Deref,
     sync::{Arc, OnceLock},
     time::Duration,
 };
@@ -61,6 +62,13 @@ impl From<&'static str> for MetricParameters {
 pub struct TemporalMeter {
     pub inner: Arc<dyn CoreMeter>,
     pub default_attribs: NewAttributes,
+}
+
+impl Deref for TemporalMeter {
+    type Target = dyn CoreMeter;
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref()
+    }
 }
 
 impl CoreMeter for Arc<dyn CoreMeter> {

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -282,10 +282,6 @@ pub trait WorkerTuner {
     fn nexus_task_slot_supplier(
         &self,
     ) -> Arc<dyn SlotSupplier<SlotKind = NexusSlotKind> + Send + Sync>;
-
-    /// Core will call this at worker initialization time, allowing the implementation to hook up to
-    /// metrics if any are configured. If not, it will not be called.
-    fn attach_metrics(&self, metrics: TemporalMeter);
 }
 
 /// Implementing this trait allows users to customize how many tasks of certain kinds the worker
@@ -339,6 +335,11 @@ pub trait SlotReservationContext: Send + Sync {
 
     /// Returns true iff this is a sticky poll for a workflow task
     fn is_sticky(&self) -> bool;
+
+    /// Returns the metrics meter if metrics are enabled
+    fn get_metrics_meter(&self) -> Option<TemporalMeter> {
+        None
+    }
 }
 
 pub trait SlotMarkUsedContext: Send + Sync {
@@ -347,6 +348,11 @@ pub trait SlotMarkUsedContext: Send + Sync {
     fn permit(&self) -> &SlotSupplierPermit;
     /// Returns the info of slot that was marked as used
     fn info(&self) -> &<Self::SlotKind as SlotKind>::Info;
+
+    /// Returns the metrics meter if metrics are enabled
+    fn get_metrics_meter(&self) -> Option<TemporalMeter> {
+        None
+    }
 }
 
 pub trait SlotReleaseContext: Send + Sync {
@@ -355,6 +361,11 @@ pub trait SlotReleaseContext: Send + Sync {
     fn permit(&self) -> &SlotSupplierPermit;
     /// Returns the info of slot that was released, if it was used
     fn info(&self) -> Option<&<Self::SlotKind as SlotKind>::Info>;
+
+    /// Returns the metrics meter if metrics are enabled
+    fn get_metrics_meter(&self) -> Option<TemporalMeter> {
+        None
+    }
 }
 
 #[derive(Default, Debug)]

--- a/core/src/worker/activities/local_activities.rs
+++ b/core/src/worker/activities/local_activities.rs
@@ -255,6 +255,7 @@ impl LocalActivityManager {
                 MetricsContext::no_op(),
                 None,
                 Arc::new(Default::default()),
+                None,
             ),
             hb_tx,
             MetricsContext::no_op(),

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -318,9 +318,6 @@ impl Worker {
             .unwrap_or_else(|| Arc::new(TunerBuilder::from_config(&config).build()));
 
         metrics.worker_registered();
-        if let Some(meter) = meter {
-            tuner.attach_metrics(meter.clone());
-        }
         let shutdown_token = CancellationToken::new();
         let slot_context_data = Arc::new(PermitDealerContextData {
             task_queue: config.task_queue.clone(),
@@ -338,6 +335,7 @@ impl Worker {
                 None
             },
             slot_context_data.clone(),
+            meter.clone(),
         );
         let wft_permits = wft_slots.get_extant_count_rcv();
         let act_slots = MeteredPermitDealer::new(
@@ -345,6 +343,7 @@ impl Worker {
             metrics.with_new_attrs([activity_worker_type()]),
             None,
             slot_context_data.clone(),
+            meter.clone(),
         );
         let act_permits = act_slots.get_extant_count_rcv();
         let (external_wft_tx, external_wft_rx) = unbounded_channel();
@@ -353,6 +352,7 @@ impl Worker {
             metrics.with_new_attrs([nexus_worker_type()]),
             None,
             slot_context_data.clone(),
+            meter.clone(),
         );
         let (wft_stream, act_poller, nexus_poller) = match task_pollers {
             TaskPollers::Real => {
@@ -438,6 +438,7 @@ impl Worker {
             metrics.with_new_attrs([local_activity_worker_type()]),
             None,
             slot_context_data,
+            meter.clone(),
         );
         let la_permits = la_pemit_dealer.get_extant_count_rcv();
         let local_act_mgr = Arc::new(LocalActivityManager::new(

--- a/core/src/worker/tuner.rs
+++ b/core/src/worker/tuner.rs
@@ -7,13 +7,10 @@ pub use resource_based::{
     ResourceSlotOptions,
 };
 
-use std::sync::{Arc, OnceLock};
-use temporal_sdk_core_api::{
-    telemetry::metrics::TemporalMeter,
-    worker::{
-        ActivitySlotKind, LocalActivitySlotKind, NexusSlotKind, SlotKind, SlotSupplier,
-        WorkerConfig, WorkerTuner, WorkflowSlotKind,
-    },
+use std::sync::Arc;
+use temporal_sdk_core_api::worker::{
+    ActivitySlotKind, LocalActivitySlotKind, NexusSlotKind, SlotKind, SlotSupplier, WorkerConfig,
+    WorkerTuner, WorkflowSlotKind,
 };
 
 /// Allows for the composition of different slot suppliers into a [WorkerTuner]
@@ -22,7 +19,6 @@ pub struct TunerHolder {
     act_supplier: Arc<dyn SlotSupplier<SlotKind = ActivitySlotKind> + Send + Sync>,
     la_supplier: Arc<dyn SlotSupplier<SlotKind = LocalActivitySlotKind> + Send + Sync>,
     nexus_supplier: Arc<dyn SlotSupplier<SlotKind = NexusSlotKind> + Send + Sync>,
-    metrics: OnceLock<TemporalMeter>,
 }
 
 /// Can be used to construct a [TunerHolder] without needing to manually construct each
@@ -245,7 +241,6 @@ impl TunerBuilder {
                 .nexus_slot_supplier
                 .clone()
                 .unwrap_or_else(|| Arc::new(FixedSizeSlotSupplier::new(100))),
-            metrics: OnceLock::new(),
         }
     }
 }
@@ -273,9 +268,5 @@ impl WorkerTuner for TunerHolder {
         &self,
     ) -> Arc<dyn SlotSupplier<SlotKind = NexusSlotKind> + Send + Sync> {
         self.nexus_supplier.clone()
-    }
-
-    fn attach_metrics(&self, m: TemporalMeter) {
-        let _ = self.metrics.set(m);
     }
 }

--- a/core/src/worker/tuner/resource_based.rs
+++ b/core/src/worker/tuner/resource_based.rs
@@ -452,7 +452,7 @@ impl<MI: SystemResourceInfo + Sync + Send> ResourceController<MI> {
             && cpu_output > self.options.cpu_output_threshold
     }
 
-    pub(crate) fn attach_metrics(&self, metrics: TemporalMeter) {
+    fn attach_metrics(&self, metrics: TemporalMeter) {
         // Launch a task to periodically emit metrics
         self.metrics.get_or_init(move || {
             let m = MetricInstruments::new(metrics);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add metrics meters to slot supplier contexts & fix bug where attach metrics was useless on a tuner holder

## Why?
Fixes bug & allows for recording metrics on slot supplier contexts.

Mostly used this as a testpiece for some agentic AI coding.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/904

2. How was this tested:
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
