### PR TITLE
add explicit WorkerShutdown input

### DIFF
--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -626,6 +626,12 @@ impl Workflows {
         rx
     }
 
+    /// Send a `WorkerShutdown` message to the workflow stream. This ensures that any pending
+    /// workflow activation polls will resolve during shutdown, even if there are no other inputs.
+    pub(super) fn send_worker_shutdown(&self) {
+        self.send_local(LocalInputs::WorkerShutdown);
+    }
+
     /// Query the state of workflow management. Can return `None` if workflow state is shut down.
     pub(super) fn get_state_info(&self) -> impl Future<Output = Option<WorkflowStateInfo>> {
         let rx = self.send_get_state_info_msg();

--- a/crates/sdk-core/src/worker/workflow/workflow_stream.rs
+++ b/crates/sdk-core/src/worker/workflow/workflow_stream.rs
@@ -147,6 +147,11 @@ impl WFStream {
                                 });
                                 None
                             }
+                            LocalInputs::WorkerShutdown => {
+                                // Worker shutdown message is used to bump the stream to ensure
+                                // pending workflow activation polls resolve during shutdown
+                                None
+                            }
                         }
                     }
                     WFStreamInput::FailedFetch {
@@ -633,6 +638,7 @@ pub(super) enum LocalInputs {
     RequestEviction(RequestEvictMsg),
     HeartbeatTimeout(String),
     GetStateInfo(GetStateInfoMsg),
+    WorkerShutdown,
 }
 impl LocalInputs {
     fn run_id(&self) -> Option<&str> {
@@ -643,7 +649,7 @@ impl LocalInputs {
             LocalInputs::PostActivation(pa) => &pa.run_id,
             LocalInputs::RequestEviction(re) => &re.run_id,
             LocalInputs::HeartbeatTimeout(hb) => hb,
-            LocalInputs::GetStateInfo(_) => return None,
+            LocalInputs::GetStateInfo(_) | LocalInputs::WorkerShutdown => return None,
         })
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add an explicit `WorkerShutdown` input call to the workflow stream

## Why?
Fix a corner case where shutdown occurs before we've polled and lang gets stuck waiting for workflow activation.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
lang side tests now pass, https://github.com/temporalio/sdk-typescript/actions/runs/19243077180/job/55010261692?pr=1817

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a `WorkerShutdown` local input and send it on worker shutdown to unblock pending workflow activation polls.
> 
> - **Workflow Stream**:
>   - Add `LocalInputs::WorkerShutdown` variant and handle it as a no-op to bump the stream.
>   - Update `LocalInputs::run_id()` to return `None` for `WorkerShutdown`.
> - **Workflows API**:
>   - Add `Workflows::send_worker_shutdown()` to enqueue `WorkerShutdown`.
>   - Replace shutdown bump via `send_get_state_info_msg()` with explicit `WorkerShutdown`.
> - **Worker Shutdown**:
>   - On `initiate_shutdown`, call `self.workflows.send_worker_shutdown()` to ensure pending activation polls resolve.
>   - Minor logic note: immediately notify local activity manager if workflows were never polled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8037470c1e51fe10dedc50a0f50a747bd347a4c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->