### PR TITLE
Fix TemporalPatchVersion search attribute type to use KeywordList format

### DIFF
--- a/crates/sdk-core/src/worker/workflow/machines/patch_state_machine.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/patch_state_machine.rs
@@ -141,10 +141,10 @@ pub(super) fn has_change<'a>(
             );
             vec![]
         } else {
-            serialized.metadata.insert(
-                "type".to_string(),
-                "KeywordList".as_bytes().to_vec(),
-            );
+            // "KeywordList" is the expected type for this search attribute
+            serialized
+                .metadata
+                .insert("type".to_string(), "KeywordList".as_bytes().to_vec());
             let indexed_fields = {
                 let mut m = HashMap::new();
                 m.insert(VERSION_SEARCH_ATTR_KEY.to_string(), serialized);

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -508,10 +508,9 @@ async fn v2_and_v3_changes(
                 );
                 if expected_num_cmds == 3 {
                     let mut as_payload = [MY_PATCH_ID].as_json_payload().unwrap();
-                    as_payload.metadata.insert(
-                        "type".to_string(),
-                        "KeywordList".as_bytes().to_vec(),
-                    );
+                    as_payload
+                        .metadata
+                        .insert("type".to_string(), "KeywordList".as_bytes().to_vec());
                     assert_matches!(
                         commands.pop_front().unwrap().attributes.as_ref().unwrap(),
                         Attributes::UpsertWorkflowSearchAttributesCommandAttributes(


### PR DESCRIPTION
## What was changed

#1032 used the wrong string for SA `type` for keyword list, causing some issues in parsing in some SDKs

## Checklist

1. Closes #1105