### PR TITLE
Update after skipped WFT NDE fix

### DIFF
--- a/core/src/worker/workflow/history_update.rs
+++ b/core/src/worker/workflow/history_update.rs
@@ -8,7 +8,7 @@ use crate::{
 use futures_util::{FutureExt, Stream, TryFutureExt, future::BoxFuture};
 use itertools::Itertools;
 use std::{
-    collections::VecDeque,
+    collections::{BTreeMap, VecDeque},
     fmt::Debug,
     future::Future,
     mem,
@@ -686,6 +686,7 @@ impl NextWFTSeqEndIndex {
 }
 
 /// Discovers the index of the last event in next WFT sequence within the passed-in slice
+/// For more on workflow task chunking, see arch_docs/workflow_task_chunking.md
 fn find_end_index_of_next_wft_seq(
     events: &[HistoryEvent],
     from_event_id: i64,
@@ -697,7 +698,13 @@ fn find_end_index_of_next_wft_seq(
     let mut last_index = 0;
     let mut saw_command_or_started = false;
     let mut saw_command = false;
-    let mut wft_started_event_id_to_index = vec![];
+    #[derive(Debug)]
+    struct WftStartedInfo {
+        index: usize,
+        was_skipped: bool,
+    }
+    // Maps wft started event id to info about that WFT started
+    let mut wft_started_info = BTreeMap::new();
     for (ix, e) in events.iter().enumerate() {
         last_index = ix;
 
@@ -718,13 +725,14 @@ fn find_end_index_of_next_wft_seq(
             return NextWFTSeqEndIndex::Complete(last_index);
         }
 
-        // TODO: Emergency undo for boundary calculation change. Remove if no problems after a bit.
-        if std::env::var("TEMPORAL_NO_WFT_BOUNDARY_CHANGE").is_ok() {
-            saw_command = false;
-        }
-
         if e.event_type() == EventType::WorkflowTaskStarted {
-            wft_started_event_id_to_index.push((e.event_id, ix));
+            wft_started_info.insert(
+                e.event_id,
+                WftStartedInfo {
+                    index: ix,
+                    was_skipped: false,
+                },
+            );
             if let Some(next_event) = events.get(ix + 1) {
                 let next_event_type = next_event.event_type();
                 // If the next event is WFT timeout or fail, or abrupt WF execution end, that
@@ -737,6 +745,7 @@ fn find_end_index_of_next_wft_seq(
                         | EventType::WorkflowExecutionTerminated
                         | EventType::WorkflowExecutionCanceled
                 ) {
+                    wft_started_info.get_mut(&e.event_id).unwrap().was_skipped = true;
                     continue;
                 } else if next_event_type == EventType::WorkflowTaskCompleted {
                     if let Some(next_next_event) = events.get(ix + 2) {
@@ -761,13 +770,18 @@ fn find_end_index_of_next_wft_seq(
                                 ),
                             ) = next_next_event.attributes
                             {
-                                // Find index of closest WFT started before sequencing id
-                                if let Some(ret_ix) = wft_started_event_id_to_index
-                                    .iter()
-                                    .rev()
-                                    .find_map(|(eid, ix)| {
-                                        if *eid < attr.accepted_request_sequencing_event_id {
-                                            return Some(*ix);
+                                // Find index of closest unskipped WFT started before sequencing id.
+                                // The fact that the WFT wasn't skipped is important. If it was, we
+                                // need to avoid stopping at that point even though that's where the
+                                // update was sequenced. If we did, we'll fail to actually include
+                                // the update accepted event and therefore fail to generate the
+                                // request to run the update handler on replay.
+                                if let Some(ret_ix) =
+                                    wft_started_info.iter().find_map(|(eid, info)| {
+                                        if *eid < attr.accepted_request_sequencing_event_id
+                                            && !info.was_skipped
+                                        {
+                                            return Some(info.index);
                                         }
                                         None
                                     })
@@ -1876,5 +1890,53 @@ mod tests {
         assert_eq!(seq.last().unwrap().event_id, 7);
         let seq = next_check_peek(&mut update, 7);
         assert_eq!(seq.last().unwrap().event_id, 11);
+    }
+
+    #[tokio::test]
+    async fn wft_fail_on_first_task_with_update() {
+        let mut t = TestHistoryBuilder::default();
+        t.add_by_type(EventType::WorkflowExecutionStarted);
+        t.add_workflow_task_scheduled_and_started();
+        t.add_workflow_task_failed_with_failure(
+            WorkflowTaskFailedCause::Unspecified,
+            Default::default(),
+        );
+        t.add_full_wf_task();
+        let accept_id = t.add_update_accepted("1", "upd");
+        let timer_id = t.add_timer_started("1".to_string());
+        t.add_update_completed(accept_id);
+        t.add_timer_fired(timer_id, "1".to_string());
+        t.add_full_wf_task();
+
+        let mut update = t.as_history_update();
+        let seq = next_check_peek(&mut update, 0);
+        // In this case, we expect to see up to the task with update, since the task failure
+        // should be skipped. This means that the peek of the _next_ task will include the update
+        // and thus properly synthesize the update request with the first activation.
+        assert_eq!(seq.len(), 6);
+        let seq = next_check_peek(&mut update, 6);
+        assert_eq!(seq.len(), 7);
+    }
+
+    #[test]
+    fn update_accepted_after_empty_wft() {
+        let mut t = TestHistoryBuilder::default();
+        t.add_by_type(EventType::WorkflowExecutionStarted);
+        t.add_full_wf_task();
+        t.add_full_wf_task();
+        let accept_id = t.add_update_accepted("1", "upd");
+        let timer_id = t.add_timer_started("1".to_string());
+        t.add_update_completed(accept_id);
+        t.add_timer_fired(timer_id, "1".to_string());
+        t.add_full_wf_task();
+
+        let mut update = t.as_history_update();
+        let seq = next_check_peek(&mut update, 0);
+        // unlike the case with a wft failure, here the first task should not extend through to
+        // the update, because here the first empty WFT happened with _just_ the workflow init,
+        // not also with the update.
+        assert_eq!(seq.len(), 3);
+        let seq = next_check_peek(&mut update, 3);
+        assert_eq!(seq.len(), 3);
     }
 }

--- a/sdk-core-protos/src/history_builder.rs
+++ b/sdk-core-protos/src/history_builder.rs
@@ -243,12 +243,12 @@ impl TestHistoryBuilder {
         self.build_and_push_event(EventType::WorkflowTaskFailed, attrs.into());
     }
 
-    pub fn add_timer_started(&mut self, timer_id: String) {
+    pub fn add_timer_started(&mut self, timer_id: String) -> i64 {
         self.add(TimerStartedEventAttributes {
             timer_id,
             workflow_task_completed_event_id: self.previous_task_completed_id,
             ..Default::default()
-        });
+        })
     }
 
     pub fn add_timer_fired(&mut self, timer_started_evt_id: i64, timer_id: String) {
@@ -451,7 +451,7 @@ impl TestHistoryBuilder {
         update_name: impl Into<String>,
     ) -> i64 {
         let protocol_instance_id = instance_id.into();
-        let last_wft_started_id = self
+        let last_wft_scheduled_id = self
             .events
             .iter()
             .rev()
@@ -465,7 +465,7 @@ impl TestHistoryBuilder {
             .expect("Must have wft scheduled event");
         let attrs = WorkflowExecutionUpdateAcceptedEventAttributes {
             accepted_request_message_id: format!("{}/request", &protocol_instance_id),
-            accepted_request_sequencing_event_id: last_wft_started_id,
+            accepted_request_sequencing_event_id: last_wft_scheduled_id,
             accepted_request: Some(update::v1::Request {
                 meta: Some(update::v1::Meta {
                     update_id: protocol_instance_id.clone(),

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -429,6 +429,11 @@ impl Future for WorkflowFuture {
                 )
                 .collect();
 
+            // The commands from the initial activation should go _after_ the updates run. This
+            // is still a bit of hacky nonsense, as the first poll of the WF future should be able
+            // to observe any state changed by the update handlers - but that's impossible to do
+            // with current handler registration. In the real SDK, this will be obviated by them
+            // being functions on a struct.
             activation_cmds.extend(init_activation_cmds);
             if self.poll_wf_future(cx, &run_id, &mut activation_cmds)? {
                 continue;

--- a/sdk/src/workflow_future.rs
+++ b/sdk/src/workflow_future.rs
@@ -368,6 +368,7 @@ impl Future for WorkflowFuture {
             }
 
             let mut activation_cmds = vec![];
+            let mut init_activation_cmds = vec![];
             // Lame hack to avoid hitting "unregistered" update handlers in a situation where
             // the history has no commands until an update is accepted. Will go away w/ SDK redesign
             if activation
@@ -382,7 +383,7 @@ impl Future for WorkflowFuture {
                 })
             {
                 // Poll the workflow future once to get things registered
-                if self.poll_wf_future(cx, &run_id, &mut activation_cmds)? {
+                if self.poll_wf_future(cx, &run_id, &mut init_activation_cmds)? {
                     continue;
                 }
             }
@@ -428,6 +429,7 @@ impl Future for WorkflowFuture {
                 )
                 .collect();
 
+            activation_cmds.extend(init_activation_cmds);
             if self.poll_wf_future(cx, &run_id, &mut activation_cmds)? {
                 continue;
             }

--- a/tests/integ_tests/update_tests.rs
+++ b/tests/integ_tests/update_tests.rs
@@ -155,12 +155,6 @@ async fn reapplied_updates_due_to_reset() {
     let with_id = HistoryForReplay::new(history, workflow_id.to_string());
 
     let replay_worker = init_core_replay_preloaded(workflow_id, [with_id]);
-    // Init workflow comes by itself
-    let act = replay_worker.poll_workflow_activation().await.unwrap();
-    replay_worker
-        .complete_workflow_activation(WorkflowActivationCompletion::empty(act.run_id))
-        .await
-        .unwrap();
     // We now recapitulate the actions that the worker took on first execution above, pretending
     // that we always followed the post-reset history.
     // First, we handled the post-reset reapplied update and did not complete the workflow.
@@ -168,7 +162,7 @@ async fn reapplied_updates_due_to_reset() {
         FailUpdate::No,
         CompleteWorkflow::No,
         replay_worker.as_ref(),
-        1,
+        2,
     )
     .await;
     // Then the timer fires
@@ -1220,113 +1214,4 @@ async fn update_lost_on_activity_mismatch() {
         .fetch_history_and_replay(worker.inner_mut())
         .await
         .unwrap();
-}
-
-#[tokio::test]
-async fn update_wft_timeout_nde() {
-    let wf_name = "update_wft_timeout_nde";
-    let mut starter = CoreWfStarter::new(wf_name);
-    let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
-    static SHOULD_TIME_OUT: AtomicBool = AtomicBool::new(true);
-    static SHOULD_FAIL_2: AtomicBool = AtomicBool::new(true);
-
-    worker.register_wf(wf_name.to_owned(), move |ctx: WfContext| async move {
-        let count = Arc::new(AtomicI32::new(0));
-        let should_complete = Arc::new(AtomicBool::new(false));
-
-        ctx.update_handler(
-            "fetchAdd",
-            |_: &_, arg: i32| {
-                if arg < 0 {
-                    return Err(anyhow!("bad arg"));
-                }
-                Ok(())
-            },
-            move |_: UpdateContext, arg: i32| {
-                let prev_ct = count.load(Ordering::Relaxed);
-                count.fetch_add(arg, Ordering::Relaxed);
-                async move { Ok(prev_ct) }
-            },
-        );
-
-        let sc = should_complete.clone();
-        ctx.update_handler(
-            "beDone",
-            |_: &_, _: ()| Ok(()),
-            move |_: UpdateContext, _: ()| {
-                sc.store(true, Ordering::Relaxed);
-                async move { Ok(()) }
-            },
-        );
-        // generate wft fail
-        if SHOULD_TIME_OUT.load(Ordering::Relaxed) {
-            SHOULD_TIME_OUT.store(false, Ordering::Release);
-            ctx.force_task_fail(anyhow!("wft fail"));
-        }
-        ctx.activity(ActivityOptions {
-            activity_type: "echo".to_string(),
-            input: "hi!".as_json_payload().expect("serializes fine"),
-            start_to_close_timeout: Some(Duration::from_secs(2)),
-            ..Default::default()
-        })
-        .await
-        .unwrap_ok_payload();
-        // if SHOULD_FAIL_2.load(Ordering::Relaxed) {
-        //     SHOULD_FAIL_2.store(false, Ordering::Release);
-        //     ctx.force_task_fail(anyhow!("wft fail 2"));
-        // }
-        ctx.wait_condition(move || should_complete.load(Ordering::Relaxed))
-            .await;
-        Ok(().into())
-    });
-    worker.register_activity("echo", |_ctx: ActContext, echo_me: String| async move {
-        Ok(echo_me)
-    });
-
-    let core_worker = worker.core_worker.clone();
-    let handle = starter.start_with_worker(wf_name, &mut worker).await;
-
-    let wf_id = starter.get_task_queue().to_string();
-    let update = async {
-        // Need time to get to wft fail
-        // tokio::time::sleep(Duration::from_millis(200)).await;
-        let res = client
-            .update_workflow_execution(
-                wf_id.clone(),
-                "".to_string(),
-                "fetchAdd".to_string(),
-                WaitPolicy {
-                    lifecycle_stage: UpdateWorkflowExecutionLifecycleStage::Completed as i32,
-                },
-                [1.as_json_payload().unwrap()].into_payloads(),
-            )
-            .await
-            .unwrap();
-        assert!(res.outcome.unwrap().is_success());
-        // Evict wf
-        core_worker.request_workflow_eviction(handle.info().run_id.as_ref().unwrap());
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        let res = client
-            .update_workflow_execution(
-                wf_id.clone(),
-                "".to_string(),
-                "beDone".to_string(),
-                WaitPolicy {
-                    lifecycle_stage: UpdateWorkflowExecutionLifecycleStage::Completed as i32,
-                },
-                [1.as_json_payload().unwrap()].into_payloads(),
-            )
-            .await
-            .unwrap();
-        dbg!(&res);
-    };
-    let runner = async {
-        worker.run_until_done().await.unwrap();
-    };
-    join!(update, runner);
-    // handle
-    //     .fetch_history_and_replay(worker.inner_mut())
-    //     .await
-    //     .unwrap();
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Do not eagerly conclude WFT sequences when finding update accepted events if those sequences should have been skipped

## Why?
Bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/943

2. How was this tested:
Unit tests and change to existing IT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
