### PR TITLE
VLN-513: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -6,6 +6,10 @@ on: # rebuild any PRs and main branch changes
     branches:
       - master
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/crates/common/protos/api_upstream/.github/workflows/create-release.yml
+++ b/crates/common/protos/api_upstream/.github/workflows/create-release.yml
@@ -20,6 +20,9 @@ on:
         description: An ID used by external tools to identify workflow runs(can be left empty when running manually)
         default: "none"
         type: string
+
+permissions:
+  contents: read
 jobs:
   dispatch:
     runs-on: ubuntu-latest
@@ -130,6 +133,8 @@ jobs:
           gh release create "$TAG" --target "$REF" --latest --generate-notes --notes-start-tag "$BASE_TAG" --draft
 
   release-api-go:
+    permissions:
+      contents: write
     needs: [prepare-inputs, create-release]
     if: |
       !cancelled() &&


### PR DESCRIPTION
## Summary

- `.github/workflows/per-pr.yml`: Added a workflow-level permissions block granting read access to repository contents and write access to Actions artifacts so each job has only the scopes it needs.
- `crates/common/protos/api_upstream/.github/workflows/create-release.yml`: Declared default read-only contents access at the workflow level and scoped contents: write to the downstream reusable release job that must publish releases.