### PR TITLE
Ensure heartbeats aren't flushed on successful activity completion

### DIFF
--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -333,7 +333,14 @@ impl WorkerActivityTasks {
             if let Some(jh) = act_info.local_timeouts_task {
                 jh.abort()
             };
-            self.heartbeat_manager.evict(task_token.clone()).await;
+            let should_flush = !known_not_found
+                && !matches!(
+                    &status,
+                    aer::Status::Completed(_) | aer::Status::WillCompleteAsync(_)
+                );
+            self.heartbeat_manager
+                .evict(task_token.clone(), should_flush)
+                .await;
 
             // No need to report activities which we already know the server doesn't care about
             if !known_not_found {

--- a/tests/integ_tests/workflow_tests/activities.rs
+++ b/tests/integ_tests/workflow_tests/activities.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{
         ActivationAssertionsInterceptor, CoreWfStarter, INTEG_CLIENT_IDENTITY, build_fake_sdk,
-        init_core_and_create_wf, mock_sdk, mock_sdk_cfg,
+        eventually, init_core_and_create_wf, mock_sdk, mock_sdk_cfg,
     },
     integ_tests::activity_functions::echo,
 };
@@ -25,7 +25,7 @@ use temporal_sdk_core_protos::{
     DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE, TaskToken, TestHistoryBuilder, canned_histories,
     coresdk::{
         ActivityHeartbeat, ActivityTaskCompletion, AsJsonPayloadExt, FromJsonPayloadExt,
-        IntoCompletion,
+        IntoCompletion, IntoPayloadsExt,
         activity_result::{
             self, ActivityExecutionResult, ActivityResolution, activity_resolution as act_res,
         },
@@ -796,6 +796,86 @@ async fn activity_cancelled_after_heartbeat_times_out() {
         .terminate_workflow_execution(task_q, None)
         .await
         .unwrap();
+}
+
+#[ignore] // Currently skipped because of https://github.com/temporalio/temporal/issues/8376
+#[tokio::test]
+async fn activity_heartbeat_not_flushed_on_success() {
+    let mut starter = init_core_and_create_wf("activity_heartbeat_not_flushed_on_success").await;
+    let core = starter.get_worker().await;
+    let task_q = starter.get_task_queue().to_string();
+    let activity_id = "act-1";
+    let task = core.poll_workflow_activation().await.unwrap();
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
+        task.run_id,
+        ScheduleActivity {
+            seq: 0,
+            activity_id: activity_id.to_string(),
+            activity_type: "dontcare".to_string(),
+            task_queue: task_q.clone(),
+            schedule_to_close_timeout: Some(prost_dur!(from_secs(60))),
+            heartbeat_timeout: Some(prost_dur!(from_secs(10))),
+            retry_policy: Some(RetryPolicy {
+                maximum_attempts: 2,
+                initial_interval: Some(prost_dur!(from_secs(5))),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+        .into(),
+    ))
+    .await
+    .unwrap();
+    // Poll activity and verify that it's been scheduled
+    let task = core.poll_activity_task().await.unwrap();
+    assert_matches!(task.variant, Some(act_task::Variant::Start(_)));
+    // heartbeat 1 (will send immediately)
+    core.record_activity_heartbeat(ActivityHeartbeat {
+        task_token: task.task_token.clone(),
+        details: vec!["one".into()],
+    });
+    // heartbeat 2 (would be throttled if not flushed)
+    core.record_activity_heartbeat(ActivityHeartbeat {
+        task_token: task.task_token.clone(),
+        details: vec!["two".into()],
+    });
+    // Complete activity with fail
+    let failure = Failure::application_failure("activity failed".to_string(), false);
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: task.task_token,
+        result: Some(ActivityExecutionResult::fail(failure)),
+    })
+    .await
+    .unwrap();
+    // The activity is still in the pending state since it has retries left
+    let client = starter.get_client().await;
+    eventually(
+        || async {
+            // Verify pending details has the flushed heartbeat
+            let details = client
+                .describe_workflow_execution(starter.get_wf_id().to_string(), None)
+                .await
+                .unwrap();
+            let last_deets = details
+                .pending_activities
+                .into_iter()
+                .find(|i| i.activity_id == activity_id)
+                .and_then(|i| i.heartbeat_details);
+            if last_deets == ["two".into()].into_payloads() {
+                Ok(())
+            } else {
+                Err("details don't yet match")
+            }
+        },
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+    client
+        .terminate_workflow_execution(task_q, None)
+        .await
+        .unwrap();
+    drain_pollers_and_shutdown(&core).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
In title

## Why?
Pointless, since these details are just erased after the activity completes successfully, and it imposes extra cost on cloud users for no reason.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added unit test. Can't integration test because I can't prove a negative, but, I seemed to discover a [server bug](https://github.com/temporalio/temporal/issues/8376) with the case where flushing _should_ happen in the process.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
