### PR TITLE
Update upstream_api to v1.61.0

### DIFF
--- a/crates/common/protos/api_upstream/openapi/openapiv2.json
+++ b/crates/common/protos/api_upstream/openapi/openapiv2.json
@@ -8195,6 +8195,17 @@
         }
       }
     },
+    "ExecuteMultiOperationResponseResponse": {
+      "type": "object",
+      "properties": {
+        "startWorkflow": {
+          "$ref": "#/definitions/v1StartWorkflowExecutionResponse"
+        },
+        "updateWorkflow": {
+          "$ref": "#/definitions/v1UpdateWorkflowExecutionResponse"
+        }
+      }
+    },
     "LinkBatchJob": {
       "type": "object",
       "properties": {
@@ -8358,7 +8369,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/v1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionSignaled event."
         }
@@ -8841,7 +8852,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionCanceled event."
         }
@@ -8899,8 +8910,7 @@
               "type": "string"
             }
           },
-          "description": "The workflow to reset. If this contains a run ID then the workflow will be reset back to the\nprovided event ID in that run. Otherwise it will be reset to the provided event ID in the\ncurrent run. In all cases the current run will be terminated and a new run started.",
-          "title": "The workflow to reset. If this contains a run ID then the workflow will be reset back to the\nprovided event ID in that run. Otherwise it will be reset to the provided event ID in the\ncurrent run. In all cases the current run will be terminated and a new run started."
+          "description": "The workflow to reset. If this contains a run ID then the workflow will be reset back to the\nprovided event ID in that run. Otherwise it will be reset to the provided event ID in the\ncurrent run. In all cases the current run will be terminated and a new run started."
         },
         "reason": {
           "type": "string"
@@ -9062,7 +9072,7 @@
           "title": "The task token as received in `PollActivityTaskQueueResponse`"
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "title": "Detailed failure information"
         },
         "identity": {
@@ -9103,7 +9113,7 @@
           "title": "Id of the activity to fail"
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "title": "Detailed failure information"
         },
         "identity": {
@@ -9309,7 +9319,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionStarted and WorkflowExecutionSignaled events."
         },
@@ -9359,7 +9369,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionSignaled event."
         }
@@ -9551,7 +9561,7 @@
           "description": "Request to get the first workflow task inline in the response bypassing matching service and worker polling.\nIf set to `true` the caller is expected to have a worker available and capable of processing the task.\nThe returned task will be marked as started and is expected to be completed by the specified\n`workflow_task_timeout`."
         },
         "continuedFailure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "These values will be available as ContinuedFailure and LastCompletionResult in the\nWorkflowExecutionStarted event and through SDKs. The are currently only used by the\nserver itself (for the schedules feature) and are not intended to be exposed in\nStartWorkflowExecution."
         },
         "lastCompletionResult": {
@@ -9577,7 +9587,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links to be associated with the workflow."
         },
@@ -9664,7 +9674,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionTerminated event."
         }
@@ -9973,8 +9983,7 @@
               }
             }
           },
-          "description": "The request information that will be delivered all the way down to the\nWorkflow Execution.",
-          "title": "The request information that will be delivered all the way down to the\nWorkflow Execution."
+          "description": "The request information that will be delivered all the way down to the\nWorkflow Execution."
         }
       }
     },
@@ -10005,82 +10014,6 @@
         }
       },
       "description": "Keep the parameters in sync with:\n  - temporal.api.batch.v1.BatchOperationUpdateWorkflowExecutionOptions.\n  - temporal.api.workflow.v1.PostResetOperation.UpdateWorkflowOptions."
