### PR TITLE
fix: evict terminated/timed-out workflows from sticky cache

### DIFF
--- a/crates/sdk-core/src/core_tests/workflow_tasks.rs
+++ b/crates/sdk-core/src/core_tests/workflow_tasks.rs
@@ -3127,3 +3127,46 @@ async fn grpc_message_too_large_doesnt_spam_task_fails() {
     core.drain_pollers_and_shutdown().await;
     // Mock only expects 1 task failure, and would fail here if we spammed
 }
+
+/// When a workflow is terminated by the server while an activity is in-flight, the worker receives
+/// a WFT containing a `WorkflowExecutionTerminated` event. The workflow code never issues a
+/// terminal command, but the run should still be evicted from the sticky cache.
+#[tokio::test]
+async fn terminated_workflow_with_pending_activity_evicts_from_cache() {
+    let wfid = "fake_wf_id";
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    t.add_activity_task_scheduled("act-1");
+    t.add_workflow_execution_terminated();
+
+    let mut mock = single_hist_mock_sg(wfid, t, [ResponseType::AllHistory, ResponseType::AllHistory], mock_worker_client(), false);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 10);
+    let core = mock_worker(mock);
+
+    // First activation: replay from start, lang schedules the activity
+    let activation = core.poll_workflow_activation().await.unwrap();
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+        activation.run_id,
+        vec![ScheduleActivity {
+            seq: 1,
+            activity_id: "act-1".to_string(),
+            ..default_act_sched()
+        }
+        .into()],
+    ))
+    .await
+    .unwrap();
+
+    // The terminated workflow should produce an eviction activation
+    let evict_act = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        evict_act.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
+        }]
+    );
+    core.complete_workflow_activation(WorkflowActivationCompletion::empty(evict_act.run_id))
+        .await
+        .unwrap();
+}

--- a/crates/sdk-core/src/worker/workflow/workflow_stream.rs
+++ b/crates/sdk-core/src/worker/workflow/workflow_stream.rs
@@ -411,6 +411,22 @@ impl WFStream {
                     })
                     .into_run_update_resp()
             }
+            // If the workflow was terminated or timed out by the server, we won't
+            // send a completion (have_seen_terminal_event causes should_respond=false),
+            // but we still need to evict the run from cache.
+            if res.is_none()
+                && rh.have_seen_terminal_event()
+                && !rh.workflow_is_finished()
+            {
+                res = rh
+                    .request_eviction(RequestEvictMsg {
+                        run_id: run_id.to_string(),
+                        message: "Workflow terminated or timed out".to_string(),
+                        reason: EvictionReason::WorkflowExecutionEnding,
+                        auto_reply_fail_tt: None,
+                    })
+                    .into_run_update_resp()
+            }
         }
         res
     }


### PR DESCRIPTION
## Summary

- Terminated and timed-out workflows are never evicted from the sticky cache, causing unbounded cache growth
- When the server terminates a workflow, `have_seen_terminal_event` is set but `workflow_end_time` is never set (because the workflow code never issues a terminal command). The existing eviction check requires both `workflow_is_finished()` (checks `workflow_end_time`) and `WFTReportStatus::Reported` — both are false for terminated workflows.
- Added a second eviction check in `process_post_activation` that fires when `have_seen_terminal_event()` is true but `workflow_is_finished()` is false, covering the termination/timeout case
- Added test `terminated_workflow_with_pending_activity_evicts_from_cache` that verifies the eviction occurs (hangs without the fix)

## Impact

Any workload that terminates workflows at scale (e.g. via `WorkflowIdConflictPolicy.TERMINATE_EXISTING`) will see `temporal_sticky_cache_size` grow unboundedly until LRU eviction kicks in when the cache is full. This causes unnecessary memory pressure on workers.