### PR TITLE
Notify stream regardless of server need for activity completion

### DIFF
--- a/core/src/worker/activities.rs
+++ b/core/src/worker/activities.rs
@@ -399,9 +399,7 @@ impl WorkerActivityTasks {
                         }
                     }
                 };
-
-                self.complete_notify.notify_waiters();
-
+                
                 if let Some(e) = maybe_net_err {
                     if e.code() == tonic::Code::NotFound {
                         warn!(task_token=?task_token, details=?e, "Activity not found on \
@@ -418,6 +416,8 @@ impl WorkerActivityTasks {
                 &task_token
             );
         }
+        
+        self.complete_notify.notify_waiters();
     }
 
     /// Attempt to record an activity heartbeat


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Title

## Why?
Without this there are scenarios where core is unable to shut down. If both sets of activities haven't been marked as completed, this completion may be required to do so, unblocking shutdown.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