-    },
-    "apicommonv1Link": {
-      "type": "object",
-      "properties": {
-        "workflowEvent": {
-          "$ref": "#/definitions/LinkWorkflowEvent"
-        },
-        "batchJob": {
-          "$ref": "#/definitions/LinkBatchJob"
-        }
-      },
-      "description": "Link can be associated with history events. It might contain information about an external entity\nrelated to the history event. For example, workflow A makes a Nexus call that starts workflow B:\nin this case, a history event in workflow A could contain a Link to the workflow started event in\nworkflow B, and vice-versa."
-    },
-    "apifailurev1Failure": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string",
-          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
-        },
-        "stackTrace": {
-          "type": "string"
-        },
-        "encodedAttributes": {
-          "$ref": "#/definitions/v1Payload",
-          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
-        },
-        "cause": {
-          "$ref": "#/definitions/apifailurev1Failure"
-        },
-        "applicationFailureInfo": {
-          "$ref": "#/definitions/v1ApplicationFailureInfo"
-        },
-        "timeoutFailureInfo": {
-          "$ref": "#/definitions/v1TimeoutFailureInfo"
-        },
-        "canceledFailureInfo": {
-          "$ref": "#/definitions/v1CanceledFailureInfo"
-        },
-        "terminatedFailureInfo": {
-          "$ref": "#/definitions/v1TerminatedFailureInfo"
-        },
-        "serverFailureInfo": {
-          "$ref": "#/definitions/v1ServerFailureInfo"
-        },
-        "resetWorkflowFailureInfo": {
-          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
-        },
-        "activityFailureInfo": {
-          "$ref": "#/definitions/v1ActivityFailureInfo"
-        },
-        "childWorkflowExecutionFailureInfo": {
-          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
-        },
-        "nexusOperationExecutionFailureInfo": {
-          "$ref": "#/definitions/v1NexusOperationFailureInfo"
-        },
-        "nexusHandlerFailureInfo": {
-          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
-        }
-      }
-    },
-    "apiupdatev1Request": {
-      "type": "object",
-      "properties": {
-        "meta": {
-          "$ref": "#/definitions/v1Meta"
-        },
-        "input": {
-          "$ref": "#/definitions/v1Input"
-        }
-      },
-      "description": "The client request that triggers a Workflow Update."
     },
     "protobufAny": {
       "type": "object",
@@ -10196,7 +10129,7 @@
           "description": "Time when the activity transitioned to a closed state."
         },
         "lastFailure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Failure details from the last failed attempt."
         },
         "lastWorkerIdentity": {
@@ -10313,7 +10246,7 @@
           "description": "The result if the activity completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The failure if the activity completed unsuccessfully."
         }
       },
@@ -10503,7 +10436,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "title": "Failure details"
         },
         "scheduledEventId": {
@@ -10605,7 +10538,7 @@
           "title": "Starting at 1, the number of times this task has been attempted"
         },
         "lastFailure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Will be set to the most recent failure details, if this task has previously failed and then\nbeen retried."
         },
         "workerVersion": {
@@ -10623,7 +10556,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "If this activity had failed, was retried, and then timed out, that failure is stored as the\n`cause` in here."
         },
         "scheduledEventId": {
@@ -11083,7 +11016,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/v1Link"
           },
           "description": "Links associated with the callback. It can be used to link to underlying resources of the\ncallback."
         }
@@ -11120,7 +11053,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -11232,7 +11165,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure"
+          "$ref": "#/definitions/v1Failure"
         },
         "namespace": {
           "type": "string",
@@ -12107,22 +12040,11 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1ExecuteMultiOperationResponseResponse"
+            "$ref": "#/definitions/ExecuteMultiOperationResponseResponse"
           }
         }
       },
       "description": "IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination (\"Update-with-Start\") when both\n  1. the workflow update for the requested update ID has already completed, and\n  2. the workflow for the requested workflow ID has already been closed,\nthen you'll receive\n  - an update response containing the update's outcome, and\n  - a start response with a `status` field that reflects the workflow's current state."
-    },
-    "v1ExecuteMultiOperationResponseResponse": {
-      "type": "object",
-      "properties": {
-        "startWorkflow": {
-          "$ref": "#/definitions/v1StartWorkflowExecutionResponse"
-        },
-        "updateWorkflow": {
-          "$ref": "#/definitions/v1UpdateWorkflowExecutionResponse"
-        }
-      }
     },
     "v1ExternalWorkflowExecutionCancelRequestedEventAttributes": {
       "type": "object",
@@ -12182,6 +12104,58 @@
         }
       },
       "title": "Represents a historical replication status of a Namespace"
