### PR TITLE
Fixed compiler warnings and lints added in Rust 1.89

### DIFF
--- a/client/src/raw.rs
+++ b/client/src/raw.rs
@@ -437,7 +437,7 @@ macro_rules! proxy {
         fn $method(
             &mut self,
             request: impl tonic::IntoRequest<$req>,
-        ) -> BoxFuture<Result<tonic::Response<$resp>, tonic::Status>> {
+        ) -> BoxFuture<'_, Result<tonic::Response<$resp>, tonic::Status>> {
             #[allow(unused_mut)]
             let mut as_req = request.into_request();
             $( type_closure_arg(&mut as_req, $closure); )*
@@ -455,7 +455,7 @@ macro_rules! proxy {
         fn $method(
             &mut self,
             request: impl tonic::IntoRequest<$req>,
-        ) -> BoxFuture<Result<tonic::Response<$resp>, tonic::Status>> {
+        ) -> BoxFuture<'_, Result<tonic::Response<$resp>, tonic::Status>> {
             #[allow(unused_mut)]
             let mut as_req = request.into_request();
             type_closure_arg(&mut as_req, $closure_request);

--- a/core-api/src/envconfig.rs
+++ b/core-api/src/envconfig.rs
@@ -443,10 +443,10 @@ impl ClientConfigProfile {
         }
 
         if let Some(ref mut tls) = self.tls {
-            if let Some(disabled_str) = env_provider.get("TEMPORAL_TLS")? {
-                if let Some(disabled) = env_var_to_bool(&disabled_str) {
-                    tls.disabled = !disabled;
-                }
+            if let Some(disabled_str) = env_provider.get("TEMPORAL_TLS")?
+                && let Some(disabled) = env_var_to_bool(&disabled_str)
+            {
+                tls.disabled = !disabled;
             }
 
             apply_data_source_env_var(
@@ -474,10 +474,10 @@ impl ClientConfigProfile {
             if let Some(v) = env_provider.get("TEMPORAL_TLS_SERVER_NAME")? {
                 tls.server_name = Some(v);
             }
-            if let Some(v) = env_provider.get("TEMPORAL_TLS_DISABLE_HOST_VERIFICATION")? {
-                if let Some(b) = env_var_to_bool(&v) {
-                    tls.disable_host_verification = b;
-                }
+            if let Some(v) = env_provider.get("TEMPORAL_TLS_DISABLE_HOST_VERIFICATION")?
+                && let Some(b) = env_var_to_bool(&v)
+            {
+                tls.disable_host_verification = b;
             }
         }
         Ok(())

--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -460,25 +460,25 @@ pub enum SlotInfo<'a> {
 }
 
 pub trait SlotInfoTrait: prost::Message {
-    fn downcast(&self) -> SlotInfo;
+    fn downcast(&self) -> SlotInfo<'_>;
 }
 impl SlotInfoTrait for WorkflowSlotInfo {
-    fn downcast(&self) -> SlotInfo {
+    fn downcast(&self) -> SlotInfo<'_> {
         SlotInfo::Workflow(self)
     }
 }
 impl SlotInfoTrait for ActivitySlotInfo {
-    fn downcast(&self) -> SlotInfo {
+    fn downcast(&self) -> SlotInfo<'_> {
         SlotInfo::Activity(self)
     }
 }
 impl SlotInfoTrait for LocalActivitySlotInfo {
-    fn downcast(&self) -> SlotInfo {
+    fn downcast(&self) -> SlotInfo<'_> {
         SlotInfo::LocalActivity(self)
     }
 }
 impl SlotInfoTrait for NexusSlotInfo {
-    fn downcast(&self) -> SlotInfo {
+    fn downcast(&self) -> SlotInfo<'_> {
         SlotInfo::Nexus(self)
     }
 }

--- a/core-c-bridge/build.rs
+++ b/core-c-bridge/build.rs
@@ -16,10 +16,11 @@ fn main() {
         .write_to_file("include/temporal-sdk-core-c-bridge.h");
 
     // If this changed and an env var disallows change, error
-    if let Ok(env_val) = env::var("TEMPORAL_SDK_BRIDGE_DISABLE_HEADER_CHANGE") {
-        if changed && env_val == "true" {
-            println!("cargo:warning=bridge's header file changed unexpectedly from what's on disk");
-            std::process::exit(1);
-        }
+    if let Ok(env_val) = env::var("TEMPORAL_SDK_BRIDGE_DISABLE_HEADER_CHANGE")
+        && changed
+        && env_val == "true"
+    {
+        println!("cargo:warning=bridge's header file changed unexpectedly from what's on disk");
+        std::process::exit(1);
     }
 }

--- a/core-c-bridge/src/runtime.rs
+++ b/core-c-bridge/src/runtime.rs
@@ -244,12 +244,12 @@ impl Runtime {
 
         // We late-bind the metrics after core runtime is created since it needs
         // the Tokio handle
-        if let Some(v) = unsafe { options.telemetry.as_ref() } {
-            if let Some(v) = unsafe { v.metrics.as_ref() } {
-                let _guard = core.tokio_handle().enter();
-                core.telemetry_mut()
-                    .attach_late_init_metrics(create_meter(v, custom_meter)?);
-            }
+        if let Some(v) = unsafe { options.telemetry.as_ref() }
+            && let Some(v) = unsafe { v.metrics.as_ref() }
+        {
+            let _guard = core.tokio_handle().enter();
+            core.telemetry_mut()
+                .attach_late_init_metrics(create_meter(v, custom_meter)?);
         }
 
         // Create runtime

--- a/core-c-bridge/src/tests/context.rs
+++ b/core-c-bridge/src/tests/context.rs
@@ -414,14 +414,14 @@ impl Context {
     fn wait_while(
         &self,
         condition: impl FnMut(&mut InnerContext) -> bool,
-    ) -> anyhow::Result<MutexGuard<InnerContext>> {
+    ) -> anyhow::Result<MutexGuard<'_, InnerContext>> {
         self.inner
             .lock()
             .and_then(|lock| self.condvar.wait_while(lock, condition))
             .map_err(|_| anyhow!("Context mutex poisoned"))
     }
 
-    fn wait_for_available(&self) -> anyhow::Result<MutexGuard<InnerContext>> {
+    fn wait_for_available(&self) -> anyhow::Result<MutexGuard<'_, InnerContext>> {
         let guard = self.wait_while(|inner| {
             !matches!(inner.operation_state, ContextOperationState::Available) && !inner.is_disposed
         })?;

--- a/core/src/test_help/mod.rs
+++ b/core/src/test_help/mod.rs
@@ -956,10 +956,8 @@ pub(crate) async fn poll_and_reply_clears_outstanding_evicts<'a>(
 
             worker.complete_workflow_activation(reply).await.unwrap();
 
-            if do_release {
-                if let Some(omap) = outstanding_map.as_ref() {
-                    omap.release_run(&res.run_id);
-                }
+            if do_release && let Some(omap) = outstanding_map.as_ref() {
+                omap.release_run(&res.run_id);
             }
             // Restart assertions from the beginning if it was an eviction (and workflow execution
             // isn't over)

--- a/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -319,7 +319,7 @@ mod tests {
         if with_patched_cmd {
             t.add_has_change_marker(&patch_id, false);
         }
-        t.add_upsert_search_attrs_for_patch(&[patch_id.clone()]);
+        t.add_upsert_search_attrs_for_patch(std::slice::from_ref(&patch_id));
         t.add_we_signaled("hi", vec![]);
         t.add_full_wf_task();
         t.add_workflow_execution_completed();

--- a/core/src/worker/workflow/machines/workflow_machines.rs
+++ b/core/src/worker/workflow/machines/workflow_machines.rs
@@ -395,7 +395,7 @@ impl WorkflowMachines {
         self.current_started_event_id
     }
 
-    pub(crate) fn prepare_for_wft_response(&mut self) -> MachinesWFTResponseContent {
+    pub(crate) fn prepare_for_wft_response(&mut self) -> MachinesWFTResponseContent<'_> {
         MachinesWFTResponseContent {
             replaying: self.replaying,
             has_pending_jobs: self.has_pending_jobs(),

--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -1441,7 +1441,7 @@ impl WorkflowManager {
 
     /// Must be called when we're ready to respond to a WFT after handling catching up on replay
     /// and handling all activation completions from lang.
-    fn prepare_for_wft_response(&mut self) -> MachinesWFTResponseContent {
+    fn prepare_for_wft_response(&mut self) -> MachinesWFTResponseContent<'_> {
         self.machines.prepare_for_wft_response()
     }
 

--- a/tests/integ_tests/queries_tests.rs
+++ b/tests/integ_tests/queries_tests.rs
@@ -125,30 +125,29 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
             let task = core.poll_workflow_activation().await.unwrap();
 
             // When we see the query, handle it.
-            if go_until_query {
-                if let [
+            if go_until_query
+                && let [
                     WorkflowActivationJob {
                         variant: Some(workflow_activation_job::Variant::QueryWorkflow(query)),
                     },
                 ] = task.jobs.as_slice()
-                {
-                    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
-                        task.run_id,
-                        QueryResult {
-                            query_id: query.query_id.clone(),
-                            variant: Some(
-                                QuerySuccess {
-                                    response: Some(query_resp.into()),
-                                }
-                                .into(),
-                            ),
-                        }
-                        .into(),
-                    ))
-                    .await
-                    .unwrap();
-                    break "".to_string();
-                }
+            {
+                core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+                    task.run_id,
+                    QueryResult {
+                        query_id: query.query_id.clone(),
+                        variant: Some(
+                            QuerySuccess {
+                                response: Some(query_resp.into()),
+                            }
+                            .into(),
+                        ),
+                    }
+                    .into(),
+                ))
+                .await
+                .unwrap();
+                break "".to_string();
             }
 
             if matches!(

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -270,12 +270,10 @@ impl WorkerInterceptor for LACancellerInterceptor {
         if let Some(workflow_activation_completion::Status::Successful(
             workflow_completion::Success { commands, .. },
         )) = completion.status.as_ref()
-        {
-            if let Some(&Variant::CompleteWorkflowExecution(_)) =
+            && let Some(&Variant::CompleteWorkflowExecution(_)) =
                 commands.last().and_then(|v| v.variant.as_ref())
-            {
-                self.token.cancel();
-            }
+        {
+            self.token.cancel();
         }
     }
     fn on_shutdown(&self, _: &temporal_sdk::Worker) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fixed compiler warnings and lints added in Rust 1.89, specifically:
- Hidden lifetimes warning
- Flattening if-let chains
- Using `std::slice::from_ref` to avoid cloning

## Why?
<!-- Tell your future self why have you made these changes -->
Removes warnings from compiler output, and CI would start failing when we upgrade to Rust 1.89.

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
Ran `cargo lint` and `cargo test-lint` locally using Rust 1.89.
