### PR TITLE
Disable worker heartbeat off by default

### DIFF
--- a/core-api/src/worker.rs
+++ b/core-api/src/worker.rs
@@ -165,8 +165,8 @@ pub struct WorkerConfig {
     /// The interval within which the worker will send a heartbeat.
     /// The timer is reset on each existing RPC call that also happens to send this data, like
     /// `PollWorkflowTaskQueueRequest`.
-    #[builder(default = "Duration::from_secs(60)")]
-    pub heartbeat_interval: Duration,
+    #[builder(default)]
+    pub heartbeat_interval: Option<Duration>,
 }
 
 impl WorkerConfig {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -103,7 +103,9 @@ where
         bail!("Client identity cannot be empty. Either lang or user should be setting this value");
     }
 
-    let heartbeat_fn = Arc::new(OnceLock::new());
+    let heartbeat_fn = worker_config
+        .heartbeat_interval
+        .map(|_| Arc::new(OnceLock::new()));
 
     let client_bag = Arc::new(WorkerClientBag::new(
         client,
@@ -118,7 +120,7 @@ where
         sticky_q,
         client_bag,
         Some(&runtime.telemetry),
-        Some(heartbeat_fn),
+        heartbeat_fn,
     ))
 }
 

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -139,7 +139,6 @@ impl WorkerClientBag {
         } else {
             None
         }
-
     }
 }
 

--- a/core/src/worker/client.rs
+++ b/core/src/worker/client.rs
@@ -50,7 +50,7 @@ pub(crate) struct WorkerClientBag {
     namespace: String,
     identity: String,
     worker_versioning_strategy: WorkerVersioningStrategy,
-    heartbeat_data: Arc<OnceLock<HeartbeatFn>>,
+    heartbeat_data: Option<Arc<OnceLock<HeartbeatFn>>>,
 }
 
 impl WorkerClientBag {
@@ -59,7 +59,7 @@ impl WorkerClientBag {
         namespace: String,
         identity: String,
         worker_versioning_strategy: WorkerVersioningStrategy,
-        heartbeat_data: Arc<OnceLock<HeartbeatFn>>,
+        heartbeat_data: Option<Arc<OnceLock<HeartbeatFn>>>,
     ) -> Self {
         Self {
             replaceable_client: RwLock::new(client),
@@ -129,12 +129,17 @@ impl WorkerClientBag {
     }
 
     fn capture_heartbeat(&self) -> Option<WorkerHeartbeat> {
-        if let Some(hb) = self.heartbeat_data.get() {
-            hb()
+        if let Some(heartbeat_data) = self.heartbeat_data.as_ref() {
+            if let Some(hb) = heartbeat_data.get() {
+                hb()
+            } else {
+                dbg_panic!("Heartbeat function never set");
+                None
+            }
         } else {
-            dbg_panic!("Heartbeat function never set");
             None
         }
+
     }
 }
 

--- a/core/src/worker/heartbeat.rs
+++ b/core/src/worker/heartbeat.rs
@@ -121,7 +121,9 @@ impl WorkerHeartbeatData {
             start_time: SystemTime::now(),
             heartbeat_time: None,
             worker_instance_key: Uuid::new_v4().to_string(),
-            heartbeat_interval: worker_config.heartbeat_interval.expect("WorkerHeartbeatData is only called when heartbeat_interval is Some"),
+            heartbeat_interval: worker_config
+                .heartbeat_interval
+                .expect("WorkerHeartbeatData is only called when heartbeat_interval is Some"),
             reset_notify,
         }
     }

--- a/core/src/worker/heartbeat.rs
+++ b/core/src/worker/heartbeat.rs
@@ -121,7 +121,7 @@ impl WorkerHeartbeatData {
             start_time: SystemTime::now(),
             heartbeat_time: None,
             worker_instance_key: Uuid::new_v4().to_string(),
-            heartbeat_interval: worker_config.heartbeat_interval,
+            heartbeat_interval: worker_config.heartbeat_interval.expect("WorkerHeartbeatData is only called when heartbeat_interval is Some"),
             reset_notify,
         }
     }


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
set worker heartbeat off by default.

## Why?
<!-- Tell your future self why have you made these changes -->
SDK logs are spamming due to server not supporting this yet, turn off by default until server is ready.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
