### PR TITLE
Allow specifying wait time before interrupting polls

### DIFF
--- a/crates/client/src/worker/mod.rs
+++ b/crates/client/src/worker/mod.rs
@@ -651,14 +651,14 @@ mod tests {
             let worker_instance_key = mock_provider.worker_instance_key();
 
             let result = manager.register_worker(Arc::new(mock_provider), false);
-            if result.is_ok() {
-                successful_registrations += 1;
-                worker_keys.push(worker_instance_key);
-            } else {
+            if let Err(err) = result {
                 // Should get error for overlapping worker task types
-                assert!(result.unwrap_err().to_string().contains(
+                assert!(err.to_string().contains(
                     "Registration of multiple workers with overlapping worker task types"
                 ));
+            } else {
+                successful_registrations += 1;
+                worker_keys.push(worker_instance_key);
             }
         }
 

--- a/crates/sdk-core/src/pollers/poll_buffer.rs
+++ b/crates/sdk-core/src/pollers/poll_buffer.rs
@@ -887,24 +887,25 @@ mod tests {
 
                 async move {
                     match count {
-                        0 => {
-                            let mut resp = PollWorkflowTaskQueueResponse::default();
-                            resp.task_token = vec![1];
-                            Ok(resp)
-                        }
+                        0 => Ok(PollWorkflowTaskQueueResponse {
+                            task_token: vec![1],
+                            ..Default::default()
+                        }),
                         1 => {
                             second_started.notify_one();
                             second_complete.notified().await;
-                            let mut resp = PollWorkflowTaskQueueResponse::default();
-                            resp.task_token = vec![2];
-                            Ok(resp)
+                            Ok(PollWorkflowTaskQueueResponse {
+                                task_token: vec![2],
+                                ..Default::default()
+                            })
                         }
                         _ => {
                             third_started.notify_one();
                             third_complete.notified().await;
-                            let mut resp = PollWorkflowTaskQueueResponse::default();
-                            resp.task_token = vec![3];
-                            Ok(resp)
+                            Ok(PollWorkflowTaskQueueResponse {
+                                task_token: vec![3],
+                                ..Default::default()
+                            })
                         }
                     }
                 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
See title

## Why?
Hot fix for a specific user situation. This will be superseded by a change to server which uses the worker shutdown call to properly terminate in-flight polls.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/1080

2. How was this tested:
Unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
