### PR TITLE
chore: exclude github workflows and uml from published crates

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,17 +9,30 @@ homepage = "https://temporal.io/"
 repository = "https://github.com/temporalio/sdk-core"
 keywords = ["temporal", "workflow"]
 categories = ["development-tools"]
+exclude = ["protos/*/.github/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 history_builders = ["rand"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
-prometheus = ["dep:prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tokio"]
+prometheus = [
+  "dep:prometheus",
+  "dep:hyper",
+  "dep:hyper-util",
+  "dep:http-body-util",
+  "dep:tokio",
+]
 envconfig = ["dep:toml", "dep:dirs"]
 serde_serialize = []
 test-utilities = ["history_builders"]
-core-based-sdk = ["otel", "prometheus", "envconfig", "dep:ringbuf", "dep:futures-channel"]
+core-based-sdk = [
+  "otel",
+  "prometheus",
+  "envconfig",
+  "dep:ringbuf",
+  "dep:futures-channel",
+]
 
 [dependencies]
 anyhow = "1.0"
@@ -31,27 +44,29 @@ dirs = { version = "6.0", optional = true }
 derive_more = { workspace = true }
 erased-serde = "0.4"
 futures = "0.3"
-futures-channel = { version = "0.3", default-features = false, features = ["std"], optional = true }
+futures-channel = { version = "0.3", default-features = false, features = [
+  "std",
+], optional = true }
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.7", optional = true }
 hyper-util = { version = "0.1", features = [
-    "server",
-    "http1",
-    "http2",
-    "tokio",
+  "server",
+  "http1",
+  "http2",
+  "tokio",
 ], optional = true }
 opentelemetry = { workspace = true, features = ["metrics"], optional = true }
 opentelemetry_sdk = { version = "0.31", features = [
-    "rt-tokio",
-    "metrics",
-    "spec_unstable_metrics_views",
+  "rt-tokio",
+  "metrics",
+  "spec_unstable_metrics_views",
 ], optional = true }
 opentelemetry-otlp = { version = "0.31", features = [
-    "tokio",
-    "metrics",
-    "tls",
-    "http-proto",
-    "grpc-tonic",
+  "tokio",
+  "metrics",
+  "tls",
+  "http-proto",
+  "grpc-tonic",
 ], optional = true }
 parking_lot = { version = "0.12", features = ["send_guard"] }
 prometheus = { version = "0.14", optional = true }
@@ -70,10 +85,10 @@ tonic-prost = { workspace = true }
 tracing = "0.1"
 # TODO [rust-sdk-branch]: Is it reasonable to make this optional?
 tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "parking_lot",
-    "env-filter",
-    "registry",
-    "ansi",
+  "parking_lot",
+  "env-filter",
+  "registry",
+  "ansi",
 ] }
 tracing-core = "0.1"
 url = "2.5"

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://temporal.io/"
 repository = "https://github.com/temporalio/sdk-core"
 keywords = ["temporal", "workflow"]
 categories = ["development-tools"]
+exclude = ["machine_coverage/*"]
 
 [lib]
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
TSIA, noticed these were ending up in our published crates.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
