### PR TITLE
Downgrade worker heartbeat log

### DIFF
--- a/crates/sdk-core/src/worker/heartbeat.rs
+++ b/crates/sdk-core/src/worker/heartbeat.rs
@@ -75,7 +75,7 @@ impl SharedNamespaceWorker {
                         .map(|caps| caps.worker_heartbeats)
                         != Some(true)
                     {
-                        trace!(
+                        debug!(
                             "Worker heartbeating configured for runtime, but server version does not support it."
                         );
                         worker.shutdown().await;


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Downgraded a log from `warn` to `debug`

## Why?
<!-- Tell your future self why have you made these changes -->
Too noisy, shouldn't be a log users see by default

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces log verbosity around worker heartbeat capability detection.
> 
> - In `worker/heartbeat.rs`, change `warn!` to `debug!` when the server does not support `worker_heartbeats`; still shuts down the worker in this case
> - No functional changes to heartbeat flow; network errors remain `warn!`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2d36713cf635a5219bb52f15845a4789a4cceb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->