+    },
+    "v1Failure": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "encodedAttributes": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
+        },
+        "cause": {
+          "$ref": "#/definitions/v1Failure"
+        },
+        "applicationFailureInfo": {
+          "$ref": "#/definitions/v1ApplicationFailureInfo"
+        },
+        "timeoutFailureInfo": {
+          "$ref": "#/definitions/v1TimeoutFailureInfo"
+        },
+        "canceledFailureInfo": {
+          "$ref": "#/definitions/v1CanceledFailureInfo"
+        },
+        "terminatedFailureInfo": {
+          "$ref": "#/definitions/v1TerminatedFailureInfo"
+        },
+        "serverFailureInfo": {
+          "$ref": "#/definitions/v1ServerFailureInfo"
+        },
+        "resetWorkflowFailureInfo": {
+          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
+        },
+        "activityFailureInfo": {
+          "$ref": "#/definitions/v1ActivityFailureInfo"
+        },
+        "childWorkflowExecutionFailureInfo": {
+          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
+        },
+        "nexusOperationExecutionFailureInfo": {
+          "$ref": "#/definitions/v1NexusOperationFailureInfo"
+        },
+        "nexusHandlerFailureInfo": {
+          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
+        }
+      }
     },
     "v1FetchWorkerConfigResponse": {
       "type": "object",
@@ -12483,7 +12457,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/v1Link"
           },
           "description": "Links associated with the event."
         },
@@ -12734,6 +12708,18 @@
       },
       "description": "IntervalSpec matches times that can be expressed as:\nepoch + n * interval + phase\nwhere n is an integer.\nphase defaults to zero if missing. interval is required.\nBoth interval and phase must be non-negative and are truncated to the nearest\nsecond before any calculations.\nFor example, an interval of 1 hour with phase of zero would match every hour,\non the hour. The same interval but a phase of 19 minutes would match every\nxx:19:00. An interval of 28 days with phase zero would match\n2022-02-17T00:00:00Z (among other times). The same interval with a phase of 3\ndays, 5 hours, and 23 minutes would match 2022-02-20T05:23:00Z instead."
     },
+    "v1Link": {
+      "type": "object",
+      "properties": {
+        "workflowEvent": {
+          "$ref": "#/definitions/LinkWorkflowEvent"
+        },
+        "batchJob": {
+          "$ref": "#/definitions/LinkBatchJob"
+        }
+      },
+      "description": "Link can be associated with history events. It might contain information about an external entity\nrelated to the history event. For example, workflow A makes a Nexus call that starts workflow B:\nin this case, a history event in workflow A could contain a Link to the workflow started event in\nworkflow B, and vice-versa."
+    },
     "v1ListActivityExecutionsResponse": {
       "type": "object",
       "properties": {
@@ -12977,7 +12963,7 @@
           "$ref": "#/definitions/v1Header"
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Some uses of markers, like a local activity, could \"fail\". If they did that is recorded here."
         }
       }
@@ -13150,6 +13136,10 @@
         "workflowPause": {
           "type": "boolean",
           "title": "True if the namespace supports pausing workflows"
+        },
+        "standaloneActivities": {
+          "type": "boolean",
+          "title": "True if the namespace supports standalone activities"
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."
@@ -13303,7 +13293,7 @@
           "description": "The `WORKFLOW_TASK_COMPLETED` event that the corresponding RequestCancelNexusOperation command was reported\nwith."
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "scheduledEventId": {
@@ -13337,7 +13327,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Cancellation details."
         },
         "requestId": {
@@ -13369,7 +13359,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -13426,7 +13416,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo."
         },
         "requestId": {
@@ -13508,6 +13498,14 @@
         "endpointId": {
           "type": "string",
           "description": "Endpoint ID as resolved in the endpoint registry at the time this event was generated.\nThis is stored on the event and used internally by the server in case the endpoint is renamed from the time the\nevent was originally scheduled."
+        },
+        "scheduleToStartTimeout": {
+          "type": "string",
+          "description": "Schedule-to-start timeout for this operation.\nSee ScheduleNexusOperationCommandAttributes.schedule_to_start_timeout for details."
+        },
+        "startToCloseTimeout": {
+          "type": "string",
+          "description": "Start-to-close timeout for this operation.\nSee ScheduleNexusOperationCommandAttributes.start_to_close_timeout for details."
         }
       },
       "description": "Event marking that an operation was scheduled by a workflow via the ScheduleNexusOperation command."
@@ -13544,7 +13542,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "requestId": {
@@ -13579,7 +13577,7 @@
           "$ref": "#/definitions/v1Payloads"
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure"
+          "$ref": "#/definitions/v1Failure"
         }
       },
       "description": "The outcome of a Workflow Update: success or failure."
