### PR TITLE
💥 feat(sdk): enforce some activity to close timeout is set

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -66,6 +66,7 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "tls-roots",
   "http-proto",
   "grpc-tonic",
+  "reqwest-blocking-client",
   "reqwest-rustls",
 ], optional = true }
 parking_lot = { version = "0.12" }

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -62,6 +62,7 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "tls-roots",
   "http-proto",
   "grpc-tonic",
+  "reqwest-blocking-client",
   "reqwest-rustls",
 ], optional = true }
 parking_lot = { version = "0.12" }

--- a/crates/sdk-core/tests/common/workflows.rs
+++ b/crates/sdk-core/tests/common/workflows.rs
@@ -32,10 +32,7 @@ impl LaProblemWorkflow {
         ctx.start_activity(
             StdActivities::delay,
             Duration::from_secs(15),
-            ActivityOptions {
-                start_to_close_timeout: Some(Duration::from_secs(20)),
-                ..Default::default()
-            },
+            ActivityOptions::start_to_close_timeout(Duration::from_secs(20)),
         )
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk-core/tests/heavy_tests.rs
+++ b/crates/sdk-core/tests/heavy_tests.rs
@@ -60,7 +60,7 @@ impl ActivityLoadWf {
             .start_activity(
                 StdActivities::echo,
                 input_str.clone(),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::Both {
+                ActivityOptions::with_close_timeouts(ActivityCloseTimeouts::Both {
                     start_to_close: Duration::from_secs(8),
                     schedule_to_close: Duration::from_secs(8),
                 })
@@ -129,11 +129,9 @@ impl ChunkyActivityWf {
             .start_activity(
                 ChunkyActivities::chunky_echo,
                 input_str.clone(),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(30),
-                ))
-                .activity_id("act-1".to_string())
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(30))
+                    .activity_id("act-1".to_string())
+                    .build(),
             )
             .await?;
         assert_eq!(res, input_str);

--- a/crates/sdk-core/tests/heavy_tests.rs
+++ b/crates/sdk-core/tests/heavy_tests.rs
@@ -60,16 +60,15 @@ impl ActivityLoadWf {
             .start_activity(
                 StdActivities::echo,
                 input_str.clone(),
-                ActivityOptions {
-                    activity_id: Some("act-1".to_string()),
-                    task_queue: Some(tq),
-                    schedule_to_start_timeout: Some(Duration::from_secs(8)),
-                    start_to_close_timeout: Some(Duration::from_secs(8)),
-                    schedule_to_close_timeout: Some(Duration::from_secs(8)),
-                    heartbeat_timeout: Some(Duration::from_secs(8)),
-                    cancellation_type: ActivityCancellationType::TryCancel,
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .activity_id("act-1".to_string())
+                    .task_queue(tq)
+                    .schedule_to_start_timeout(Duration::from_secs(8))
+                    .start_to_close_timeout(Duration::from_secs(8))
+                    .schedule_to_close_timeout(Duration::from_secs(8))
+                    .heartbeat_timeout(Duration::from_secs(8))
+                    .cancellation_type(ActivityCancellationType::TryCancel)
+                    .build(),
             )
             .await?;
         assert_eq!(res, input_str);
@@ -129,11 +128,10 @@ impl ChunkyActivityWf {
             .start_activity(
                 ChunkyActivities::chunky_echo,
                 input_str.clone(),
-                ActivityOptions {
-                    activity_id: Some("act-1".to_string()),
-                    start_to_close_timeout: Some(Duration::from_secs(30)),
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .activity_id("act-1".to_string())
+                    .start_to_close_timeout(Duration::from_secs(30))
+                    .build(),
             )
             .await?;
         assert_eq!(res, input_str);
@@ -222,10 +220,7 @@ impl WorkflowLoadWf {
                 .start_activity(
                     StdActivities::echo,
                     "hi!".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
                 .await;
             ctx.timer(Duration::from_secs(1)).await;
@@ -439,10 +434,7 @@ impl PollerLoadWf {
                 .start_activity(
                     JitteryActivities::jittery_echo,
                     "hi!".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
                 .await;
         }

--- a/crates/sdk-core/tests/heavy_tests.rs
+++ b/crates/sdk-core/tests/heavy_tests.rs
@@ -39,7 +39,7 @@ use temporalio_common::{
     worker::WorkerTaskTypes,
 };
 use temporalio_sdk::{
-    ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    ActivityCloseTimeouts, ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
     workflows,
 };
@@ -60,15 +60,16 @@ impl ActivityLoadWf {
             .start_activity(
                 StdActivities::echo,
                 input_str.clone(),
-                ActivityOptions::builder()
-                    .activity_id("act-1".to_string())
-                    .task_queue(tq)
-                    .schedule_to_start_timeout(Duration::from_secs(8))
-                    .start_to_close_timeout(Duration::from_secs(8))
-                    .schedule_to_close_timeout(Duration::from_secs(8))
-                    .heartbeat_timeout(Duration::from_secs(8))
-                    .cancellation_type(ActivityCancellationType::TryCancel)
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::Both {
+                    start_to_close: Duration::from_secs(8),
+                    schedule_to_close: Duration::from_secs(8),
+                })
+                .activity_id("act-1".to_string())
+                .task_queue(tq)
+                .schedule_to_start_timeout(Duration::from_secs(8))
+                .heartbeat_timeout(Duration::from_secs(8))
+                .cancellation_type(ActivityCancellationType::TryCancel)
+                .build(),
             )
             .await?;
         assert_eq!(res, input_str);
@@ -128,10 +129,11 @@ impl ChunkyActivityWf {
             .start_activity(
                 ChunkyActivities::chunky_echo,
                 input_str.clone(),
-                ActivityOptions::builder()
-                    .activity_id("act-1".to_string())
-                    .start_to_close_timeout(Duration::from_secs(30))
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(30),
+                ))
+                .activity_id("act-1".to_string())
+                .build(),
             )
             .await?;
         assert_eq!(res, input_str);

--- a/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
+++ b/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
@@ -54,10 +54,7 @@ impl FuzzyWf {
                     .start_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
-                        ActivityOptions {
-                            start_to_close_timeout: Some(Duration::from_secs(5)),
-                            ..Default::default()
-                        },
+                        ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                     )
                     .await;
             }

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -11,7 +11,8 @@ use temporalio_common::protos::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityExecutionError, ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
+    ActivityCloseTimeouts, ActivityExecutionError, ActivityOptions, CancellableFuture,
+    WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 use tokio::sync::mpsc;
@@ -110,14 +111,15 @@ async fn async_activity_completions(
             let activity_future = ctx.start_activity(
                 AsyncActivities::complete_async_activity,
                 expected_outcome,
-                ActivityOptions::builder()
-                    .start_to_close_timeout(Duration::from_secs(30))
-                    .retry_policy(RetryPolicy {
-                        maximum_attempts: 1,
-                        ..Default::default()
-                    })
-                    .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(30),
+                ))
+                .retry_policy(RetryPolicy {
+                    maximum_attempts: 1,
+                    ..Default::default()
+                })
+                .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
+                .build(),
             );
 
             // For cancellation, wait a bit to let the activity start, then request cancel

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -11,8 +11,7 @@ use temporalio_common::protos::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityExecutionError, ActivityOptions, CancellableFuture,
-    WorkflowContext, WorkflowResult,
+    ActivityExecutionError, ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 use tokio::sync::mpsc;
@@ -111,15 +110,13 @@ async fn async_activity_completions(
             let activity_future = ctx.start_activity(
                 AsyncActivities::complete_async_activity,
                 expected_outcome,
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(30),
-                ))
-                .retry_policy(RetryPolicy {
-                    maximum_attempts: 1,
-                    ..Default::default()
-                })
-                .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(30))
+                    .retry_policy(RetryPolicy {
+                        maximum_attempts: 1,
+                        ..Default::default()
+                    })
+                    .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
+                    .build(),
             );
 
             // For cancellation, wait a bit to let the activity start, then request cancel

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -110,15 +110,14 @@ async fn async_activity_completions(
             let activity_future = ctx.start_activity(
                 AsyncActivities::complete_async_activity,
                 expected_outcome,
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(30)),
-                    retry_policy: Some(RetryPolicy {
+                ActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(30))
+                    .retry_policy(RetryPolicy {
                         maximum_attempts: 1,
                         ..Default::default()
-                    }),
-                    cancellation_type: ActivityCancellationType::WaitCancellationCompleted,
-                    ..Default::default()
-                },
+                    })
+                    .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
+                    .build(),
             );
 
             // For cancellation, wait a bit to let the activity start, then request cancel

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -105,10 +105,7 @@ impl DataConverterTestWorkflow {
             .start_activity(
                 TestActivities::process_tracked,
                 input,
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -132,10 +129,7 @@ impl DescribeDataConverterWorkflow {
             .start_activity(
                 TestActivities::process_tracked,
                 input,
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
@@ -42,15 +42,14 @@ impl ActivityDoesntHeartbeatHitsTimeoutThenCompletesWf {
             .start_activity(
                 StdActivities::delay,
                 Duration::from_secs(4),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(10)),
-                    heartbeat_timeout: Some(Duration::from_secs(2)),
-                    retry_policy: Some(RetryPolicy {
+                ActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(10))
+                    .heartbeat_timeout(Duration::from_secs(2))
+                    .retry_policy(RetryPolicy {
                         maximum_attempts: 1,
                         ..Default::default()
-                    }),
-                    ..Default::default()
-                },
+                    })
+                    .build(),
             )
             .await;
         let err = res.unwrap_err();

--- a/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
@@ -26,7 +26,9 @@ use temporalio_common::{
     },
 };
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{ActivityExecutionError, ActivityOptions, WorkflowContext, WorkflowResult};
+use temporalio_sdk::{
+    ActivityCloseTimeouts, ActivityExecutionError, ActivityOptions, WorkflowContext, WorkflowResult,
+};
 use temporalio_sdk_core::test_help::{WorkerTestHelpers, drain_pollers_and_shutdown};
 use tokio::time::sleep;
 
@@ -42,14 +44,15 @@ impl ActivityDoesntHeartbeatHitsTimeoutThenCompletesWf {
             .start_activity(
                 StdActivities::delay,
                 Duration::from_secs(4),
-                ActivityOptions::builder()
-                    .start_to_close_timeout(Duration::from_secs(10))
-                    .heartbeat_timeout(Duration::from_secs(2))
-                    .retry_policy(RetryPolicy {
-                        maximum_attempts: 1,
-                        ..Default::default()
-                    })
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(10),
+                ))
+                .heartbeat_timeout(Duration::from_secs(2))
+                .retry_policy(RetryPolicy {
+                    maximum_attempts: 1,
+                    ..Default::default()
+                })
+                .build(),
             )
             .await;
         let err = res.unwrap_err();

--- a/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
@@ -26,9 +26,7 @@ use temporalio_common::{
     },
 };
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityExecutionError, ActivityOptions, WorkflowContext, WorkflowResult,
-};
+use temporalio_sdk::{ActivityExecutionError, ActivityOptions, WorkflowContext, WorkflowResult};
 use temporalio_sdk_core::test_help::{WorkerTestHelpers, drain_pollers_and_shutdown};
 use tokio::time::sleep;
 
