### PR TITLE
Fix c bridge worker heartbeat config passing

### DIFF
--- a/crates/sdk-core-c-bridge/src/runtime.rs
+++ b/crates/sdk-core-c-bridge/src/runtime.rs
@@ -239,11 +239,10 @@ impl Runtime {
 
         let core_runtime_options = CoreRuntimeOptions::builder()
             .telemetry_options(telemetry_options)
-            .maybe_heartbeat_interval((options.worker_heartbeat_interval_millis != 0).then(|| {
-                Some(Duration::from_millis(
-                    options.worker_heartbeat_interval_millis,
-                ))
-            }))
+            .heartbeat_interval(
+                (options.worker_heartbeat_interval_millis != 0)
+                    .then(|| Duration::from_millis(options.worker_heartbeat_interval_millis)),
+            )
             .build()
             .map_err(|e| anyhow::anyhow!(e))?;
 

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -58,7 +58,6 @@ pub(crate) async fn grpc_message_too_large() {
                     false
                 }
         }),
-        "Expected workflow task failure or termination b/c grpc message too large: {:?}",
-        events
+        "Expected workflow task failure or termination b/c grpc message too large: {events:?}",
     );
 }


### PR DESCRIPTION
## What was changed
use `heartbeat_interval` instead of `maybe_heartbeat_interval`

random test lint fix that failed locally

## Why?
dotnet will only pass in 0, which disables heartbeating, and > 0 for a value to set the config (dotnet handles defaulting to 60 here). The recent change from #1074 was returning `None` and `Some(Some(val))` for these cases, where `maybe_heartbeat_interval(None)` sets it to its default value, which is 60, instead of disabling heartbeating.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested with dotnet SDK

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `heartbeat_interval` to pass worker heartbeat interval (0 disables, >0 sets), plus a minor test assertion formatting tweak.
> 
> - **Core runtime (C bridge)**:
>   - Switch to `CoreRuntimeOptions::builder().heartbeat_interval(...)` with `Option<Duration>` derived from `worker_heartbeat_interval_millis` (0 => `None`, >0 => `Some(Duration)`), fixing heartbeat configuration.
> - **Tests**:
>   - Update assertion message to use captured formatting for `events`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1a7daa2e511a9ad5494857268130f625ecb9e4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->