### PR TITLE
[DRAFT] Fix LA completion order on replay

### DIFF
--- a/core/src/worker/workflow/managed_run.rs
+++ b/core/src/worker/workflow/managed_run.rs
@@ -723,6 +723,8 @@ impl ManagedRun {
             if !completion.activation_was_eviction && !self.am_broken {
                 self.wfm.apply_next_task_if_ready()?;
             }
+
+            self.wfm.apply_pending_local_activity_resolutions()?;
             let new_local_acts = self.wfm.drain_queued_local_activities();
             self.sink_la_requests(new_local_acts)?;
 
@@ -1443,6 +1445,11 @@ impl WorkflowManager {
     /// and handling all activation completions from lang.
     fn prepare_for_wft_response(&mut self) -> MachinesWFTResponseContent<'_> {
         self.machines.prepare_for_wft_response()
+    }
+
+    /// Apply local activity resolutions that have been queued up.
+    fn apply_pending_local_activity_resolutions(&mut self) -> Result<()> {
+        self.machines.apply_pending_local_activity_resolutions()
     }
 
     /// Remove and return all queued local activities. Once this is called, they need to be

--- a/sdk-core-protos/src/canned_histories.rs
+++ b/sdk-core-protos/src/canned_histories.rs
@@ -1321,6 +1321,23 @@ pub fn two_local_activities_one_wft(parallel: bool) -> TestHistoryBuilder {
     t
 }
 
+///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+///  2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+///  3: EVENT_TYPE_WORKFLOW_TASK_STARTED
+///  4: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+///  5: EVENT_TYPE_MARKER_RECORDED (LA 2 result)
+///  7: EVENT_TYPE_MARKER_RECORDED (LA 1 result)
+///  8: EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
+pub fn parallel_las_job_order_hist() -> TestHistoryBuilder {
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    t.add_local_activity_result_marker(2, "2", b"hi2".into());
+    t.add_local_activity_result_marker(1, "1", b"hi1".into());
+    t.add_workflow_task_scheduled_and_started();
+    t
+}
+
 /// Useful for one-of needs to write a crafted history to a file. Writes it as serialized proto
 /// binary to the provided path.
 pub fn write_hist_to_binfile(

--- a/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/tests/integ_tests/workflow_tests/local_activities.rs
@@ -710,7 +710,7 @@ async fn third_weird_la_nondeterminism_repro() {
 /// activity cancellation, that would be wrong because, during execution, the LA resolution is
 /// always going to take _longer_ than the instantaneous cancel effect.
 ///
-/// This affect applies regardless of how you choose to interleave cancellations and LAs. Ultimately
+/// This effect applies regardless of how you choose to interleave cancellations and LAs. Ultimately
 /// all cancellations will happen at once (in the order they are submitted) while the LA executions
 /// are queued (because this all happens synchronously in the workflow machines). If you were to
 /// _wait_ on an LA, and then cancel something else, and then run another LA, such that all commands
@@ -2585,6 +2585,80 @@ async fn two_sequential_las(
     worker.register_activity(
         DEFAULT_ACTIVITY_TYPE,
         move |_ctx: ActContext, _: ()| async move { Ok("Resolved") },
+    );
+    worker.run().await.unwrap();
+}
+
+async fn parallel_las_job_order_wf(ctx: WfContext) -> WorkflowResult<()> {
+    tokio::join!(
+        ctx.local_activity(LocalActivityOptions {
+            activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
+            input: 100.as_json_payload().unwrap(),
+            ..Default::default()
+        }),
+        ctx.local_activity(LocalActivityOptions {
+            activity_type: DEFAULT_ACTIVITY_TYPE.to_string(),
+            input: 1.as_json_payload().unwrap(),
+            ..Default::default()
+        })
+    );
+    Ok(().into())
+}
+
+#[rstest]
+#[tokio::test]
+async fn parallel_las_job_order(#[values(true, false)] replay: bool) {
+    let t = canned_histories::parallel_las_job_order_hist();
+    let mut mock_cfg = if replay {
+        MockPollCfg::from_resps(t, [ResponseType::AllHistory])
+    } else {
+        MockPollCfg::from_hist_builder(t)
+    };
+
+    let mut aai = ActivationAssertionsInterceptor::default();
+    // Verify ResolveActivity jobs are received in completion order (seq 2 first, then seq 1)
+    // This catches the bug where they might be sent in request order instead
+    aai.skip_one().then(move |a| {
+        assert_matches!(
+            a.jobs.as_slice(),
+            [WorkflowActivationJob {
+                variant: Some(workflow_activation_job::Variant::ResolveActivity(ra1))
+            }, WorkflowActivationJob {
+                variant: Some(workflow_activation_job::Variant::ResolveActivity(ra2))
+            }] => {assert_eq!(ra1.seq, 2); assert_eq!(ra2.seq, 1)}
+        );
+    });
+
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts.then(move |wft| {
+            let commands = &wft.commands;
+            if !replay {
+                assert_eq!(commands.len(), 3);
+                assert_eq!(commands[0].command_type(), CommandType::RecordMarker);
+                assert_eq!(commands[1].command_type(), CommandType::RecordMarker);
+                assert_matches!(
+                    commands[2].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+            } else {
+                assert_eq!(commands.len(), 1);
+                assert_matches!(
+                    commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+            }
+        });
+    });
+
+    let mut worker = build_fake_sdk(mock_cfg);
+    worker.set_worker_interceptor(aai);
+    worker.register_wf(DEFAULT_WORKFLOW_TYPE, parallel_las_job_order_wf);
+    worker.register_activity(
+        DEFAULT_ACTIVITY_TYPE,
+        move |_ctx: ActContext, sleep_ms: u64| async move {
+            tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+            Ok("Resolved")
+        },
     );
     worker.run().await.unwrap();
 }


### PR DESCRIPTION
## What was changed

When multiple LAs run concurrently (i.e. started from the same Workflow Activation), Core records LA markers in the order that the activities completed, and queue up lang jobs in that same order, which is the expected behavior.

However, on replay, Core would previously queue LA completion jobs in the order that the LAs are started by the workflow, which could have resulted in NDEs on replay in the rare case where other commands are scheduled by the workflow on completion of each LA independently (i.e. rather than on completion of _all_ the LAs). See [this issue](https://github.com/temporalio/sdk-typescript/issues/1744) for example.

This incorrect behavior is that we'd previously look ahead for an LA completion on creation, immediately switching to the `ReplayingPreResolved` state in such case, which would record the LA completion job.

This PR fixes this behavior by:
1. In replay, LAs are now created in the `WaitingResolveFromMarkerLookAhead` state (i.e. they can't be "preresolved");
2. The LA lookahead buffer is now structured as an ordered queue rather than a `Map<seq_number, result>`;
3. LA lookaheads are consumed and applied to state machines in their historical order, once all activation commands have been decoded;
4. Consuming/applying LA completions blocks when we reach a completion marker for which the LA state machine does not yet exists.
5. If LA completions are left in the queue at the end of the WFT, that means that some LA that should have been executed by the workflow code, which is reported as an NDE.