### PR TITLE
feat: add last_sdk_version to workflow activation

### DIFF
--- a/crates/common/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/crates/common/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -92,6 +92,8 @@ message WorkflowActivation {
     // build id, if this worker was using the deprecated Build ID-only
     // feature(s).
     common.WorkerDeploymentVersion deployment_version_for_current_task = 9;
+    // The last seen SDK version from the most recent WFT completed event
+    string last_sdk_version = 10;
 }
 
 message WorkflowActivationJob {

--- a/crates/common/src/protos/mod.rs
+++ b/crates/common/src/protos/mod.rs
@@ -519,6 +519,7 @@ pub mod coresdk {
                 history_size_bytes: 0,
                 continue_as_new_suggested: false,
                 deployment_version_for_current_task: None,
+                last_sdk_version: String::new(),
             }
         }
 

--- a/crates/sdk-core/src/internal_flags.rs
+++ b/crates/sdk-core/src/internal_flags.rs
@@ -203,6 +203,15 @@ impl InternalFlags {
             Self::Disabled => Either::Right(iter::empty()),
         }
     }
+
+    pub(crate) fn last_sdk_version(&self) -> Option<&str> {
+        match self {
+            InternalFlags::Enabled {
+                last_sdk_version, ..
+            } if !last_sdk_version.is_empty() => Some(last_sdk_version),
+            InternalFlags::Enabled { .. } | InternalFlags::Disabled => None,
+        }
+    }
 }
 
 impl CoreInternalFlags {

--- a/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
@@ -465,6 +465,11 @@ impl WorkflowMachines {
             continue_as_new_suggested: self.continue_as_new_suggested,
             deployment_version_for_current_task: deployment_version_for_current_task
                 .map(Into::into),
+            last_sdk_version: (*self.observed_internal_flags)
+                .borrow()
+                .last_sdk_version()
+                .unwrap_or_default()
+                .to_owned(),
         }
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add `last_sdk_version` field to `WorkflowActivation`

## Why?
In order to provide a backwards compatible fix for https://github.com/temporalio/sdk-typescript/issues/1677, we need to be able to identify if the workflow was ran with an affected version. Making this field available to lang SDKs allow us to do this check.

## Checklist
<!--- add/delete as needed --->

1. Part of https://github.com/temporalio/sdk-typescript/issues/1677

2. How was this tested:
Unsure any additional testing is needed as this change just depends on `InternalFlags` behavior which already has tests for extracting metadata from workflow task completed events.

3. Any docs updates needed?
No
