### PR TITLE
Upgrade otel and tonic deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,12 @@ derive_more = { version = "2.0", features = [
     "try_into",
 ] }
 thiserror = "2"
-tonic = "0.13"
-tonic-build = "0.13"
-opentelemetry = { version = "0.30", features = ["metrics"] }
-prost = "0.13"
-prost-types = "0.13"
+tonic = "0.14"
+tonic-prost = "0.14"
+tonic-prost-build = "0.14"
+opentelemetry = { version = "0.31", features = ["metrics"] }
+prost = "0.14"
+prost-types = "0.14"
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -64,12 +64,12 @@ itertools = "0.14"
 lru = "0.16"
 mockall = "0.13"
 opentelemetry = { workspace = true, features = ["metrics"], optional = true }
-opentelemetry_sdk = { version = "0.30", features = [
+opentelemetry_sdk = { version = "0.31", features = [
     "rt-tokio",
     "metrics",
     "spec_unstable_metrics_views",
 ], optional = true }
-opentelemetry-otlp = { version = "0.30", features = [
+opentelemetry-otlp = { version = "0.31", features = [
     "tokio",
     "metrics",
     "tls",
@@ -81,7 +81,7 @@ pid = "4.0"
 pin-project = "1.1"
 prometheus = { version = "0.14", optional = true }
 prost = { workspace = true }
-prost-types = { version = "0.6", package = "prost-wkt-types" }
+prost-types = { version = "0.7", package = "prost-wkt-types" }
 rand = "0.9"
 reqwest = { version = "0.12", features = [
     "json",

--- a/sdk-core-protos/Cargo.toml
+++ b/sdk-core-protos/Cargo.toml
@@ -20,19 +20,20 @@ anyhow = "1.0"
 base64 = "0.22"
 derive_more = { workspace = true }
 prost = { workspace = true }
-prost-wkt = "0.6"
-prost-wkt-types = "0.6"
+prost-wkt = "0.7"
+prost-wkt-types = "0.7"
 rand = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { workspace = true }
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 uuid = { version = "1.18", features = ["v4"], optional = true }
 
 [build-dependencies]
-tonic-build = { workspace = true }
-prost-build = "0.13"
-prost-wkt-build = "0.6"
+tonic-prost-build = { workspace = true }
+prost-build = "0.14"
+prost-wkt-build = "0.7"
 
 [lints]
 workspace = true

--- a/sdk-core-protos/build.rs
+++ b/sdk-core-protos/build.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=./protos");
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
     let descriptor_file = out.join("descriptors.bin");
-    tonic_build::configure()
+    tonic_prost_build::configure()
         // We don't actually want to build the grpc definitions - we don't need them (for now).
         // Just build the message structs.
         .build_server(false)
@@ -117,7 +117,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "::prost_wkt_types::FieldMask"
         )
         .file_descriptor_set_path(descriptor_file)
-        .skip_debug("temporal.api.common.v1.Payload")
+        .skip_debug(["temporal.api.common.v1.Payload"])
         .compile_protos(
             &[
                 "./protos/local/temporal/sdk/core/core_interface.proto",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 derive_more = { workspace = true }
 futures-util = { version = "0.3", default-features = false }
 parking_lot = { version = "0.12", features = ["send_guard"] }
-prost-types = { version = "0.6", package = "prost-wkt-types" }
+prost-types = { version = "0.7", package = "prost-wkt-types" }
 serde = "1.0"
 tokio = { version = "1.47", features = ["rt", "rt-multi-thread", "parking_lot", "time", "fs"] }
 tokio-util = { version = "0.7" }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Upgrade opentelemetry to 0.31
Upgraded tonic, tonic-build to 0.14
Upgraded prost to 0.14

## Why?
Actually no real reason other than to reduce conflicting build dependencies and compile times.
If not ready to be merged, this PR can be used as a reference.
Also tonic 0.14 release points to some stability in the API (https://github.com/hyperium/tonic/releases/tag/v0.14.0)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

   Ran unit-tests, integ-tests, heavy-tests locally

3. Any docs updates needed?

   No
