### PR TITLE
Remove system.enableNexus dynamic config flag

### DIFF
--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -1062,8 +1062,6 @@ pub(crate) fn integ_dev_server_config(
             // TODO: Delete when temporalCLI enables it by default.
             "--dynamic-config-value".to_string(),
             "system.enableEagerWorkflowStart=true".to_string(),
-            "--dynamic-config-value".to_string(),
-            "system.enableNexus=true".to_string(),
             "--dynamic-config-value".to_owned(),
             "frontend.workerVersioningWorkflowAPIs=true".to_owned(),
             "--dynamic-config-value".to_owned(),


### PR DESCRIPTION

## What changed?

Deleted `"system.enableNexus"`.

## Why?

Nexus has been GA since Dec 2024.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