@@ -44,15 +42,13 @@ impl ActivityDoesntHeartbeatHitsTimeoutThenCompletesWf {
             .start_activity(
                 StdActivities::delay,
                 Duration::from_secs(4),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(10),
-                ))
-                .heartbeat_timeout(Duration::from_secs(2))
-                .retry_policy(RetryPolicy {
-                    maximum_attempts: 1,
-                    ..Default::default()
-                })
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(10))
+                    .heartbeat_timeout(Duration::from_secs(2))
+                    .retry_policy(RetryPolicy {
+                        maximum_attempts: 1,
+                        ..Default::default()
+                    })
+                    .build(),
             )
             .await;
         let err = res.unwrap_err();

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -857,22 +857,18 @@ async fn activity_metrics() {
             let normal_act_pass = ctx.start_activity(
                 PassFailActivities::pass_fail_act,
                 "pass".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(1)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(1)),
             );
             let normal_act_fail = ctx.start_activity(
                 PassFailActivities::pass_fail_act,
                 "fail".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(1)),
-                    retry_policy: Some(RetryPolicy {
+                ActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(1))
+                    .retry_policy(RetryPolicy {
                         maximum_attempts: 1,
                         ..Default::default()
-                    }),
-                    ..Default::default()
-                },
+                    })
+                    .build(),
             );
             let _ = join!(normal_act_pass, normal_act_fail);
             let local_act_pass = ctx.start_local_activity(

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -65,8 +65,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityOptions, CancellableFuture, LocalActivityOptions,
-    NexusOperationOptions, WorkflowContext, WorkflowResult,
+    ActivityOptions, CancellableFuture, LocalActivityOptions, NexusOperationOptions,
+    WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::{
@@ -862,14 +862,12 @@ async fn activity_metrics() {
             let normal_act_fail = ctx.start_activity(
                 PassFailActivities::pass_fail_act,
                 "fail".to_string(),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(1),
-                ))
-                .retry_policy(RetryPolicy {
-                    maximum_attempts: 1,
-                    ..Default::default()
-                })
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(1))
+                    .retry_policy(RetryPolicy {
+                        maximum_attempts: 1,
+                        ..Default::default()
+                    })
+                    .build(),
             );
             let _ = join!(normal_act_pass, normal_act_fail);
             let local_act_pass = ctx.start_local_activity(

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -65,8 +65,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, CancellableFuture, LocalActivityOptions, NexusOperationOptions,
-    WorkflowContext, WorkflowResult,
+    ActivityCloseTimeouts, ActivityOptions, CancellableFuture, LocalActivityOptions,
+    NexusOperationOptions, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::{
@@ -862,13 +862,14 @@ async fn activity_metrics() {
             let normal_act_fail = ctx.start_activity(
                 PassFailActivities::pass_fail_act,
                 "fail".to_string(),
-                ActivityOptions::builder()
-                    .start_to_close_timeout(Duration::from_secs(1))
-                    .retry_policy(RetryPolicy {
-                        maximum_attempts: 1,
-                        ..Default::default()
-                    })
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(1),
+                ))
+                .retry_policy(RetryPolicy {
+                    maximum_attempts: 1,
+                    ..Default::default()
+                })
+                .build(),
             );
             let _ = join!(normal_act_pass, normal_act_fail);
             let local_act_pass = ctx.start_local_activity(

--- a/crates/sdk-core/tests/integ_tests/polling_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/polling_tests.rs
@@ -265,10 +265,7 @@ impl OnlyOneWorkflowSlotAndTwoPollers {
                 .start_activity(
                     StdActivities::echo,
                     "hi!".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
                 .await;
         }

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -1119,10 +1119,7 @@ async fn worker_restarted_in_middle_of_update() {
             ctx.start_activity(
                 BlockingActivities::blocks,
                 "hi!".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(2)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
             )
             .await?;
             Ok(())
@@ -1223,10 +1220,7 @@ async fn update_after_empty_wft() {
                     .start_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
-                        ActivityOptions {
-                            start_to_close_timeout: Some(Duration::from_secs(2)),
-                            ..Default::default()
-                        },
+                        ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
                     )
                     .await;
                 ACT_STARTED.store(false, Ordering::Release);
@@ -1251,10 +1245,7 @@ async fn update_after_empty_wft() {
                 .start_activity(
                     StdActivities::echo,
                     "hi!".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(2)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
                 )
                 .await;
         }
@@ -1324,10 +1315,7 @@ async fn update_lost_on_activity_mismatch() {
                     .start_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
-                        ActivityOptions {
-                            start_to_close_timeout: Some(Duration::from_secs(2)),
-                            ..Default::default()
-                        },
+                        ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
                     )
                     .await;
                 ctx.state_mut(|s| s.can_run -= 1);

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -35,7 +35,7 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    ActivityCloseTimeouts, ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::{
@@ -896,15 +896,16 @@ async fn worker_heartbeat_failure_metrics() {
                 .start_activity(
                     FailingActivities::failing_act,
                     "boom".to_string(),
-                    ActivityOptions::builder()
-                        .start_to_close_timeout(Duration::from_secs(5))
-                        .retry_policy(RetryPolicy {
-                            initial_interval: Some(prost_dur!(from_millis(10))),
-                            backoff_coefficient: 1.0,
-                            maximum_attempts: 4,
-                            ..Default::default()
-                        })
-                        .build(),
+                    ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                        Duration::from_secs(5),
+                    ))
+                    .retry_policy(RetryPolicy {
+                        initial_interval: Some(prost_dur!(from_millis(10))),
+                        backoff_coefficient: 1.0,
+                        maximum_attempts: 4,
+                        ..Default::default()
+                    })
+                    .build(),
                 )
                 .await;
 

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -35,7 +35,7 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::{
@@ -896,16 +896,14 @@ async fn worker_heartbeat_failure_metrics() {
                 .start_activity(
                     FailingActivities::failing_act,
                     "boom".to_string(),
-                    ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                        Duration::from_secs(5),
-                    ))
-                    .retry_policy(RetryPolicy {
-                        initial_interval: Some(prost_dur!(from_millis(10))),
-                        backoff_coefficient: 1.0,
-                        maximum_attempts: 4,
-                        ..Default::default()
-                    })
-                    .build(),
+                    ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                        .retry_policy(RetryPolicy {
+                            initial_interval: Some(prost_dur!(from_millis(10))),
+                            backoff_coefficient: 1.0,
+                            maximum_attempts: 4,
+                            ..Default::default()
+                        })
+                        .build(),
                 )
                 .await;
 

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -203,10 +203,7 @@ async fn docker_worker_heartbeat_basic(#[values("otel", "prom", "no_metrics")] b
                 .start_activity(
                     NotifyActivities::pass_fail_act,
                     "pass".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
                 .await;
             Ok(())
@@ -356,10 +353,7 @@ async fn docker_worker_heartbeat_tuner() {
                 .start_activity(
                     StdActivities::echo,
                     "pass".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(1)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(1)),
                 )
                 .await;
             Ok(())
@@ -661,10 +655,7 @@ async fn worker_heartbeat_sticky_cache_miss() {
                 .start_activity(
                     StickyCacheActivities::sticky_cache_history_act,
                     wf_marker.clone(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
                 .await;
 
@@ -905,16 +896,15 @@ async fn worker_heartbeat_failure_metrics() {
                 .start_activity(
                     FailingActivities::failing_act,
                     "boom".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        retry_policy: Some(RetryPolicy {
+                    ActivityOptions::builder()
+                        .start_to_close_timeout(Duration::from_secs(5))
+                        .retry_policy(RetryPolicy {
                             initial_interval: Some(prost_dur!(from_millis(10))),
                             backoff_coefficient: 1.0,
                             maximum_attempts: 4,
                             ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
+                        })
+                        .build(),
                 )
                 .await;
 
@@ -1048,10 +1038,7 @@ async fn worker_heartbeat_no_runtime_heartbeat() {
                 .start_activity(
                     StdActivities::echo,
                     "pass".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(1)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(1)),
                 )
                 .await;
             Ok(())
@@ -1121,10 +1108,7 @@ async fn worker_heartbeat_skip_client_worker_set_check() {
                 .start_activity(
                     StdActivities::echo,
                     "pass".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(1)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(1)),
                 )
                 .await;
             Ok(())

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -414,10 +414,10 @@ async fn activity_tasks_from_completion_reserve_slots() {
     impl ActivityTasksCompletionWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(FakeAct::act1, (), ActivityOptions::default())
+            ctx.start_activity(FakeAct::act1, (), ActivityOptions::builder().build())
                 .await
                 .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
-            ctx.start_activity(FakeAct::act2, (), ActivityOptions::default())
+            ctx.start_activity(FakeAct::act2, (), ActivityOptions::builder().build())
                 .await
                 .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
             ctx.state(|wf| wf.complete_token.cancel());
@@ -782,10 +782,7 @@ async fn test_custom_slot_supplier_simple() {
                 .start_activity(
                     StdActivities::no_op,
                     (),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(10)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
                 )
                 .await;
             let _result = ctx

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -414,12 +414,20 @@ async fn activity_tasks_from_completion_reserve_slots() {
     impl ActivityTasksCompletionWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(FakeAct::act1, (), ActivityOptions::builder().build())
-                .await
-                .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
-            ctx.start_activity(FakeAct::act2, (), ActivityOptions::builder().build())
-                .await
-                .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            ctx.start_activity(
+                FakeAct::act1,
+                (),
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+            )
+            .await
+            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            ctx.start_activity(
+                FakeAct::act2,
+                (),
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+            )
+            .await
+            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
             ctx.state(|wf| wf.complete_token.cancel());
             Ok(())
         }

--- a/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
@@ -300,10 +300,7 @@ impl ActivityHasDeploymentStampWf {
             .start_activity(
                 StdActivities::echo,
                 "hi!".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await;
         Ok(())

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -504,10 +504,7 @@ impl SlowCompletesWf {
             ctx.start_activity(
                 StdActivities::echo,
                 "hi!".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -883,10 +880,7 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
             ctx.start_activity(
                 StdActivities::echo,
                 "hi".to_owned(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -968,10 +962,7 @@ async fn history_out_of_order_on_restart() {
             ctx.start_activity(
                 StdActivities::echo,
                 "hi".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -1004,10 +995,7 @@ async fn history_out_of_order_on_restart() {
             ctx.start_activity(
                 StdActivities::echo,
                 "hi".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -46,7 +46,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult, WorkflowTermination,
+    ActivityCloseTimeouts, ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
+    WorkflowTermination,
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::{
@@ -957,10 +958,11 @@ impl OneActivityAbandonCancelledBeforeStarted {
         let act_fut = ctx.start_activity(
             StdActivities::delay,
             Duration::from_secs(2),
-            ActivityOptions::builder()
-                .start_to_close_timeout(Duration::from_secs(5))
-                .cancellation_type(ActivityCancellationType::Abandon)
-                .build(),
+            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                Duration::from_secs(5),
+            ))
+            .cancellation_type(ActivityCancellationType::Abandon)
+            .build(),
         );
         act_fut.cancel();
         let _ = act_fut.await;
@@ -1002,10 +1004,11 @@ impl OneActivityAbandonCancelledAfterComplete {
         let act_fut = ctx.start_activity(
             StdActivities::delay,
             Duration::from_secs(2),
-            ActivityOptions::builder()
-                .start_to_close_timeout(Duration::from_secs(5))
-                .cancellation_type(ActivityCancellationType::Abandon)
-                .build(),
+            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                Duration::from_secs(5),
+            ))
+            .cancellation_type(ActivityCancellationType::Abandon)
+            .build(),
         );
         ctx.timer(Duration::from_secs(1)).await;
         act_fut.cancel();
@@ -1086,14 +1089,15 @@ async fn graceful_shutdown() {
                 ctx.start_activity(
                     SleeperActivities::sleeper,
                     "hi".to_string(),
-                    ActivityOptions::builder()
-                        .start_to_close_timeout(Duration::from_secs(5))
-                        .retry_policy(RetryPolicy {
-                            maximum_attempts: 1,
-                            ..Default::default()
-                        })
-                        .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
-                        .build(),
+                    ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                        Duration::from_secs(5),
+                    ))
+                    .retry_policy(RetryPolicy {
+                        maximum_attempts: 1,
+                        ..Default::default()
+                    })
+                    .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
+                    .build(),
                 )
             });
             temporalio_sdk::workflows::join_all(act_futs).await;
@@ -1179,13 +1183,14 @@ async fn activity_can_be_cancelled_by_local_timeout() {
                 .start_activity(
                     CancellableEchoActivities::cancellable_echo,
                     "hi!".to_string(),
-                    ActivityOptions::builder()
-                        .start_to_close_timeout(Duration::from_secs(1))
-                        .retry_policy(RetryPolicy {
-                            maximum_attempts: 1,
-                            ..Default::default()
-                        })
-                        .build(),
+                    ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                        Duration::from_secs(1),
+                    ))
+                    .retry_policy(RetryPolicy {
+                        maximum_attempts: 1,
+                        ..Default::default()
+                    })
+                    .build(),
                 )
                 .await;
             assert!(res.is_err_and(|e| e.is_timeout()));
@@ -1244,13 +1249,14 @@ async fn long_activity_timeout_repro() {
                     .start_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
-                        ActivityOptions::builder()
-                            .start_to_close_timeout(Duration::from_secs(1))
-                            .retry_policy(RetryPolicy {
-                                maximum_attempts: 1,
-                                ..Default::default()
-                            })
-                            .build(),
+                        ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                            Duration::from_secs(1),
+                        ))
+                        .retry_policy(RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        })
+                        .build(),
                     )
                     .await;
                 assert!(res.is_ok());
@@ -1311,9 +1317,11 @@ async fn pass_activity_summary_to_metadata() {
             ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions::builder()
-                    .summary("activity summary".to_string())
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(5),
+                ))
+                .summary("activity summary".to_string())
+                .build(),
             )
             .await
             .map_err(|e| anyhow!("{e}"))?;
@@ -1373,10 +1381,11 @@ async fn abandoned_activities_ignore_start_and_complete(hist_batches: &'static [
             let act_fut = ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions::builder()
-                    .start_to_close_timeout(Duration::from_secs(5))
-                    .cancellation_type(ActivityCancellationType::Abandon)
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(5),
+                ))
+                .cancellation_type(ActivityCancellationType::Abandon)
+                .build(),
             );
             ctx.timer(Duration::from_secs(1)).await;
             act_fut.cancel();
@@ -1410,7 +1419,7 @@ impl ImmediateActivityCancelationWorkflow {
         let cancel_activity_future = ctx.start_activity(
             StdActivities::default,
             (),
-            ActivityOptions::builder().build(),
+            ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
         );
         cancel_activity_future.cancel();
         let _ = cancel_activity_future.await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -46,8 +46,7 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
-    WorkflowTermination,
+    ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult, WorkflowTermination,
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::{
@@ -958,11 +957,9 @@ impl OneActivityAbandonCancelledBeforeStarted {
         let act_fut = ctx.start_activity(
             StdActivities::delay,
             Duration::from_secs(2),
-            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                Duration::from_secs(5),
-            ))
-            .cancellation_type(ActivityCancellationType::Abandon)
-            .build(),
+            ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                .cancellation_type(ActivityCancellationType::Abandon)
+                .build(),
         );
         act_fut.cancel();
         let _ = act_fut.await;
@@ -1004,11 +1001,9 @@ impl OneActivityAbandonCancelledAfterComplete {
         let act_fut = ctx.start_activity(
             StdActivities::delay,
             Duration::from_secs(2),
-            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                Duration::from_secs(5),
-            ))
-            .cancellation_type(ActivityCancellationType::Abandon)
-            .build(),
+            ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                .cancellation_type(ActivityCancellationType::Abandon)
+                .build(),
         );
         ctx.timer(Duration::from_secs(1)).await;
         act_fut.cancel();
@@ -1089,15 +1084,13 @@ async fn graceful_shutdown() {
                 ctx.start_activity(
                     SleeperActivities::sleeper,
                     "hi".to_string(),
-                    ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                        Duration::from_secs(5),
-                    ))
-                    .retry_policy(RetryPolicy {
-                        maximum_attempts: 1,
-                        ..Default::default()
-                    })
-                    .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
-                    .build(),
+                    ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                        .retry_policy(RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        })
+                        .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
+                        .build(),
                 )
             });
             temporalio_sdk::workflows::join_all(act_futs).await;
@@ -1183,14 +1176,12 @@ async fn activity_can_be_cancelled_by_local_timeout() {
                 .start_activity(
                     CancellableEchoActivities::cancellable_echo,
                     "hi!".to_string(),
-                    ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                        Duration::from_secs(1),
-                    ))
-                    .retry_policy(RetryPolicy {
-                        maximum_attempts: 1,
-                        ..Default::default()
-                    })
-                    .build(),
+                    ActivityOptions::with_start_to_close_timeout(Duration::from_secs(1))
+                        .retry_policy(RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        })
+                        .build(),
                 )
                 .await;
             assert!(res.is_err_and(|e| e.is_timeout()));
@@ -1249,14 +1240,12 @@ async fn long_activity_timeout_repro() {
                     .start_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
-                        ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                            Duration::from_secs(1),
-                        ))
-                        .retry_policy(RetryPolicy {
-                            maximum_attempts: 1,
-                            ..Default::default()
-                        })
-                        .build(),
+                        ActivityOptions::with_start_to_close_timeout(Duration::from_secs(1))
+                            .retry_policy(RetryPolicy {
+                                maximum_attempts: 1,
+                                ..Default::default()
+                            })
+                            .build(),
                     )
                     .await;
                 assert!(res.is_ok());
@@ -1317,11 +1306,9 @@ async fn pass_activity_summary_to_metadata() {
             ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(5),
-                ))
-                .summary("activity summary".to_string())
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                    .summary("activity summary".to_string())
+                    .build(),
             )
             .await
             .map_err(|e| anyhow!("{e}"))?;
@@ -1381,11 +1368,9 @@ async fn abandoned_activities_ignore_start_and_complete(hist_batches: &'static [
             let act_fut = ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(5),
-                ))
-                .cancellation_type(ActivityCancellationType::Abandon)
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                    .cancellation_type(ActivityCancellationType::Abandon)
+                    .build(),
             );
             ctx.timer(Duration::from_secs(1)).await;
             act_fut.cancel();

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -70,10 +70,7 @@ impl OneActivityWorkflow {
             .start_activity(
                 StdActivities::echo,
                 input,
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await
             .map_err(|e| anyhow!("{e}"))?;
@@ -93,10 +90,7 @@ impl MultiArgActivityWorkflow {
             .start_activity(
                 StdActivities::concat,
                 (input, " world".to_string()),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await
             .map_err(|e| anyhow!("{e}"))?;
@@ -963,11 +957,10 @@ impl OneActivityAbandonCancelledBeforeStarted {
         let act_fut = ctx.start_activity(
             StdActivities::delay,
             Duration::from_secs(2),
-            ActivityOptions {
-                start_to_close_timeout: Some(Duration::from_secs(5)),
-                cancellation_type: ActivityCancellationType::Abandon,
-                ..Default::default()
-            },
+            ActivityOptions::builder()
+                .start_to_close_timeout(Duration::from_secs(5))
+                .cancellation_type(ActivityCancellationType::Abandon)
+                .build(),
         );
         act_fut.cancel();
         let _ = act_fut.await;
@@ -1009,11 +1002,10 @@ impl OneActivityAbandonCancelledAfterComplete {
         let act_fut = ctx.start_activity(
             StdActivities::delay,
             Duration::from_secs(2),
-            ActivityOptions {
-                start_to_close_timeout: Some(Duration::from_secs(5)),
-                cancellation_type: ActivityCancellationType::Abandon,
-                ..Default::default()
-            },
+            ActivityOptions::builder()
+                .start_to_close_timeout(Duration::from_secs(5))
+                .cancellation_type(ActivityCancellationType::Abandon)
+                .build(),
         );
         ctx.timer(Duration::from_secs(1)).await;
         act_fut.cancel();
@@ -1094,15 +1086,14 @@ async fn graceful_shutdown() {
                 ctx.start_activity(
                     SleeperActivities::sleeper,
                     "hi".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        retry_policy: Some(RetryPolicy {
+                    ActivityOptions::builder()
+                        .start_to_close_timeout(Duration::from_secs(5))
+                        .retry_policy(RetryPolicy {
                             maximum_attempts: 1,
                             ..Default::default()
-                        }),
-                        cancellation_type: ActivityCancellationType::WaitCancellationCompleted,
-                        ..Default::default()
-                    },
+                        })
+                        .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
+                        .build(),
                 )
             });
             temporalio_sdk::workflows::join_all(act_futs).await;
@@ -1188,14 +1179,13 @@ async fn activity_can_be_cancelled_by_local_timeout() {
                 .start_activity(
                     CancellableEchoActivities::cancellable_echo,
                     "hi!".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(1)),
-                        retry_policy: Some(RetryPolicy {
+                    ActivityOptions::builder()
+                        .start_to_close_timeout(Duration::from_secs(1))
+                        .retry_policy(RetryPolicy {
                             maximum_attempts: 1,
                             ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
+                        })
+                        .build(),
                 )
                 .await;
             assert!(res.is_err_and(|e| e.is_timeout()));
@@ -1254,14 +1244,13 @@ async fn long_activity_timeout_repro() {
                     .start_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
-                        ActivityOptions {
-                            start_to_close_timeout: Some(Duration::from_secs(1)),
-                            retry_policy: Some(RetryPolicy {
+                        ActivityOptions::builder()
+                            .start_to_close_timeout(Duration::from_secs(1))
+                            .retry_policy(RetryPolicy {
                                 maximum_attempts: 1,
                                 ..Default::default()
-                            }),
-                            ..Default::default()
-                        },
+                            })
+                            .build(),
                     )
                     .await;
                 assert!(res.is_ok());
@@ -1322,10 +1311,9 @@ async fn pass_activity_summary_to_metadata() {
             ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions {
-                    summary: Some("activity summary".to_string()),
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .summary("activity summary".to_string())
+                    .build(),
             )
             .await
             .map_err(|e| anyhow!("{e}"))?;
@@ -1385,11 +1373,10 @@ async fn abandoned_activities_ignore_start_and_complete(hist_batches: &'static [
             let act_fut = ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    cancellation_type: ActivityCancellationType::Abandon,
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(5))
+                    .cancellation_type(ActivityCancellationType::Abandon)
+                    .build(),
             );
             ctx.timer(Duration::from_secs(1)).await;
             act_fut.cancel();
@@ -1420,8 +1407,11 @@ struct ImmediateActivityCancelationWorkflow;
 impl ImmediateActivityCancelationWorkflow {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        let cancel_activity_future =
-            ctx.start_activity(StdActivities::default, (), ActivityOptions::default());
+        let cancel_activity_future = ctx.start_activity(
+            StdActivities::default,
+            (),
+            ActivityOptions::builder().build(),
+        );
         cancel_activity_future.cancel();
         let _ = cancel_activity_future.await;
         Ok(())

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -26,8 +26,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityOptions, ChildWorkflowOptions, LocalActivityOptions,
-    WorkflowContext, WorkflowResult, workflows,
+    ActivityOptions, ChildWorkflowOptions, LocalActivityOptions, WorkflowContext, WorkflowResult,
+    workflows,
 };
 use temporalio_sdk_core::{
     replay::DEFAULT_WORKFLOW_TYPE,
@@ -302,11 +302,9 @@ impl ActivityIdOrTypeChangeWf {
             ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(5),
-                ))
-                .activity_id("I'm bad and wrong!".to_string())
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                    .activity_id("I'm bad and wrong!".to_string())
+                    .build(),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -26,8 +26,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, ChildWorkflowOptions, LocalActivityOptions, WorkflowContext, WorkflowResult,
-    workflows,
+    ActivityCloseTimeouts, ActivityOptions, ChildWorkflowOptions, LocalActivityOptions,
+    WorkflowContext, WorkflowResult, workflows,
 };
 use temporalio_sdk_core::{
     replay::DEFAULT_WORKFLOW_TYPE,
@@ -56,7 +56,7 @@ impl TimerWfNondeterministic {
                 ctx.start_activity(
                     StdActivities::default,
                     (),
-                    ActivityOptions::builder().build(),
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -302,16 +302,22 @@ impl ActivityIdOrTypeChangeWf {
             ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions::builder()
-                    .activity_id("I'm bad and wrong!".to_string())
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(5),
+                ))
+                .activity_id("I'm bad and wrong!".to_string())
+                .build(),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         } else {
-            ctx.start_activity(StdActivities::no_op, (), ActivityOptions::builder().build())
-                .await
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            ctx.start_activity(
+                StdActivities::no_op,
+                (),
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
         }
         Ok(())
     }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -53,9 +53,13 @@ impl TimerWfNondeterministic {
                 }
             }
             2 => {
-                ctx.start_activity(StdActivities::default, (), ActivityOptions::default())
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                ctx.start_activity(
+                    StdActivities::default,
+                    (),
+                    ActivityOptions::builder().build(),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
             _ => panic!("Ran too many times"),
         }
@@ -104,10 +108,7 @@ impl TaskFailReplayWf {
             .start_activity(
                 StdActivities::echo,
                 "hi!".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(2)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
             )
             .await;
         if !ctx.state(|wf| wf.did_fail.load(Ordering::Relaxed)) {
@@ -301,15 +302,14 @@ impl ActivityIdOrTypeChangeWf {
             ctx.start_activity(
                 StdActivities::default,
                 (),
-                ActivityOptions {
-                    activity_id: Some("I'm bad and wrong!".to_string()),
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .activity_id("I'm bad and wrong!".to_string())
+                    .build(),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         } else {
-            ctx.start_activity(StdActivities::no_op, (), ActivityOptions::default())
+            ctx.start_activity(StdActivities::no_op, (), ActivityOptions::builder().build())
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
         }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -48,8 +48,9 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityExecutionError, ActivityOptions, CancellableFuture, LocalActivityOptions,
-    WorkflowContext, WorkflowContextView, WorkflowResult, WorkflowTermination,
+    ActivityCloseTimeouts, ActivityExecutionError, ActivityOptions, CancellableFuture,
+    LocalActivityOptions, WorkflowContext, WorkflowContextView, WorkflowResult,
+    WorkflowTermination,
     activities::{ActivityContext, ActivityError},
     interceptors::{FailOnNondeterminismInterceptor, WorkerInterceptor},
 };
@@ -1024,10 +1025,11 @@ async fn la_resolve_same_time_as_other_cancel() {
             let mut normal_act = ctx.start_activity(
                 DelayWithCancellation::delay,
                 Duration::from_secs(9),
-                ActivityOptions::builder()
-                    .cancellation_type(ActivityCancellationType::TryCancel)
-                    .start_to_close_timeout(Duration::from_secs(9000))
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(9000),
+                ))
+                .cancellation_type(ActivityCancellationType::TryCancel)
+                .build(),
             );
             // Make new task
             ctx.timer(Duration::from_millis(1)).await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -48,9 +48,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityExecutionError, ActivityOptions, CancellableFuture,
-    LocalActivityOptions, WorkflowContext, WorkflowContextView, WorkflowResult,
-    WorkflowTermination,
+    ActivityExecutionError, ActivityOptions, CancellableFuture, LocalActivityOptions,
+    WorkflowContext, WorkflowContextView, WorkflowResult, WorkflowTermination,
     activities::{ActivityContext, ActivityError},
     interceptors::{FailOnNondeterminismInterceptor, WorkerInterceptor},
 };
@@ -1025,11 +1024,9 @@ async fn la_resolve_same_time_as_other_cancel() {
             let mut normal_act = ctx.start_activity(
                 DelayWithCancellation::delay,
                 Duration::from_secs(9),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(9000),
-                ))
-                .cancellation_type(ActivityCancellationType::TryCancel)
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(9000))
+                    .cancellation_type(ActivityCancellationType::TryCancel)
+                    .build(),
             );
             // Make new task
             ctx.timer(Duration::from_millis(1)).await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -1024,11 +1024,10 @@ async fn la_resolve_same_time_as_other_cancel() {
             let mut normal_act = ctx.start_activity(
                 DelayWithCancellation::delay,
                 Duration::from_secs(9),
-                ActivityOptions {
-                    cancellation_type: ActivityCancellationType::TryCancel,
-                    start_to_close_timeout: Some(Duration::from_secs(9000)),
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .cancellation_type(ActivityCancellationType::TryCancel)
+                    .start_to_close_timeout(Duration::from_secs(9000))
+                    .build(),
             );
             // Make new task
             ctx.timer(Duration::from_millis(1)).await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -410,10 +410,9 @@ async fn v1(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions {
-                activity_id: Some("no_change".to_owned()),
-                ..Default::default()
-            },
+            ActivityOptions::builder()
+                .activity_id("no_change".to_owned())
+                .build(),
         )
         .await;
 }
@@ -424,10 +423,9 @@ async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
             .start_activity(
                 FakeAct::nameless,
                 (),
-                ActivityOptions {
-                    activity_id: Some("had_change".to_owned()),
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .activity_id("had_change".to_owned())
+                    .build(),
             )
             .await;
         true
@@ -436,10 +434,9 @@ async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
             .start_activity(
                 FakeAct::nameless,
                 (),
-                ActivityOptions {
-                    activity_id: Some("no_change".to_owned()),
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .activity_id("no_change".to_owned())
+                    .build(),
             )
             .await;
         false
@@ -452,10 +449,9 @@ async fn v3(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions {
-                activity_id: Some("had_change".to_owned()),
-                ..Default::default()
-            },
+            ActivityOptions::builder()
+                .activity_id("had_change".to_owned())
+                .build(),
         )
         .await;
 }
@@ -465,10 +461,9 @@ async fn v4(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions {
-                activity_id: Some("had_change".to_owned()),
-                ..Default::default()
-            },
+            ActivityOptions::builder()
+                .activity_id("had_change".to_owned())
+                .build(),
         )
         .await;
 }
@@ -682,7 +677,7 @@ impl SameChangeMultipleSpotsWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         if ctx.patched(MY_PATCH_ID) {
             let _ = ctx
-                .start_activity(FakeAct::nameless, (), ActivityOptions::default())
+                .start_activity(FakeAct::nameless, (), ActivityOptions::builder().build())
                 .await;
         } else {
             ctx.timer(ONE_SECOND).await;
@@ -690,7 +685,7 @@ impl SameChangeMultipleSpotsWf {
         ctx.timer(ONE_SECOND).await;
         if ctx.patched(MY_PATCH_ID) {
             let _ = ctx
-                .start_activity(FakeAct::nameless, (), ActivityOptions::default())
+                .start_activity(FakeAct::nameless, (), ActivityOptions::builder().build())
                 .await;
         } else {
             ctx.timer(ONE_SECOND).await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -36,7 +36,7 @@ use temporalio_common::{
 use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    ActivityCloseTimeouts, ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::test_help::{CoreInternalFlags, MockPollCfg, ResponseType};
@@ -410,9 +410,11 @@ async fn v1(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions::builder()
-                .activity_id("no_change".to_owned())
-                .build(),
+            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                Duration::from_secs(5),
+            ))
+            .activity_id("no_change".to_owned())
+            .build(),
         )
         .await;
 }
@@ -423,9 +425,11 @@ async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
             .start_activity(
                 FakeAct::nameless,
                 (),
-                ActivityOptions::builder()
-                    .activity_id("had_change".to_owned())
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(5),
+                ))
+                .activity_id("had_change".to_owned())
+                .build(),
             )
             .await;
         true
@@ -434,9 +438,11 @@ async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
             .start_activity(
                 FakeAct::nameless,
                 (),
-                ActivityOptions::builder()
-                    .activity_id("no_change".to_owned())
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(5),
+                ))
+                .activity_id("no_change".to_owned())
+                .build(),
             )
             .await;
         false
@@ -449,9 +455,11 @@ async fn v3(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions::builder()
-                .activity_id("had_change".to_owned())
-                .build(),
+            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                Duration::from_secs(5),
+            ))
+            .activity_id("had_change".to_owned())
+            .build(),
         )
         .await;
 }
