### PR TITLE
Poller autoscaler: further refinement of backoff on grpc errors

### DIFF
--- a/crates/sdk-core/src/pollers/poll_buffer.rs
+++ b/crates/sdk-core/src/pollers/poll_buffer.rs
@@ -378,7 +378,7 @@ where
                         if let Some(duration) = backoff_duration {
                             // Apply backoff BEFORE dropping active_guard to prevent next poll from starting
                             tokio::select! {
-                                _ = tokio::time::sleep(duration) => (),
+                                _ = tokio::time::sleep(duration) => return,
                                 _ = shutdown_clone.cancelled() => (),
                             };
                         }


### PR DESCRIPTION
## What was changed

- In Poller Autoscaler logic, also apply exponential backoff on `ResourceExhausted` errors in the case where we've never seen a scaling decision from the server.
- In Poller Autoscaler logic, also apply exponential backoff on other grpc errors, with lower parameters.

## Why?

In #1110, we added exponential backoff logic to the poller autoscaller. We however only applied the backoff if we had previously received a scaling decision from the server, and only for `ResourceExhausted` errors.

## How was it tested?

- Added unit tests
- Ran e2e tests locally using the Python SDK
