### PR TITLE
Fix bug where we count first WFT as sticky cache hit

### DIFF
--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -191,6 +191,7 @@ impl ManagedRun {
             attempt = %work.attempt,
             "Applying new workflow task from server"
         );
+        let is_incremental = work.is_incremental();
         let wft_info = WorkflowTaskInfo {
             attempt: work.attempt,
             task_token: work.task_token,
@@ -239,7 +240,9 @@ impl ManagedRun {
 
         // The update field is only populated in the event we hit the cache
         let activation = if work.update.is_real() {
-            self.metrics.sticky_cache_hit();
+            if is_incremental {
+                self.metrics.sticky_cache_hit();
+            }
             self.wfm.new_work_from_server(work.update, work.messages)?
         } else {
             let r = self.wfm.get_next_activation()?;

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -519,7 +519,7 @@ fn after_shutdown_checks(
         activity_poller_info.last_successful_poll_time.unwrap()
     ));
 
-    assert_eq!(heartbeat.total_sticky_cache_hit, 2);
+    assert_eq!(heartbeat.total_sticky_cache_hit, 1);
     assert_eq!(heartbeat.current_sticky_cache_size, 0);
     assert_eq!(
         heartbeat.plugins,


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Use `is_incremental` to decide when to count sticky cache hit.

## Why?
<!-- Tell your future self why have you made these changes -->
Sticky cache is not being hit on the first WFT of a new workflow. `is_incremental` seems like the right way to guard against this
```
/// Returns true if the contained history update is incremental (IE: expects to hit a cached
/// workflow)
fn is_incremental(&self) -> bool {
```

Found this when comparing heartbeat results with Go implementation.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Existing tests pass. Updated heartbeat test to expect 1 instead of 2.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes overcounting of sticky cache hits on initial workflow tasks.
> 
> - Gate `metrics.sticky_cache_hit()` behind `work.is_incremental()` in `managed_run.rs`
> - Update heartbeat test to expect `total_sticky_cache_hit == 1` instead of `2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28b89044c42be978e6cc71a3ca89e3b0b50cbb6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->