### PR TITLE
Nexus cancellation type fixes

### DIFF
--- a/sdk-core-protos/protos/local/temporal/sdk/core/nexus/nexus.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/nexus/nexus.proto
@@ -72,15 +72,15 @@ enum NexusTaskCancelReason {
 
 // Controls at which point to report back to lang when a nexus operation is cancelled
 enum NexusOperationCancellationType {
+    // Wait for operation cancellation completion. Default.
+    WAIT_CANCELLATION_COMPLETED = 0;
     // Do not request cancellation of the nexus operation if already scheduled
-    ABANDON = 0;
+    ABANDON = 1;
 
     // Initiate a cancellation request for the Nexus operation and immediately report cancellation
     // to the caller. Note that it doesn't guarantee that cancellation is delivered to the operation if calling workflow exits before the delivery is done.
     // If you want to ensure that cancellation is delivered to the operation, use WAIT_CANCELLATION_REQUESTED.
-    TRY_CANCEL = 1;
+    TRY_CANCEL = 2;
     // Request cancellation of the operation and wait for confirmation that the request was received.
-    WAIT_CANCELLATION_REQUESTED = 2;
-    // Wait for operation cancellation completion. Default.
-    WAIT_CANCELLATION_COMPLETED = 3;
+    WAIT_CANCELLATION_REQUESTED = 3;
 }


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
WAIT_CANCELLATION_COMPLETED should be default, populate operation_token on cancellation failures

## Why?
Default should have the same behavior as before the expansion of cancellation types.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Tested the change in the python SDK

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
