### PR TITLE
Cgroup cpu usage

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -104,6 +104,8 @@ jobs:
     container:
       image: ubuntu
       options: --cpus=1 --memory=512m
+    env:
+      CGROUP_TESTS_ENABLED: true
     steps:
       - name: Download cgroup test executable
         uses: actions/download-artifact@v5

--- a/docker-cgroup-tests.sh
+++ b/docker-cgroup-tests.sh
@@ -22,4 +22,4 @@ memory="${2:-256m}"
 
 printf 'Running with cpus=%s memory=%s\n' "$cpus" "$memory"
 
-docker run --rm -v "$PWD":/app -w /app --cpus="$cpus" --memory="$memory" ubuntu bash -c "./$relative_path cgroup_ --nocapture"
+docker run --rm -v "$PWD":/app -w /app --cpus="$cpus" --memory="$memory" --env CGROUP_TESTS_ENABLED=true ubuntu bash -c "./$relative_path cgroup_ --nocapture"


### PR DESCRIPTION
## What was changed

Update RealSysInfo to read cgroupv2 CPU limits when the sysinfo crate has cgroup memory limits available.

## Why?

When running in a container it's more appropriate to report the CPU usage as a factor of it's limit rather than the host system.

## Checklist
<!--- add/delete as needed --->

1. Closes #903 

2. How was this tested:

- Added unit tests for reading the cgroupv2 CPU files and calculating usage based on their contents.
- Added unit tests that confirm RealSysInfo respects cgroup limits. These tests skip when not running in a cgroup. A small helper script is included at `docker-cgroup-tests.sh` to cross-compile tests and execute only cgroup tests via docker.


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