@@ -13662,7 +13660,7 @@
           "format": "date-time"
         },
         "lastFailure": {
-          "$ref": "#/definitions/apifailurev1Failure"
+          "$ref": "#/definitions/v1Failure"
         },
         "lastWorkerIdentity": {
           "type": "string"
@@ -13800,7 +13798,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -13823,6 +13821,14 @@
         "operationToken": {
           "type": "string",
           "description": "Operation token. Only set for asynchronous operations after a successful StartOperation call."
+        },
+        "scheduleToStartTimeout": {
+          "type": "string",
+          "description": "Schedule-to-start timeout for this operation."
+        },
+        "startToCloseTimeout": {
+          "type": "string",
+          "description": "Start-to-close timeout for this operation."
         }
       },
       "description": "PendingNexusOperationInfo contains the state of a pending Nexus operation."
@@ -14259,6 +14265,18 @@
       ],
       "default": "REPLICATION_STATE_UNSPECIFIED"
     },
+    "v1Request": {
+      "type": "object",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/v1Meta"
+        },
+        "input": {
+          "$ref": "#/definitions/v1Input"
+        }
+      },
+      "description": "The client request that triggers a Workflow Update."
+    },
     "v1RequestCancelActivityExecutionResponse": {
       "type": "object"
     },
@@ -14507,7 +14525,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apifailurev1Failure"
+            "$ref": "#/definitions/v1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -14520,7 +14538,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apifailurev1Failure"
+            "$ref": "#/definitions/v1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -15352,7 +15370,7 @@
           "description": "Request to get the first workflow task inline in the response bypassing matching service and worker polling.\nIf set to `true` the caller is expected to have a worker available and capable of processing the task.\nThe returned task will be marked as started and is expected to be completed by the specified\n`workflow_task_timeout`."
         },
         "continuedFailure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "These values will be available as ContinuedFailure and LastCompletionResult in the\nWorkflowExecutionStarted event and through SDKs. The are currently only used by the\nserver itself (for the schedules feature) and are not intended to be exposed in\nStartWorkflowExecution."
         },
         "lastCompletionResult": {
@@ -15378,7 +15396,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apicommonv1Link"
+            "$ref": "#/definitions/v1Link"
           },
           "description": "Links to be associated with the workflow."
         },
@@ -15420,7 +15438,7 @@
           "description": "When `request_eager_execution` is set on the `StartWorkflowExecutionRequest`, the server - if supported - will\nreturn the first workflow task to be eagerly executed.\nThe caller is expected to have a worker available to process the task."
         },
         "link": {
-          "$ref": "#/definitions/apicommonv1Link",
+          "$ref": "#/definitions/v1Link",
           "description": "Link to the workflow event."
         }
       }
@@ -16051,7 +16069,7 @@
           "description": "Specifies client's intent to wait for Update results.\nNOTE: This field works together with API call timeout which is limited by\nserver timeout (maximum wait time). If server timeout is expired before\nuser specified timeout, API call returns even if specified stage is not reached.\nActual reached stage will be included in the response."
         },
         "request": {
-          "$ref": "#/definitions/apiupdatev1Request",
+          "$ref": "#/definitions/v1Request",
           "description": "The request information that will be delivered all the way down to the\nWorkflow Execution."
         }
       }
@@ -16760,7 +16778,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Deprecated. If a workflow's retry policy would cause a new run to start when the current one\nhas failed, this field would be populated with that failure. Now (when supported by server\nand sdk) the final event will be `WORKFLOW_EXECUTION_FAILED` with `new_execution_run_id` set."
         },
         "lastCompletionResult": {
@@ -16835,7 +16853,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "title": "Serialized result of workflow failure (ex: An exception thrown, or error returned)"
         },
         "retryState": {
@@ -17116,7 +17134,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "continuedFailure": {
-          "$ref": "#/definitions/apifailurev1Failure"
+          "$ref": "#/definitions/v1Failure"
         },
         "lastCompletionResult": {
           "$ref": "#/definitions/v1Payloads"
@@ -17301,7 +17319,7 @@
           "description": "The event ID used to sequence the original request message."
         },
         "acceptedRequest": {
-          "$ref": "#/definitions/apiupdatev1Request",
+          "$ref": "#/definitions/v1Request",
           "description": "The message payload of the original request message that initiated this\nupdate."
         }
       }
