### PR TITLE
Fix temporal prefix not applied to resource tuner metrics

### DIFF
--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -156,7 +156,6 @@ impl AllPermitsTracker {
 
 #[derive(Clone)]
 pub(crate) struct WorkerTelemetry {
-    metric_meter: Option<TemporalMeter>,
     temporal_metric_meter: Option<TemporalMeter>,
     trace_subscriber: Option<Arc<dyn Subscriber + Send + Sync>>,
 }
@@ -313,7 +312,6 @@ impl Worker {
         info!(task_queue=%config.task_queue, namespace=%config.namespace, "Initializing worker");
 
         let worker_telemetry = telem_instance.map(|telem| WorkerTelemetry {
-            metric_meter: telem.get_metric_meter(),
             temporal_metric_meter: telem.get_temporal_metric_meter(),
             trace_subscriber: telem.trace_subscriber(),
         });
@@ -382,7 +380,7 @@ impl Worker {
                     config.task_queue.clone(),
                     wt.temporal_metric_meter.clone(),
                 ),
-                wt.metric_meter.clone(),
+                wt.temporal_metric_meter.clone(),
             )
         } else {
             (MetricsContext::no_op(), None)

--- a/crates/sdk-core/src/worker/tuner/resource_based.rs
+++ b/crates/sdk-core/src/worker/tuner/resource_based.rs
@@ -233,14 +233,10 @@ impl PidControllers {
 
 impl MetricInstruments {
     fn new(meter: TemporalMeter) -> Self {
-        let mem_usage = meter.inner.gauge_f64("resource_slots_mem_usage".into());
-        let cpu_usage = meter.inner.gauge_f64("resource_slots_cpu_usage".into());
-        let mem_pid_output = meter
-            .inner
-            .gauge_f64("resource_slots_mem_pid_output".into());
-        let cpu_pid_output = meter
-            .inner
-            .gauge_f64("resource_slots_cpu_pid_output".into());
+        let mem_usage = meter.gauge_f64("resource_slots_mem_usage".into());
+        let cpu_usage = meter.gauge_f64("resource_slots_cpu_usage".into());
+        let mem_pid_output = meter.gauge_f64("resource_slots_mem_pid_output".into());
+        let cpu_pid_output = meter.gauge_f64("resource_slots_cpu_pid_output".into());
         let attribs = meter.inner.new_attributes(meter.default_attribs);
         Self {
             attribs,
@@ -732,15 +728,17 @@ impl CGroupCpuFileSystem for CgroupV2CpuFileSystem {
 mod tests {
     use super::*;
     use crate::{abstractions::MeteredPermitDealer, telemetry::metrics::MetricsContext};
-    use std::cell::RefCell;
-    use std::env;
-    use std::hint::black_box;
-    use std::rc::Rc;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
+    use std::{
+        cell::RefCell,
+        env,
+        hint::black_box,
+        rc::Rc,
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        thread::sleep,
     };
-    use std::thread::sleep;
     use temporalio_common::worker::WorkflowSlotKind;
 
     struct FakeMIS {


### PR DESCRIPTION
These metrics were missing the `temporal` prefix, which led to user confusion. Technically a breaking change, but, very very few people are inspecting these right now anyway, and more people are probably missing them because of this.

Also needs to be done in Java (or, at least, we have a report they're also missing in Java)