### PR TITLE
Move Core-specific test utilities out of the Common crate

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -14,7 +14,6 @@ exclude = ["protos/*/.github/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-history_builders = ["dep:rand"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
 prometheus = [
   "dep:prometheus",
@@ -25,7 +24,6 @@ prometheus = [
 ]
 envconfig = ["dep:toml", "dep:dirs"]
 serde_serialize = []
-test-utilities = ["history_builders"]
 core-telemetry-bridge = ["dep:ringbuf", "dep:futures-channel"]
 core-based-sdk = ["core-telemetry-bridge", "prometheus", "envconfig"]
 
@@ -70,7 +68,6 @@ prometheus = { version = "0.14", optional = true, default-features = false }
 prost = { workspace = true }
 prost-wkt = "0.7"
 prost-types = { workspace = true }
-rand = { version = "0.10", optional = true }
 ringbuf = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/common/src/protos/mod.rs
+++ b/crates/common/src/protos/mod.rs
@@ -6,26 +6,10 @@ pub mod constants;
 /// Utility functions for working with protobuf types.
 pub mod utilities;
 
-#[cfg(feature = "test-utilities")]
-/// Pre-built test histories for common workflow patterns.
-pub mod canned_histories;
-#[cfg(feature = "history_builders")]
-mod history_builder;
-#[cfg(feature = "history_builders")]
-mod history_info;
 mod task_token;
-#[cfg(feature = "test-utilities")]
-pub mod test_utils;
 
 use std::time::Duration;
 
-#[cfg(feature = "history_builders")]
-pub use history_builder::{
-    DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, default_act_sched,
-    default_wes_attribs,
-};
-#[cfg(feature = "history_builders")]
-pub use history_info::HistoryInfo;
 pub use task_token::TaskToken;
 
 /// Payload metadata key that identifies the encoding format.

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -27,6 +27,9 @@ otel = [
 ]
 ephemeral-server = ["dep:flate2", "dep:reqwest", "dep:tar", "dep:zip"]
 debug-plugin = ["dep:reqwest", "dep:hyper"]
+# Exposes mocks and helpers used by sdk-core's own integration tests, benches,
+# and the `histfetch` binary. Not part of the public API surface; downstream
+# crates should not enable this feature.
 test-utilities = ["dep:assert_matches", "dep:bimap"]
 antithesis_assertions = ["dep:antithesis_sdk"]
 
@@ -119,7 +122,7 @@ zip = { version = "8.4", optional = true, default-features = false, features = [
 path = "../common"
 version = "0.3"
 default-features = false
-features = ["core-telemetry-bridge", "history_builders"]
+features = ["core-telemetry-bridge"]
 
 [dependencies.temporalio-client]
 path = "../client"
@@ -149,9 +152,7 @@ hyper-util = { version = "0.1", features = [
 rstest = "0.26"
 semver = "1.0"
 temporalio-sdk = { path = "../sdk" }
-temporalio-common = { path = "../common", version = "0.3", default-features = false, features = [
-  "test-utilities",
-] }
+temporalio-common = { path = "../common", version = "0.3", default-features = false }
 tokio = { version = "1.47", default-features = false, features = [
   "rt",
   "rt-multi-thread",

--- a/crates/sdk-core/benches/workflow_replay_bench.rs
+++ b/crates/sdk-core/benches/workflow_replay_bench.rs
@@ -12,13 +12,13 @@ use std::{
     thread,
     time::Duration,
 };
-use temporalio_common::{
-    protos::{DEFAULT_WORKFLOW_TYPE, canned_histories},
-    telemetry::metrics::{MetricKeyValue, MetricParameters, NewAttributes},
-};
+use temporalio_common::telemetry::metrics::{MetricKeyValue, MetricParameters, NewAttributes};
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{SyncWorkflowContext, WorkflowContext, WorkflowResult};
-use temporalio_sdk_core::{CoreRuntime, replay::HistoryForReplay};
+use temporalio_sdk_core::{
+    CoreRuntime,
+    replay::{DEFAULT_WORKFLOW_TYPE, HistoryForReplay, canned_histories},
+};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let tokio_runtime = tokio::runtime::Builder::new_current_thread()

--- a/crates/sdk-core/src/core_tests/activity_tasks.rs
+++ b/crates/sdk-core/src/core_tests/activity_tasks.rs
@@ -1,10 +1,11 @@
 use crate::{
     ActivityHeartbeat, CompleteActivityError, Worker, advance_fut, job_assert, prost_dur,
+    replay::{TestHistoryBuilder, canned_histories},
     test_help::{
         FakeWfResponses, MockPollCfg, MockWorkerInputs, MocksHolder, QueueResponse, WorkerExt,
         WorkflowCachingPolicy, build_fake_worker, build_mock_pollers, build_multihist_mock_sg,
         fanout_tasks, gen_assert_and_reply, mock_manual_poller, mock_poller, mock_worker,
-        poll_and_reply, single_hist_mock_sg, test_worker_cfg,
+        poll_and_reply, single_hist_mock_sg, start_timer_cmd, test_worker_cfg,
     },
     worker::{
         PollerBehavior,
@@ -26,7 +27,6 @@ use std::{
 };
 use temporalio_common::{
     protos::{
-        TestHistoryBuilder, canned_histories,
         coresdk::{
             ActivityTaskCompletion,
             activity_result::{
@@ -52,7 +52,6 @@ use temporalio_common::{
                 RespondActivityTaskFailedResponse, RespondWorkflowTaskCompletedResponse,
             },
         },
-        test_utils::start_timer_cmd,
     },
     worker::WorkerTaskTypes,
 };

--- a/crates/sdk-core/src/core_tests/mod.rs
+++ b/crates/sdk-core/src/core_tests/mod.rs
@@ -8,6 +8,7 @@ mod workflow_tasks;
 
 use crate::{
     PollError, Worker,
+    replay::{TestHistoryBuilder, canned_histories},
     test_help::{
         MockPollCfg, build_mock_pollers, mock_worker, single_hist_mock_sg, test_worker_cfg,
     },
@@ -19,7 +20,6 @@ use crate::{
 use futures_util::FutureExt;
 use std::{sync::LazyLock, time::Duration};
 use temporalio_common::protos::{
-    TestHistoryBuilder, canned_histories,
     coresdk::{
         workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_completion::WorkflowActivationCompletion,

--- a/crates/sdk-core/src/core_tests/queries.rs
+++ b/crates/sdk-core/src/core_tests/queries.rs
@@ -1,7 +1,9 @@
 use crate::{
+    replay::{TestHistoryBuilder, canned_histories},
     test_help::{
         MockPollCfg, MocksHolder, ResponseType, WorkerExt, WorkerTestHelpers, build_mock_pollers,
-        hist_to_poll_resp, mock_worker, single_hist_mock_sg,
+        hist_to_poll_resp, mock_worker, query_ok, schedule_activity_cmd, single_hist_mock_sg,
+        start_timer_cmd,
     },
     worker::{
         LEGACY_QUERY_ID, WorkerVersioningStrategy,
@@ -19,7 +21,6 @@ use std::{
 };
 use temporalio_client::MESSAGE_TOO_LARGE_KEY;
 use temporalio_common::protos::{
-    TestHistoryBuilder, canned_histories,
     coresdk::{
         workflow_activation::{
             WorkflowActivationJob, remove_from_cache::EvictionReason, workflow_activation_job,
@@ -40,7 +41,6 @@ use temporalio_common::protos::{
             GetWorkflowExecutionHistoryResponse, RespondWorkflowTaskCompletedResponse,
         },
     },
-    test_utils::{query_ok, schedule_activity_cmd, start_timer_cmd},
 };
 
 #[rstest::rstest]

--- a/crates/sdk-core/src/core_tests/replay_flag.rs
+++ b/crates/sdk-core/src/core_tests/replay_flag.rs
@@ -1,16 +1,18 @@
 use crate::{
-    test_help::{MockPollCfg, ResponseType, build_mock_pollers, hist_to_poll_resp, mock_worker},
+    replay::{TestHistoryBuilder, canned_histories},
+    test_help::{
+        MockPollCfg, ResponseType, build_mock_pollers, hist_to_poll_resp, mock_worker, query_ok,
+        start_timer_cmd,
+    },
     worker::{LEGACY_QUERY_ID, client::mocks::mock_worker_client},
 };
 use std::{collections::VecDeque, time::Duration};
 use temporalio_common::protos::{
-    TestHistoryBuilder, canned_histories,
     coresdk::{
         workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_completion::WorkflowActivationCompletion,
     },
     temporal::api::{enums::v1::EventType, query::v1::WorkflowQuery},
-    test_utils::{query_ok, start_timer_cmd},
 };
 
 #[tokio::test]

--- a/crates/sdk-core/src/core_tests/updates.rs
+++ b/crates/sdk-core/src/core_tests/updates.rs
@@ -1,5 +1,6 @@
 use crate::{
     prost_dur,
+    replay::{DEFAULT_ACTIVITY_TYPE, TestHistoryBuilder},
     test_help::{
         MockPollCfg, PollWFTRespExt, ResponseType, WorkerTestHelpers, build_mock_pollers,
         hist_to_poll_resp, mock_worker,
@@ -7,7 +8,6 @@ use crate::{
     worker::client::mocks::mock_worker_client,
 };
 use temporalio_common::protos::{
-    DEFAULT_ACTIVITY_TYPE, TestHistoryBuilder,
     coresdk::{
         workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         workflow_commands::{

--- a/crates/sdk-core/src/core_tests/workers.rs
+++ b/crates/sdk-core/src/core_tests/workers.rs
@@ -1,8 +1,10 @@
 use crate::{
     CompleteNexusError, PollError, prost_dur,
+    replay::canned_histories,
     test_help::{
         MockPollCfg, MockWorkerInputs, MocksHolder, QueueResponse, ResponseType, WorkerExt,
-        WorkerTestHelpers, build_fake_worker, build_mock_pollers, mock_worker, test_worker_cfg,
+        WorkerTestHelpers, build_fake_worker, build_mock_pollers, mock_worker, start_timer_cmd,
+        test_worker_cfg,
     },
     worker::{
         self, PollerBehavior,
@@ -24,7 +26,6 @@ use temporalio_common::protos::temporal::api::{
 };
 use temporalio_common::{
     protos::{
-        canned_histories,
         coresdk::{
             ActivityTaskCompletion,
             activity_result::ActivityExecutionResult,
@@ -55,7 +56,6 @@ use temporalio_common::{
                 RespondWorkflowTaskCompletedResponse, ShutdownWorkerResponse,
             },
         },
-        test_utils::start_timer_cmd,
     },
     worker::WorkerTaskTypes,
 };

--- a/crates/sdk-core/src/core_tests/workflow_cancels.rs
+++ b/crates/sdk-core/src/core_tests/workflow_cancels.rs
@@ -1,21 +1,18 @@
 use crate::{
     job_assert,
+    replay::canned_histories,
     test_help::{
         ResponseType, WorkflowCachingPolicy::NonSticky, build_fake_worker, gen_assert_and_reply,
-        poll_and_reply,
+        poll_and_reply, start_timer_cmd,
     },
 };
 use rstest::rstest;
 use std::time::Duration;
-use temporalio_common::protos::{
-    canned_histories,
-    coresdk::{
-        workflow_activation::{WorkflowActivationJob, workflow_activation_job},
-        workflow_commands::{
-            CancelWorkflowExecution, CompleteWorkflowExecution, FailWorkflowExecution,
-        },
+use temporalio_common::protos::coresdk::{
+    workflow_activation::{WorkflowActivationJob, workflow_activation_job},
+    workflow_commands::{
+        CancelWorkflowExecution, CompleteWorkflowExecution, FailWorkflowExecution,
     },
-    test_utils::start_timer_cmd,
 };
 
 enum CompletionType {

--- a/crates/sdk-core/src/core_tests/workflow_tasks.rs
+++ b/crates/sdk-core/src/core_tests/workflow_tasks.rs
@@ -2,13 +2,14 @@ use crate::{
     PollError, PollWorkflowOptions, Worker, advance_fut,
     internal_flags::CoreInternalFlags,
     job_assert,
-    replay::TestHistoryBuilder,
+    replay::{TestHistoryBuilder, canned_histories, default_act_sched, default_wes_attribs},
     test_help::{
         FakeWfResponses, MockPollCfg, MocksHolder, ResponseType, WorkerExt, WorkerTestHelpers,
         WorkflowCachingPolicy::{self, AfterEveryReply, NonSticky},
         build_fake_worker, build_mock_pollers, build_multihist_mock_sg, fanout_tasks,
         gen_assert_and_fail, gen_assert_and_reply, hist_to_poll_resp, mock_worker, poll_and_reply,
-        poll_and_reply_clears_outstanding_evicts, single_hist_mock_sg, test_worker_cfg,
+        poll_and_reply_clears_outstanding_evicts, single_hist_mock_sg, start_timer_cmd,
+        test_worker_cfg,
     },
     worker::{
         PollerBehavior, SlotMarkUsedContext, SlotReleaseContext, SlotReservationContext,
@@ -31,7 +32,6 @@ use std::{
 use temporalio_client::MESSAGE_TOO_LARGE_KEY;
 use temporalio_common::{
     protos::{
-        canned_histories,
         coresdk::{
             activity_result::{self as ar, ActivityResolution, activity_resolution},
             common::VersioningIntent,
@@ -47,7 +47,6 @@ use temporalio_common::{
             },
             workflow_completion::WorkflowActivationCompletion,
         },
-        default_act_sched, default_wes_attribs,
         temporal::api::{
             command::v1::command::Attributes,
             common::v1::{Payload, RetryPolicy},
@@ -61,7 +60,6 @@ use temporalio_common::{
                 GetWorkflowExecutionHistoryResponse, RespondWorkflowTaskCompletedResponse,
             },
         },
-        test_utils::start_timer_cmd,
     },
     worker::WorkerTaskTypes,
 };
@@ -2391,7 +2389,13 @@ async fn lang_internal_flag_with_update() {
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    t.set_flags_last_wft(&[1, 2], &[1]);
+    t.set_flags_last_wft(
+        &[
+            CoreInternalFlags::IdAndTypeDeterminismChecks,
+            CoreInternalFlags::UpsertSearchAttributeOnPatch,
+        ],
+        &[1],
+    );
     let updid = t.add_update_accepted("upd1", "upd");
     t.add_update_completed(updid);
     t.add_workflow_execution_completed();
@@ -2513,7 +2517,7 @@ async fn post_terminal_commands_are_retained_when_replaying_and_flag_set() {
     t.add_full_wf_task();
     t.add_timer_started("1".to_string());
     t.add_workflow_execution_completed();
-    t.set_flags_last_wft(&[CoreInternalFlags::MoveTerminalCommands as u32], &[]);
+    t.set_flags_last_wft(&[CoreInternalFlags::MoveTerminalCommands], &[]);
 
     let commands_sent_by_lang = vec![
         CompleteWorkflowExecution { result: None }.into(),

--- a/crates/sdk-core/src/replay/canned_histories.rs
+++ b/crates/sdk-core/src/replay/canned_histories.rs
@@ -1,5 +1,8 @@
-use crate::protos::{
-    TestHistoryBuilder,
+use crate::replay::TestHistoryBuilder;
+use prost::Message;
+use rand::Rng;
+use std::{fs::File, io::Write, path::PathBuf};
+use temporalio_common::protos::{
     coresdk::common::NamespacedWorkflowExecution,
     temporal::api::{
         common::v1::{Payload, WorkflowExecution},
@@ -8,9 +11,6 @@ use crate::protos::{
         history::v1::*,
     },
 };
-use prost::Message;
-use rand::Rng;
-use std::{fs::File, io::Write, path::PathBuf};
 
 ///  1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
 ///  2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED

--- a/crates/sdk-core/src/replay/history_builder.rs
+++ b/crates/sdk-core/src/replay/history_builder.rs
@@ -1,5 +1,11 @@
-use crate::protos::{
-    HistoryInfo,
+use crate::{replay::HistoryInfo, test_help::CoreInternalFlags};
+use anyhow::bail;
+use prost_types::Timestamp;
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
+use temporalio_common::protos::{
     constants::{LOCAL_ACTIVITY_MARKER_NAME, PATCH_MARKER_NAME},
     coresdk::{
         AsJsonPayloadExt, IntoPayloadsExt,
@@ -21,12 +27,6 @@ use crate::protos::{
         update,
         update::v1::outcome,
     },
-};
-use anyhow::bail;
-use prost_types::Timestamp;
-use std::{
-    collections::HashMap,
-    time::{Duration, SystemTime},
 };
 use uuid::Uuid;
 
@@ -599,13 +599,21 @@ impl TestHistoryBuilder {
     }
 
     /// Sets internal patches which should appear in the first WFT complete event
-    pub fn set_flags_first_wft(&mut self, core: &[u32], lang: &[u32]) {
-        Self::set_flags(self.events.iter_mut(), core, lang)
+    pub fn set_flags_first_wft(&mut self, core: &[CoreInternalFlags], lang: &[u32]) {
+        Self::set_flags(
+            self.events.iter_mut(),
+            &core.iter().map(|f| *f as u32).collect::<Vec<_>>(),
+            lang,
+        )
     }
 
     /// Sets internal patches which should appear in the most recent complete event
-    pub fn set_flags_last_wft(&mut self, core: &[u32], lang: &[u32]) {
-        Self::set_flags(self.events.iter_mut().rev(), core, lang)
+    pub fn set_flags_last_wft(&mut self, core: &[CoreInternalFlags], lang: &[u32]) {
+        Self::set_flags(
+            self.events.iter_mut().rev(),
+            &core.iter().map(|f| *f as u32).collect::<Vec<_>>(),
+            lang,
+        )
     }
 
     /// Get the event ID of the most recently added event

--- a/crates/sdk-core/src/replay/history_info.rs
+++ b/crates/sdk-core/src/replay/history_info.rs
@@ -1,12 +1,12 @@
-use crate::protos::temporal::api::{
+use anyhow::{anyhow, bail};
+use rand::random;
+use temporalio_common::protos::temporal::api::{
     common::v1::WorkflowType,
     enums::v1::{EventType, TaskQueueKind},
     history::v1::{History, HistoryEvent, WorkflowExecutionStartedEventAttributes, history_event},
     taskqueue::v1::TaskQueue,
     workflowservice::v1::{GetWorkflowExecutionHistoryResponse, PollWorkflowTaskQueueResponse},
 };
-use anyhow::{anyhow, bail};
-use rand::random;
 
 /// Contains information about a validated history. Used for replay and other testing.
 #[derive(Clone, Debug, PartialEq)]
@@ -209,7 +209,8 @@ impl From<HistoryInfo> for GetWorkflowExecutionHistoryResponse {
 
 #[cfg(test)]
 mod tests {
-    use crate::protos::{TestHistoryBuilder, temporal::api::enums::v1::EventType};
+    use crate::replay::TestHistoryBuilder;
+    use temporalio_common::protos::temporal::api::enums::v1::EventType;
 
     fn single_timer(timer_id: &str) -> TestHistoryBuilder {
         let mut t = TestHistoryBuilder::default();

--- a/crates/sdk-core/src/replay/mod.rs
+++ b/crates/sdk-core/src/replay/mod.rs
@@ -2,6 +2,17 @@
 //! to replay canned histories. It should be used by Lang SDKs to provide replay capabilities to
 //! users during testing.
 
+mod history_info;
+
+/// Pre-built test histories for common workflow patterns.
+#[cfg(any(feature = "test-utilities", test))]
+pub mod canned_histories;
+
+#[cfg(any(feature = "test-utilities", test))]
+mod history_builder;
+
+pub use history_info::HistoryInfo;
+
 use crate::{
     Worker, WorkerConfig,
     worker::{
@@ -15,9 +26,6 @@ use std::{
     pin::Pin,
     sync::{Arc, OnceLock},
     task::{Context, Poll},
-};
-pub use temporalio_common::protos::{
-    DEFAULT_WORKFLOW_TYPE, HistoryInfo, TestHistoryBuilder, default_wes_attribs,
 };
 use temporalio_common::{
     protos::{
@@ -35,6 +43,12 @@ use temporalio_common::{
 use tokio::sync::{Mutex as TokioMutex, mpsc, mpsc::UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
+
+#[cfg(any(feature = "test-utilities", test))]
+pub use history_builder::{
+    DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, default_act_sched,
+    default_wes_attribs,
+};
 
 /// Contains inputs to a replay worker
 pub struct ReplayWorkerInput<I> {
@@ -140,11 +154,13 @@ impl HistoryForReplay {
         }
     }
 }
+#[cfg(any(feature = "test-utilities", test))]
 impl From<TestHistoryBuilder> for HistoryForReplay {
     fn from(thb: TestHistoryBuilder) -> Self {
         thb.get_full_history_info().unwrap().into()
     }
 }
+#[cfg(any(feature = "test-utilities", test))]
 impl From<HistoryInfo> for HistoryForReplay {
     fn from(histinfo: HistoryInfo) -> Self {
         HistoryForReplay::new(histinfo, "fake".to_owned())

--- a/crates/sdk-core/src/test_help/mod.rs
+++ b/crates/sdk-core/src/test_help/mod.rs
@@ -6,8 +6,12 @@ pub use unit_helpers::*;
 
 #[cfg(any(feature = "test-utilities", test))]
 pub use integ_helpers::*;
+#[cfg(any(feature = "test-utilities", test))]
+pub use test_utils::*;
 
 #[cfg(any(feature = "test-utilities", test))]
 mod integ_helpers;
+#[cfg(any(feature = "test-utilities", test))]
+mod test_utils;
 #[cfg(test)]
 mod unit_helpers;

--- a/crates/sdk-core/src/test_help/test_utils.rs
+++ b/crates/sdk-core/src/test_help/test_utils.rs
@@ -1,25 +1,15 @@
 //! Test utilities for creating workflow commands and histories
 //! Only available when the test-utilities feature is enabled
 
-use crate::protos::{
-    DEFAULT_ACTIVITY_TYPE,
+use crate::replay::DEFAULT_ACTIVITY_TYPE;
+use std::time::Duration;
+use temporalio_common::protos::{
     coresdk::workflow_commands::{
         ActivityCancellationType, QueryResult, QuerySuccess, ScheduleActivity,
         ScheduleLocalActivity, StartTimer, workflow_command,
     },
     temporal::api::common::v1::Payload,
 };
-use std::time::Duration;
-
-/// Convenience macro for creating prost Duration from std::time::Duration
-#[macro_export]
-macro_rules! prost_dur {
-    ($dur_call:ident $args:tt) => {
-        std::time::Duration::$dur_call$args
-            .try_into()
-            .expect("test duration fits")
-    };
-}
 
 /// Create a start timer command for use in tests
 pub fn start_timer_cmd(seq: u32, duration: Duration) -> workflow_command::Variant {

--- a/crates/sdk-core/src/worker/workflow/history_update.rs
+++ b/crates/sdk-core/src/worker/workflow/history_update.rs
@@ -805,17 +805,14 @@ fn find_end_index_of_next_wft_seq(
 mod tests {
     use super::*;
     use crate::{
-        replay::{HistoryInfo, TestHistoryBuilder},
+        replay::{HistoryInfo, TestHistoryBuilder, canned_histories},
         test_help::{ResponseType, hist_to_poll_resp},
         worker::client::mocks::mock_worker_client,
     };
     use futures_util::TryStreamExt;
-    use temporalio_common::protos::{
-        canned_histories,
-        temporal::api::{
-            common::v1::WorkflowExecution, enums::v1::WorkflowTaskFailedCause,
-            workflowservice::v1::GetWorkflowExecutionHistoryResponse,
-        },
+    use temporalio_common::protos::temporal::api::{
+        common::v1::WorkflowExecution, enums::v1::WorkflowTaskFailedCause,
+        workflowservice::v1::GetWorkflowExecutionHistoryResponse,
     };
 
     impl From<HistoryInfo> for HistoryUpdate {

--- a/crates/sdk-core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/upsert_search_attributes_state_machine.rs
@@ -253,10 +253,7 @@ mod tests {
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_full_wf_task();
         if flag_in_history {
-            t.set_flags_first_wft(
-                &[CoreInternalFlags::UpsertSearchAttributeOnPatch as u32],
-                &[],
-            );
+            t.set_flags_first_wft(&[CoreInternalFlags::UpsertSearchAttributeOnPatch], &[]);
         }
         if with_patched_cmd {
             t.add_has_change_marker(&patch_id, false);

--- a/crates/sdk-core/tests/common/activity_functions.rs
+++ b/crates/sdk-core/tests/common/activity_functions.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
-use temporalio_common::{data_converters::RawValue, protos::DEFAULT_ACTIVITY_TYPE};
+use temporalio_common::data_converters::RawValue;
 use temporalio_macros::activities;
 use temporalio_sdk::activities::{ActivityContext, ActivityError};
+use temporalio_sdk_core::replay::DEFAULT_ACTIVITY_TYPE;
 use tokio::time::sleep;
 
 pub(crate) struct StdActivities;

--- a/crates/sdk-core/tests/common/workflows.rs
+++ b/crates/sdk-core/tests/common/workflows.rs
@@ -1,8 +1,9 @@
 use crate::common::activity_functions::StdActivities;
 use std::time::Duration;
-use temporalio_common::{prost_dur, protos::temporal::api::common::v1::RetryPolicy};
+use temporalio_common::protos::temporal::api::common::v1::RetryPolicy;
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{ActivityOptions, LocalActivityOptions, WorkflowContext, WorkflowResult};
+use temporalio_sdk_core::prost_dur;
 
 #[workflow]
 #[derive(Default)]

--- a/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
@@ -2,32 +2,29 @@ use crate::common::{CoreWfStarter, activity_functions::StdActivities, init_core_
 use assert_matches::assert_matches;
 use std::time::Duration;
 use temporalio_client::WorkflowStartOptions;
-use temporalio_common::{
-    prost_dur,
-    protos::{
-        DEFAULT_ACTIVITY_TYPE,
-        coresdk::{
-            ActivityHeartbeat, ActivityTaskCompletion, IntoCompletion,
-            activity_result::{
-                self, ActivityExecutionResult, ActivityResolution, activity_resolution as act_res,
-            },
-            activity_task::activity_task,
-            workflow_activation::{
-                ResolveActivity, WorkflowActivationJob, workflow_activation_job,
-            },
-            workflow_commands::{ActivityCancellationType, ScheduleActivity},
-            workflow_completion::WorkflowActivationCompletion,
+use temporalio_common::protos::{
+    coresdk::{
+        ActivityHeartbeat, ActivityTaskCompletion, IntoCompletion,
+        activity_result::{
+            self, ActivityExecutionResult, ActivityResolution, activity_resolution as act_res,
         },
-        temporal::api::{
-            common::v1::{Payload, RetryPolicy},
-            enums::v1::TimeoutType,
-        },
-        test_utils::schedule_activity_cmd,
+        activity_task::activity_task,
+        workflow_activation::{ResolveActivity, WorkflowActivationJob, workflow_activation_job},
+        workflow_commands::{ActivityCancellationType, ScheduleActivity},
+        workflow_completion::WorkflowActivationCompletion,
+    },
+    temporal::api::{
+        common::v1::{Payload, RetryPolicy},
+        enums::v1::TimeoutType,
     },
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{ActivityExecutionError, ActivityOptions, WorkflowContext, WorkflowResult};
-use temporalio_sdk_core::test_help::{WorkerTestHelpers, drain_pollers_and_shutdown};
+use temporalio_sdk_core::{
+    prost_dur,
+    replay::DEFAULT_ACTIVITY_TYPE,
+    test_help::{WorkerTestHelpers, drain_pollers_and_shutdown, schedule_activity_cmd},
+};
 use tokio::time::sleep;
 
 #[workflow]

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -21,7 +21,6 @@ use temporalio_client::{
 };
 use temporalio_common::{
     data_converters::RawValue,
-    prost_dur,
     protos::{
         coresdk::{
             ActivityTaskCompletion,
@@ -73,7 +72,7 @@ use temporalio_sdk_core::{
     CoreRuntime, FixedSizeSlotSupplier, PollError, PollerBehavior, SlotKind, SlotMarkUsedContext,
     SlotReleaseContext, SlotReservationContext, SlotSupplier, SlotSupplierPermit,
     TokioRuntimeBuilder, TunerBuilder, WorkerConfig, WorkerVersioningStrategy, WorkflowSlotKind,
-    init_worker,
+    init_worker, prost_dur,
     replay::TestHistoryBuilder,
     test_help::{
         MockPollCfg, ResponseType, TemporalMeter, WorkerExt, WorkerTestHelpers, build_mock_pollers,

--- a/crates/sdk-core/tests/integ_tests/pagination_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/pagination_tests.rs
@@ -3,18 +3,18 @@ use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
 };
-use temporalio_common::protos::{
-    DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder,
-    temporal::api::{
-        common::v1::WorkflowExecution,
-        enums::v1::{EventType, WorkflowTaskFailedCause},
-        history::v1::{History, HistoryEvent},
-        workflowservice::v1::GetWorkflowExecutionHistoryResponse,
-    },
+use temporalio_common::protos::temporal::api::{
+    common::v1::WorkflowExecution,
+    enums::v1::{EventType, WorkflowTaskFailedCause},
+    history::v1::{History, HistoryEvent},
+    workflowservice::v1::GetWorkflowExecutionHistoryResponse,
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{SyncWorkflowContext, WorkflowContext, WorkflowResult};
-use temporalio_sdk_core::test_help::{MockPollCfg, ResponseType, mock_worker_client};
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
+    test_help::{MockPollCfg, ResponseType, mock_worker_client},
+};
 
 #[workflow]
 struct WeirdPaginationWf {

--- a/crates/sdk-core/tests/integ_tests/polling_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/polling_tests.rs
@@ -19,7 +19,6 @@ use temporalio_client::{
 };
 use temporalio_common::{
     data_converters::RawValue,
-    prost_dur,
     protos::{
         coresdk::{
             IntoCompletion,
@@ -29,7 +28,6 @@ use temporalio_common::{
             workflow_completion::WorkflowActivationCompletion,
         },
         temporal::api::enums::v1::EventType,
-        test_utils::schedule_activity_cmd,
     },
     telemetry::{CoreLogStreamConsumer, Logger, TelemetryOptions},
 };
@@ -38,8 +36,8 @@ use temporalio_sdk::{ActivityOptions, WorkflowContext, WorkflowResult};
 use temporalio_sdk_core::{
     CoreRuntime, PollerBehavior, RuntimeOptions, TunerHolder,
     ephemeral_server::{TemporalDevServerConfig, default_cached_download},
-    init_worker,
-    test_help::{NAMESPACE, WorkerTestHelpers, drain_pollers_and_shutdown},
+    init_worker, prost_dur,
+    test_help::{NAMESPACE, WorkerTestHelpers, drain_pollers_and_shutdown, schedule_activity_cmd},
 };
 use tokio::{sync::Notify, time::timeout};
 use tracing::info;

--- a/crates/sdk-core/tests/integ_tests/queries_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/queries_tests.rs
@@ -8,7 +8,6 @@ use temporalio_client::{
 };
 use temporalio_common::{
     data_converters::RawValue,
-    prost_dur,
     protos::{
         coresdk::{
             workflow_activation::{WorkflowActivationJob, workflow_activation_job},
@@ -16,10 +15,12 @@ use temporalio_common::{
             workflow_completion::WorkflowActivationCompletion,
         },
         temporal::api::failure::v1::Failure,
-        test_utils::start_timer_cmd,
     },
 };
-use temporalio_sdk_core::test_help::{WorkerTestHelpers, drain_pollers_and_shutdown};
+use temporalio_sdk_core::{
+    prost_dur,
+    test_help::{WorkerTestHelpers, drain_pollers_and_shutdown, start_timer_cmd},
+};
 use tokio::join;
 
 #[tokio::test]

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -19,7 +19,6 @@ use temporalio_client::{
 };
 use temporalio_common::{
     data_converters::RawValue,
-    prost_dur,
     protos::{
         coresdk::{
             ActivityTaskCompletion,
@@ -37,7 +36,6 @@ use temporalio_common::{
             enums::v1::{EventType, ResetReapplyType},
             workflowservice::v1::{ResetStickyTaskQueueRequest, ResetWorkflowExecutionRequest},
         },
-        test_utils::start_timer_cmd,
     },
     worker::WorkerTaskTypes,
 };
@@ -48,9 +46,9 @@ use temporalio_sdk::{
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::{
-    Worker,
+    Worker, prost_dur,
     replay::HistoryForReplay,
-    test_help::{WorkerTestHelpers, drain_pollers_and_shutdown},
+    test_help::{WorkerTestHelpers, drain_pollers_and_shutdown, start_timer_cmd},
 };
 use tokio::{join, sync::Barrier};
 use tonic::IntoRequest;

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -18,7 +18,6 @@ use temporalio_client::{
     grpc::WorkflowService,
 };
 use temporalio_common::{
-    prost_dur,
     protos::{
         coresdk::AsJsonPayloadExt,
         temporal::api::{
@@ -40,7 +39,7 @@ use temporalio_sdk::{
 };
 use temporalio_sdk_core::{
     CoreRuntime, PollerBehavior, ResourceBasedTuner, ResourceSlotOptions, RuntimeOptions,
-    TunerHolder,
+    TunerHolder, prost_dur,
 };
 use tokio::{sync::Notify, time::sleep};
 use tonic::IntoRequest;

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -22,7 +22,6 @@ use temporalio_client::{Connection, WorkflowStartOptions};
 use temporalio_common::{
     data_converters::{DataConverter, RawValue},
     protos::{
-        DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories,
         coresdk::{
             ActivityTaskCompletion,
             activity_result::ActivityExecutionResult,
@@ -65,6 +64,7 @@ use temporalio_sdk_core::{
     ResourceBasedTuner, ResourceSlotOptions, SlotInfo, SlotInfoTrait, SlotMarkUsedContext,
     SlotReleaseContext, SlotReservationContext, SlotSupplier, SlotSupplierPermit, TunerBuilder,
     WorkerConfig, WorkerValidationError, WorkerVersioningStrategy, WorkflowSlotKind, init_worker,
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
     test_help::{
         FakeWfResponses, MockPollCfg, ResponseType, build_mock_pollers, drain_pollers_and_shutdown,
         hist_to_poll_resp, mock_worker, mock_worker_client,

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -40,9 +40,7 @@ use temporalio_client::{
 };
 use temporalio_common::{
     data_converters::RawValue,
-    prost_dur,
     protos::{
-        DEFAULT_WORKFLOW_TYPE, canned_histories,
         coresdk::{
             ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
             activity_result::ActivityExecutionResult,
@@ -61,7 +59,6 @@ use temporalio_common::{
             sdk::v1::UserMetadata,
             workflowservice::v1::ResetStickyTaskQueueRequest,
         },
-        test_utils::schedule_activity_cmd,
     },
     worker::{WorkerDeploymentOptions, WorkerDeploymentVersion, WorkerTaskTypes},
 };
@@ -71,9 +68,11 @@ use temporalio_sdk::{
     interceptors::WorkerInterceptor,
 };
 use temporalio_sdk_core::{
-    CoreRuntime, PollError, PollerBehavior, TunerHolder, WorkflowErrorType,
-    replay::HistoryForReplay,
-    test_help::{MockPollCfg, WorkerTestHelpers, drain_pollers_and_shutdown},
+    CoreRuntime, PollError, PollerBehavior, TunerHolder, WorkflowErrorType, prost_dur,
+    replay::{DEFAULT_WORKFLOW_TYPE, HistoryForReplay, canned_histories},
+    test_help::{
+        MockPollCfg, WorkerTestHelpers, drain_pollers_and_shutdown, schedule_activity_cmd,
+    },
 };
 use tokio::{join, sync::Notify, time::sleep};
 use tonic::IntoRequest;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -16,32 +16,27 @@ use temporalio_client::{
     ActivityIdentifier, UntypedWorkflow, WorkflowDescribeOptions, WorkflowStartOptions,
     WorkflowTerminateOptions,
 };
-use temporalio_common::{
-    prost_dur,
-    protos::{
-        DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories,
-        coresdk::{
-            ActivityHeartbeat, ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
-            IntoPayloadsExt,
-            activity_result::{
-                self, ActivityExecutionResult, ActivityResolution, activity_resolution as act_res,
-            },
-            activity_task::activity_task as act_task,
-            workflow_activation::{
-                FireTimer, ResolveActivity, WorkflowActivationJob, workflow_activation_job,
-            },
-            workflow_commands::{
-                ActivityCancellationType, RequestCancelActivity, ScheduleActivity, StartTimer,
-            },
-            workflow_completion::WorkflowActivationCompletion,
+use temporalio_common::protos::{
+    coresdk::{
+        ActivityHeartbeat, ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
+        IntoPayloadsExt,
+        activity_result::{
+            self, ActivityExecutionResult, ActivityResolution, activity_resolution as act_res,
         },
-        temporal::api::{
-            common::v1::{ActivityType, Payload, Payloads, RetryPolicy},
-            enums::v1::{CommandType, EventType, RetryState},
-            failure::v1::{ActivityFailureInfo, Failure, failure::FailureInfo},
-            sdk::v1::UserMetadata,
+        activity_task::activity_task as act_task,
+        workflow_activation::{
+            FireTimer, ResolveActivity, WorkflowActivationJob, workflow_activation_job,
         },
-        test_utils::schedule_activity_cmd,
+        workflow_commands::{
+            ActivityCancellationType, RequestCancelActivity, ScheduleActivity, StartTimer,
+        },
+        workflow_completion::WorkflowActivationCompletion,
+    },
+    temporal::api::{
+        common::v1::{ActivityType, Payload, Payloads, RetryPolicy},
+        enums::v1::{CommandType, EventType, RetryState},
+        failure::v1::{ActivityFailureInfo, Failure, failure::FailureInfo},
+        sdk::v1::UserMetadata,
     },
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
@@ -50,10 +45,11 @@ use temporalio_sdk::{
     activities::{ActivityContext, ActivityError},
 };
 use temporalio_sdk_core::{
-    PollerBehavior,
+    PollerBehavior, prost_dur,
+    replay::{DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
     test_help::{
         MockPollCfg, ResponseType, WorkerTestHelpers, drain_pollers_and_shutdown,
-        mock_worker_client,
+        mock_worker_client, schedule_activity_cmd,
     },
 };
 use tokio::{join, sync::Semaphore, time::sleep};

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -2,7 +2,6 @@ use crate::common::{CoreWfStarter, build_fake_sdk};
 use temporalio_client::WorkflowStartOptions;
 use temporalio_common::{
     protos::{
-        DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder,
         coresdk::common::NamespacedWorkflowExecution,
         temporal::api::enums::v1::{CommandType, EventType},
     },
@@ -10,7 +9,10 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult};
-use temporalio_sdk_core::test_help::MockPollCfg;
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
+    test_help::MockPollCfg,
+};
 
 #[workflow]
 #[derive(Default)]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -5,7 +5,6 @@ use temporalio_client::{
 };
 use temporalio_common::{
     protos::{
-        DEFAULT_WORKFLOW_TYPE, canned_histories,
         coresdk::workflow_activation::{WorkflowActivationJob, workflow_activation_job},
         temporal::api::enums::v1::{CommandType, WorkflowExecutionStatus},
     },
@@ -13,7 +12,10 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult, WorkflowTermination};
-use temporalio_sdk_core::test_help::MockPollCfg;
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, canned_histories},
+    test_help::MockPollCfg,
+};
 
 #[workflow]
 #[derive(Default)]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -7,7 +7,6 @@ use temporalio_common::{
     UntypedWorkflow,
     data_converters::RawValue,
     protos::{
-        TestHistoryBuilder, canned_histories,
         coresdk::{
             AsJsonPayloadExt,
             child_workflow::{
@@ -37,7 +36,7 @@ use temporalio_sdk::{
     SyncWorkflowContext, WorkflowContext, WorkflowResult, WorkflowTermination,
 };
 use temporalio_sdk_core::{
-    replay::DEFAULT_WORKFLOW_TYPE,
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
     test_help::{MockPollCfg, ResponseType, mock_worker, mock_worker_client, single_hist_mock_sg},
 };
 use tokio::{

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -3,7 +3,6 @@ use std::{sync::Arc, time::Duration};
 use temporalio_client::WorkflowStartOptions;
 use temporalio_common::{
     protos::{
-        DEFAULT_WORKFLOW_TYPE, canned_histories,
         coresdk::workflow_commands::ContinueAsNewWorkflowExecution,
         temporal::api::{
             command::v1::command::Attributes,
@@ -15,7 +14,11 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{ContinueAsNewOptions, WorkflowContext, WorkflowResult, WorkflowTermination};
-use temporalio_sdk_core::{TunerHolder, test_help::MockPollCfg};
+use temporalio_sdk_core::{
+    TunerHolder,
+    replay::{DEFAULT_WORKFLOW_TYPE, canned_histories},
+    test_help::MockPollCfg,
+};
 
 #[workflow]
 #[derive(Default)]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -14,7 +14,6 @@ use temporalio_common::{
     UntypedWorkflow,
     data_converters::RawValue,
     protos::{
-        TestHistoryBuilder, canned_histories,
         coresdk::AsJsonPayloadExt,
         temporal::api::{
             enums::v1::{EventType, WorkflowTaskFailedCause},
@@ -30,7 +29,7 @@ use temporalio_sdk::{
     workflows,
 };
 use temporalio_sdk_core::{
-    replay::DEFAULT_WORKFLOW_TYPE,
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
     test_help::{CoreInternalFlags, MockPollCfg, ResponseType, mock_worker_client},
 };
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -334,7 +334,7 @@ async fn activity_id_or_type_change_is_nondeterministic(
     } else {
         canned_histories::single_activity("1")
     };
-    t.set_flags_first_wft(&[CoreInternalFlags::IdAndTypeDeterminismChecks as u32], &[]);
+    t.set_flags_first_wft(&[CoreInternalFlags::IdAndTypeDeterminismChecks], &[]);
     t.set_wf_input((id_change, local_act).as_json_payload().unwrap());
     let mock = mock_worker_client();
     let mut mh = MockPollCfg::from_resp_batches(
@@ -417,7 +417,7 @@ async fn child_wf_id_or_type_change_is_nondeterministic(
     let wf_id = "fakeid";
     let wf_type = DEFAULT_WORKFLOW_TYPE;
     let mut t = canned_histories::single_child_workflow("1");
-    t.set_flags_first_wft(&[CoreInternalFlags::IdAndTypeDeterminismChecks as u32], &[]);
+    t.set_flags_first_wft(&[CoreInternalFlags::IdAndTypeDeterminismChecks], &[]);
     t.set_wf_input(id_change.as_json_payload().unwrap());
     let mock = mock_worker_client();
     let mut mh = MockPollCfg::from_resp_batches(

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -23,7 +23,6 @@ use temporalio_client::{
 use temporalio_common::{
     data_converters::RawValue,
     protos::{
-        DEFAULT_ACTIVITY_TYPE, canned_histories,
         coresdk::{
             ActivityTaskCompletion, AsJsonPayloadExt, FromJsonPayloadExt,
             activity_result::ActivityExecutionResult,
@@ -43,7 +42,6 @@ use temporalio_common::{
             history::v1::history_event::Attributes::MarkerRecordedEventAttributes,
             query::v1::WorkflowQuery,
         },
-        test_utils::{query_ok, schedule_local_activity_cmd, start_timer_cmd},
     },
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
@@ -55,11 +53,14 @@ use temporalio_sdk::{
 };
 use temporalio_sdk_core::{
     PollError, TunerHolder, prost_dur,
-    replay::{DEFAULT_WORKFLOW_TYPE, HistoryForReplay, TestHistoryBuilder, default_wes_attribs},
+    replay::{
+        DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE, HistoryForReplay, TestHistoryBuilder,
+        canned_histories, default_wes_attribs,
+    },
     test_help::{
         LEGACY_QUERY_ID, MockPollCfg, ResponseType, WorkerExt, WorkerTestHelpers,
-        build_mock_pollers, hist_to_poll_resp, mock_worker, mock_worker_client,
-        single_hist_mock_sg,
+        build_mock_pollers, hist_to_poll_resp, mock_worker, mock_worker_client, query_ok,
+        schedule_local_activity_cmd, single_hist_mock_sg, start_timer_cmd,
     },
 };
 use tokio::{join, select, sync::Barrier};

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/modify_wf_properties.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/modify_wf_properties.rs
@@ -4,7 +4,6 @@ use temporalio_client::{
 };
 use temporalio_common::{
     protos::{
-        DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder,
         coresdk::{AsJsonPayloadExt, FromJsonPayloadExt},
         temporal::api::{
             command::v1::{Command, command},
@@ -16,7 +15,10 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult};
-use temporalio_sdk_core::test_help::MockPollCfg;
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
+    test_help::MockPollCfg,
+};
 use uuid::Uuid;
 
 static FIELD_A: &str = "cat_name";

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -13,7 +13,7 @@ use temporalio_client::{WorkflowSignalOptions, WorkflowStartOptions};
 use temporalio_common::{
     data_converters::RawValue,
     protos::{
-        DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, VERSION_SEARCH_ATTR_KEY,
+        VERSION_SEARCH_ATTR_KEY,
         constants::PATCH_MARKER_NAME,
         coresdk::{
             AsJsonPayloadExt, FromJsonPayloadExt,
@@ -42,7 +42,10 @@ use temporalio_sdk::{
     ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
-use temporalio_sdk_core::test_help::{CoreInternalFlags, MockPollCfg, ResponseType};
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
+    test_help::{CoreInternalFlags, MockPollCfg, ResponseType},
+};
 use tokio::{join, sync::Notify};
 
 const MY_PATCH_ID: &str = "integ_test_change_name";

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -346,10 +346,7 @@ fn patch_marker_single_activity(
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    t.set_flags_first_wft(
-        &[CoreInternalFlags::UpsertSearchAttributeOnPatch as u32],
-        &[],
-    );
+    t.set_flags_first_wft(&[CoreInternalFlags::UpsertSearchAttributeOnPatch], &[]);
     match marker_type {
         MarkerType::Deprecated => {
             t.add_has_change_marker(MY_PATCH_ID, true);
@@ -720,10 +717,7 @@ async fn same_change_multiple_spots(#[case] have_marker_in_hist: bool, #[case] r
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    t.set_flags_first_wft(
-        &[CoreInternalFlags::UpsertSearchAttributeOnPatch as u32],
-        &[],
-    );
+    t.set_flags_first_wft(&[CoreInternalFlags::UpsertSearchAttributeOnPatch], &[]);
     if have_marker_in_hist {
         t.add_has_change_marker(MY_PATCH_ID, false);
         t.add_upsert_search_attrs_for_patch(&[MY_PATCH_ID.to_string()]);
@@ -830,10 +824,7 @@ async fn many_patches_combine_in_search_attrib_update(#[case] num_patches: usize
     let mut t = TestHistoryBuilder::default();
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
-    t.set_flags_first_wft(
-        &[CoreInternalFlags::UpsertSearchAttributeOnPatch as u32],
-        &[],
-    );
+    t.set_flags_first_wft(&[CoreInternalFlags::UpsertSearchAttributeOnPatch], &[]);
     for i in 1..=num_patches {
         let id = format!("patch-{i}");
         t.add_has_change_marker(&id, false);

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/queries.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/queries.rs
@@ -4,7 +4,6 @@ use crate::common::build_fake_sdk;
 use serde::{Deserialize, Serialize};
 use std::{cell::Cell, collections::HashMap, future::poll_fn, task::Poll, time::Duration};
 use temporalio_common::protos::{
-    DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder,
     coresdk::workflow_commands::query_result,
     temporal::api::{
         common::v1::WorkflowType,
@@ -16,8 +15,11 @@ use temporalio_common::protos::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{SyncWorkflowContext, WorkflowContext, WorkflowContextView, WorkflowResult};
-use temporalio_sdk_core::test_help::{
-    LegacyQueryResult, MockPollCfg, ResponseType, hist_to_poll_resp, mock_worker_client,
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
+    test_help::{
+        LegacyQueryResult, MockPollCfg, ResponseType, hist_to_poll_resp, mock_worker_client,
+    },
 };
 
 /// A workflow that returns Pending on first poll and Ready on second poll.

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/replay.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/replay.rs
@@ -8,26 +8,25 @@ use crate::{
 use assert_matches::assert_matches;
 use parking_lot::Mutex;
 use std::{collections::HashSet, sync::Arc, time::Duration};
-use temporalio_common::{
-    prost_dur,
-    protos::{
-        DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories,
-        coresdk::{
-            AsJsonPayloadExt,
-            workflow_activation::remove_from_cache::EvictionReason,
-            workflow_commands::{ScheduleActivity, StartTimer},
-            workflow_completion::WorkflowActivationCompletion,
-        },
-        temporal::api::enums::v1::EventType,
+use temporalio_common::protos::{
+    coresdk::{
+        AsJsonPayloadExt,
+        workflow_activation::remove_from_cache::EvictionReason,
+        workflow_commands::{ScheduleActivity, StartTimer},
+        workflow_completion::WorkflowActivationCompletion,
     },
+    temporal::api::enums::v1::EventType,
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
     Worker, WorkflowContext, WorkflowContextView, WorkflowResult, interceptors::WorkerInterceptor,
 };
 use temporalio_sdk_core::{
-    PollError,
-    replay::{HistoryFeeder, HistoryForReplay},
+    PollError, prost_dur,
+    replay::{
+        DEFAULT_WORKFLOW_TYPE, HistoryFeeder, HistoryForReplay, TestHistoryBuilder,
+        canned_histories,
+    },
     test_help::{MockPollCfg, ResponseType, WorkerTestHelpers},
 };
 use tokio::join;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -2,7 +2,6 @@ use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter, build_fake_s
 use std::collections::HashMap;
 use temporalio_client::{WorkflowStartOptions, WorkflowStartSignal};
 use temporalio_common::protos::{
-    DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder,
     coresdk::{
         AsJsonPayloadExt, IntoPayloadsExt,
         workflow_activation::{
@@ -15,6 +14,7 @@ use temporalio_common::protos::{
         enums::v1::{CommandType, EventType},
     },
 };
+use temporalio_sdk_core::replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder};
 
 use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_macros::{workflow, workflow_methods};

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/timers.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/timers.rs
@@ -3,9 +3,7 @@ use futures_util::{StreamExt, stream::FuturesUnordered};
 use std::{future::Future, pin::Pin, time::Duration};
 use temporalio_client::WorkflowStartOptions;
 use temporalio_common::{
-    prost_dur,
     protos::{
-        DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories,
         coresdk::{
             workflow_commands::{CancelTimer, CompleteWorkflowExecution, StartTimer},
             workflow_completion::WorkflowActivationCompletion,
@@ -14,13 +12,16 @@ use temporalio_common::{
             enums::v1::{CommandType, EventType, WorkflowTaskFailedCause},
             failure::v1::Failure,
         },
-        test_utils::start_timer_cmd,
     },
     worker::WorkerTaskTypes,
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{CancellableFuture, WorkflowContext, WorkflowResult};
-use temporalio_sdk_core::test_help::{MockPollCfg, WorkerTestHelpers, drain_pollers_and_shutdown};
+use temporalio_sdk_core::{
+    prost_dur,
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
+    test_help::{MockPollCfg, WorkerTestHelpers, drain_pollers_and_shutdown, start_timer_cmd},
+};
 
 #[workflow]
 #[derive(Default)]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
@@ -6,7 +6,6 @@ use temporalio_client::{
 };
 use temporalio_common::{
     protos::{
-        DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder,
         coresdk::{AsJsonPayloadExt, FromJsonPayloadExt},
         temporal::api::{
             command::v1::{Command, command},
@@ -18,7 +17,10 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult, WorkflowTermination};
-use temporalio_sdk_core::test_help::MockPollCfg;
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
+    test_help::MockPollCfg,
+};
 use uuid::Uuid;
 
 #[workflow]


### PR DESCRIPTION
## What changed

- Moved `HistoryBuilder`, `HistoryInfo`, `test_utils.rs` and canned histories out of the `common` create to the `sdk-core` crate.
- Removed the `history_builders` and `test-utilities` features on the `common` crate.

## Why

- The content of those files is exclusively used by the `sdk-core` crate's internal tests. They are not meant for public usage.
- Having them in the `sdk-core` crate makes it possible for `HistoryBuilder` and canned histories to have access to the `InternalFlags` enum.