### PR TITLE
Fix test broken on windows by fake server binding to ipv6

### DIFF
--- a/crates/sdk-core/tests/integ_tests/client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/client_tests.rs
@@ -375,7 +375,7 @@ async fn http_proxy() {
     opts.set_skip_get_system_info(true);
 
     // Connect client with no proxy and make call and confirm reached
-    opts.target = format!("http://127.0.0.1:{}", server.addr.port())
+    opts.target = format!("http://[::1]:{}", server.addr.port())
         .parse()
         .unwrap();
     let connection = Connection::connect(opts.clone()).await.unwrap();


### PR DESCRIPTION
This test got broken by the changes in https://github.com/temporalio/sdk-core/pull/1212 which changed the fake server to bind to ipv6. Windows doesn't have a dual 4/6 stack.