### PR TITLE
Allow activity/workflow/nexus only workers to be registered on the same client/NS/TQ

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -36,7 +36,6 @@ pub use temporalio_common::protos::temporal::api::{
 pub use tonic;
 pub use worker_registry::{
     ClientWorker, ClientWorkerSet, HeartbeatCallback, SharedNamespaceWorkerTrait, Slot,
-    WorkerCapabilities,
 };
 pub use workflow_handle::{
     GetWorkflowResultOpts, WorkflowExecutionInfo, WorkflowExecutionResult, WorkflowHandle,

--- a/crates/client/src/raw.rs
+++ b/crates/client/src/raw.rs
@@ -1598,11 +1598,12 @@ proxier! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ClientOptionsBuilder, RetryClient, WorkerCapabilities};
+    use crate::{ClientOptionsBuilder, RetryClient};
     use std::collections::HashSet;
     use temporalio_common::protos::temporal::api::{
         operatorservice::v1::DeleteNamespaceRequest, workflowservice::v1::ListNamespacesRequest,
     };
+    use temporalio_common::worker::WorkerTaskTypes;
     use tonic::IntoRequest;
     use uuid::Uuid;
 
@@ -1866,11 +1867,11 @@ mod tests {
             .expect_worker_instance_key()
             .return_const(uuid);
         mock_provider
-            .expect_worker_capabilities()
-            .return_const(WorkerCapabilities {
-                handles_workflows: true,
-                handles_activities: true,
-                handles_nexus: true,
+            .expect_worker_task_types()
+            .return_const(WorkerTaskTypes {
+                enable_workflows: true,
+                enable_activities: true,
+                enable_nexus: true,
             });
 
         let client_worker_set = Arc::new(ClientWorkerSet::new());

--- a/crates/common/src/worker.rs
+++ b/crates/common/src/worker.rs
@@ -67,6 +67,12 @@ impl WorkerTaskTypes {
             enable_nexus: true,
         }
     }
+
+    pub fn overlaps_with(&self, other: &WorkerTaskTypes) -> bool {
+        (self.enable_workflows && other.enable_workflows)
+            || (self.enable_activities && other.enable_activities)
+            || (self.enable_nexus && other.enable_nexus)
+    }
 }
 
 /// Defines per-worker configuration options

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -67,6 +67,7 @@ use std::{
 use temporalio_client::{
     ClientWorker, HeartbeatCallback, SharedNamespaceWorkerTrait, Slot as SlotTrait,
 };
+use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_common::{
     errors::{CompleteNexusError, WorkerValidationError},
     protos::{
@@ -652,26 +653,13 @@ impl Worker {
             )
         });
 
-        // Determine worker capabilities based on configuration
-        let capabilities = temporalio_client::WorkerCapabilities {
-            handles_workflows: !matches!(
-                config.workflow_task_poller_behavior,
-                PollerBehavior::SimpleMaximum(0)
-            ),
-            handles_activities: !config.no_remote_activities,
-            handles_nexus: !matches!(
-                config.nexus_task_poller_behavior,
-                PollerBehavior::SimpleMaximum(0)
-            ),
-        };
-
         let client_worker_registrator = Arc::new(ClientWorkerRegistrator {
             worker_instance_key,
             slot_provider: provider,
             heartbeat_manager: worker_heartbeat,
             client: RwLock::new(client.clone()),
             shared_namespace_worker,
-            capabilities,
+            task_types: config.task_types,
         });
 
         if !shared_namespace_worker {
@@ -1102,7 +1090,7 @@ struct ClientWorkerRegistrator {
     heartbeat_manager: Option<WorkerHeartbeatManager>,
     client: RwLock<Arc<dyn WorkerClient>>,
     shared_namespace_worker: bool,
-    capabilities: temporalio_client::WorkerCapabilities,
+    task_types: WorkerTaskTypes,
 }
 
 impl ClientWorker for ClientWorkerRegistrator {
@@ -1152,8 +1140,8 @@ impl ClientWorker for ClientWorkerRegistrator {
         }
     }
 
-    fn worker_capabilities(&self) -> temporalio_client::WorkerCapabilities {
-        self.capabilities
+    fn worker_task_types(&self) -> WorkerTaskTypes {
+        self.task_types
     }
 }
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Make `worker_registry` aware of `WorkerTaskType`, to allow multiple workers without overlapping types to be registered on the same client/NS/TQ

## Why?
<!-- Tell your future self why have you made these changes -->
We want to support this to minimize the breakage for users, since previously this scenario did not return an error. This is likely primarily used in tests or maybe code organization.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added new tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables registering workflow/activity/nexus-only workers on the same client/namespace/task queue when their task types don’t overlap, updates slot selection to use task types, and adds validations/tests.
> 
> - **Worker Registry (`crates/client/src/worker_registry`)**:
>   - Store per-worker metadata via `RegisteredWorkerInfo` including `build_id` and `WorkerTaskTypes`.
>   - Permit multiple workers on the same `namespace`/`task_queue` if their `task_types` don’t overlap (same `build_id` allowed if non-overlapping); reject empty capabilities.
>   - Reserve WFT slots only from workers with `enable_workflows`.
>   - Extend `ClientWorker` trait with `worker_task_types()`.
> - **Common (`crates/common/src/worker.rs`)**:
>   - Introduce `WorkerTaskTypes::overlaps_with` helper; validate `WorkerConfig.task_types` and related invariants.
> - **Core (`crates/sdk-core/src/worker/mod.rs`)**:
>   - Pass `config.task_types` into client worker registration; implement `worker_task_types()` in `ClientWorkerRegistrator`.
>   - Gate pollers/managers by `task_types` (workflows/activities/nexus) where applicable.
> - **Client Raw (`crates/client/src/raw.rs`)**:
>   - Tests updated to provide `WorkerTaskTypes` when registering workers for eager start path.
> - **Tests**:
>   - Add coverage for coexistence of workflow-only/activity-only/nexus-only workers, rejection of overlapping/empty capabilities, and WFT reservation ignoring non-workflow workers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e0b754351291d002226222464e1e4d159a3cba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->