### PR TITLE
Fail Nexus start operations on sync failure

### DIFF
--- a/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/sdk-core-protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -350,10 +350,9 @@ message ResolveNexusOperationStart {
         // If true the operation "started" but only because it's also already resolved. A
         // `ResolveNexusOperation` job will be in the same activation.
         bool started_sync = 3;
-        // The operation was cancelled before it was ever sent to server (same WFT).
-        // Note that core will still send a `ResolveNexusOperation` job in the same activation, so
-        // there does not need to be an exceptional case for this in lang.
-        temporal.api.failure.v1.Failure cancelled_before_start = 4;
+        // The operation either failed to start, was cancelled before it started, timed out, or
+        // failed synchronously. Details are included inside the message.
+        temporal.api.failure.v1.Failure failed = 4;
     }
 }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -741,7 +741,7 @@ impl Unblockable for NexusStartResult {
                         unblock_dat: od,
                     })
                 }
-                resolve_nexus_operation_start::Status::CancelledBeforeStart(f) => Err(f),
+                resolve_nexus_operation_start::Status::Failed(f) => Err(f),
             },
             _ => panic!("Invalid unblock event for nexus operation"),
         }

--- a/tests/integ_tests/metrics_tests.rs
+++ b/tests/integ_tests/metrics_tests.rs
@@ -929,35 +929,29 @@ async fn nexus_metrics() {
                         .await
                 },
                 async {
-                    ctx.start_nexus_operation(NexusOperationOptions {
-                        input: Some("fail".into()),
-                        ..partial_op.clone()
-                    })
-                    .await
-                    .unwrap()
-                    .result()
-                    .await
+                    let _ = ctx
+                        .start_nexus_operation(NexusOperationOptions {
+                            input: Some("fail".into()),
+                            ..partial_op.clone()
+                        })
+                        .await;
                 },
                 async {
-                    ctx.start_nexus_operation(NexusOperationOptions {
-                        input: Some("handler-fail".into()),
-                        ..partial_op.clone()
-                    })
-                    .await
-                    .unwrap()
-                    .result()
-                    .await
+                    let _ = ctx
+                        .start_nexus_operation(NexusOperationOptions {
+                            input: Some("handler-fail".into()),
+                            ..partial_op.clone()
+                        })
+                        .await;
                 },
                 async {
-                    ctx.start_nexus_operation(NexusOperationOptions {
-                        input: Some("timeout".into()),
-                        schedule_to_close_timeout: Some(Duration::from_secs(2)),
-                        ..partial_op.clone()
-                    })
-                    .await
-                    .unwrap()
-                    .result()
-                    .await
+                    let _ = ctx
+                        .start_nexus_operation(NexusOperationOptions {
+                            input: Some("timeout".into()),
+                            schedule_to_close_timeout: Some(Duration::from_secs(2)),
+                            ..partial_op.clone()
+                        })
+                        .await;
                 }
             );
             Ok(().into())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed core to fail nexus start ops when failure happens in sync operations, rather than asking lang to look ahead to the operation resolution.

## Why?
Easier for lang. Not really a bug, this was working as intended, but it can be easier this way.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/965

2. How was this tested:
Existing tests.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
