### PR TITLE
Add support for configuring client-wide gRPC binary metadata values, validate metadata earlier

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -150,9 +150,9 @@ pub struct ClientOptions {
 
     /// HTTP headers to include on every RPC call.
     ///
-    /// These must be valid gRPC metadata keys, and must not end with a `-bin` suffix (to set binary
-    /// headers, see [ClientOptions::binary_headers]). Invalid header keys will cause an error to be
-    /// returned when connecting.
+    /// These must be valid gRPC metadata keys, and must not be binary metadata keys (ending in
+    /// `-bin). To set binary headers, use [ClientOptions::binary_headers]. Invalid header keys or
+    /// values will cause an error to be returned when connecting.
     #[builder(default)]
     pub headers: Option<HashMap<String, String>>,
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -156,8 +156,7 @@ pub struct ClientOptions {
     #[builder(default)]
     pub headers: Option<HashMap<String, String>>,
 
-    /// HTTP headers to include on every RPC call as binary gRPC metadata (typically encoded as
-    /// base64).
+    /// HTTP headers to include on every RPC call as binary gRPC metadata (encoded as base64).
     ///
     /// These must be valid binary gRPC metadata keys (and end with a `-bin` suffix). Invalid
     /// header keys will cause an error to be returned when connecting.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -338,7 +338,7 @@ pub enum ClientInitError {
     #[error("Invalid URI: {0:?}")]
     InvalidUri(#[from] InvalidUri),
     /// Invalid gRPC metadata headers. Configuration error.
-    #[error("Invalid headers: {0:?}")]
+    #[error("Invalid headers: {0}")]
     InvalidHeaders(#[from] InvalidHeaderError),
     /// Server connection error. Crashing and restarting the worker is likely best.
     #[error("Server connection error: {0:?}")]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -32,9 +32,6 @@ pub use temporal_sdk_core_protos::temporal::api::{
     },
 };
 pub use tonic;
-use tonic::metadata::{
-    AsciiMetadataKey, AsciiMetadataValue, BinaryMetadataKey, BinaryMetadataValue,
-};
 pub use worker_registry::{Slot, SlotManager, SlotProvider, WorkerKey};
 pub use workflow_handle::{
     GetWorkflowResultOpts, WorkflowExecutionInfo, WorkflowExecutionResult, WorkflowHandle,
@@ -81,7 +78,10 @@ use tonic::{
     body::Body,
     client::GrpcService,
     codegen::InterceptedService,
-    metadata::{MetadataKey, MetadataMap, MetadataValue},
+    metadata::{
+        AsciiMetadataKey, AsciiMetadataValue, BinaryMetadataKey, BinaryMetadataValue, MetadataMap,
+        MetadataValue,
+    },
     service::Interceptor,
     transport::{Certificate, Channel, Endpoint, Identity},
 };

--- a/core-c-bridge/src/client.rs
+++ b/core-c-bridge/src/client.rs
@@ -240,7 +240,7 @@ pub extern "C" fn temporal_core_client_update_metadata(
     metadata: ByteArrayRef,
 ) {
     let client = unsafe { &*client };
-    client
+    let _result = client
         .core
         .get_client()
         .set_headers(metadata.to_string_map_on_newlines());

--- a/tests/integ_tests/client_tests.rs
+++ b/tests/integ_tests/client_tests.rs
@@ -77,7 +77,7 @@ async fn per_call_timeout_respected_whole_client() {
     let mut raw_client = opts.connect_no_namespace(None).await.unwrap();
     let mut hm = HashMap::new();
     hm.insert("grpc-timeout".to_string(), "0S".to_string());
-    raw_client.get_client().set_headers(hm);
+    raw_client.get_client().set_headers(hm).unwrap();
     let err = raw_client
         .describe_namespace(DescribeNamespaceRequest {
             namespace: NAMESPACE.to_string(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This PR allows configuring [gRPC binary metadata key/values](https://chromium.googlesource.com/external/github.com/grpc/grpc/+/HEAD/doc/PROTOCOL-HTTP2.md#:~:text=Applications%20define%20binary%20headers%20by%20having%20their%20names%20end%20with%20%E2%80%9C%2Dbin%E2%80%9D.%20Runtime%20libraries%20use%20this%20suffix%20to%20detect%20binary%20headers%20and%20properly%20apply%20base64%20encoding%20%26%20decoding%20as%20headers%20are%20sent%20and%20received.) (where the key ends in `-bin`) on the Temporal client struct. It's already possible for Rust users of the Temporal client struct to set per-request gRPC binary metadata key/values; this allows setting client-wide headers.

The main API changes are:
- Added: `ClientOptions.binary_headers: Option<HashMap<String, Vec<u8>>>`
- Added: `ConfiguredClient::set_binary_headers(&self, binary_headers: HashMap<String, Vec<u8>>) -> Result<(), InvalidHeaderError>`
- Added: `InvalidHeaderError`
- Modified: `ConfiguredClient::set_headers` (for setting ASCII headers) now returns `Err(InvalidHeaderError)` if the keys or values are invalid, **and no headers are modified**. Before, it would just silently discard/skip invalid keys or values.
- Modified: `ClientOptions::connect` (and the related methods) now returns an `Err(ClientInitError::InvalidHeaders(InvalidHeaderError))` if any of the keys or values passed in `ClientOptions` are invalid

The approach taken is to parse the metadata keys/values early, and store an already-parsed representation (that can be infallibly applied to the outbound metadata, in `ClientHeaders ::apply_to_metadata`).

This PR is depended on by https://github.com/temporalio/sdk-python/pull/1070

## Why?
https://github.com/temporalio/sdk-core/issues/991

(for the specific parts in Core SDK that are needed for the Python SDK; this doesn't cover all Core-SDK changes that are needed (for e.g. the Rust SDK or the C bridge)).

## Checklist
1. ~~Closes~~
   - This is a partial implementation of https://github.com/temporalio/sdk-core/issues/991, and is a prereq to closing https://github.com/temporalio/sdk-python/issues/1063

2. How was this tested:
    - See added/modified unit tests in `client/src/lib.rs`
    - Existing tests pass (so the behavior for ASCII headers shouldn't have regressed)
    - In https://github.com/temporalio/sdk-python/pull/1070, I modified the client tests to cover both per-request gRPC binary metadata and client-wide gRPC binary metadata

3. Any docs updates needed?
    - I don't think so? Afaik there are no docs on the Core SDK from a "Rust integrators" perspective. The updates to docs.rs should be sufficient IMO.
