### PR TITLE
fix(sdk): provide default worker identity

### DIFF
--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -483,7 +483,7 @@ impl CoreWfStarter {
                 };
                 let mut core_config = self
                     .sdk_config
-                    .to_core_options(client.namespace())
+                    .to_core_options(client.namespace(), client.identity())
                     .expect("sdk config converts to core config");
                 if let Some(ref ccm) = self.core_config_mutator {
                     ccm(&mut core_config);

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0"
 bon = { workspace = true }
 derive_more = { workspace = true }
 futures-util = { version = "0.3", default-features = false }
+gethostname = "1.0.2"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 prost-types = { workspace = true }
 serde = "1.0"
@@ -52,6 +53,7 @@ version = "0.1"
 
 [dev-dependencies]
 futures = "0.3"
+rstest = "0.26"
 
 [features]
 default = []


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Provide a default worker identity when none is present on worker config or connection. This matches the behavior of other SDKs.

## Why?
Match behavior of existing SDKs. Currently if you copy doc example you will hit
https://github.com/temporalio/sdk-core/blob/a0caec4223e473d3a15a5df9ba4007dc87882694/crates/sdk-core/src/lib.rs#L98

A few notes:
 - `temporalio-sdk-core` already has a dependency on `gethostname` so this isn't adding a net new crate dep
 - `to_core_options` is currently public as it is used in test setup for `sdk-core`, I expect we will stop exposing this before the SDK goes public

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added some unit tests to verify the default doesn't override user set values.

3. Any docs updates needed?
No, this fix is so our docs are correct.
