### PR TITLE
:boom: Only enable native roots if CA override not specified

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -607,11 +607,13 @@ impl ClientOptions {
     /// Passes it through if TLS options not set.
     async fn add_tls_to_channel(&self, mut channel: Endpoint) -> Result<Endpoint, ClientInitError> {
         if let Some(tls_cfg) = &self.tls_cfg {
-            let mut tls = tonic::transport::ClientTlsConfig::new().with_native_roots();
+            let mut tls = tonic::transport::ClientTlsConfig::new();
 
             if let Some(root_cert) = &tls_cfg.server_root_ca_cert {
                 let server_root_ca_cert = Certificate::from_pem(root_cert);
                 tls = tls.ca_certificate(server_root_ca_cert);
+            } else {
+                tls = tls.with_native_roots();
             }
 
             if let Some(domain) = &tls_cfg.domain {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Don't enable native TLS roots if a CA override is specified. This is technically breaking, but only if you were doing a somewhat odd  thing in the first place.

## Why?
People using CA overrides often want to do it in an environment where there are no native roots, which this change enables.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/1004

2. How was this tested:
Could not come up with any kind of reasonable test that wasn't dramatically more LOC than it feels worth. Open to ideas.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
