### PR TITLE
Update docker compose to use newer server image

### DIFF
--- a/etc/docker/docker-compose.yaml
+++ b/etc/docker/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
   #      - '9042:9042'
 
   temporal:
-    image: temporalio/auto-setup:1.22.0
+    image: temporalio/temporal:1.5.1
     ports:
       - "7233:7233"
       - "7234:7234"
@@ -26,6 +26,7 @@ services:
       - ../dynamic-config.yaml:/etc/dynamic-config.yaml
     depends_on:
       - cassandra
+    command: ["server", "start-dev"]
 
   temporal-web:
     image: temporalio/ui:2.8.0


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
`temporalio/auto-setup` is being deprecated, replace with `temporalio/temporal`.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