@@ -17310,7 +17328,7 @@
       "type": "object",
       "properties": {
         "request": {
-          "$ref": "#/definitions/apiupdatev1Request",
+          "$ref": "#/definitions/v1Request",
           "description": "The update request associated with this event."
         },
         "origin": {
@@ -17354,11 +17372,11 @@
           "description": "The event ID used to sequence the original request message."
         },
         "rejectedRequest": {
-          "$ref": "#/definitions/apiupdatev1Request",
+          "$ref": "#/definitions/v1Request",
           "description": "The message payload of the original request message that initiated this\nupdate."
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The cause of rejection."
         }
       }
@@ -17667,10 +17685,11 @@
         "WORKFLOW_TASK_FAILED_CAUSE_PENDING_NEXUS_OPERATIONS_LIMIT_EXCEEDED",
         "WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES",
         "WORKFLOW_TASK_FAILED_CAUSE_FEATURE_DISABLED",
-        "WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE"
+        "WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE",
+        "WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE"
       ],
       "default": "WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED",
-      "description": "Workflow tasks can fail for various reasons. Note that some of these reasons can only originate\nfrom the server, and some of them can only originate from the SDK/worker.\n\n - WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND: Between starting and completing the workflow task (with a workflow completion command), some\nnew command (like a signal) was processed into workflow history. The outstanding task will be\nfailed with this reason, and a worker must pick up a new task.\n - WORKFLOW_TASK_FAILED_CAUSE_RESET_STICKY_TASK_QUEUE: The worker wishes to fail the task and have the next one be generated on a normal, not sticky\nqueue. Generally workers should prefer to use the explicit `ResetStickyTaskQueue` RPC call.\n - WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR: The worker encountered a mismatch while replaying history between what was expected, and\nwhat the workflow code actually did.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_CHILD_WORKFLOWS_LIMIT_EXCEEDED: We send the below error codes to users when their requests would violate a size constraint\nof their workflow. We do this to ensure that the state of their workflow does not become too\nlarge because that can cause severe performance degradation. You can modify the thresholds for\neach of these errors within your dynamic config.\n\nSpawning a new child workflow would cause this workflow to exceed its limit of pending child\nworkflows.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_ACTIVITIES_LIMIT_EXCEEDED: Starting a new activity would cause this workflow to exceed its limit of pending activities\nthat we track.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_SIGNALS_LIMIT_EXCEEDED: A workflow has a buffer of signals that have not yet reached their destination. We return this\nerror when sending a new signal would exceed the capacity of this buffer.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_REQUEST_CANCEL_LIMIT_EXCEEDED: Similarly, we have a buffer of pending requests to cancel other workflows. We return this error\nwhen our capacity for pending cancel requests is already reached.\n - WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE: Workflow execution update message (update.Acceptance, update.Rejection, or update.Response)\nhas wrong format, or missing required fields.\n - WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_UPDATE: Similar to WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, but for updates.\n - WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES: A workflow task completed with an invalid ScheduleNexusOperation command.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_NEXUS_OPERATIONS_LIMIT_EXCEEDED: A workflow task completed requesting to schedule a Nexus Operation exceeding the server configured limit.\n - WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES: A workflow task completed with an invalid RequestCancelNexusOperation command.\n - WORKFLOW_TASK_FAILED_CAUSE_FEATURE_DISABLED: A workflow task completed requesting a feature that's disabled on the server (either system wide or - typically -\nfor the workflow's namespace).\nCheck the workflow task failure message for more information.\n - WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE: A workflow task failed because a grpc message was too large."
+      "description": "Workflow tasks can fail for various reasons. Note that some of these reasons can only originate\nfrom the server, and some of them can only originate from the SDK/worker.\n\n - WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND: Between starting and completing the workflow task (with a workflow completion command), some\nnew command (like a signal) was processed into workflow history. The outstanding task will be\nfailed with this reason, and a worker must pick up a new task.\n - WORKFLOW_TASK_FAILED_CAUSE_RESET_STICKY_TASK_QUEUE: The worker wishes to fail the task and have the next one be generated on a normal, not sticky\nqueue. Generally workers should prefer to use the explicit `ResetStickyTaskQueue` RPC call.\n - WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR: The worker encountered a mismatch while replaying history between what was expected, and\nwhat the workflow code actually did.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_CHILD_WORKFLOWS_LIMIT_EXCEEDED: We send the below error codes to users when their requests would violate a size constraint\nof their workflow. We do this to ensure that the state of their workflow does not become too\nlarge because that can cause severe performance degradation. You can modify the thresholds for\neach of these errors within your dynamic config.\n\nSpawning a new child workflow would cause this workflow to exceed its limit of pending child\nworkflows.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_ACTIVITIES_LIMIT_EXCEEDED: Starting a new activity would cause this workflow to exceed its limit of pending activities\nthat we track.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_SIGNALS_LIMIT_EXCEEDED: A workflow has a buffer of signals that have not yet reached their destination. We return this\nerror when sending a new signal would exceed the capacity of this buffer.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_REQUEST_CANCEL_LIMIT_EXCEEDED: Similarly, we have a buffer of pending requests to cancel other workflows. We return this error\nwhen our capacity for pending cancel requests is already reached.\n - WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE: Workflow execution update message (update.Acceptance, update.Rejection, or update.Response)\nhas wrong format, or missing required fields.\n - WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_UPDATE: Similar to WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, but for updates.\n - WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES: A workflow task completed with an invalid ScheduleNexusOperation command.\n - WORKFLOW_TASK_FAILED_CAUSE_PENDING_NEXUS_OPERATIONS_LIMIT_EXCEEDED: A workflow task completed requesting to schedule a Nexus Operation exceeding the server configured limit.\n - WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES: A workflow task completed with an invalid RequestCancelNexusOperation command.\n - WORKFLOW_TASK_FAILED_CAUSE_FEATURE_DISABLED: A workflow task completed requesting a feature that's disabled on the server (either system wide or - typically -\nfor the workflow's namespace).\nCheck the workflow task failure message for more information.\n - WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE: A workflow task failed because a grpc message was too large.\n - WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE: A workflow task failed because payloads were too large."
     },
     "v1WorkflowTaskFailedEventAttributes": {
       "type": "object",
@@ -17689,7 +17708,7 @@
           "$ref": "#/definitions/v1WorkflowTaskFailedCause"
         },
         "failure": {
-          "$ref": "#/definitions/apifailurev1Failure",
+          "$ref": "#/definitions/v1Failure",
           "title": "The failure details"
         },
         "identity": {

--- a/crates/common/protos/api_upstream/openapi/openapiv3.yaml
+++ b/crates/common/protos/api_upstream/openapi/openapiv3.yaml
@@ -10262,6 +10262,9 @@ components:
         workflowPause:
           type: boolean
           description: True if the namespace supports pausing workflows
+        standaloneActivities:
+          type: boolean
+          description: True if the namespace supports standalone activities
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceInfo_Limits:
       type: object
@@ -10576,6 +10579,22 @@ components:
             Endpoint ID as resolved in the endpoint registry at the time this event was generated.
              This is stored on the event and used internally by the server in case the endpoint is renamed from the time the
              event was originally scheduled.
+        scheduleToStartTimeout:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            Schedule-to-start timeout for this operation.
+             See ScheduleNexusOperationCommandAttributes.schedule_to_start_timeout for details.
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: "to" is used to indicate interval. --)
+        startToCloseTimeout:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            Start-to-close timeout for this operation.
+             See ScheduleNexusOperationCommandAttributes.start_to_close_timeout for details.
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: "to" is used to indicate interval. --)
       description: Event marking that an operation was scheduled by a workflow via the ScheduleNexusOperation command.
     NexusOperationStartedEventAttributes:
       type: object
