### PR TITLE
Switched to Rust 1.90 in CI

### DIFF
--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.90.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
+          toolchain: 1.90.0
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/core/src/internal_flags.rs
+++ b/core/src/internal_flags.rs
@@ -18,6 +18,7 @@ use temporal_sdk_core_protos::temporal::api::{
 /// may be removed from the enum. *Importantly*, all variants must be given explicit values, such
 /// that removing older variants does not create any change in existing values. Removed flag
 /// variants must be reserved forever (a-la protobuf), and should be called out in a comment.
+#[allow(unreachable_pub)] // re-exported in test_help::integ_helpers
 #[repr(u32)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug, enum_iterator::Sequence)]
 pub enum CoreInternalFlags {

--- a/core/src/worker/mod.rs
+++ b/core/src/worker/mod.rs
@@ -18,6 +18,8 @@ pub(crate) use activities::{
     NewLocalAct,
 };
 pub(crate) use wft_poller::WFTPollerShared;
+
+#[allow(unreachable_pub)] // re-exported in test_help::integ_helpers
 pub use workflow::LEGACY_QUERY_ID;
 
 use crate::{

--- a/core/src/worker/workflow/mod.rs
+++ b/core/src/worker/workflow/mod.rs
@@ -99,6 +99,7 @@ use tracing::Span;
 /// Id used by server for "legacy" queries. IE: Queries that come in the `query` rather than
 /// `queries` field of a WFT, and are responded to on the separate `respond_query_task_completed`
 /// rpc.
+#[allow(unreachable_pub)] // re-exported in supermodule
 pub const LEGACY_QUERY_ID: &str = "legacy_query";
 /// What percentage of a WFT timeout we are willing to wait before sending a WFT heartbeat when
 /// necessary.

--- a/fsm/rustfsm_procmacro/tests/trybuild/dupe_transitions_fail.stderr
+++ b/fsm/rustfsm_procmacro/tests/trybuild/dupe_transitions_fail.stderr
@@ -1,11 +1,11 @@
 error: Duplicate transitions are not allowed!
   --> $DIR/dupe_transitions_fail.rs:5:1
    |
-5  | / fsm! {
-6  | |     name SimpleMachine; command SimpleMachineCommand; error Infallible;
-7  | |
-8  | |     One --(A)--> Two;
-9  | |     One --(A)--> Two;
+ 5 | / fsm! {
+ 6 | |     name SimpleMachine; command SimpleMachineCommand; error Infallible;
+ 7 | |
+ 8 | |     One --(A)--> Two;
+ 9 | |     One --(A)--> Two;
 10 | | }
    | |_^
    |


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Switched to Rust 1.90 in CI.
- Explicity set heavy tests CI job to use the same Rust version as the main CI job.
- Updated one trybuild test that started failing due to output difference between Rust 1.88 and 1.90.
- Disabled new false-positive warnings about unreachable pub items.

## Why?
<!-- Tell your future self why have you made these changes -->
To maintain compatibility with current latest Rust version.

## Checklist
1. How was this tested:
Unit tests, integration tests and heavy tests pass.