@@ -461,9 +469,11 @@ async fn v4(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions::builder()
-                .activity_id("had_change".to_owned())
-                .build(),
+            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                Duration::from_secs(5),
+            ))
+            .activity_id("had_change".to_owned())
+            .build(),
         )
         .await;
 }
@@ -677,7 +687,11 @@ impl SameChangeMultipleSpotsWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         if ctx.patched(MY_PATCH_ID) {
             let _ = ctx
-                .start_activity(FakeAct::nameless, (), ActivityOptions::builder().build())
+                .start_activity(
+                    FakeAct::nameless,
+                    (),
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+                )
                 .await;
         } else {
             ctx.timer(ONE_SECOND).await;
@@ -685,7 +699,11 @@ impl SameChangeMultipleSpotsWf {
         ctx.timer(ONE_SECOND).await;
         if ctx.patched(MY_PATCH_ID) {
             let _ = ctx
-                .start_activity(FakeAct::nameless, (), ActivityOptions::builder().build())
+                .start_activity(
+                    FakeAct::nameless,
+                    (),
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+                )
                 .await;
         } else {
             ctx.timer(ONE_SECOND).await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -36,7 +36,7 @@ use temporalio_common::{
 use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::test_help::{CoreInternalFlags, MockPollCfg, ResponseType};
@@ -410,11 +410,9 @@ async fn v1(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                Duration::from_secs(5),
-            ))
-            .activity_id("no_change".to_owned())
-            .build(),
+            ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                .activity_id("no_change".to_owned())
+                .build(),
         )
         .await;
 }
@@ -425,11 +423,9 @@ async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
             .start_activity(
                 FakeAct::nameless,
                 (),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(5),
-                ))
-                .activity_id("had_change".to_owned())
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                    .activity_id("had_change".to_owned())
+                    .build(),
             )
             .await;
         true