@@ -10968,6 +10987,20 @@ components:
         operationToken:
           type: string
           description: Operation token. Only set for asynchronous operations after a successful StartOperation call.
+        scheduleToStartTimeout:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            Schedule-to-start timeout for this operation.
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: "to" is used to indicate interval. --)
+        startToCloseTimeout:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            Start-to-close timeout for this operation.
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: "to" is used to indicate interval. --)
       description: PendingNexusOperationInfo contains the state of a pending Nexus operation.
     PendingWorkflowTaskInfo:
       type: object
@@ -16454,6 +16487,7 @@ components:
             - WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES
             - WORKFLOW_TASK_FAILED_CAUSE_FEATURE_DISABLED
             - WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE
+            - WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE
           type: string
           format: enum
         failure:

--- a/crates/common/protos/api_upstream/temporal/api/command/v1/message.proto
+++ b/crates/common/protos/api_upstream/temporal/api/command/v1/message.proto
@@ -249,6 +249,27 @@ message ScheduleNexusOperationCommandAttributes {
     // Note these headers are not the same as Temporal headers on internal activities and child workflows, these are
     // transmitted to Nexus operations that may be external and are not traditional payloads.
     map<string, string> nexus_header = 6;
+
+    // Schedule-to-start timeout for this operation.
+    // Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
+    // by the handler. If the operation is not started within this timeout, it will fail with
+    // TIMEOUT_TYPE_SCHEDULE_TO_START.
+    // If not set or zero, no schedule-to-start timeout is enforced.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    // Requires server version 1.31.0 or later.
+    google.protobuf.Duration schedule_to_start_timeout = 7;
+
+    // Start-to-close timeout for this operation.
+    // Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
+    // started. If the operation does not complete within this timeout after starting, it will fail with
+    // TIMEOUT_TYPE_START_TO_CLOSE.
+    // Only applies to asynchronous operations. Synchronous operations ignore this timeout.
+    // If not set or zero, no start-to-close timeout is enforced.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    // Requires server version 1.31.0 or later.
+    google.protobuf.Duration start_to_close_timeout = 8;
 }
 
 message RequestCancelNexusOperationCommandAttributes {

--- a/crates/common/protos/api_upstream/temporal/api/enums/v1/failed_cause.proto
+++ b/crates/common/protos/api_upstream/temporal/api/enums/v1/failed_cause.proto
@@ -81,6 +81,8 @@ enum WorkflowTaskFailedCause {
     WORKFLOW_TASK_FAILED_CAUSE_FEATURE_DISABLED = 35;
     // A workflow task failed because a grpc message was too large.
     WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE = 36;
+    // A workflow task failed because payloads were too large.
+    WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE = 37;
 }
 
 enum StartChildWorkflowExecutionFailedCause {

--- a/crates/common/protos/api_upstream/temporal/api/history/v1/message.proto
+++ b/crates/common/protos/api_upstream/temporal/api/history/v1/message.proto
@@ -975,6 +975,18 @@ message NexusOperationScheduledEventAttributes {
     // This is stored on the event and used internally by the server in case the endpoint is renamed from the time the
     // event was originally scheduled.
     string endpoint_id = 9;
+
+    // Schedule-to-start timeout for this operation.
+    // See ScheduleNexusOperationCommandAttributes.schedule_to_start_timeout for details.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    google.protobuf.Duration schedule_to_start_timeout = 10;
+
+    // Start-to-close timeout for this operation.
+    // See ScheduleNexusOperationCommandAttributes.start_to_close_timeout for details.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    google.protobuf.Duration start_to_close_timeout = 11;
 }
 
 // Event marking an asynchronous operation was started by the responding Nexus handler.

--- a/crates/common/protos/api_upstream/temporal/api/namespace/v1/message.proto
+++ b/crates/common/protos/api_upstream/temporal/api/namespace/v1/message.proto
@@ -40,6 +40,8 @@ message NamespaceInfo {
         bool reported_problems_search_attribute = 5;
         // True if the namespace supports pausing workflows
         bool workflow_pause = 6;
+        // True if the namespace supports standalone activities
+        bool standalone_activities = 7;
     }
 
     // Namespace configured limits

--- a/crates/common/protos/api_upstream/temporal/api/workflow/v1/message.proto
+++ b/crates/common/protos/api_upstream/temporal/api/workflow/v1/message.proto
@@ -526,6 +526,16 @@ message PendingNexusOperationInfo {
 
     // Operation token. Only set for asynchronous operations after a successful StartOperation call.
     string operation_token = 15;
+
+    // Schedule-to-start timeout for this operation.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    google.protobuf.Duration schedule_to_start_timeout = 16;
+
+    // Start-to-close timeout for this operation.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    google.protobuf.Duration start_to_close_timeout = 17;
 }
 
 // NexusOperationCancellationInfo contains the state of a nexus operation cancellation.

--- a/crates/common/protos/api_upstream/temporal/api/workflowservice/v1/request_response.proto
+++ b/crates/common/protos/api_upstream/temporal/api/workflowservice/v1/request_response.proto
@@ -494,6 +494,8 @@ message PollActivityTaskQueueResponse {
     temporal.api.taskqueue.v1.PollerScalingDecision poller_scaling_decision = 18;
     // Priority metadata
     temporal.api.common.v1.Priority priority = 19;
+    // The run ID of the activity execution, only set for standalone activities.
+    string activity_run_id = 20;
 }
 
 message RecordActivityTaskHeartbeatRequest {

--- a/crates/common/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/crates/common/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -378,6 +378,19 @@ message ScheduleNexusOperation {
     map<string, string> nexus_header = 7;
     // Defines behaviour of the underlying nexus operation when operation cancellation has been requested.
     nexus.NexusOperationCancellationType cancellation_type = 8;
+    // Schedule-to-start timeout for this operation.
+    // Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
+    // by the handler. If the operation is not started within this timeout, it will fail with
+    // TIMEOUT_TYPE_SCHEDULE_TO_START.
+    // If not set or zero, no schedule-to-start timeout is enforced.
+    google.protobuf.Duration schedule_to_start_timeout = 9;
+    // Start-to-close timeout for this operation.
+    // Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
+    // started. If the operation does not complete within this timeout after starting, it will fail with
+    // TIMEOUT_TYPE_START_TO_CLOSE.
+    // Only applies to asynchronous operations. Synchronous operations ignore this timeout.
+    // If not set or zero, no start-to-close timeout is enforced.
+    google.protobuf.Duration start_to_close_timeout = 10;
 }
 
 // Request cancellation of a nexus operation started via `ScheduleNexusOperation`

--- a/crates/common/src/protos/mod.rs
+++ b/crates/common/src/protos/mod.rs
@@ -1930,6 +1930,8 @@ pub mod temporal {
                                 operation: c.operation,
                                 input: c.input,
                                 schedule_to_close_timeout: c.schedule_to_close_timeout,
+                                schedule_to_start_timeout: c.schedule_to_start_timeout,
+                                start_to_close_timeout: c.start_to_close_timeout,
                                 nexus_header: c.nexus_header,
                             },
                         )

--- a/crates/sdk/src/workflow_context/options.rs
+++ b/crates/sdk/src/workflow_context/options.rs
@@ -409,6 +409,19 @@ pub struct NexusOperationOptions {
     pub nexus_header: HashMap<String, String>,
     /// Cancellation type for the operation
     pub cancellation_type: Option<NexusOperationCancellationType>,
+    /// Schedule-to-start timeout for this operation.
+    /// Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
+    /// by the handler. If the operation is not started within this timeout, it will fail with
+    /// TIMEOUT_TYPE_SCHEDULE_TO_START.
+    /// If not set or zero, no schedule-to-start timeout is enforced.
+    pub schedule_to_start_timeout: Option<Duration>,
+    /// Start-to-close timeout for this operation.
+    /// Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
+    /// started. If the operation does not complete within this timeout after starting, it will fail with
+    /// TIMEOUT_TYPE_START_TO_CLOSE.
+    /// Only applies to asynchronous operations. Synchronous operations ignore this timeout.
+    /// If not set or zero, no start-to-close timeout is enforced.
+    pub start_to_close_timeout: Option<Duration>,
 }
 
 impl IntoWorkflowCommand for NexusOperationOptions {
@@ -424,6 +437,12 @@ impl IntoWorkflowCommand for NexusOperationOptions {
                     input: self.input,
                     schedule_to_close_timeout: self
                         .schedule_to_close_timeout
+                        .and_then(|t| t.try_into().ok()),
+                    schedule_to_start_timeout: self
+                        .schedule_to_start_timeout
+                        .and_then(|t| t.try_into().ok()),
+                    start_to_close_timeout: self
+                        .start_to_close_timeout
                         .and_then(|t| t.try_into().ok()),
                     nexus_header: self.nexus_header,
                     cancellation_type: self


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Updated api_upstream to the [1.61.0](https://github.com/temporalio/api/releases/tag/v1.61.0) release from temporal/api.
- Adjusted sdk-core code to changes in the protos.

## Why?

Getting latest protos from latest release to leverage them in new features.

## Checklist
1. How was this tested: Unit and integration tests
1. Any docs updates needed? No
