### PR TITLE
Don't retry on grpc message too large errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,7 @@ CLI_VERSION_OVERRIDE = "v1.3.1-priority.0"
 
 [alias]
 integ-test = ["run", "--package", "temporal-sdk-core", "--example", "integ_runner", "--"]
+cloud-test = ["run", "--package", "temporal-sdk-core", "--example", "integ_runner", "--", "--test-name", "cloud_tests"]
 lint = ["clippy", "--workspace", "--examples", "--all-features",
     "--test", "integ_tests", "--test", "heavy_tests", "--test", "manual_tests",
     "--", "--D", "warnings"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,6 @@ CLI_VERSION_OVERRIDE = "v1.3.1-priority.0"
 
 [alias]
 integ-test = ["run", "--package", "temporal-sdk-core", "--example", "integ_runner", "--"]
-cloud-test = ["run", "--package", "temporal-sdk-core", "--example", "integ_runner", "--", "--test-name", "cloud_tests"]
 lint = ["clippy", "--workspace", "--examples", "--all-features",
     "--test", "integ_tests", "--test", "heavy_tests", "--test", "manual_tests",
     "--", "--D", "warnings"]

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -129,7 +129,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --test cloud-tests
+      - run: cargo test --test cloud_tests
 
   docker-integ-tests:
     name: Docker integ tests

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -129,7 +129,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: Swatinem/rust-cache@v2
-      - run: cargo cloud-test
+      - run: cargo test --test cloud-tests
 
   docker-integ-tests:
     name: Docker integ tests

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -76,11 +76,6 @@ jobs:
 
   integ-tests:
     name: Integ tests
-    env:
-      TEMPORAL_CLOUD_ADDRESS: https://${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
-      TEMPORAL_CLOUD_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
-      TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
-      TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -110,6 +105,31 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
       - run: cargo integ-test
+
+  cloud-tests:
+    if: github.repository_owner == 'temporalio'
+    name: Cloud tests
+    env:
+      TEMPORAL_CLOUD_ADDRESS: https://${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
+      TEMPORAL_CLOUD_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
+      TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
+      TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo cloud-test
 
   docker-integ-tests:
     name: Docker integ tests

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -111,7 +111,7 @@ jobs:
     name: Cloud tests
     env:
       TEMPORAL_CLOUD_ADDRESS: https://${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
-      TEMPORAL_CLOUD_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
+      TEMPORAL_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
       TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
       TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
     timeout-minutes: 20

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -86,6 +86,10 @@ use uuid::Uuid;
 static CLIENT_NAME_HEADER_KEY: &str = "client-name";
 static CLIENT_VERSION_HEADER_KEY: &str = "client-version";
 static TEMPORAL_NAMESPACE_HEADER_KEY: &str = "temporal-namespace";
+
+/// Key used to communicate when a GRPC message is too large
+pub static MESSAGE_TOO_LARGE_KEY: &str = "message-too-large";
+
 /// The server times out polls after 60 seconds. Set our timeout to be slightly beyond that.
 const LONG_POLL_TIMEOUT: Duration = Duration::from_secs(70);
 const OTHER_CALL_TIMEOUT: Duration = Duration::from_secs(30);

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -201,7 +201,11 @@ where
 {
     type OutError = tonic::Status;
 
-    fn handle(&mut self, current_attempt: usize, e: tonic::Status) -> RetryPolicy<tonic::Status> {
+    fn handle(
+        &mut self,
+        current_attempt: usize,
+        mut e: tonic::Status,
+    ) -> RetryPolicy<tonic::Status> {
         // 0 max retries means unlimited retries
         if self.max_retries > 0 && current_attempt >= self.max_retries {
             return RetryPolicy::ForwardError(e);
@@ -211,6 +215,17 @@ where
             if (sc.predicate)(&e) {
                 return RetryPolicy::ForwardError(e);
             }
+        }
+
+        // Short circuit if message is too large - this is not retryable
+        if e.code() == Code::ResourceExhausted
+            && e.message()
+                .contains("grpc: received message larger than max")
+        {
+            // Leave a marker so we don't have duplicate detection logic in the workflow
+            e.metadata_mut()
+                .insert("message-too-large", tonic::metadata::MetadataValue::from(0));
+            return RetryPolicy::ForwardError(e);
         }
 
         // Task polls are OK with being cancelled or running into the timeout because there's
@@ -421,6 +436,26 @@ mod tests {
         );
         let result = err_handler.handle(1, Status::new(Code::ResourceExhausted, "leave me alone"));
         assert_matches!(result, RetryPolicy::ForwardError(_))
+    }
+
+    #[tokio::test]
+    async fn message_too_large_not_retried() {
+        let mut err_handler = TonicErrorHandler::new_with_clock(
+            CallInfo {
+                call_type: CallType::TaskLongPoll,
+                call_name: POLL_WORKFLOW_METH_NAME,
+                retry_cfg: TEST_RETRY_CONFIG,
+                retry_short_circuit: None,
+            },
+            TEST_RETRY_CONFIG,
+            FixedClock(Instant::now()),
+            FixedClock(Instant::now()),
+        );
+        let result = err_handler.handle(
+            1,
+            Status::new(Code::ResourceExhausted, "received message larger than max"),
+        );
+        assert_matches!(result, RetryPolicy::ForwardError(_));
     }
 
     #[rstest::rstest]

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -219,8 +219,10 @@ where
 
         // Short circuit if message is too large - this is not retryable
         if e.code() == Code::ResourceExhausted
-            && e.message()
-                .contains("grpc: received message larger than max")
+            && (e.message()
+                .starts_with("grpc: received message larger than max") ||
+                e.message().starts_with("grpc: message after decompression larger than max") ||
+                e.message().starts_with("grpc: received message after decompression larger than max")
         {
             // Leave a marker so we don't have duplicate detection logic in the workflow
             e.metadata_mut()

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -120,6 +120,11 @@ name = "global_metric_tests"
 path = "../tests/global_metric_tests.rs"
 test = false
 
+[[test]]
+name = "cloud_tests"
+path = "../tests/cloud_tests.rs"
+test = false
+
 [[bench]]
 name = "workflow_replay"
 harness = false

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -14,6 +14,7 @@ mod workflow_stream;
 pub(crate) use driven_workflow::DrivenWorkflow;
 pub(crate) use history_update::HistoryUpdate;
 
+use crate::protosext::ValidPollWFTQResponse;
 use crate::{
     MetricsContext,
     abstractions::{
@@ -317,6 +318,180 @@ impl Workflows {
         }
     }
 
+    async fn handle_activation_completed_success(
+        &self,
+        run_id: &str,
+        wft_from_complete: &mut Option<ValidPollWFTQResponse>,
+        completion_time: Instant,
+        report: ServerCommandsWithWorkflowInfo,
+    ) -> WFTReportStatus {
+        match report {
+            ServerCommandsWithWorkflowInfo {
+                task_token,
+                action:
+                    ActivationAction::WftComplete {
+                        mut commands,
+                        messages,
+                        query_responses,
+                        force_new_wft,
+                        sdk_metadata,
+                        mut versioning_behavior,
+                    },
+            } => {
+                let reserved_act_permits =
+                    self.reserve_activity_slots_for_outgoing_commands(commands.as_mut_slice());
+                debug!(commands=%commands.display(), query_responses=%query_responses.display(),
+                           messages=%messages.display(), force_new_wft,
+                           "Sending responses to server");
+                if let Some(default_vb) = self.default_versioning_behavior.as_ref() {
+                    if versioning_behavior == VersioningBehavior::Unspecified {
+                        versioning_behavior = *default_vb;
+                    }
+                }
+                let mut completion = WorkflowTaskCompletion {
+                    task_token: task_token.clone(),
+                    commands,
+                    messages,
+                    query_responses,
+                    sticky_attributes: None,
+                    return_new_workflow_task: true,
+                    force_create_new_workflow_task: force_new_wft,
+                    sdk_metadata,
+                    metering_metadata: MeteringMetadata {
+                        nonfirst_local_activity_execution_attempts: self
+                            .local_act_mgr
+                            .get_nonfirst_attempt_count(run_id)
+                            as u32,
+                    },
+                    versioning_behavior,
+                };
+                let sticky_attrs = self.sticky_attrs.clone();
+                // Do not return new WFT if we would not cache, because returned new WFTs are
+                // always partial.
+                if sticky_attrs.is_none() {
+                    completion.return_new_workflow_task = false;
+                }
+                completion.sticky_attributes = sticky_attrs;
+
+                let mut reset_last_started_to = None;
+                self.handle_wft_reporting_errs(run_id, || async {
+                    match self.client.complete_workflow_task(completion).await {
+                        Ok(response) => {
+                            if response.reset_history_event_id > 0 {
+                                reset_last_started_to = Some(response.reset_history_event_id);
+                            }
+                            if let Some(wft) = response.workflow_task {
+                                *wft_from_complete = Some(validate_wft(wft)?);
+                            }
+                            self.handle_eager_activities(
+                                reserved_act_permits,
+                                response.activity_tasks,
+                            );
+                        }
+                        Err(e) if e.metadata().contains_key("message-too-large") => {
+                            let failure = Failure {
+                                failure: Some(
+                                    temporal_sdk_core_protos::temporal::api::failure::v1::Failure {
+                                        message: "GRPC Message too large".to_string(),
+                                        ..Default::default()
+                                    },
+                                ),
+                                force_cause: 0,
+                            };
+                            // TODO: tim - Update workflow cause when API is ready
+                            let new_outcome = FailedActivationWFTReport::Report(
+                                task_token,
+                                WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure,
+                                failure,
+                            );
+                            self.handle_activation_failed(run_id, completion_time, new_outcome)
+                                .await;
+                        }
+                        e => {
+                            e?;
+                        }
+                    };
+
+                    Ok(())
+                })
+                .await;
+                WFTReportStatus::Reported {
+                    reset_last_started_to,
+                    completion_time,
+                }
+            }
+            ServerCommandsWithWorkflowInfo {
+                task_token,
+                action: ActivationAction::RespondLegacyQuery { result },
+            } => {
+                self.respond_legacy_query(task_token, *result).await;
+                WFTReportStatus::Reported {
+                    reset_last_started_to: None,
+                    completion_time,
+                }
+            }
+        }
+    }
+
+    async fn handle_activation_failed(
+        &self,
+        run_id: &str,
+        completion_time: Instant,
+        outcome: FailedActivationWFTReport,
+    ) -> WFTReportStatus {
+        match outcome {
+            FailedActivationWFTReport::Report(tt, cause, failure) => {
+                warn!(run_id=%run_id, failure=?failure, "Failing workflow task");
+                self.handle_wft_reporting_errs(run_id, || async {
+                    self.client
+                        .fail_workflow_task(tt, cause, failure.failure)
+                        .await
+                })
+                .await;
+                WFTReportStatus::Reported {
+                    reset_last_started_to: None,
+                    completion_time,
+                }
+            }
+            FailedActivationWFTReport::ReportLegacyQueryFailure(task_token, failure) => {
+                warn!(run_id=%run_id, failure=?failure, "Failing legacy query request");
+                self.respond_legacy_query(task_token, legacy_query_failure(failure))
+                    .await;
+                WFTReportStatus::Reported {
+                    reset_last_started_to: None,
+                    completion_time,
+                }
+            }
+        }
+    }
+
+    async fn handle_activation_completed_result(
+        &self,
+        run_id: &str,
+        wft_from_complete: &mut Option<ValidPollWFTQResponse>,
+        completion_outcome: ActivationCompleteResult,
+    ) -> WFTReportStatus {
+        let completion_time = Instant::now();
+
+        match completion_outcome.outcome {
+            ActivationCompleteOutcome::ReportWFTSuccess(report) => {
+                self.handle_activation_completed_success(
+                    run_id,
+                    wft_from_complete,
+                    completion_time,
+                    report,
+                )
+                .await
+            }
+            ActivationCompleteOutcome::ReportWFTFail(outcome) => {
+                self.handle_activation_failed(run_id, completion_time, outcome)
+                    .await
+            }
+            ActivationCompleteOutcome::WFTFailedDontReport => WFTReportStatus::DropWft,
+            ActivationCompleteOutcome::DoNothing => WFTReportStatus::NotReported,
+        }
+    }
+
     /// Queue an activation completion for processing, returning a future that will resolve with
     /// the outcome of that completion. See [ActivationCompletedOutcome].
     ///
@@ -357,114 +532,12 @@ impl Workflows {
             );
             return Ok(());
         };
+        let replaying = completion_outcome.replaying;
 
         let mut wft_from_complete = None;
-        let completion_time = Instant::now();
-        let wft_report_status = match completion_outcome.outcome {
-            ActivationCompleteOutcome::ReportWFTSuccess(report) => match report {
-                ServerCommandsWithWorkflowInfo {
-                    task_token,
-                    action:
-                        ActivationAction::WftComplete {
-                            mut commands,
-                            messages,
-                            query_responses,
-                            force_new_wft,
-                            sdk_metadata,
-                            mut versioning_behavior,
-                        },
-                } => {
-                    let reserved_act_permits =
-                        self.reserve_activity_slots_for_outgoing_commands(commands.as_mut_slice());
-                    debug!(commands=%commands.display(), query_responses=%query_responses.display(),
-                           messages=%messages.display(), force_new_wft,
-                           "Sending responses to server");
-                    if let Some(default_vb) = self.default_versioning_behavior.as_ref() {
-                        if versioning_behavior == VersioningBehavior::Unspecified {
-                            versioning_behavior = *default_vb;
-                        }
-                    }
-                    let mut completion = WorkflowTaskCompletion {
-                        task_token,
-                        commands,
-                        messages,
-                        query_responses,
-                        sticky_attributes: None,
-                        return_new_workflow_task: true,
-                        force_create_new_workflow_task: force_new_wft,
-                        sdk_metadata,
-                        metering_metadata: MeteringMetadata {
-                            nonfirst_local_activity_execution_attempts: self
-                                .local_act_mgr
-                                .get_nonfirst_attempt_count(&run_id)
-                                as u32,
-                        },
-                        versioning_behavior,
-                    };
-                    let sticky_attrs = self.sticky_attrs.clone();
-                    // Do not return new WFT if we would not cache, because returned new WFTs are
-                    // always partial.
-                    if sticky_attrs.is_none() {
-                        completion.return_new_workflow_task = false;
-                    }
-                    completion.sticky_attributes = sticky_attrs;
-
-                    let mut reset_last_started_to = None;
-                    self.handle_wft_reporting_errs(&run_id, || async {
-                        let response = self.client.complete_workflow_task(completion).await?;
-                        if response.reset_history_event_id > 0 {
-                            reset_last_started_to = Some(response.reset_history_event_id);
-                        }
-                        if let Some(wft) = response.workflow_task {
-                            wft_from_complete = Some(validate_wft(wft)?);
-                        }
-                        self.handle_eager_activities(reserved_act_permits, response.activity_tasks);
-                        Ok(())
-                    })
-                    .await;
-                    WFTReportStatus::Reported {
-                        reset_last_started_to,
-                        completion_time,
-                    }
-                }
-                ServerCommandsWithWorkflowInfo {
-                    task_token,
-                    action: ActivationAction::RespondLegacyQuery { result },
-                } => {
-                    self.respond_legacy_query(task_token, *result).await;
-                    WFTReportStatus::Reported {
-                        reset_last_started_to: None,
-                        completion_time,
-                    }
-                }
-            },
-            ActivationCompleteOutcome::ReportWFTFail(outcome) => match outcome {
-                FailedActivationWFTReport::Report(tt, cause, failure) => {
-                    warn!(run_id=%run_id, failure=?failure, "Failing workflow task");
-                    self.handle_wft_reporting_errs(&run_id, || async {
-                        self.client
-                            .fail_workflow_task(tt, cause, failure.failure)
-                            .await
-                    })
-                    .await;
-                    WFTReportStatus::Reported {
-                        reset_last_started_to: None,
-                        completion_time,
-                    }
-                }
-                FailedActivationWFTReport::ReportLegacyQueryFailure(task_token, failure) => {
-                    warn!(run_id=%run_id, failure=?failure, "Failing legacy query request");
-                    self.respond_legacy_query(task_token, legacy_query_failure(failure))
-                        .await;
-                    WFTReportStatus::Reported {
-                        reset_last_started_to: None,
-                        completion_time,
-                    }
-                }
-            },
-            ActivationCompleteOutcome::WFTFailedDontReport => WFTReportStatus::DropWft,
-            ActivationCompleteOutcome::DoNothing => WFTReportStatus::NotReported,
-        };
+        let wft_report_status = self
+            .handle_activation_completed_result(&run_id, &mut wft_from_complete, completion_outcome)
+            .await;
 
         let maybe_pwft = if let Some(wft) = wft_from_complete {
             match HistoryPaginator::from_poll(wft, self.client.clone()).await {
@@ -485,7 +558,7 @@ impl Workflows {
         if let Some(h) = post_activate_hook {
             h(PostActivateHookData {
                 run_id: &run_id,
-                replaying: completion_outcome.replaying,
+                replaying,
             });
         }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -213,8 +213,12 @@ impl CoreWfStarter {
     pub fn new_with_client(test_name: &str, client: RetryClient<Client>) -> Self {
         Self::_new(test_name, None, Some(client))
     }
-    
-    fn _new(test_name: &str, runtime_override: Option<CoreRuntime>, client_override: Option<RetryClient<Client>>) -> Self {
+
+    fn _new(
+        test_name: &str,
+        runtime_override: Option<CoreRuntime>,
+        client_override: Option<RetryClient<Client>>,
+    ) -> Self {
         let task_q_salt = rand_6_chars();
         let task_queue = format!("{test_name}_{task_q_salt}");
         let mut worker_config = integ_worker_config(&task_queue);
@@ -376,15 +380,17 @@ impl CoreWfStarter {
                     .expect("Worker config must be valid");
                 let client = if let Some(client) = self.client_override.take() {
                     client
-                } else { Arc::new(
-                    get_integ_server_options()
-                        .connect(
-                            cfg.namespace.clone(),
-                            rt.telemetry().get_temporal_metric_meter(),
-                        )
-                        .await
-                        .expect("Must connect")
-                )};
+                } else {
+                    Arc::new(
+                        get_integ_server_options()
+                            .connect(
+                                cfg.namespace.clone(),
+                                rt.telemetry().get_temporal_metric_meter(),
+                            )
+                            .await
+                            .expect("Must connect"),
+                    )
+                };
                 let worker = init_worker(rt, cfg, client.clone()).expect("Worker inits cleanly");
                 InitializedWorker {
                     worker: Arc::new(worker),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -211,6 +211,7 @@ impl CoreWfStarter {
     }
 
     pub fn new_with_client(test_name: &str, client: RetryClient<Client>) -> Self {
+        init_integ_telem();
         Self::_new(test_name, None, Some(client))
     }
 

--- a/tests/cloud_tests.rs
+++ b/tests/cloud_tests.rs
@@ -1,11 +1,18 @@
 use std::env;
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::Relaxed;
 use temporal_client::{
     Client, ClientOptionsBuilder, ClientTlsConfig, RetryClient, TlsConfig, WorkflowClientTrait,
 };
 use url::Url;
+use temporal_sdk::WfContext;
+use temporal_sdk_core_protos::temporal::api::enums::v1::EventType;
+use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure;
+use temporal_sdk_core_protos::temporal::api::history::v1::history_event::Attributes::WorkflowTaskFailedEventAttributes;
+use temporal_sdk_core_test_utils::CoreWfStarter;
 
-async fn get_client() -> RetryClient<Client> {
+async fn get_client(client_name: &str) -> RetryClient<Client> {
     let cloud_addr = env::var("TEMPORAL_CLOUD_ADDRESS").unwrap();
     let cloud_key = env::var("TEMPORAL_CLIENT_KEY").unwrap();
 
@@ -16,7 +23,7 @@ async fn get_client() -> RetryClient<Client> {
     let client_private_key = cloud_key.replace("\\n", "\n").into_bytes();
     let sgo = ClientOptionsBuilder::default()
         .target_url(Url::from_str(&cloud_addr).unwrap())
-        .client_name("tls_tester")
+        .client_name(client_name)
         .client_version("clientver")
         .tls_cfg(TlsConfig {
             client_tls_config: Some(ClientTlsConfig {
@@ -37,7 +44,7 @@ async fn get_client() -> RetryClient<Client> {
 
 #[tokio::test]
 async fn tls_test() {
-    let con = get_client().await;
+    let con = get_client("tls_tester").await;
     con.list_workflow_executions(100, vec![], "".to_string())
         .await
         .unwrap();
@@ -45,5 +52,32 @@ async fn tls_test() {
 
 #[tokio::test]
 async fn grpc_message_too_large_test() {
-    // TODO
+    let wf_name = "oversize_grpc_message";
+    let mut starter = CoreWfStarter::new_with_client(wf_name,  get_client("grpc_message_too_large").await);
+    starter.worker_config.no_remote_activities(true);
+    let mut core = starter.worker().await;
+
+    static OVERSIZE_GRPC_MESSAGE_RUN: AtomicBool = AtomicBool::new(false);
+    core.register_wf(wf_name.to_owned(), |_ctx: WfContext| async move {
+        if OVERSIZE_GRPC_MESSAGE_RUN.load(Relaxed) {
+            Ok(vec![].into())
+        } else {
+            OVERSIZE_GRPC_MESSAGE_RUN.store(true, Relaxed);
+            let result: Vec<u8> = vec![0; 5000000];
+            Ok(result.into())
+        }
+    });
+    starter.start_with_worker(wf_name, &mut core).await;
+    core.run_until_done().await.unwrap();
+
+    assert!(starter.get_history().await.events.iter().any(|e| {
+        e.event_type == EventType::WorkflowTaskFailed as i32
+            && if let WorkflowTaskFailedEventAttributes(attr) = e.attributes.as_ref().unwrap() {
+            // TODO tim: Change to custom cause
+            attr.cause == WorkflowWorkerUnhandledFailure as i32
+                && attr.failure.as_ref().unwrap().message == "GRPC Message too large"
+        } else {
+            false
+        }
+    }))
 }

--- a/tests/cloud_tests.rs
+++ b/tests/cloud_tests.rs
@@ -1,0 +1,48 @@
+use std::env;
+use std::str::FromStr;
+use url::Url;
+use temporal_client::{Client, ClientOptionsBuilder, ClientTlsConfig, RetryClient, TlsConfig, WorkflowClientTrait};
+
+async fn get_client() -> RetryClient<Client> {
+    let cloud_addr = env::var("TEMPORAL_CLOUD_ADDRESS").unwrap();
+    let cloud_key = env::var("TEMPORAL_CLIENT_KEY").unwrap();
+
+    let client_cert = env::var("TEMPORAL_CLIENT_CERT")
+        .expect("TEMPORAL_CLIENT_CERT must be set")
+        .replace("\\n", "\n")
+        .into_bytes();
+    let client_private_key = cloud_key.replace("\\n", "\n").into_bytes();
+    let sgo = ClientOptionsBuilder::default()
+        .target_url(Url::from_str(&cloud_addr).unwrap())
+        .client_name("tls_tester")
+        .client_version("clientver")
+        .tls_cfg(TlsConfig {
+            client_tls_config: Some(ClientTlsConfig {
+                client_cert,
+                client_private_key,
+            }),
+            ..Default::default()
+        })
+        .build()
+        .unwrap();
+    sgo
+        .connect(
+            env::var("TEMPORAL_CLOUD_NAMESPACE").expect("TEMPORAL_CLOUD_NAMESPACE must be set"),
+            None,
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn tls_test() {
+    let con = get_client().await;
+    con.list_workflow_executions(100, vec![], "".to_string())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn grpc_message_too_large_test() {
+    // TODO
+}

--- a/tests/cloud_tests.rs
+++ b/tests/cloud_tests.rs
@@ -35,7 +35,7 @@ async fn get_client(client_name: &str) -> RetryClient<Client> {
         .build()
         .unwrap();
     sgo.connect(
-        env::var("TEMPORAL_CLOUD_NAMESPACE").expect("TEMPORAL_CLOUD_NAMESPACE must be set"),
+        env::var("TEMPORAL_NAMESPACE").expect("TEMPORAL_NAMESPACE must be set"),
         None,
     )
     .await

--- a/tests/cloud_tests.rs
+++ b/tests/cloud_tests.rs
@@ -5,12 +5,12 @@ use std::sync::atomic::Ordering::Relaxed;
 use temporal_client::{
     Client, ClientOptionsBuilder, ClientTlsConfig, RetryClient, TlsConfig, WorkflowClientTrait,
 };
-use url::Url;
 use temporal_sdk::WfContext;
 use temporal_sdk_core_protos::temporal::api::enums::v1::EventType;
 use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure;
 use temporal_sdk_core_protos::temporal::api::history::v1::history_event::Attributes::WorkflowTaskFailedEventAttributes;
 use temporal_sdk_core_test_utils::CoreWfStarter;
+use url::Url;
 
 async fn get_client(client_name: &str) -> RetryClient<Client> {
     let cloud_addr = env::var("TEMPORAL_CLOUD_ADDRESS").unwrap();
@@ -53,7 +53,8 @@ async fn tls_test() {
 #[tokio::test]
 async fn grpc_message_too_large_test() {
     let wf_name = "oversize_grpc_message";
-    let mut starter = CoreWfStarter::new_with_client(wf_name,  get_client("grpc_message_too_large").await);
+    let mut starter =
+        CoreWfStarter::new_with_client(wf_name, get_client("grpc_message_too_large").await);
     starter.worker_config.no_remote_activities(true);
     let mut core = starter.worker().await;
 
@@ -73,11 +74,11 @@ async fn grpc_message_too_large_test() {
     assert!(starter.get_history().await.events.iter().any(|e| {
         e.event_type == EventType::WorkflowTaskFailed as i32
             && if let WorkflowTaskFailedEventAttributes(attr) = e.attributes.as_ref().unwrap() {
-            // TODO tim: Change to custom cause
-            attr.cause == WorkflowWorkerUnhandledFailure as i32
-                && attr.failure.as_ref().unwrap().message == "GRPC Message too large"
-        } else {
-            false
-        }
+                // TODO tim: Change to custom cause
+                attr.cause == WorkflowWorkerUnhandledFailure as i32
+                    && attr.failure.as_ref().unwrap().message == "GRPC Message too large"
+            } else {
+                false
+            }
     }))
 }

--- a/tests/cloud_tests.rs
+++ b/tests/cloud_tests.rs
@@ -1,7 +1,9 @@
 use std::env;
 use std::str::FromStr;
+use temporal_client::{
+    Client, ClientOptionsBuilder, ClientTlsConfig, RetryClient, TlsConfig, WorkflowClientTrait,
+};
 use url::Url;
-use temporal_client::{Client, ClientOptionsBuilder, ClientTlsConfig, RetryClient, TlsConfig, WorkflowClientTrait};
 
 async fn get_client() -> RetryClient<Client> {
     let cloud_addr = env::var("TEMPORAL_CLOUD_ADDRESS").unwrap();
@@ -25,13 +27,12 @@ async fn get_client() -> RetryClient<Client> {
         })
         .build()
         .unwrap();
-    sgo
-        .connect(
-            env::var("TEMPORAL_CLOUD_NAMESPACE").expect("TEMPORAL_CLOUD_NAMESPACE must be set"),
-            None,
-        )
-        .await
-        .unwrap()
+    sgo.connect(
+        env::var("TEMPORAL_CLOUD_NAMESPACE").expect("TEMPORAL_CLOUD_NAMESPACE must be set"),
+        None,
+    )
+    .await
+    .unwrap()
 }
 
 #[tokio::test]

--- a/tests/integ_tests/worker_tests.rs
+++ b/tests/integ_tests/worker_tests.rs
@@ -1,4 +1,6 @@
 use assert_matches::assert_matches;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::Relaxed;
 use std::{cell::Cell, sync::Arc, time::Duration};
 use temporal_client::WorkflowOptions;
 use temporal_sdk::{WfContext, interceptors::WorkerInterceptor};
@@ -8,6 +10,9 @@ use temporal_sdk_core_api::{
     errors::WorkerValidationError,
     worker::{PollerBehavior, WorkerConfigBuilder, WorkerVersioningStrategy},
 };
+use temporal_sdk_core_protos::temporal::api::enums::v1::EventType;
+use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure;
+use temporal_sdk_core_protos::temporal::api::history::v1::history_event::Attributes::WorkflowTaskFailedEventAttributes;
 use temporal_sdk_core_protos::{
     coresdk::workflow_completion::{
         Failure, WorkflowActivationCompletion, workflow_activation_completion::Status,
@@ -152,4 +157,36 @@ async fn resource_based_few_pollers_guarantees_non_sticky_poll() {
             .unwrap();
     }
     worker.run_until_done().await.unwrap();
+}
+
+static OVERSIZE_GRPC_MESSAGE_RUN: AtomicBool = AtomicBool::new(false);
+#[tokio::test]
+async fn oversize_grpc_message() {
+    let wf_name = "oversize_grpc_message";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.worker_config.no_remote_activities(true);
+    let mut core = starter.worker().await;
+
+    core.register_wf(wf_name.to_owned(), |_ctx: WfContext| async move {
+        if OVERSIZE_GRPC_MESSAGE_RUN.load(Relaxed) {
+            Ok(vec![].into())
+        } else {
+            OVERSIZE_GRPC_MESSAGE_RUN.store(true, Relaxed);
+            let result: Vec<u8> = vec![0; 5000000];
+            Ok(result.into())
+        }
+    });
+    starter.start_with_worker(wf_name, &mut core).await;
+    core.run_until_done().await.unwrap();
+
+    assert!(starter.get_history().await.events.iter().any(|e| {
+        e.event_type == EventType::WorkflowTaskFailed as i32
+            && if let WorkflowTaskFailedEventAttributes(attr) = e.attributes.as_ref().unwrap() {
+                // TODO tim: Change to custom cause
+                attr.cause == WorkflowWorkerUnhandledFailure as i32
+                    && attr.failure.as_ref().unwrap().message == "GRPC Message too large"
+            } else {
+                false
+            }
+    }))
 }

--- a/tests/integ_tests/worker_tests.rs
+++ b/tests/integ_tests/worker_tests.rs
@@ -159,7 +159,6 @@ async fn resource_based_few_pollers_guarantees_non_sticky_poll() {
     worker.run_until_done().await.unwrap();
 }
 
-static OVERSIZE_GRPC_MESSAGE_RUN: AtomicBool = AtomicBool::new(false);
 #[tokio::test]
 async fn oversize_grpc_message() {
     let wf_name = "oversize_grpc_message";
@@ -167,6 +166,7 @@ async fn oversize_grpc_message() {
     starter.worker_config.no_remote_activities(true);
     let mut core = starter.worker().await;
 
+    static OVERSIZE_GRPC_MESSAGE_RUN: AtomicBool = AtomicBool::new(false);
     core.register_wf(wf_name.to_owned(), |_ctx: WfContext| async move {
         if OVERSIZE_GRPC_MESSAGE_RUN.load(Relaxed) {
             Ok(vec![].into())

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -20,12 +20,9 @@ mod integ_tests {
     mod worker_versioning_tests;
     mod workflow_tests;
 
-    use std::{env, str::FromStr, time::Duration};
+    use std::time::Duration;
     use temporal_client::{NamespacedClient, WorkflowService};
-    use temporal_sdk_core::{
-        ClientOptionsBuilder, ClientTlsConfig, CoreRuntime, TlsConfig, WorkflowClientTrait,
-        init_worker,
-    };
+    use temporal_sdk_core::{CoreRuntime, init_worker};
     use temporal_sdk_core_api::worker::WorkerConfigBuilder;
     use temporal_sdk_core_protos::temporal::api::{
         nexus::v1::{EndpointSpec, EndpointTarget, endpoint_target},
@@ -35,7 +32,6 @@ mod integ_tests {
     use temporal_sdk_core_test_utils::{
         CoreWfStarter, get_integ_server_options, get_integ_telem_options, rand_6_chars,
     };
-    use url::Url;
 
     // Create a worker like a bridge would (unwraps aside)
     #[tokio::test]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Don't retry on grpc message too large errors. Forward the error and fail the workflow task

## Why?
Retries will not succeed, as they don't change the size of the message

## Checklist
<!--- add/delete as needed --->

1. Closes #462 

2. How was this tested:
New worker tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