@@ -438,11 +434,9 @@ async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
             .start_activity(
                 FakeAct::nameless,
                 (),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(5),
-                ))
-                .activity_id("no_change".to_owned())
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                    .activity_id("no_change".to_owned())
+                    .build(),
             )
             .await;
         false
@@ -455,11 +449,9 @@ async fn v3(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                Duration::from_secs(5),
-            ))
-            .activity_id("had_change".to_owned())
-            .build(),
+            ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                .activity_id("had_change".to_owned())
+                .build(),
         )
         .await;
 }
@@ -469,11 +461,9 @@ async fn v4(ctx: &mut WorkflowContext<PatchWf>) {
         .start_activity(
             FakeAct::nameless,
             (),
-            ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                Duration::from_secs(5),
-            ))
-            .activity_id("had_change".to_owned())
-            .build(),
+            ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                .activity_id("had_change".to_owned())
+                .build(),
         )
         .await;
 }

--- a/crates/sdk-core/tests/manual_tests.rs
+++ b/crates/sdk-core/tests/manual_tests.rs
@@ -60,10 +60,7 @@ impl PollerLoadSpikyWf {
                 .start_activity(
                     JitteryEchoActivities::echo,
                     "hi!".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
                 .await;
         }
@@ -110,10 +107,7 @@ impl PollerLoadSpikeThenSustainedWf {
                 .start_activity(
                     JitteryEchoActivities::echo,
                     "hi!".to_string(),
-                    ActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(5)),
-                        ..Default::default()
-                    },
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
                 .await;
         }

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -74,16 +74,15 @@ pub(crate) async fn priority_values_sent_to_server() {
             let activity = ctx.start_activity(
                 PriorityActivities::echo,
                 "hello".to_string(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    priority: Some(Priority {
+                ActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(5))
+                    .priority(Priority {
                         priority_key: Some(5),
                         fairness_key: Some("fair-act".to_string()),
                         fairness_weight: Some(1.1),
-                    }),
-                    do_not_eagerly_execute: true,
-                    ..Default::default()
-                },
+                    })
+                    .do_not_eagerly_execute(true)
+                    .build(),
             );
             let _ = started.result().await;
             let _ = activity.await;

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -8,7 +8,7 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityOptions, ChildWorkflowOptions, WorkflowContext, WorkflowResult,
+    ActivityOptions, ChildWorkflowOptions, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 
@@ -74,16 +74,14 @@ pub(crate) async fn priority_values_sent_to_server() {
             let activity = ctx.start_activity(
                 PriorityActivities::echo,
                 "hello".to_string(),
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(5),
-                ))
-                .priority(Priority {
-                    priority_key: Some(5),
-                    fairness_key: Some("fair-act".to_string()),
-                    fairness_weight: Some(1.1),
-                })
-                .do_not_eagerly_execute(true)
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                    .priority(Priority {
+                        priority_key: Some(5),
+                        fairness_key: Some("fair-act".to_string()),
+                        fairness_weight: Some(1.1),
+                    })
+                    .do_not_eagerly_execute(true)
+                    .build(),
             );
             let _ = started.result().await;
             let _ = activity.await;

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -8,7 +8,7 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, ChildWorkflowOptions, WorkflowContext, WorkflowResult,
+    ActivityCloseTimeouts, ActivityOptions, ChildWorkflowOptions, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 
@@ -74,15 +74,16 @@ pub(crate) async fn priority_values_sent_to_server() {
             let activity = ctx.start_activity(
                 PriorityActivities::echo,
                 "hello".to_string(),
-                ActivityOptions::builder()
-                    .start_to_close_timeout(Duration::from_secs(5))
-                    .priority(Priority {
-                        priority_key: Some(5),
-                        fairness_key: Some("fair-act".to_string()),
-                        fairness_weight: Some(1.1),
-                    })
-                    .do_not_eagerly_execute(true)
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(5),
+                ))
+                .priority(Priority {
+                    priority_key: Some(5),
+                    fairness_key: Some("fair-act".to_string()),
+                    fairness_weight: Some(1.1),
+                })
+                .do_not_eagerly_execute(true)
+                .build(),
             );
             let _ = started.result().await;
             let _ = activity.await;

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -68,10 +68,7 @@ impl GreetingWorkflow {
         let greeting = ctx.start_activity(
             MyActivities::greet,
             name,
-            ActivityOptions {
-                start_to_close_timeout: Some(Duration::from_secs(10)),
-                ..Default::default()
-            }
+            ActivityOptions::start_to_close_timeout(Duration::from_secs(10))
         )?.await?;
 
         Ok(greeting)

--- a/crates/sdk/examples/activity_heartbeating/workflows.rs
+++ b/crates/sdk/examples/activity_heartbeating/workflows.rs
@@ -48,11 +48,10 @@ impl HeartbeatingWorkflow {
             .start_activity(
                 HeartbeatingActivities::long_running_activity,
                 total_steps,
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(30)),
-                    heartbeat_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                ActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(30))
+                    .heartbeat_timeout(Duration::from_secs(5))
+                    .build(),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk/examples/activity_heartbeating/workflows.rs
+++ b/crates/sdk/examples/activity_heartbeating/workflows.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use temporalio_common::protos::coresdk::AsJsonPayloadExt;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityOptions, WorkflowContext, WorkflowResult,
+    ActivityOptions, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 
@@ -48,11 +48,9 @@ impl HeartbeatingWorkflow {
             .start_activity(
                 HeartbeatingActivities::long_running_activity,
                 total_steps,
-                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-                    Duration::from_secs(30),
-                ))
-                .heartbeat_timeout(Duration::from_secs(5))
-                .build(),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(30))
+                    .heartbeat_timeout(Duration::from_secs(5))
+                    .build(),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk/examples/activity_heartbeating/workflows.rs
+++ b/crates/sdk/examples/activity_heartbeating/workflows.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use temporalio_common::protos::coresdk::AsJsonPayloadExt;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, WorkflowContext, WorkflowResult,
+    ActivityCloseTimeouts, ActivityOptions, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 
@@ -48,10 +48,11 @@ impl HeartbeatingWorkflow {
             .start_activity(
                 HeartbeatingActivities::long_running_activity,
                 total_steps,
-                ActivityOptions::builder()
-                    .start_to_close_timeout(Duration::from_secs(30))
-                    .heartbeat_timeout(Duration::from_secs(5))
-                    .build(),
+                ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+                    Duration::from_secs(30),
+                ))
+                .heartbeat_timeout(Duration::from_secs(5))
+                .build(),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk/examples/cancellation/workflows.rs
+++ b/crates/sdk/examples/cancellation/workflows.rs
@@ -31,11 +31,10 @@ impl CancellationActivities {
 }
 
 fn activity_opts() -> ActivityOptions {
-    ActivityOptions {
-        start_to_close_timeout: Some(Duration::from_secs(300)),
-        heartbeat_timeout: Some(Duration::from_secs(5)),
-        ..Default::default()
-    }
+    ActivityOptions::builder()
+        .start_to_close_timeout(Duration::from_secs(300))
+        .heartbeat_timeout(Duration::from_secs(5))
+        .build()
 }
 
 #[workflow]
