### PR TITLE
Fix recording workflow termination metrics before receiving server response

### DIFF
--- a/crates/sdk-core/src/pollers/poll_buffer.rs
+++ b/crates/sdk-core/src/pollers/poll_buffer.rs
@@ -800,8 +800,7 @@ mod tests {
     };
     use futures_util::FutureExt;
     use std::time::Duration;
-    use tokio::select;
-    use tokio::sync::Notify;
+    use tokio::{select, sync::Notify};
 
     #[tokio::test]
     async fn only_polls_once_with_1_poller() {

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -163,6 +163,15 @@ pub(crate) struct WorkerTelemetry {
     trace_subscriber: Option<Arc<dyn Subscriber + Send + Sync>>,
 }
 
+impl WorkerTelemetry {
+    pub(crate) fn from_meter(meter: TemporalMeter) -> Self {
+        Self {
+            temporal_metric_meter: Some(meter),
+            trace_subscriber: None,
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl WorkerTrait for Worker {
     async fn validate(&self) -> Result<NamespaceInfo, WorkerValidationError> {

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -41,7 +41,6 @@ use temporalio_common::{
             workflow_completion,
         },
         temporal::api::{
-            command::v1::command::Attributes as CmdAttribs,
             enums::v1::{VersioningBehavior, WorkflowTaskFailedCause},
             failure::v1::Failure,
         },
@@ -443,6 +442,7 @@ impl ManagedRun {
                     action: ActivationAction::RespondLegacyQuery {
                         result: Box::new(qr),
                     },
+                    metrics: self.metrics.clone(),
                 }),
                 resp_chan,
             );
@@ -1130,27 +1130,6 @@ impl ManagedRun {
                 )
             };
 
-            // Record metrics for any outgoing terminal commands
-            for cmd in commands.iter() {
-                match cmd.attributes.as_ref() {
-                    Some(CmdAttribs::CompleteWorkflowExecutionCommandAttributes(_)) => {
-                        self.metrics.wf_completed();
-                    }
-                    Some(CmdAttribs::FailWorkflowExecutionCommandAttributes(attrs)) => {
-                        if metrics::should_record_failure_metric(&attrs.failure) {
-                            self.metrics.wf_failed();
-                        }
-                    }
-                    Some(CmdAttribs::ContinueAsNewWorkflowExecutionCommandAttributes(_)) => {
-                        self.metrics.wf_continued_as_new();
-                    }
-                    Some(CmdAttribs::CancelWorkflowExecutionCommandAttributes(_)) => {
-                        self.metrics.wf_canceled();
-                    }
-                    _ => (),
-                }
-            }
-
             let attempt = self.wft.as_ref().map(|t| t.info.attempt).unwrap_or(1);
             ActivationCompleteOutcome::ReportWFTSuccess(ServerCommandsWithWorkflowInfo {
                 task_token: data.task_token,
@@ -1163,6 +1142,7 @@ impl ManagedRun {
                     versioning_behavior: data.versioning_behavior,
                     attempt,
                 },
+                metrics: self.metrics.clone(),
             })
         } else {
             ActivationCompleteOutcome::DoNothing

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -67,7 +67,15 @@ use temporalio_sdk::{
 };
 use temporalio_sdk_core::{
     CoreRuntime, FixedSizeSlotSupplier, TokioRuntimeBuilder, TunerBuilder, init_worker,
-    telemetry::{WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME, build_otlp_metric_exporter},
+    replay::TestHistoryBuilder,
+    telemetry::{
+        WORKFLOW_TASK_EXECUTION_LATENCY_HISTOGRAM_NAME, build_otlp_metric_exporter,
+        start_prometheus_metric_exporter,
+    },
+    test_help::{
+        MockPollCfg, ResponseType, TemporalMeter, WorkerExt, WorkerTestHelpers, build_mock_pollers,
+        mock_worker, mock_worker_client,
+    },
 };
 use tokio::{join, sync::Barrier};
 use tonic::IntoRequest;
@@ -1470,4 +1478,87 @@ async fn resource_based_tuner_metrics() {
         body.contains("temporal_resource_slots_cpu_pid_output"),
         "CPU PID output metric should be present"
     );
+}
+
+#[tokio::test]
+async fn terminal_metric_not_recorded_on_rejected_completion() {
+    let prom_info = start_prometheus_metric_exporter(
+        PrometheusExporterOptions::builder()
+            .socket_addr(ANY_PORT.parse().unwrap())
+            .build(),
+    )
+    .unwrap();
+    let addr = prom_info.bound_addr;
+    let _abort = prom_info.abort_handle;
+    let meter = TemporalMeter::new(
+        prom_info.meter as Arc<dyn CoreMeter>,
+        NewAttributes { attributes: vec![] },
+        TaskQueueLabelStrategy::UseNormal,
+    );
+
+    // Build a simple workflow history: start + WFT
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(
+        temporalio_common::protos::temporal::api::enums::v1::EventType::WorkflowExecutionStarted,
+    );
+    t.add_workflow_task_scheduled_and_started();
+
+    // First WFT completion is rejected by server, second succeeds
+    let mut call_count = 0;
+    let mut mh = MockPollCfg::from_resp_batches(
+        "fake_wf_id",
+        t,
+        [ResponseType::AllHistory, ResponseType::AllHistory],
+        mock_worker_client(),
+    );
+    mh.completion_mock_fn = Some(Box::new(move |_| {
+        call_count += 1;
+        if call_count == 1 {
+            Err(tonic::Status::not_found("Workflow task not found"))
+        } else {
+            Ok(Default::default())
+        }
+    }));
+
+    let mut mock = build_mock_pollers(mh);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
+    mock.set_temporal_meter(meter);
+    let core = mock_worker(mock);
+
+    // First attempt: get WFT activation and complete the workflow
+    let act = core.poll_workflow_activation().await.unwrap();
+    core.complete_execution(&act.run_id).await;
+
+    // Handle eviction (triggered by NotFound error from server)
+    core.handle_eviction().await;
+
+    // Second attempt (replay after eviction): complete workflow again
+    let act = core.poll_workflow_activation().await.unwrap();
+    core.complete_execution(&act.run_id).await;
+
+    core.drain_pollers_and_shutdown().await;
+
+    // The workflow_completed metric should be recorded exactly once — only for
+    // the successful server response, not for the rejected first attempt.
+    let body = get_text(format!("http://{addr}/metrics")).await;
+    let matching_line = body.lines().find(|l| l.starts_with("workflow_completed{"));
+    match matching_line {
+        Some(line) => {
+            assert!(
+                line.ends_with(" 1"),
+                "Expected workflow_completed count of 1, got: {line}"
+            );
+            assert!(
+                line.contains("workflow_type=\"default_wf_type\""),
+                "Expected workflow_type label on metric, got: {line}"
+            );
+        }
+        None => panic!(
+            "workflow_completed metric not found. Available metrics:\n{}",
+            body.lines()
+                .filter(|l| l.contains("workflow"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+    }
 }


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Title

## Why?
Bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/1084 and https://github.com/temporalio/features/issues/222

2. How was this tested:
Added test / existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
