### PR TITLE
Rename operation_id to operation_token in Nexus code paths

### DIFF
--- a/core/src/worker/workflow/machines/nexus_operation_state_machine.rs
+++ b/core/src/worker/workflow/machines/nexus_operation_state_machine.rs
@@ -85,7 +85,7 @@ fsm! {
 #[derive(Debug, derive_more::Display)]
 pub(super) enum NexusOperationCommand {
     #[display("Start")]
-    Start { operation_id: String },
+    Start { operation_token: String },
     #[display("StartSync")]
     StartSync,
     #[display("CancelBeforeStart")]
@@ -249,7 +249,7 @@ impl ScheduledEventRecorded {
         sa: NexusOperationStartedEventAttributes,
     ) -> NexusOperationMachineTransition<Started> {
         NexusOperationMachineTransition::commands([NexusOperationCommand::Start {
-            operation_id: sa.operation_id,
+            operation_token: sa.operation_token,
         }])
     }
 }
@@ -478,12 +478,12 @@ impl WFMachinesAdapter for NexusOperationMachine {
                     .into(),
                 ]
             }
-            NexusOperationCommand::Start { operation_id } => {
+            NexusOperationCommand::Start { operation_token } => {
                 vec![
                     ResolveNexusOperationStart {
                         seq: self.shared_state.lang_seq_num,
-                        status: Some(resolve_nexus_operation_start::Status::OperationId(
-                            operation_id,
+                        status: Some(resolve_nexus_operation_start::Status::OperationToken(
+                            operation_token,
                         )),
                     }
                     .into(),

--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -343,10 +343,10 @@ message ResolveNexusOperationStart {
     // Sequence number as provided by lang in the corresponding ScheduleNexusOperation command
     uint32 seq = 1;
     oneof status {
-        // The operation started asynchronously. Contains an ID that can be used to perform
+        // The operation started asynchronously. Contains a token that can be used to perform
         // operations on the started operation by, ex, clients. A `ResolveNexusOperation` job will
         // follow at some point.
-        string operation_id = 2;
+        string operation_token = 2;
         // If true the operation "started" but only because it's also already resolved. A
         // `ResolveNexusOperation` job will be in the same activation.
         bool started_sync = 3;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -711,15 +711,15 @@ impl Unblockable for NexusStartResult {
     fn unblock(ue: UnblockEvent, od: Self::OtherDat) -> Self {
         match ue {
             UnblockEvent::NexusOperationStart(_, result) => match *result {
-                resolve_nexus_operation_start::Status::OperationId(op_id) => {
+                resolve_nexus_operation_start::Status::OperationToken(op_token) => {
                     Ok(StartedNexusOperation {
-                        operation_id: Some(op_id),
+                        operation_token: Some(op_token),
                         unblock_dat: od,
                     })
                 }
                 resolve_nexus_operation_start::Status::StartedSync(_) => {
                     Ok(StartedNexusOperation {
-                        operation_id: None,
+                        operation_token: None,
                         unblock_dat: od,
                     })
                 }

--- a/sdk/src/workflow_context.rs
+++ b/sdk/src/workflow_context.rs
@@ -866,10 +866,10 @@ impl StartedChildWorkflow {
 }
 
 #[derive(derive_more::Debug)]
-#[debug("StartedNexusOperation{{ operation_id: {operation_id:?} }}")]
+#[debug("StartedNexusOperation{{ operation_token: {operation_token:?} }}")]
 pub struct StartedNexusOperation {
-    /// The operation id, if the operation started asynchronously
-    pub operation_id: Option<String>,
+    /// The operation token, if the operation started asynchronously
+    pub operation_token: Option<String>,
     pub(crate) unblock_dat: NexusUnblockData,
 }
 

--- a/tests/integ_tests/workflow_tests/nexus.rs
+++ b/tests/integ_tests/workflow_tests/nexus.rs
@@ -64,7 +64,7 @@ async fn nexus_basic(
                 })
                 .await
                 .unwrap();
-            assert_eq!(started.operation_id, None);
+            assert_eq!(started.operation_token, None);
             let res = started.result().await;
             Ok(res.into())
         }


### PR DESCRIPTION
Operation ID was deprecated in favor of the token concept.