@@ -64,10 +63,7 @@ impl CancellationWorkflow {
                     .start_activity(
                         CancellationActivities::cleanup,
                         (),
-                        ActivityOptions {
-                            start_to_close_timeout: Some(Duration::from_secs(10)),
-                            ..Default::default()
-                        },
+                        ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
                     )
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk/examples/cancellation/workflows.rs
+++ b/crates/sdk/examples/cancellation/workflows.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
+    ActivityCloseTimeouts, ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 
@@ -31,10 +31,11 @@ impl CancellationActivities {
 }
 
 fn activity_opts() -> ActivityOptions {
-    ActivityOptions::builder()
-        .start_to_close_timeout(Duration::from_secs(300))
-        .heartbeat_timeout(Duration::from_secs(5))
-        .build()
+    ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(Duration::from_secs(
+        300,
+    )))
+    .heartbeat_timeout(Duration::from_secs(5))
+    .build()
 }
 
 #[workflow]

--- a/crates/sdk/examples/cancellation/workflows.rs
+++ b/crates/sdk/examples/cancellation/workflows.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityCloseTimeouts, ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
+    ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 
@@ -31,11 +31,9 @@ impl CancellationActivities {
 }
 
 fn activity_opts() -> ActivityOptions {
-    ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(Duration::from_secs(
-        300,
-    )))
-    .heartbeat_timeout(Duration::from_secs(5))
-    .build()
+    ActivityOptions::with_start_to_close_timeout(Duration::from_secs(300))
+        .heartbeat_timeout(Duration::from_secs(5))
+        .build()
 }
 
 #[workflow]

