### PR TITLE
Expose continue_as_new_suggested on WorkflowContext

### DIFF
--- a/crates/sdk/src/workflow_context.rs
+++ b/crates/sdk/src/workflow_context.rs
@@ -557,6 +557,11 @@ impl<W> SyncWorkflowContext<W> {
         self.base.inner.shared.borrow().is_replaying
     }
 
+    /// Returns true if the server suggests this workflow should continue-as-new
+    pub fn continue_as_new_suggested(&self) -> bool {
+        self.base.inner.shared.borrow().continue_as_new_suggested
+    }
+
     /// Returns the headers for the current handler invocation (signal, update, query, etc.).
     ///
     /// When called from within a signal handler, returns the headers that were sent with that
@@ -862,6 +867,11 @@ impl<W> WorkflowContext<W> {
         self.sync.is_replaying()
     }
 
+    /// Returns true if the server suggests this workflow should continue-as-new
+    pub fn continue_as_new_suggested(&self) -> bool {
+        self.sync.continue_as_new_suggested()
+    }
+
     /// Returns the headers for the current handler invocation (signal, update, query, etc.).
     pub fn headers(&self) -> &HashMap<String, Payload> {
         self.sync.headers()
@@ -1066,6 +1076,7 @@ pub(crate) struct WorkflowContextSharedData {
     pub(crate) is_replaying: bool,
     pub(crate) wf_time: Option<SystemTime>,
     pub(crate) history_length: u32,
+    pub(crate) continue_as_new_suggested: bool,
     pub(crate) current_deployment_version: Option<WorkerDeploymentVersion>,
     pub(crate) search_attributes: SearchAttributes,
     pub(crate) random_seed: u64,

--- a/crates/sdk/src/workflow_future.rs
+++ b/crates/sdk/src/workflow_future.rs
@@ -444,6 +444,7 @@ impl Future for WorkflowFuture {
                 wlock.is_replaying = activation.is_replaying;
                 wlock.wf_time = activation.timestamp.try_into_or_none();
                 wlock.history_length = activation.history_length;
+                wlock.continue_as_new_suggested = activation.continue_as_new_suggested;
                 wlock.current_deployment_version = activation
                     .deployment_version_for_current_task
                     .map(Into::into);


### PR DESCRIPTION
## Summary
- Plumb `continue_as_new_suggested` flag from workflow activations through to `WorkflowContext`, following the same pattern as `is_replaying` and `history_length`.
- Expose via `SyncWorkflowContext::continue_as_new_suggested()` and `WorkflowContext::continue_as_new_suggested()` so workflow authors can react to the server's suggestion to continue-as-new.
- Add test using `modify_event` to set the flag on a WFT started event and assert it's visible across workflow tasks.

## Test plan
- [ ] `cargo check --tests` passes with no new warnings
- [ ] `continue_as_new_suggested_flag_exposed` test passes against mock history

🤖 Generated with [Claude Code](https://claude.com/claude-code)