### PR TITLE
Add bounds check for heartbeat interval

### DIFF
--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -454,12 +454,8 @@ fn after_shutdown_checks(
     assert!(!host_info.host_name.is_empty());
     assert!(!host_info.process_key.is_empty());
     assert!(!host_info.process_id.is_empty());
-    eprintln!(
-        "DEBUG after_shutdown_checks: cpu_usage={}, mem_usage={}, host_name={}",
-        host_info.current_host_cpu_usage, host_info.current_host_mem_usage, host_info.host_name
-    );
-    assert_ne!(host_info.current_host_cpu_usage, 0.0);
-    assert_ne!(host_info.current_host_mem_usage, 0.0);
+    assert!(host_info.current_host_cpu_usage >= 0.0);
+    assert!(host_info.current_host_mem_usage >= 0.0);
 
     assert!(heartbeat.task_queue.starts_with(wf_name));
     assert_eq!(


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->
Only allow worker heartbeating interval to be between 1s and 60s

Also changed heartbeat test to account for if `host_cpu_usage` is so low it rounds down to 0.0.

## Why?
<!-- Tell your future self why have you made these changes -->


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds builder validation to enforce `heartbeat_interval` between 1s and 60s and updates integration tests to use 1s heartbeats with adjusted timings/assertions.
> 
> - **Core**:
>   - `RuntimeOptions` now uses builder validation to enforce `heartbeat_interval` in `[1s, 60s]` and derives `Default` (default remains `Some(60s)`) in `crates/sdk-core/src/lib.rs`.
> - **Tests**:
>   - Update integration tests in `crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs` to use `heartbeat_interval(Some(Duration::from_secs(1)))` instead of 100ms.
>   - Increase sleeps/time thresholds (e.g., `150ms→1500ms`, `200ms→2000ms`, `sleep 200ms→2s`) and bump some activity `start_to_close_timeout` values (`1s→5s`).
>   - Relax host usage assertions from nonzero to `>= 0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bef7d412c018dd4a31b309a91c2372898b3f2039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->