--- a/crates/sdk/examples/hello_world/workflows.rs
+++ b/crates/sdk/examples/hello_world/workflows.rs
@@ -18,10 +18,7 @@ impl HelloWorldWorkflow {
             .start_activity(
                 GreetingActivities::greet,
                 name,
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(10)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk/examples/local_activities/workflows.rs
+++ b/crates/sdk/examples/local_activities/workflows.rs
@@ -31,10 +31,7 @@ impl LocalActivitiesWorkflow {
             .start_activity(
                 GreetingActivities::greet,
                 name.clone(),
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(10)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk/examples/polling/workflows.rs
+++ b/crates/sdk/examples/polling/workflows.rs
@@ -20,10 +20,7 @@ impl PollingActivities {
 }
 
 fn activity_opts() -> ActivityOptions {
-    ActivityOptions {
-        start_to_close_timeout: Some(Duration::from_secs(10)),
-        ..Default::default()
-    }
+    ActivityOptions::start_to_close_timeout(Duration::from_secs(10))
 }
 
 #[workflow]

--- a/crates/sdk/examples/saga/workflows.rs
+++ b/crates/sdk/examples/saga/workflows.rs
@@ -168,8 +168,5 @@ impl BookingActivities {
 }
 
 fn activity_opts() -> ActivityOptions {
-    ActivityOptions {
-        start_to_close_timeout: Some(Duration::from_secs(1)),
-        ..Default::default()
-    }
+    ActivityOptions::start_to_close_timeout(Duration::from_secs(1))
 }

--- a/crates/sdk/examples/schedules/workflows.rs
+++ b/crates/sdk/examples/schedules/workflows.rs
@@ -28,10 +28,7 @@ impl ScheduledWorkflow {
             .start_activity(
                 ScheduledActivities::greet,
                 name,
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(10)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk/examples/timer_examples/workflows.rs
+++ b/crates/sdk/examples/timer_examples/workflows.rs
@@ -35,10 +35,7 @@ impl TimerWorkflow {
             result = ctx.start_activity(
                 TimerActivities::slow_activity,
                 100u64,
-                ActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(30)),
-                    ..Default::default()
-                },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(30)),
             ) => {
                 result.map_err(|e| anyhow::anyhow!("{e}"))?;
                 "activity"

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1375,11 +1375,15 @@ mod tests {
     #[allow(unused, clippy::diverging_sub_expression)]
     fn test_activity_via_workflow_context() {
         let wf_ctx: WorkflowContext<MyWorkflow> = unimplemented!();
-        wf_ctx.start_activity(MyActivities::my_activity, (), ActivityOptions::default());
+        wf_ctx.start_activity(
+            MyActivities::my_activity,
+            (),
+            ActivityOptions::builder().build(),
+        );
         wf_ctx.start_activity(
             MyActivities::takes_self,
             "Hi".to_owned(),
-            ActivityOptions::default(),
+            ActivityOptions::builder().build(),
         );
     }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -98,8 +98,8 @@ use workflow_future::WorkflowFunction;
 
 pub use temporalio_client::Namespace;
 pub use workflow_context::{
-    ActivityExecutionError, ActivityOptions, BaseWorkflowContext, CancellableFuture,
-    ChildWorkflowExecutionError, ChildWorkflowOptions, ChildWorkflowSignalError,
+    ActivityCloseTimeouts, ActivityExecutionError, ActivityOptions, BaseWorkflowContext,
+    CancellableFuture, ChildWorkflowExecutionError, ChildWorkflowOptions, ChildWorkflowSignalError,
     ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions, NexusOperationOptions,
     ParentWorkflowInfo, RootWorkflowInfo, Signal, SignalData,
     StartChildWorkflowExecutionFailedCause, StartedChildWorkflow, SyncWorkflowContext,
@@ -1378,12 +1378,12 @@ mod tests {
         wf_ctx.start_activity(
             MyActivities::my_activity,
             (),
-            ActivityOptions::builder().build(),
+            ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
         );
         wf_ctx.start_activity(
             MyActivities::takes_self,
             "Hi".to_owned(),
-            ActivityOptions::builder().build(),
+            ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
         );
     }
 

--- a/crates/sdk/src/workflow_context.rs
+++ b/crates/sdk/src/workflow_context.rs
@@ -1,8 +1,8 @@
 mod options;
 
 pub use options::{
-    ActivityOptions, ChildWorkflowOptions, ContinueAsNewOptions, LocalActivityOptions,
-    NexusOperationOptions, Signal, SignalData, TimerOptions,
+    ActivityCloseTimeouts, ActivityOptions, ChildWorkflowOptions, ContinueAsNewOptions,
+    LocalActivityOptions, NexusOperationOptions, Signal, SignalData, TimerOptions,
 };
 pub use temporalio_common::protos::coresdk::child_workflow::StartChildWorkflowExecutionFailedCause;
 

--- a/crates/sdk/src/workflow_context/options.rs
+++ b/crates/sdk/src/workflow_context/options.rs
@@ -33,13 +33,13 @@ pub(crate) trait IntoWorkflowCommand {
 /// Options for scheduling an activity
 #[derive(Debug, bon::Builder, Clone)]
 #[non_exhaustive]
-#[builder(start_fn = with_close_timeout, on(String, into), state_mod(vis = "pub"))]
+#[builder(start_fn = with_close_timeouts, on(String, into), state_mod(vis = "pub"))]
 pub struct ActivityOptions {
     /// Timeouts for activity completion.
     ///
     /// See [`ActivityCloseTimeouts`] for the meaning of each timeout variant.
     #[builder(start_fn)]
-    pub close_timeout: ActivityCloseTimeouts,
+    pub close_timeouts: ActivityCloseTimeouts,
     /// Identifier to use for tracking the activity in Workflow history.
     /// The `activityId` can be accessed by the activity function.
     /// Does not need to be unique.
@@ -77,12 +77,12 @@ pub struct ActivityOptions {
 impl ActivityOptions {
     /// Returns a builder with `close_timeout` set to [`ActivityCloseTimeouts::StartToClose`].
     pub fn with_start_to_close_timeout(duration: Duration) -> ActivityOptionsBuilder {
-        Self::with_close_timeout(ActivityCloseTimeouts::StartToClose(duration))
+        Self::with_close_timeouts(ActivityCloseTimeouts::StartToClose(duration))
     }
 
     /// Returns a builder with `close_timeout` set to [`ActivityCloseTimeouts::ScheduleToClose`].
     pub fn with_schedule_to_close_timeout(duration: Duration) -> ActivityOptionsBuilder {
-        Self::with_close_timeout(ActivityCloseTimeouts::ScheduleToClose(duration))
+        Self::with_close_timeouts(ActivityCloseTimeouts::ScheduleToClose(duration))
     }
 
     /// Creates activity options with only `start_to_close_timeout` set.
@@ -111,7 +111,7 @@ impl ActivityOptions {
             converter: &payload_converter,
         };
         let (start_to_close_timeout, schedule_to_close_timeout) =
-            self.close_timeout.into_durations();
+            self.close_timeouts.into_durations();
         WorkflowCommand {
             variant: Some(
                 ScheduleActivity {
@@ -589,7 +589,7 @@ mod tests {
             .build();
 
         assert_eq!(
-            opts.close_timeout,
+            opts.close_timeouts,
             ActivityCloseTimeouts::StartToClose(Duration::from_secs(5))
         );
         assert_eq!(opts.heartbeat_timeout, Some(Duration::from_secs(2)));
@@ -602,7 +602,7 @@ mod tests {
             .build();
 
         assert_eq!(
-            opts.close_timeout,
+            opts.close_timeouts,
             ActivityCloseTimeouts::ScheduleToClose(Duration::from_secs(5))
         );
         assert_eq!(opts.heartbeat_timeout, Some(Duration::from_secs(2)));
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn activity_options_both_close_timeouts_map_to_command() {
-        let cmd = ActivityOptions::with_close_timeout(ActivityCloseTimeouts::Both {
+        let cmd = ActivityOptions::with_close_timeouts(ActivityCloseTimeouts::Both {
             start_to_close: Duration::from_secs(3),
             schedule_to_close: Duration::from_secs(8),
         })

--- a/crates/sdk/src/workflow_context/options.rs
+++ b/crates/sdk/src/workflow_context/options.rs
@@ -37,7 +37,7 @@ pub(crate) trait IntoWorkflowCommand {
 pub struct ActivityOptions {
     /// Timeouts for activity completion.
     ///
-    /// See [`ActivityCloseTimeouts`] for the meaning of each timeout mode.
+    /// See [`ActivityCloseTimeouts`] for the meaning of each timeout variant.
     #[builder(start_fn)]
     pub close_timeout: ActivityCloseTimeouts,
     /// Identifier to use for tracking the activity in Workflow history.
@@ -75,12 +75,12 @@ pub struct ActivityOptions {
 }
 
 impl ActivityOptions {
-    /// Returns a builder with a [`ActivityCloseTimeouts::StartToClose`] set.
+    /// Returns a builder with `close_timeout` set to [`ActivityCloseTimeouts::StartToClose`].
     pub fn with_start_to_close_timeout(duration: Duration) -> ActivityOptionsBuilder {
         Self::with_close_timeout(ActivityCloseTimeouts::StartToClose(duration))
     }
 
-    /// Returns a builder with a [`ActivityCloseTimeouts::ScheduleToClose`] set.
+    /// Returns a builder with `close_timeout` set to [`ActivityCloseTimeouts::ScheduleToClose`].
     pub fn with_schedule_to_close_timeout(duration: Duration) -> ActivityOptionsBuilder {
         Self::with_close_timeout(ActivityCloseTimeouts::ScheduleToClose(duration))
     }

--- a/crates/sdk/src/workflow_context/options.rs
+++ b/crates/sdk/src/workflow_context/options.rs
@@ -31,7 +31,9 @@ pub(crate) trait IntoWorkflowCommand {
 }
 
 /// Options for scheduling an activity
-#[derive(Default, Debug)]
+#[derive(Default, Debug, bon::Builder)]
+#[non_exhaustive]
+#[builder(on(String, into), state_mod(vis = "pub"))]
 pub struct ActivityOptions {
     /// Identifier to use for tracking the activity in Workflow history.
     /// The `activityId` can be accessed by the activity function.
@@ -67,6 +69,7 @@ pub struct ActivityOptions {
     /// heartbeat or activity start.
     pub heartbeat_timeout: Option<Duration>,
     /// Determines what the SDK does when the Activity is cancelled.
+    #[builder(default)]
     pub cancellation_type: ActivityCancellationType,
     /// Activity retry policy
     pub retry_policy: Option<RetryPolicy>,
@@ -75,10 +78,21 @@ pub struct ActivityOptions {
     /// Priority for the activity
     pub priority: Option<Priority>,
     /// If true, disable eager execution for this activity
+    #[builder(default)]
     pub do_not_eagerly_execute: bool,
 }
 
 impl ActivityOptions {
+    /// Creates activity options with only `start_to_close_timeout` set.
+    pub fn start_to_close_timeout(duration: Duration) -> Self {
+        Self::builder().start_to_close_timeout(duration).build()
+    }
+
+    /// Creates activity options with only `schedule_to_close_timeout` set.
+    pub fn schedule_to_close_timeout(duration: Duration) -> Self {
+        Self::builder().schedule_to_close_timeout(duration).build()
+    }
+
     pub(crate) fn into_command(
         self,
         activity_type: String,
@@ -525,6 +539,56 @@ impl ContinueAsNewOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn activity_options_builder_defaults_match_default_impl() {
+        let built = ActivityOptions::builder().build();
+        let defaulted = ActivityOptions::default();
+
+        assert_eq!(built.activity_id, defaulted.activity_id);
+        assert_eq!(built.task_queue, defaulted.task_queue);
+        assert_eq!(
+            built.schedule_to_start_timeout,
+            defaulted.schedule_to_start_timeout
+        );
+        assert_eq!(
+            built.start_to_close_timeout,
+            defaulted.start_to_close_timeout
+        );
+        assert_eq!(
+            built.schedule_to_close_timeout,
+            defaulted.schedule_to_close_timeout
+        );
+        assert_eq!(built.heartbeat_timeout, defaulted.heartbeat_timeout);
+        assert_eq!(built.cancellation_type, defaulted.cancellation_type);
+        assert_eq!(built.retry_policy, defaulted.retry_policy);
+        assert_eq!(built.summary, defaulted.summary);
+        assert_eq!(built.priority, defaulted.priority);
+        assert_eq!(
+            built.do_not_eagerly_execute,
+            defaulted.do_not_eagerly_execute
+        );
+    }
+
+    #[test]
+    fn activity_options_start_to_close_timeout_constructor_sets_only_that_timeout() {
+        let opts = ActivityOptions::start_to_close_timeout(Duration::from_secs(5));
+
+        assert_eq!(opts.start_to_close_timeout, Some(Duration::from_secs(5)));
+        assert_eq!(opts.schedule_to_close_timeout, None);
+        assert_eq!(opts.schedule_to_start_timeout, None);
+        assert_eq!(opts.heartbeat_timeout, None);
+    }
+
+    #[test]
+    fn activity_options_schedule_to_close_timeout_constructor_sets_only_that_timeout() {
+        let opts = ActivityOptions::schedule_to_close_timeout(Duration::from_secs(5));
+
+        assert_eq!(opts.start_to_close_timeout, None);
+        assert_eq!(opts.schedule_to_close_timeout, Some(Duration::from_secs(5)));
+        assert_eq!(opts.schedule_to_start_timeout, None);
+        assert_eq!(opts.heartbeat_timeout, None);
+    }
 
     #[test]
     fn child_workflow_run_timeout_uses_run_timeout_field() {

--- a/crates/sdk/src/workflow_context/options.rs
+++ b/crates/sdk/src/workflow_context/options.rs
@@ -31,7 +31,7 @@ pub(crate) trait IntoWorkflowCommand {
 }
 
 /// Options for scheduling an activity
-#[derive(Debug, bon::Builder)]
+#[derive(Debug, bon::Builder, Clone)]
 #[non_exhaustive]
 #[builder(start_fn = with_close_timeout, on(String, into), state_mod(vis = "pub"))]
 pub struct ActivityOptions {
@@ -75,14 +75,28 @@ pub struct ActivityOptions {
 }
 
 impl ActivityOptions {
+    /// Returns a builder with a [`ActivityCloseTimeouts::StartToClose`] set.
+    pub fn with_start_to_close_timeout(duration: Duration) -> ActivityOptionsBuilder {
+        Self::with_close_timeout(ActivityCloseTimeouts::StartToClose(duration))
+    }
+
+    /// Returns a builder with a [`ActivityCloseTimeouts::ScheduleToClose`] set.
+    pub fn with_schedule_to_close_timeout(duration: Duration) -> ActivityOptionsBuilder {
+        Self::with_close_timeout(ActivityCloseTimeouts::ScheduleToClose(duration))
+    }
+
     /// Creates activity options with only `start_to_close_timeout` set.
+    ///
+    /// If you need additional fields set, use [`Self::with_start_to_close_timeout`].
     pub fn start_to_close_timeout(duration: Duration) -> Self {
-        Self::with_close_timeout(ActivityCloseTimeouts::StartToClose(duration)).build()
+        Self::with_start_to_close_timeout(duration).build()
     }
 
     /// Creates activity options with only `schedule_to_close_timeout` set.
+    ///
+    /// If you need additional fields set, use [`Self::with_schedule_to_close_timeout`].
     pub fn schedule_to_close_timeout(duration: Duration) -> Self {
-        Self::with_close_timeout(ActivityCloseTimeouts::ScheduleToClose(duration)).build()
+        Self::with_schedule_to_close_timeout(duration).build()
     }
 
     pub(crate) fn into_command(
@@ -569,53 +583,29 @@ mod tests {
     use temporalio_common::protos::coresdk::workflow_commands::workflow_command::Variant;
 
     #[test]
-    fn activity_options_builder_defaults_match_start_to_close_constructor() {
-        let built = ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
-            Duration::from_secs(5),
-        ))
-        .build();
-        let constructed = ActivityOptions::start_to_close_timeout(Duration::from_secs(5));
-
-        assert_eq!(built.close_timeout, constructed.close_timeout);
-        assert_eq!(built.activity_id, constructed.activity_id);
-        assert_eq!(built.task_queue, constructed.task_queue);
-        assert_eq!(
-            built.schedule_to_start_timeout,
-            constructed.schedule_to_start_timeout
-        );
-        assert_eq!(built.heartbeat_timeout, constructed.heartbeat_timeout);
-        assert_eq!(built.cancellation_type, constructed.cancellation_type);
-        assert_eq!(built.retry_policy, constructed.retry_policy);
-        assert_eq!(built.summary, constructed.summary);
-        assert_eq!(built.priority, constructed.priority);
-        assert_eq!(
-            built.do_not_eagerly_execute,
-            constructed.do_not_eagerly_execute
-        );
-    }
-
-    #[test]
-    fn activity_options_start_to_close_timeout_constructor_sets_only_that_timeout() {
-        let opts = ActivityOptions::start_to_close_timeout(Duration::from_secs(5));
+    fn activity_options_with_start_to_close_timeout_wrapper_supports_builder_chaining() {
+        let opts = ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+            .heartbeat_timeout(Duration::from_secs(2))
+            .build();
 
         assert_eq!(
             opts.close_timeout,
             ActivityCloseTimeouts::StartToClose(Duration::from_secs(5))
         );
-        assert_eq!(opts.schedule_to_start_timeout, None);
-        assert_eq!(opts.heartbeat_timeout, None);
+        assert_eq!(opts.heartbeat_timeout, Some(Duration::from_secs(2)));
     }
 
     #[test]
-    fn activity_options_schedule_to_close_timeout_constructor_sets_only_that_timeout() {
-        let opts = ActivityOptions::schedule_to_close_timeout(Duration::from_secs(5));
+    fn activity_options_with_schedule_to_close_timeout_wrapper_supports_builder_chaining() {
+        let opts = ActivityOptions::with_schedule_to_close_timeout(Duration::from_secs(5))
+            .heartbeat_timeout(Duration::from_secs(2))
+            .build();
 
         assert_eq!(
             opts.close_timeout,
             ActivityCloseTimeouts::ScheduleToClose(Duration::from_secs(5))
         );
-        assert_eq!(opts.schedule_to_start_timeout, None);
-        assert_eq!(opts.heartbeat_timeout, None);
+        assert_eq!(opts.heartbeat_timeout, Some(Duration::from_secs(2)));
     }
 
     #[test]

--- a/crates/sdk/src/workflow_context/options.rs
+++ b/crates/sdk/src/workflow_context/options.rs
@@ -31,10 +31,15 @@ pub(crate) trait IntoWorkflowCommand {
 }
 
 /// Options for scheduling an activity
-#[derive(Default, Debug, bon::Builder)]
+#[derive(Debug, bon::Builder)]
 #[non_exhaustive]
-#[builder(on(String, into), state_mod(vis = "pub"))]
+#[builder(start_fn = with_close_timeout, on(String, into), state_mod(vis = "pub"))]
 pub struct ActivityOptions {
+    /// Timeouts for activity completion.
+    ///
+    /// See [`ActivityCloseTimeouts`] for the meaning of each timeout mode.
+    #[builder(start_fn)]
+    pub close_timeout: ActivityCloseTimeouts,
     /// Identifier to use for tracking the activity in Workflow history.
     /// The `activityId` can be accessed by the activity function.
     /// Does not need to be unique.
@@ -52,19 +57,6 @@ pub struct ActivityOptions {
     /// Retrying after this timeout doesn't make sense as it would just put the Activity Task back
     /// into the same Task Queue.
     pub schedule_to_start_timeout: Option<Duration>,
-    /// Maximum time of a single Activity execution attempt.
-    /// Note that the Temporal Server doesn't detect Worker process failures directly.
-    /// It relies on this timeout to detect that an Activity that didn't complete on time.
-    /// So this timeout should be as short as the longest possible execution of the Activity body.
-    /// Potentially long running Activities must specify `heartbeat_timeout` and heartbeat from the
-    /// activity periodically for timely failure detection.
-    /// Either this option or `schedule_to_close_timeout` is required.
-    pub start_to_close_timeout: Option<Duration>,
-    /// Total time that a workflow is willing to wait for Activity to complete.
-    /// `schedule_to_close_timeout` limits the total time of an Activity's execution including
-    /// retries (use `start_to_close_timeout` to limit the time of a single attempt).
-    /// Either this option or `start_to_close_timeout` is required.
-    pub schedule_to_close_timeout: Option<Duration>,
     /// Heartbeat interval. Activity must heartbeat before this interval passes after a last
     /// heartbeat or activity start.
     pub heartbeat_timeout: Option<Duration>,
@@ -85,12 +77,12 @@ pub struct ActivityOptions {
 impl ActivityOptions {
     /// Creates activity options with only `start_to_close_timeout` set.
     pub fn start_to_close_timeout(duration: Duration) -> Self {
-        Self::builder().start_to_close_timeout(duration).build()
+        Self::with_close_timeout(ActivityCloseTimeouts::StartToClose(duration)).build()
     }
 
     /// Creates activity options with only `schedule_to_close_timeout` set.
     pub fn schedule_to_close_timeout(duration: Duration) -> Self {
-        Self::builder().schedule_to_close_timeout(duration).build()
+        Self::with_close_timeout(ActivityCloseTimeouts::ScheduleToClose(duration)).build()
     }
 
     pub(crate) fn into_command(
@@ -104,6 +96,8 @@ impl ActivityOptions {
             data: &SerializationContextData::Workflow,
             converter: &payload_converter,
         };
+        let (start_to_close_timeout, schedule_to_close_timeout) =
+            self.close_timeout.into_durations();
         WorkflowCommand {
             variant: Some(
                 ScheduleActivity {
@@ -114,15 +108,12 @@ impl ActivityOptions {
                     },
                     activity_type,
                     task_queue: self.task_queue.unwrap_or_default(),
-                    schedule_to_close_timeout: self
-                        .schedule_to_close_timeout
+                    schedule_to_close_timeout: schedule_to_close_timeout
                         .and_then(|d| d.try_into().ok()),
                     schedule_to_start_timeout: self
                         .schedule_to_start_timeout
                         .and_then(|d| d.try_into().ok()),
-                    start_to_close_timeout: self
-                        .start_to_close_timeout
-                        .and_then(|d| d.try_into().ok()),
+                    start_to_close_timeout: start_to_close_timeout.and_then(|d| d.try_into().ok()),
                     heartbeat_timeout: self.heartbeat_timeout.and_then(|d| d.try_into().ok()),
                     cancellation_type: self.cancellation_type as i32,
                     arguments,
@@ -144,6 +135,42 @@ impl ActivityOptions {
                     summary: Some(summary),
                     details: None,
                 }),
+        }
+    }
+}
+
+/// The timeouts applied to an activity's completion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityCloseTimeouts {
+    /// Total time that a workflow is willing to wait for Activity to complete.
+    /// `ActivityCloseTimeouts::ScheduleToClose` limits the total time of an Activity's execution including
+    /// retries (use `ActivityCloseTimeouts::StartToClose` to limit the time of a single attempt).
+    ScheduleToClose(Duration),
+    /// Maximum time of a single Activity execution attempt.
+    /// Note that the Temporal Server doesn't detect Worker process failures directly.
+    /// It relies on this timeout to detect that an Activity that didn't complete on time.
+    /// So this timeout should be as short as the longest possible execution of the Activity body.
+    /// Potentially long running Activities must specify `ActivityOptions::heartbeat_timeout` and heartbeat from the
+    /// activity periodically for timely failure detection.
+    StartToClose(Duration),
+    /// Applies both execution-attempt and overall-completion bounds.
+    Both {
+        /// Maximum time of a single Activity execution attempt.
+        start_to_close: Duration,
+        /// Total time that a workflow is willing to wait for Activity to complete.
+        schedule_to_close: Duration,
+    },
+}
+
+impl ActivityCloseTimeouts {
+    fn into_durations(self) -> (Option<Duration>, Option<Duration>) {
+        match self {
+            Self::ScheduleToClose(schedule_to_close) => (None, Some(schedule_to_close)),
+            Self::StartToClose(start_to_close) => (Some(start_to_close), None),
+            Self::Both {
+                start_to_close,
+                schedule_to_close,
+            } => (Some(start_to_close), Some(schedule_to_close)),
         }
     }
 }
@@ -539,34 +566,31 @@ impl ContinueAsNewOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use temporalio_common::protos::coresdk::workflow_commands::workflow_command::Variant;
 
     #[test]
-    fn activity_options_builder_defaults_match_default_impl() {
-        let built = ActivityOptions::builder().build();
-        let defaulted = ActivityOptions::default();
+    fn activity_options_builder_defaults_match_start_to_close_constructor() {
+        let built = ActivityOptions::with_close_timeout(ActivityCloseTimeouts::StartToClose(
+            Duration::from_secs(5),
+        ))
+        .build();
+        let constructed = ActivityOptions::start_to_close_timeout(Duration::from_secs(5));
 
-        assert_eq!(built.activity_id, defaulted.activity_id);
-        assert_eq!(built.task_queue, defaulted.task_queue);
+        assert_eq!(built.close_timeout, constructed.close_timeout);
+        assert_eq!(built.activity_id, constructed.activity_id);
+        assert_eq!(built.task_queue, constructed.task_queue);
         assert_eq!(
             built.schedule_to_start_timeout,
-            defaulted.schedule_to_start_timeout
+            constructed.schedule_to_start_timeout
         );
-        assert_eq!(
-            built.start_to_close_timeout,
-            defaulted.start_to_close_timeout
-        );
-        assert_eq!(
-            built.schedule_to_close_timeout,
-            defaulted.schedule_to_close_timeout
-        );
-        assert_eq!(built.heartbeat_timeout, defaulted.heartbeat_timeout);
-        assert_eq!(built.cancellation_type, defaulted.cancellation_type);
-        assert_eq!(built.retry_policy, defaulted.retry_policy);
-        assert_eq!(built.summary, defaulted.summary);
-        assert_eq!(built.priority, defaulted.priority);
+        assert_eq!(built.heartbeat_timeout, constructed.heartbeat_timeout);
+        assert_eq!(built.cancellation_type, constructed.cancellation_type);
+        assert_eq!(built.retry_policy, constructed.retry_policy);
+        assert_eq!(built.summary, constructed.summary);
+        assert_eq!(built.priority, constructed.priority);
         assert_eq!(
             built.do_not_eagerly_execute,
-            defaulted.do_not_eagerly_execute
+            constructed.do_not_eagerly_execute
         );
     }
 
@@ -574,8 +598,10 @@ mod tests {
     fn activity_options_start_to_close_timeout_constructor_sets_only_that_timeout() {
         let opts = ActivityOptions::start_to_close_timeout(Duration::from_secs(5));
 
-        assert_eq!(opts.start_to_close_timeout, Some(Duration::from_secs(5)));
-        assert_eq!(opts.schedule_to_close_timeout, None);
+        assert_eq!(
+            opts.close_timeout,
+            ActivityCloseTimeouts::StartToClose(Duration::from_secs(5))
+        );
         assert_eq!(opts.schedule_to_start_timeout, None);
         assert_eq!(opts.heartbeat_timeout, None);
     }
@@ -584,10 +610,29 @@ mod tests {
     fn activity_options_schedule_to_close_timeout_constructor_sets_only_that_timeout() {
         let opts = ActivityOptions::schedule_to_close_timeout(Duration::from_secs(5));
 
-        assert_eq!(opts.start_to_close_timeout, None);
-        assert_eq!(opts.schedule_to_close_timeout, Some(Duration::from_secs(5)));
+        assert_eq!(
+            opts.close_timeout,
+            ActivityCloseTimeouts::ScheduleToClose(Duration::from_secs(5))
+        );
         assert_eq!(opts.schedule_to_start_timeout, None);
         assert_eq!(opts.heartbeat_timeout, None);
+    }
+
+    #[test]
+    fn activity_options_both_close_timeouts_map_to_command() {
+        let cmd = ActivityOptions::with_close_timeout(ActivityCloseTimeouts::Both {
+            start_to_close: Duration::from_secs(3),
+            schedule_to_close: Duration::from_secs(8),
+        })
+        .build()
+        .into_command("test".to_string(), vec![], 7);
+        let schedule_cmd = match cmd.variant.unwrap() {
+            Variant::ScheduleActivity(cmd) => cmd,
+            other => panic!("Expected ScheduleActivity, got {other:?}"),
+        };
+
+        assert_eq!(schedule_cmd.start_to_close_timeout.unwrap().seconds, 3);
+        assert_eq!(schedule_cmd.schedule_to_close_timeout.unwrap().seconds, 8);
     }
 
     #[test]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Move to a builder for `ActivityOptions`
- Combine `schedule_to_close_timeout` and `start_to_close_timeout` into a combined field of `close_timeouts: ActivityCloseTimeouts` to enforce that some timeout to close is set.

Aside from the vanilla builder we add a few methods to help with ergonomics by letting them skip importing the new enum:
 - `ActivityOptions::schedule_to_close_timeout`/`ActivityOptions::start_to_close_timeout`: Directly construct activity options with just this timeout set
 - `ActivityOptions::with_schedule_to_close_timeout`/`ActivityOptions::with_start_to_close_timeout`: Start an options builder with one of these timeouts set
There is no both variant for these since it would take 2 `Duration` objects and there isn't a clear way to indicate which one is for which timeout without a struct, which we already have this with the enum.

## Why?
Collapsing the close timeouts allows us to enforce that all activities must have a timeout to close.

I ended up combining this with moving `ActivityOptions` to a builder as the close timeout change was invasive enough and at the end of the day I wanted to see the end state of how we want users to construct these options.

### Alternatives Considered

There is a nice design where we continue to expose the activity timeout setting only via the builder with `.start_to_close_timeout` and `schedule_to_close_timeout` setters that both flow into a single required field.
https://github.com/elastio/bon/issues/149

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Migrated existing tests/examples to use new activity options API

3. Any docs updates needed?
README was updated
