### PR TITLE
Remove logic that auto adds TLS when api key is enabled

### DIFF
--- a/core-api/src/envconfig.rs
+++ b/core-api/src/envconfig.rs
@@ -358,9 +358,6 @@ pub fn load_client_config_profile(
         profile.load_from_env(env_vars)?;
     }
 
-    // Apply API key → TLS auto-enabling logic
-    profile.apply_api_key_tls_logic();
-
     Ok(profile)
 }
 
@@ -527,14 +524,6 @@ impl ClientConfigProfile {
             }
         }
         Ok(())
-    }
-
-    /// Apply automatic TLS enabling when API key is present
-    pub fn apply_api_key_tls_logic(&mut self) {
-        if self.api_key.is_some() && self.tls.is_none() {
-            // If API key is present but no TLS config exists, create one with TLS enabled
-            self.tls = Some(ClientConfigTLS::default());
-        }
     }
 }
 
@@ -1580,27 +1569,6 @@ address = "localhost:7233"
         let profile = load_client_config_profile(options, Some(&vars)).unwrap();
         assert_eq!(profile.address.as_ref().unwrap(), "env-address");
         assert_eq!(profile.namespace.as_ref().unwrap(), "env-namespace");
-    }
-
-    #[test]
-    fn test_api_key_tls_auto_enable() {
-        // Test 1: When API key is present, TLS should be automatically enabled
-        let toml_str = r#"
-[profile.default]
-api_key = "my-api-key"
-"#;
-
-        let options = LoadClientConfigProfileOptions {
-            config_source: Some(DataSource::Data(toml_str.as_bytes().to_vec())),
-            ..Default::default()
-        };
-
-        let profile = load_client_config_profile(options, None).unwrap();
-
-        // TLS should be enabled due to API key presence
-        assert!(profile.tls.is_some());
-        let tls = profile.tls.as_ref().unwrap();
-        assert_eq!(tls.disabled, None); // Not explicitly set
     }
 
     #[test]


### PR DESCRIPTION
## What was changed
This PR removes logic that adds a default TLS config object when api key is enabled, but no TLS configuration was provided.

## Why?
This makes the API semantics more clear.
Lang SDKs will now know:
- when a TLS config object is provided by core, a configuration has been explicitly specified
- when no TLS configuration was specified (will receive no object, instead of an empty object)

Lang SDKs now know with certainty when to apply default TLS configuration to the client (generally this means `tls: true` in the client config):
- when an `api_key` is provided, but no TLS config was specified
