### PR TITLE
Callback-based gRPC client with C interface

### DIFF
--- a/client/src/callback_based.rs
+++ b/client/src/callback_based.rs
@@ -1,0 +1,125 @@
+//! This module implements support for callback-based gRPC service that has a callback invoked for
+//! every gRPC call instead of using network.
+
+use anyhow::anyhow;
+use bytes::{BufMut, BytesMut};
+use futures_util::future::BoxFuture;
+use futures_util::stream;
+use http::{HeaderMap, Request, Response};
+use http_body_util::{BodyExt, StreamBody, combinators::BoxBody};
+use hyper::body::{Bytes, Frame};
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tonic::{Status, metadata::GRPC_CONTENT_TYPE};
+use tower::Service;
+
+/// gRPC request for use by a callback.
+pub struct GrpcRequest<'a> {
+    /// Reference to the gRPC service name.
+    pub service: &'a str,
+
+    /// Reference to the gRPC RPC name.
+    pub rpc: &'a str,
+
+    /// Reference to the gRPC request headers.
+    pub headers: &'a HeaderMap,
+
+    /// Reference to the gRPC protobuf bytes of the request.
+    pub proto: Bytes,
+}
+
+/// Successful gRPC response returned by a callback.
+pub struct GrpcSuccessResponse {
+    /// Response headers.
+    pub headers: HeaderMap,
+
+    /// Response proto bytes.
+    pub proto: Vec<u8>,
+}
+
+/// gRPC service that invokes the given callback on each call.
+#[derive(Clone)]
+pub struct CallbackBasedGrpcService {
+    /// Callback to invoke on each RPC call.
+    pub callback: Arc<
+        dyn for<'a> Fn(GrpcRequest<'a>) -> BoxFuture<'a, Result<GrpcSuccessResponse, Status>>
+            + Send
+            + Sync,
+    >,
+}
+
+impl Service<Request<tonic::body::Body>> for CallbackBasedGrpcService {
+    type Response = http::Response<tonic::body::Body>;
+    type Error = anyhow::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<tonic::body::Body>) -> Self::Future {
+        let callback = self.callback.clone();
+
+        Box::pin(async move {
+            // Build req
+            let (parts, body) = req.into_parts();
+            let mut path_parts = parts.uri.path().trim_start_matches('/').split('/');
+            let req_body = body.collect().await.map_err(|e| anyhow!(e))?.to_bytes();
+            // Body is flag saying whether compressed (we do not support that), then 32-bit length,
+            // then the actual proto.
+            if req_body.len() < 5 {
+                return Err(anyhow!("Too few request bytes: {}", req_body.len()));
+            } else if req_body[0] != 0 {
+                return Err(anyhow!("Compression not supported"));
+            }
+            let req_proto_len =
+                u32::from_be_bytes([req_body[1], req_body[2], req_body[3], req_body[4]]) as usize;
+            if req_body.len() < 5 + req_proto_len {
+                return Err(anyhow!(
+                    "Expected request body length at least {}, got {}",
+                    5 + req_proto_len,
+                    req_body.len()
+                ));
+            }
+            let req = GrpcRequest {
+                service: path_parts.next().unwrap_or_default(),
+                rpc: path_parts.next().unwrap_or_default(),
+                headers: &parts.headers,
+                proto: req_body.slice(5..5 + req_proto_len),
+            };
+
+            // Invoke and handle response
+            match (callback)(req).await {
+                Ok(success) => {
+                    // Create body bytes which requires a flag saying whether compressed, then
+                    // message len, then actual message. So we create a Bytes for those 5 prepend
+                    // parts, then stream it alongside the user-provided Vec. This allows us to
+                    // avoid copying the vec
+                    let mut body_prepend = BytesMut::with_capacity(5);
+                    body_prepend.put_u8(0); // 0 means no compression
+                    body_prepend.put_u32(success.proto.len() as u32);
+                    let stream = stream::iter(vec![
+                        Ok::<_, Status>(Frame::data(Bytes::from(body_prepend))),
+                        Ok::<_, Status>(Frame::data(Bytes::from(success.proto))),
+                    ]);
+                    let stream_body = StreamBody::new(stream);
+                    let full_body = BoxBody::new(stream_body).boxed();
+
+                    // Build response appending headers
+                    let mut resp_builder = Response::builder()
+                        .status(200)
+                        .header(http::header::CONTENT_TYPE, GRPC_CONTENT_TYPE);
+                    for (key, value) in success.headers.iter() {
+                        resp_builder = resp_builder.header(key, value);
+                    }
+                    Ok(resp_builder
+                        .body(tonic::body::Body::new(full_body))
+                        .map_err(|e| anyhow!(e))?)
+                }
+                Err(status) => Ok(status.into_http()),
+            }
+        })
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,6 +7,7 @@
 #[macro_use]
 extern crate tracing;
 
+pub mod callback_based;
 mod metrics;
 mod proxy;
 mod raw;
@@ -35,7 +36,7 @@ pub use workflow_handle::{
 };
 
 use crate::{
-    metrics::{GrpcMetricSvc, MetricsContext},
+    metrics::{ChannelOrGrpcOverride, GrpcMetricSvc, MetricsContext},
     raw::{AttachMetricLabels, sealed::RawClientLike},
     sealed::WfHandleClient,
     workflow_handle::UntypedWorkflowHandle,
@@ -432,34 +433,59 @@ impl ClientOptions {
         metrics_meter: Option<TemporalMeter>,
     ) -> Result<RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>, ClientInitError>
     {
-        let channel = Channel::from_shared(self.target_url.to_string())?;
-        let channel = self.add_tls_to_channel(channel).await?;
-        let channel = if let Some(keep_alive) = self.keep_alive.as_ref() {
-            channel
-                .keep_alive_while_idle(true)
-                .http2_keep_alive_interval(keep_alive.interval)
-                .keep_alive_timeout(keep_alive.timeout)
-        } else {
-            channel
-        };
-        let channel = if let Some(origin) = self.override_origin.clone() {
-            channel.origin(origin)
-        } else {
-            channel
-        };
-        // If there is a proxy, we have to connect that way
-        let channel = if let Some(proxy) = self.http_connect_proxy.as_ref() {
-            proxy.connect_endpoint(&channel).await?
-        } else {
-            channel.connect().await?
-        };
-        let service = ServiceBuilder::new()
-            .layer_fn(move |channel| GrpcMetricSvc {
-                inner: channel,
+        self.connect_no_namespace_with_service_override(metrics_meter, None)
+            .await
+    }
+
+    /// Attempt to establish a connection to the Temporal server and return a gRPC client which is
+    /// intercepted with retry, default headers functionality, and metrics if provided. If a
+    /// service_override is present, network-specific options are ignored and the callback is
+    /// invoked for each gRPC call.
+    ///
+    /// See [RetryClient] for more
+    pub async fn connect_no_namespace_with_service_override(
+        &self,
+        metrics_meter: Option<TemporalMeter>,
+        service_override: Option<callback_based::CallbackBasedGrpcService>,
+    ) -> Result<RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>, ClientInitError>
+    {
+        let service = if let Some(service_override) = service_override {
+            GrpcMetricSvc {
+                inner: ChannelOrGrpcOverride::GrpcOverride(service_override),
                 metrics: metrics_meter.clone().map(MetricsContext::new),
                 disable_errcode_label: self.disable_error_code_metric_tags,
-            })
-            .service(channel);
+            }
+        } else {
+            let channel = Channel::from_shared(self.target_url.to_string())?;
+            let channel = self.add_tls_to_channel(channel).await?;
+            let channel = if let Some(keep_alive) = self.keep_alive.as_ref() {
+                channel
+                    .keep_alive_while_idle(true)
+                    .http2_keep_alive_interval(keep_alive.interval)
+                    .keep_alive_timeout(keep_alive.timeout)
+            } else {
+                channel
+            };
+            let channel = if let Some(origin) = self.override_origin.clone() {
+                channel.origin(origin)
+            } else {
+                channel
+            };
+            // If there is a proxy, we have to connect that way
+            let channel = if let Some(proxy) = self.http_connect_proxy.as_ref() {
+                proxy.connect_endpoint(&channel).await?
+            } else {
+                channel.connect().await?
+            };
+            ServiceBuilder::new()
+                .layer_fn(move |channel| GrpcMetricSvc {
+                    inner: ChannelOrGrpcOverride::Channel(channel),
+                    metrics: metrics_meter.clone().map(MetricsContext::new),
+                    disable_errcode_label: self.disable_error_code_metric_tags,
+                })
+                .service(channel)
+        };
+
         let headers = Arc::new(RwLock::new(ClientHeaders {
             user_headers: self.headers.clone().unwrap_or_default(),
             api_key: self.api_key.clone(),

--- a/core-c-bridge/Cargo.toml
+++ b/core-c-bridge/Cargo.toml
@@ -10,6 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+futures-util = { version = "0.3", default-features = false }
+http = "1.1"
 libc = "0.2"
 prost = { workspace = true }
 # We rely on Cargo semver rules not updating a 0.x to 0.y. Per the rand

--- a/core-c-bridge/src/tests/context.rs
+++ b/core-c-bridge/src/tests/context.rs
@@ -277,6 +277,14 @@ impl Context {
     }
 
     pub fn client_connect(self: &Arc<Self>, options: Box<ClientOptions>) -> anyhow::Result<()> {
+        Self::client_connect_with_override(self, options, None)
+    }
+
+    pub fn client_connect_with_override(
+        self: &Arc<Self>,
+        options: Box<ClientOptions>,
+        grpc_override_callback: crate::client::ClientGrpcOverrideCallback,
+    ) -> anyhow::Result<()> {
         let metadata = options
             .headers
             .as_ref()
@@ -339,6 +347,7 @@ impl Context {
             retry_options: &*retry_options,
             keep_alive_options: pointer_or_null(keep_alive_options.as_deref()),
             http_connect_proxy_options: pointer_or_null(proxy_options.as_deref()),
+            grpc_override_callback,
         });
 
         let client_options_ptr = &*client_options as *const _;

--- a/core-c-bridge/src/tests/mod.rs
+++ b/core-c-bridge/src/tests/mod.rs
@@ -1,12 +1,21 @@
-use crate::client::RpcService;
+use crate::ByteArrayRef;
+use crate::client::{
+    ClientGrpcOverrideRequest, ClientGrpcOverrideResponse, RpcService,
+    temporal_core_client_grpc_override_request_proto,
+    temporal_core_client_grpc_override_request_respond,
+    temporal_core_client_grpc_override_request_rpc,
+    temporal_core_client_grpc_override_request_service,
+};
 use crate::tests::utils::{
     OwnedRpcCallOptions, RpcCallError, default_client_options, default_server_config,
 };
 use context::Context;
 use prost::Message;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex};
+use temporal_sdk_core_protos::temporal::api::failure::v1::Failure;
 use temporal_sdk_core_protos::temporal::api::workflowservice::v1::{
-    GetSystemInfoRequest, GetSystemInfoResponse,
+    GetSystemInfoRequest, GetSystemInfoResponse, QueryWorkflowRequest,
+    StartWorkflowExecutionRequest, StartWorkflowExecutionResponse,
 };
 
 mod context;
@@ -174,5 +183,156 @@ fn test_all_rpc_calls_exist() {
             RpcService::Health,
             include_str!("../../../sdk-core-protos/protos/grpc/health/v1/health.proto"),
         ));
+    });
+}
+
+static CALLBACK_OVERRIDE_CALLS: LazyLock<Mutex<Vec<String>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
+struct ClientOverrideError {
+    message: String,
+    details: Option<Vec<u8>>,
+}
+
+impl ClientOverrideError {
+    pub fn new(message: String) -> Self {
+        Self {
+            message,
+            details: None,
+        }
+    }
+}
+
+unsafe extern "C" fn callback_override<'a>(req: *mut ClientGrpcOverrideRequest<'a>) {
+    let mut calls = CALLBACK_OVERRIDE_CALLS.lock().unwrap();
+    calls.push(format!(
+        "service: {}, rpc: {}",
+        temporal_core_client_grpc_override_request_service(req).to_string(),
+        temporal_core_client_grpc_override_request_rpc(req).to_string()
+    ));
+    let resp_raw = match temporal_core_client_grpc_override_request_rpc(req).to_str() {
+        "GetSystemInfo" => Ok(GetSystemInfoResponse::default().encode_to_vec()),
+        "StartWorkflowExecution" => match StartWorkflowExecutionRequest::decode(
+            temporal_core_client_grpc_override_request_proto(req).to_slice(),
+        ) {
+            Ok(req) => Ok(StartWorkflowExecutionResponse {
+                run_id: format!("run-id for {}", req.workflow_id),
+                ..Default::default()
+            }
+            .encode_to_vec()),
+            Err(err) => Err(ClientOverrideError::new(format!("Bad bytes: {}", err))),
+        },
+        "QueryWorkflow" => match QueryWorkflowRequest::decode(
+            temporal_core_client_grpc_override_request_proto(req).to_slice(),
+        ) {
+            // Demonstrate fail details
+            Ok(_) => Err(ClientOverrideError {
+                message: "query-fail".to_string(),
+                details: Some(
+                    Failure {
+                        message: "intentional failure".to_string(),
+                        ..Default::default()
+                    }
+                    .encode_to_vec(),
+                ),
+            }),
+            Err(err) => Err(ClientOverrideError::new(format!("Bad bytes: {}", err))),
+        },
+        v => Err(ClientOverrideError::new(format!("Unknown RPC: {}", v))),
+    };
+    // It is very important that we borrow not move resp_raw here. If this were a "match resp_raw"
+    // without the &, ownership of bytes moves into the match arm and can drop bytes after the
+    // match arm. This is why we have a "let _" below for resp_raw to ensure a developed doesn't
+    // accidentally move it.
+    let resp = match &resp_raw {
+        Ok(bytes) => ClientGrpcOverrideResponse {
+            status_code: 0,
+            headers: ByteArrayRef::empty(),
+            success_proto: bytes.as_slice().into(),
+            fail_message: ByteArrayRef::empty(),
+            fail_details: ByteArrayRef::empty(),
+        },
+        Err(err) => ClientGrpcOverrideResponse {
+            status_code: tonic::Code::Internal.into(),
+            headers: ByteArrayRef::empty(),
+            success_proto: ByteArrayRef::empty(),
+            fail_message: err.message.as_str().into(),
+            fail_details: if let Some(details) = &err.details {
+                details.as_slice().into()
+            } else {
+                ByteArrayRef::empty()
+            },
+        },
+    };
+    temporal_core_client_grpc_override_request_respond(req, resp);
+    let _ = resp_raw;
+}
+
+#[test]
+fn test_simple_callback_override() {
+    Context::with(|context| {
+        context.runtime_new().unwrap();
+        // Create client which will invoke GetSystemInfo
+        context
+            .client_connect_with_override(
+                Box::new(default_client_options("127.0.0.1:4567")),
+                Some(callback_override),
+            )
+            .unwrap();
+
+        // Invoke start workflow so we can confirm complex proto in/out
+        let start_resp_raw = context
+            .rpc_call(Box::new(OwnedRpcCallOptions {
+                service: RpcService::Workflow,
+                rpc: "StartWorkflowExecution".into(),
+                req: StartWorkflowExecutionRequest {
+                    workflow_id: "my-workflow-id".into(),
+                    ..Default::default()
+                }
+                .encode_to_vec(),
+                retry: false,
+                metadata: None,
+                timeout_millis: 0,
+                cancellation_token: None,
+            }))
+            .unwrap();
+        let start_resp = StartWorkflowExecutionResponse::decode(&*start_resp_raw).unwrap();
+        assert!(start_resp.run_id == "run-id for my-workflow-id");
+
+        // Try a query where a query failure will actually be delivered as failure details.
+        // However, we don't currently have temporal_sdk_core_protos::google::rpc::Status in
+        // the crate, so we'll just use the details directly even though a proper gRPC
+        // implementation will only provide a google.rpc.Status proto.
+        let query_err = context
+            .rpc_call(Box::new(OwnedRpcCallOptions {
+                service: RpcService::Workflow,
+                rpc: "QueryWorkflow".into(),
+                req: QueryWorkflowRequest::default().encode_to_vec(),
+                retry: false,
+                metadata: None,
+                timeout_millis: 0,
+                cancellation_token: None,
+            }))
+            .unwrap_err()
+            .downcast::<RpcCallError>()
+            .unwrap();
+        assert!(query_err.status_code == tonic::Code::Internal as u32);
+        assert!(query_err.message == "query-fail");
+        assert!(
+            Failure::decode(query_err.details.as_ref().unwrap().as_slice())
+                .unwrap()
+                .message
+                == "intentional failure"
+        );
+
+        // Confirm we got the expected calls
+        assert!(
+            *CALLBACK_OVERRIDE_CALLS.lock().unwrap()
+                == vec![
+                    "service: temporal.api.workflowservice.v1.WorkflowService, rpc: GetSystemInfo",
+                    "service: temporal.api.workflowservice.v1.WorkflowService, rpc: StartWorkflowExecution",
+                    "service: temporal.api.workflowservice.v1.WorkflowService, rpc: QueryWorkflow"
+                ]
+        );
     });
 }


### PR DESCRIPTION
## What was changed

* Added `temporal_client::callback_based` module with a Tonic-compatible Tower service implementation that invokes a callback instead of making a network call
* Added `connect_no_namespace_with_service_override` overload that accepts an optional callback service (and moved stuff from `connect_no_namespace` into there)
* Adapted `temporal_client::metrics::GrpcMetricSvc` to work with channel or callback-based service
* Added `grpc_override_callback` option in C bridge's `ClientOptions` that can be set with a C function for callback
* Added supporting structures and methods to support C-based callbacks with a careful eye towards lifetimes
* Added minimal test to confirm some behaviors

Missing/future features:

* Cancellation support - There is currently no way to notify the callback implementer when a call needs to be canceled which is an important feature
* Easy way to delegate to traditional Core client from inside callback - This is needed to be able to use the callback-based client as an interception mechanism for langs
