### PR TITLE
Fix encoding problems in heavy tests

### DIFF
--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -104,6 +104,7 @@ impl WorkflowHistory {
 
 /// A workflow handle which can refer to a specific workflow run, or a chain of workflow runs with
 /// the same workflow id.
+#[derive(Clone)]
 pub struct WorkflowHandle<ClientT, W> {
     client: ClientT,
     info: WorkflowExecutionInfo,


### PR DESCRIPTION
Fixes log spam / slow heavy test that was encountering encoding issues b/c of empty-value signal param