### PR TITLE
Fix activities per second config mixup

### DIFF
--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -393,7 +393,7 @@ impl Worker {
                         shutdown_token.child_token(),
                         Some(move |np| act_metrics.record_num_pollers(np)),
                         ActivityTaskOptions {
-                            max_worker_acts_per_second: config.max_task_queue_activities_per_second,
+                            max_worker_acts_per_second: config.max_worker_activities_per_second,
                             max_tps: config.max_task_queue_activities_per_second,
                         },
                     );


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
The max _task queue activities_ per second was being used as the value for the local ratelimit. This fixes that. This setting is quite rare compared to the task queue limit, which probably explains why no one ever noticed.

## Why?
Bug

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
