### PR TITLE
feat(sdk): add workflow_id and run_id to workflow context

### DIFF
--- a/crates/sdk/src/workflow_context.rs
+++ b/crates/sdk/src/workflow_context.rs
@@ -510,6 +510,16 @@ impl BaseWorkflowContext {
 }
 
 impl<W> SyncWorkflowContext<W> {
+    /// Return the workflow's unique identifier
+    pub fn workflow_id(&self) -> &str {
+        &self.base.inner.inital_information.workflow_id
+    }
+
+    /// Return the run id of this workflow execution
+    pub fn run_id(&self) -> &str {
+        &self.base.inner.run_id
+    }
+
     /// Return the namespace the workflow is executing in
     pub fn namespace(&self) -> &str {
         &self.base.inner.namespace
@@ -824,6 +834,16 @@ impl<W> WorkflowContext<W> {
     }
 
     // --- Delegated methods from SyncWorkflowContext ---
+
+    /// Return the workflow's unique identifier
+    pub fn workflow_id(&self) -> &str {
+        self.sync.workflow_id()
+    }
+
+    /// Return the run id of this workflow execution
+    pub fn run_id(&self) -> &str {
+        self.sync.run_id()
+    }
 
     /// Return the namespace the workflow is executing in
     pub fn namespace(&self) -> &str {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose `run_id` and `workflow_id` on workflow context(s)

## Why?
Match capabilities of other SDKs

Note that for workflow code there are now 2 ways to access `workflow_id`:
 - `ctx.workflow_id()`
 - `ctx.workflow_initial_info().workflow_id`

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-core/issues/629

2. How was this tested:
Simply exposing this information

3. Any docs updates needed?
N/A
