### PR TITLE
Expose Nexus Endpoint in a Nexus Operation Handler

### DIFF
--- a/crates/common/protos/local/temporal/sdk/core/nexus/nexus.proto
+++ b/crates/common/protos/local/temporal/sdk/core/nexus/nexus.proto
@@ -61,6 +61,9 @@ message NexusTask {
     // Only set when variant is `task` and the header was present with a valid value.
     // Represented as an absolute timestamp.
     google.protobuf.Timestamp request_deadline = 3;
+    // The endpoint this request was addressed to. Extracted from the request for convenient access.
+    // Only set when variant is `task`.
+    string endpoint = 4;
 }
 
 message CancelNexusTask {

--- a/crates/sdk-core/src/worker/nexus.rs
+++ b/crates/sdk-core/src/worker/nexus.rs
@@ -413,6 +413,13 @@ where
                                 }
                             }
 
+                            let endpoint = t
+                                .resp
+                                .request
+                                .as_ref()
+                                .map(|r| r.endpoint.clone())
+                                .unwrap_or_default();
+
                             let (service, operation, request_kind) = t
                                 .resp
                                 .request
@@ -456,6 +463,7 @@ where
                             Some(Ok(NexusTask {
                                 variant: Some(nexus_task::Variant::Task(t.resp)),
                                 request_deadline,
+                                endpoint,
                             }))
                         },
                         Err(e) => Some(Err(PollError::TonicError(e)))
@@ -463,6 +471,7 @@ where
                     TaskStreamInput::Cancel(c) => Some(Ok(NexusTask {
                         variant: Some(nexus_task::Variant::CancelTask(c)),
                         request_deadline: None,
+                        endpoint: String::new(),
                     })),
                     TaskStreamInput::SourceComplete => {
                         source_done.cancel();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose the Nexus Endpoint to the SDK.

## Why?
So the handler knows what endpoint the request originally came from for visibility and per endpoint encryption

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

closes: https://github.com/temporalio/sdk-core/issues/1210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new protobuf field and populates it in the Nexus task stream; while proto field additions are generally compatible, SDKs/bridges must regenerate and handle the new data correctly.
> 
> **Overview**
> Exposes the Nexus request endpoint to language SDK handlers by adding `endpoint` to the `NexusTask` protobuf and wiring it through core when emitting polled tasks.
> 
> Core now extracts `request.endpoint` from `PollNexusTaskQueueResponse` and sets it on emitted `NexusTask`s (leaving cancel notifications with an empty endpoint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa7fa765407d6c77ada7396828cf986e2e8a21d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->