### PR TITLE
chore(ci): bump macos-intel timeout

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -46,7 +46,7 @@ jobs:
   test:
     name: Unit Tests
     # Give extra time to ensure pushes to main have time to populate the cache
-    timeout-minutes: ${{ github.ref == 'refs/heads/master' && 20 || 15 }}
+    timeout-minutes: ${{ matrix.timeoutMinutes || (github.ref == 'refs/heads/master' && 20 || 15) }}
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +60,7 @@ jobs:
             runsOn: macos-14
           - os: macos-intel
             runsOn: macos-15-intel
+            timeoutMinutes: 20
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
TSIA

## Why?
macos-intel runners have become abysmal. Even with Rust cache hits it is taking ~10minutes to just compile the unit tests

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI

3. Any docs updates needed?
N/A
