### PR TITLE
Support user metadata in local activity

### DIFF
--- a/core/src/protosext/mod.rs
+++ b/core/src/protosext/mod.rs
@@ -37,6 +37,7 @@ use temporal_sdk_core_protos::{
         failure::v1::Failure,
         history::v1::{History, HistoryEvent, MarkerRecordedEventAttributes, history_event},
         query::v1::WorkflowQuery,
+        sdk::v1::UserMetadata,
         workflowservice::v1::PollWorkflowTaskQueueResponse,
     },
     utilities::TryIntoOrNone,
@@ -320,6 +321,7 @@ pub(crate) struct ValidScheduleLA {
     pub(crate) retry_policy: RetryPolicy,
     pub(crate) local_retry_threshold: Duration,
     pub(crate) cancellation_type: ActivityCancellationType,
+    pub(crate) user_metadata: Option<UserMetadata>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -349,7 +351,10 @@ impl Default for LACloseTimeouts {
 }
 
 impl ValidScheduleLA {
-    pub(crate) fn from_schedule_la(v: ScheduleLocalActivity) -> Result<Self, anyhow::Error> {
+    pub(crate) fn from_schedule_la(
+        v: ScheduleLocalActivity,
+        user_metadata: Option<UserMetadata>,
+    ) -> Result<Self, anyhow::Error> {
         let original_schedule_time = v
             .original_schedule_time
             .map(|x| {
@@ -423,6 +428,7 @@ impl ValidScheduleLA {
             retry_policy,
             local_retry_threshold,
             cancellation_type,
+            user_metadata,
         })
     }
 }

--- a/core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -31,7 +31,7 @@ use temporal_sdk_core_protos::{
         workflow_commands::ActivityCancellationType,
     },
     temporal::api::{
-        command::v1::{RecordMarkerCommandAttributes, command},
+        command::v1::{Command as ProtoCommand, RecordMarkerCommandAttributes, command},
         enums::v1::{CommandType, EventType, RetryState},
         failure::v1::{Failure, failure::FailureInfo},
     },
@@ -772,9 +772,11 @@ impl WFMachinesAdapter for LocalActivityMachine {
                         header: None,
                         failure: maybe_failure,
                     };
-                    responses.push(MachineResponse::IssueNewCommand(
-                        command::Attributes::RecordMarkerCommandAttributes(marker_data).into(),
-                    ));
+                    let command = ProtoCommand {
+                        user_metadata: self.shared_state.attrs.user_metadata.clone(),
+                        ..command::Attributes::RecordMarkerCommandAttributes(marker_data).into()
+                    };
+                    responses.push(MachineResponse::IssueNewCommand(command));
                 }
                 Ok(responses)
             }

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -1352,7 +1352,7 @@ impl WorkflowMachines {
                 WFCommandVariant::AddLocalActivity(attrs) => {
                     let seq = attrs.seq;
                     let attrs: ValidScheduleLA =
-                        ValidScheduleLA::from_schedule_la(attrs).map_err(|e| {
+                        ValidScheduleLA::from_schedule_la(attrs, cmd.metadata).map_err(|e| {
                             WFMachinesError::Fatal(format!(
                                 "Invalid schedule local activity request (seq {seq}): {e}"
                             ))

--- a/sdk/src/workflow_context/options.rs
+++ b/sdk/src/workflow_context/options.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, time::Duration};
 use temporal_client::{Priority, WorkflowOptions};
 use temporal_sdk_core_protos::{
     coresdk::{
+        AsJsonPayloadExt,
         child_workflow::ChildWorkflowCancellationType,
         nexus::NexusOperationCancellationType,
         workflow_commands::{
@@ -155,6 +156,8 @@ pub struct LocalActivityOptions {
     /// specified. If set, this must be <= `schedule_to_close_timeout`, if not, it will be clamped
     /// down.
     pub start_to_close_timeout: Option<Duration>,
+    /// Single-line summary for this activity that will appear in UI/CLI.
+    pub summary: Option<String>,
 }
 
 impl IntoWorkflowCommand for LocalActivityOptions {
@@ -194,7 +197,13 @@ impl IntoWorkflowCommand for LocalActivityOptions {
                 }
                 .into(),
             ),
-            user_metadata: None,
+            user_metadata: self
+                .summary
+                .and_then(|summary| summary.as_json_payload().ok())
+                .map(|summary| UserMetadata {
+                    summary: Some(summary),
+                    details: None,
+                }),
         }
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
User metadata is read from `ScheduleLocalActivity` core command and passed to `RECORD_MARKER` server command on local activity completion.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/637

## Checklist
<!--- add/delete as needed --->

1. Closes #960 

2. How was this tested: Added integration test `integ_tests::workflow_tests::local_activities::local_activity_with_summary`