### PR TITLE
Fix bad balacing between sticky & nonsticky WFT polling with low slot/poller counts

### DIFF
--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -521,7 +521,7 @@ pub enum PollerBehavior {
     /// requires a slot to be available before beginning polling.
     Autoscaling {
         /// At least this many poll calls will always be attempted (assuming slots are available).
-        /// Cannot be less than two for workflow tasks, or one for other tasks.
+        /// Cannot be zero.
         minimum: usize,
         /// At most this many poll calls will ever be open at once. Must be >= `minimum`.
         maximum: usize,

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -225,6 +225,19 @@ impl WorkerConfigBuilder {
             }
         }
 
+        if matches!(self.max_outstanding_workflow_tasks.as_ref(), Some(Some(v)) if *v == 0) {
+            return Err("`max_outstanding_workflow_tasks` must be > 0".to_owned());
+        }
+        if matches!(self.max_outstanding_activities.as_ref(), Some(Some(v)) if *v == 0) {
+            return Err("`max_outstanding_activities` must be > 0".to_owned());
+        }
+        if matches!(self.max_outstanding_local_activities.as_ref(), Some(Some(v)) if *v == 0) {
+            return Err("`max_outstanding_local_activities` must be > 0".to_owned());
+        }
+        if matches!(self.max_outstanding_nexus_tasks.as_ref(), Some(Some(v)) if *v == 0) {
+            return Err("`max_outstanding_nexus_tasks` must be > 0".to_owned());
+        }
+
         if let Some(cache) = self.max_cached_workflows.as_ref() {
             if *cache > 0 {
                 if let Some(Some(max_wft)) = self.max_outstanding_workflow_tasks.as_ref() {
@@ -288,8 +301,8 @@ impl WorkerConfigBuilder {
 /// For more, see the docstrings of the traits in the return types of its functions.
 pub trait WorkerTuner {
     /// Return a [SlotSupplier] for workflow tasks. Note that workflow task slot suppliers must be
-    /// willing to hand out a minimum of two slots if workflow caching is enabled, otherwise the
-    /// worker may fail to process new tasks.
+    /// willing to hand out a minimum of one non-sticky slot and one sticky slot if workflow caching
+    /// is enabled, otherwise the worker may fail to process new tasks.
     fn workflow_task_slot_supplier(
         &self,
     ) -> Arc<dyn SlotSupplier<SlotKind = WorkflowSlotKind> + Send + Sync>;
@@ -413,11 +426,6 @@ impl SlotSupplierPermit {
     /// Returns none if there is no data or the data is not of the appropriate type.
     pub fn user_data_mut<T: Any + Send + Sync>(&mut self) -> Option<&mut T> {
         self.user_data.as_mut().and_then(|b| b.downcast_mut())
-    }
-
-    /// Deconstruct this permit and return the inner data
-    pub fn into_user_data(self) -> Option<Box<dyn Any + Send + Sync>> {
-        self.user_data
     }
 }
 

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -40,8 +40,8 @@ pub struct WorkerConfig {
     #[builder(setter(into = false, strip_option), default)]
     pub tuner: Option<Arc<dyn WorkerTuner + Send + Sync>>,
     /// Maximum number of concurrent poll workflow task requests we will perform at a time on this
-    /// worker's task queue. See also [WorkerConfig::nonsticky_to_sticky_poll_ratio]. Must be at
-    /// least 1.
+    /// worker's task queue. See also [WorkerConfig::nonsticky_to_sticky_poll_ratio].
+    /// If using SimpleMaximum, Must be at least 2 when `max_cached_workflows` > 0, or is an error.
     #[builder(default = "PollerBehavior::SimpleMaximum(5)")]
     pub workflow_task_poller_behavior: PollerBehavior,
     /// Only applies when using [PollerBehavior::SimpleMaximum]
@@ -135,7 +135,8 @@ pub struct WorkerConfig {
 
     /// The maximum allowed number of workflow tasks that will ever be given to this worker at one
     /// time. Note that one workflow task may require multiple activations - so the WFT counts as
-    /// "outstanding" until all activations it requires have been completed.
+    /// "outstanding" until all activations it requires have been completed. Must be at least 2 if
+    /// `max_cached_workflows` is > 0, or is an error.
     ///
     /// Mutually exclusive with `tuner`
     #[builder(setter(into, strip_option), default)]
@@ -224,6 +225,28 @@ impl WorkerConfigBuilder {
             }
         }
 
+        if let Some(cache) = self.max_cached_workflows.as_ref() {
+            if *cache > 0 {
+                if let Some(Some(max_wft)) = self.max_outstanding_workflow_tasks.as_ref() {
+                    if *max_wft < 2 {
+                        return Err(
+                            "`max_cached_workflows` > 0 requires `max_outstanding_workflow_tasks` >= 2"
+                                .to_owned(),
+                        );
+                    }
+                }
+                if let Some(b) = self.workflow_task_poller_behavior.as_ref() {
+                    if matches!(b, PollerBehavior::SimpleMaximum(u) if *u < 2) {
+                        return Err(
+                            "`max_cached_workflows` > 0 requires `workflow_task_poller_behavior` to be at least 2"
+                                .to_owned(),
+                        );
+                    }
+                    b.validate()?
+                }
+            }
+        }
+
         if self.tuner.is_some()
             && (self.max_outstanding_workflow_tasks.is_some()
                 || self.max_outstanding_activities.is_some()
@@ -264,7 +287,9 @@ impl WorkerConfigBuilder {
 /// This trait allows users to customize the performance characteristics of workers dynamically.
 /// For more, see the docstrings of the traits in the return types of its functions.
 pub trait WorkerTuner {
-    /// Return a [SlotSupplier] for workflow tasks
+    /// Return a [SlotSupplier] for workflow tasks. Note that workflow task slot suppliers must be
+    /// willing to hand out a minimum of two slots if workflow caching is enabled, otherwise the
+    /// worker may fail to process new tasks.
     fn workflow_task_slot_supplier(
         &self,
     ) -> Arc<dyn SlotSupplier<SlotKind = WorkflowSlotKind> + Send + Sync>;

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -389,6 +389,11 @@ impl SlotSupplierPermit {
     pub fn user_data_mut<T: Any + Send + Sync>(&mut self) -> Option<&mut T> {
         self.user_data.as_mut().and_then(|b| b.downcast_mut())
     }
+
+    /// Deconstruct this permit and return the inner data
+    pub fn into_user_data(self) -> Option<Box<dyn Any + Send + Sync>> {
+        self.user_data
+    }
 }
 
 #[derive(Debug, Copy, Clone, derive_more::Display, Eq, PartialEq)]

--- a/core/src/abstractions.rs
+++ b/core/src/abstractions.rs
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 /// as handling associated metrics tracking.
 #[derive(Clone)]
 pub(crate) struct MeteredPermitDealer<SK: SlotKind> {
-    pub(crate) supplier: Arc<dyn SlotSupplier<SlotKind = SK> + Send + Sync>,
+    supplier: Arc<dyn SlotSupplier<SlotKind = SK> + Send + Sync>,
     /// The number of permit owners who have acquired a permit, but are not yet meaningfully using
     /// that permit. This is useful for giving a more semantically accurate count of used task
     /// slots, since we typically wait for a permit first before polling, but that slot isn't used

--- a/core/src/pollers/poll_buffer.rs
+++ b/core/src/pollers/poll_buffer.rs
@@ -724,7 +724,7 @@ mod tests {
             CancellationToken::new(),
             None::<fn(usize)>,
             WorkflowTaskOptions {
-                wft_poller_shared: Some(Arc::new(WFTPollerShared::new())),
+                wft_poller_shared: Some(Arc::new(WFTPollerShared::new(false))),
             },
         );
 

--- a/core/src/pollers/poll_buffer.rs
+++ b/core/src/pollers/poll_buffer.rs
@@ -724,7 +724,7 @@ mod tests {
             CancellationToken::new(),
             None::<fn(usize)>,
             WorkflowTaskOptions {
-                wft_poller_shared: Some(Arc::new(WFTPollerShared::new(false))),
+                wft_poller_shared: Some(Arc::new(WFTPollerShared::new(Some(10)))),
             },
         );
 

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -867,9 +867,10 @@ fn wft_poller_behavior(config: &WorkerConfig, is_sticky: bool) -> PollerBehavior
                 config.nonsticky_to_sticky_poll_ratio,
             ))
         } else {
-            PollerBehavior::SimpleMaximum(m.saturating_sub(
-                calc_max_nonsticky(m, config.nonsticky_to_sticky_poll_ratio).max(1),
-            ))
+            PollerBehavior::SimpleMaximum(
+                m.saturating_sub(calc_max_nonsticky(m, config.nonsticky_to_sticky_poll_ratio))
+                    .max(1),
+            )
         }
     } else {
         config.workflow_task_poller_behavior

--- a/core/src/worker/workflow/wft_poller.rs
+++ b/core/src/worker/workflow/wft_poller.rs
@@ -34,7 +34,11 @@ pub(crate) fn make_wft_poller(
 > + Sized
 + 'static {
     let wft_metrics = metrics.with_new_attrs([workflow_poller()]);
-    let wft_poller_shared = Arc::new(WFTPollerShared::new());
+    let wft_poller_shared = if sticky_queue_name.is_some() {
+        Some(Arc::new(WFTPollerShared::new()))
+    } else {
+        None
+    };
     let wf_task_poll_buffer = LongPollBuffer::new_workflow_task(
         client.clone(),
         config.task_queue.clone(),

--- a/core/src/worker/workflow/wft_poller.rs
+++ b/core/src/worker/workflow/wft_poller.rs
@@ -121,7 +121,11 @@ impl WFTPollerShared {
             }
         }
 
-        // If there's no sticky backlog, balance poller counts
+        // If there's no sticky backlog, balance poller counts. This logic allows the poller
+        // to proceed if it has the same or fewer pollers as it's opposite. There is a preference
+        // for the sticky poller when counts are equal. This does not mean we always have equal
+        // numbers of pollers, as later on the scaler will also prevent polling based on the scaling
+        // information provided independently by the sticky/nonsticky queues.
         if *self.last_seen_sticky_backlog.0.borrow() == 0 {
             if let Some((sticky_active, non_sticky_active)) =
                 self.sticky_active.get().zip(self.non_sticky_active.get())

--- a/core/src/worker/workflow/wft_poller.rs
+++ b/core/src/worker/workflow/wft_poller.rs
@@ -104,11 +104,6 @@ impl WFTPollerShared {
         if is_sticky {
             self.wait_for_first_nonsticky_poll.notified().await;
         }
-        info!(
-            "Waiting if needed. Sticky: {} / backlog {}",
-            is_sticky,
-            *self.last_seen_sticky_backlog.0.borrow()
-        );
         // If there's a sticky backlog, prioritize it.
         if !is_sticky {
             let backlog = *self.last_seen_sticky_backlog.0.borrow();
@@ -127,12 +122,6 @@ impl WFTPollerShared {
             if let Some((sticky_active, non_sticky_active)) =
                 self.sticky_active.get().zip(self.non_sticky_active.get())
             {
-                info!(
-                    "Balance (sticky {}), non-sticky {} sticky {}",
-                    is_sticky,
-                    *non_sticky_active.borrow(),
-                    *sticky_active.borrow()
-                );
                 if is_sticky {
                     let _ = sticky_active
                         .clone()
@@ -147,7 +136,6 @@ impl WFTPollerShared {
                         })
                         .await;
                 }
-                info!("Done balance (sticky {})", is_sticky);
             }
         }
     }

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -154,7 +154,7 @@ async fn one_slot_worker_reports_available_slot() {
         // Need to use two for WFTs because there are a minimum of 2 pollers b/c of sticky polling
         .max_outstanding_workflow_tasks(2_usize)
         .max_outstanding_nexus_tasks(1_usize)
-        .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(1_usize))
+        .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(2_usize))
         .build()
         .unwrap();
 

--- a/tests/integ_tests/polling_tests.rs
+++ b/tests/integ_tests/polling_tests.rs
@@ -212,20 +212,16 @@ async fn switching_worker_client_changes_poll() {
     server2.shutdown().await.unwrap();
 }
 
-#[rstest::rstest]
 #[tokio::test]
-async fn small_workflow_slots_and_pollers(
-    #[values(1, 2)] wft_slots: usize,
-    #[values(1, 2)] wft_pollers: usize,
-) {
+async fn small_workflow_slots_and_pollers() {
     let wf_name = "only_one_workflow_slot_and_two_pollers";
     let mut starter = CoreWfStarter::new(wf_name);
     starter
         .worker_config
-        .max_outstanding_workflow_tasks(wft_slots)
+        .max_outstanding_workflow_tasks(2_usize)
         .max_outstanding_local_activities(1_usize)
         .activity_task_poller_behavior(PollerBehavior::SimpleMaximum(1))
-        .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(wft_pollers))
+        .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(2))
         .max_outstanding_activities(1_usize);
     let mut worker = starter.worker().await;
     worker.register_wf(wf_name.to_owned(), |ctx: WfContext| async move {
@@ -244,6 +240,15 @@ async fn small_workflow_slots_and_pollers(
     worker
         .submit_wf(
             starter.get_task_queue(),
+            wf_name.to_owned(),
+            vec![],
+            WorkflowOptions::default(),
+        )
+        .await
+        .unwrap();
+    worker
+        .submit_wf(
+            format!("{}-2", starter.get_task_queue()),
             wf_name.to_owned(),
             vec![],
             WorkflowOptions::default(),

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -22,13 +22,11 @@ use crate::integ_tests::{activity_functions::echo, metrics_tests};
 use assert_matches::assert_matches;
 use std::{
     collections::{HashMap, HashSet},
-    sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 use temporal_client::{WfClientExt, WorkflowClientTrait, WorkflowExecutionResult, WorkflowOptions};
 use temporal_sdk::{
-    ActivityOptions, LocalActivityOptions, WfContext, WorkflowResult,
-    interceptors::WorkerInterceptor,
+    ActivityOptions, LocalActivityOptions, WfContext, interceptors::WorkerInterceptor,
 };
 use temporal_sdk_core::{CoreRuntime, replay::HistoryForReplay};
 use temporal_sdk_core_api::{
@@ -57,7 +55,7 @@ use temporal_sdk_core_test_utils::{
     init_core_and_create_wf, init_core_replay_preloaded, prom_metrics, schedule_activity_cmd,
 };
 use tokio::{join, sync::Notify, time::sleep};
-use uuid::Uuid;
+
 // TODO: We should get expected histories for these tests and confirm that the history at the end
 //  matches.
 
@@ -83,56 +81,6 @@ async fn parallel_workflows_same_queue() {
         .unwrap();
     }
     core.run_until_done().await.unwrap();
-}
-
-static RUN_CT: AtomicUsize = AtomicUsize::new(0);
-
-pub(crate) async fn cache_evictions_wf(command_sink: WfContext) -> WorkflowResult<()> {
-    RUN_CT.fetch_add(1, Ordering::SeqCst);
-    command_sink.timer(Duration::from_secs(1)).await;
-    Ok(().into())
-}
-
-#[tokio::test]
-async fn workflow_lru_cache_evictions() {
-    let wf_type = "workflow_lru_cache_evictions";
-    let mut starter = CoreWfStarter::new(wf_type);
-    starter
-        .worker_config
-        .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(2_usize))
-        .no_remote_activities(true)
-        .max_cached_workflows(1_usize);
-    let mut worker = starter.worker().await;
-    worker.register_wf(wf_type.to_string(), cache_evictions_wf);
-
-    let n_workflows = 3;
-    for _ in 0..n_workflows {
-        worker
-            .submit_wf(
-                format!("wce-{}", Uuid::new_v4()),
-                wf_type.to_string(),
-                vec![],
-                WorkflowOptions::default(),
-            )
-            .await
-            .unwrap();
-    }
-    struct CacheAsserter;
-    #[async_trait::async_trait(?Send)]
-    impl WorkerInterceptor for CacheAsserter {
-        async fn on_workflow_activation_completion(&self, _: &WorkflowActivationCompletion) {}
-        fn on_shutdown(&self, sdk_worker: &temporal_sdk::Worker) {
-            // 0 since the sdk worker force-evicts and drains everything on shutdown.
-            assert_eq!(sdk_worker.cached_workflows(), 0);
-        }
-    }
-    worker
-        .run_until_done_intercepted(Some(CacheAsserter))
-        .await
-        .unwrap();
-    // The wf must have started more than # workflows times, since all but one must experience
-    // an eviction
-    assert!(RUN_CT.load(Ordering::SeqCst) > n_workflows);
 }
 
 // Ideally this would be a unit test, but returning a pending future with mockall bloats the mock

--- a/tests/integ_tests/workflow_tests.rs
+++ b/tests/integ_tests/workflow_tests.rs
@@ -99,7 +99,7 @@ async fn workflow_lru_cache_evictions() {
     let mut starter = CoreWfStarter::new(wf_type);
     starter
         .worker_config
-        .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(1_usize))
+        .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(2_usize))
         .no_remote_activities(true)
         .max_cached_workflows(1_usize);
     let mut worker = starter.worker().await;


### PR DESCRIPTION
Fixes an issue that could cause task timeouts when using very small (<2) numbers of WFT slots or pollers.