### PR TITLE
Ensure waiters are always notified in Nexus worker

### DIFF
--- a/crates/sdk-core/src/core_tests/workers.rs
+++ b/crates/sdk-core/src/core_tests/workers.rs
@@ -1333,7 +1333,7 @@ async fn graceful_shutdown_sends_shutdown_worker_rpc_during_initiate() {
 
 /// Verifies that even if the a nexus task completion is dropped, the nexus worker
 /// is able to trigger PollShutdown.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn nexus_shutdown_does_not_hang_when_pending_completion_is_cancelled() {
     let telemetry = telemetry_init(
         TelemetryOptions::builder()

--- a/crates/sdk-core/src/core_tests/workers.rs
+++ b/crates/sdk-core/src/core_tests/workers.rs
@@ -1330,11 +1330,15 @@ async fn graceful_shutdown_sends_shutdown_worker_rpc_during_initiate() {
     worker.finalize_shutdown().await;
 }
 
+/// Verifies that even if the a nexus task completion is dropped, the nexus worker
+/// is able to trigger PollShutdown.
 #[tokio::test]
 async fn nexus_shutdown_does_not_hang_when_pending_completion_is_cancelled() {
     let mut client = mock_manual_worker_client();
     let completion_rpc_started = Arc::new(Barrier::new(2));
     let completion_rpc_started_clone = completion_rpc_started.clone();
+
+    // Create a client that will hang on complete_nexus_task
     client
         .expect_complete_nexus_task()
         .times(1)
@@ -1370,16 +1374,22 @@ async fn nexus_shutdown_does_not_hang_when_pending_completion_is_cancelled() {
     });
     let worker = mock_worker(mocks);
 
+    // Poll the first task from the stream and initiate shutdown
     let nexus_task = worker.poll_nexus_task().await.unwrap();
     worker.initiate_shutdown();
 
-    let mut shutdown_poll = Box::pin(worker.poll_nexus_task());
-    tokio::time::timeout(Duration::from_millis(50), shutdown_poll.as_mut())
+    // Poll the stream again and expect it to wait for the task to complete
+    let mut poll_future = Box::pin(worker.poll_nexus_task());
+    tokio::time::timeout(Duration::from_millis(50), poll_future.as_mut())
         .await
-        .expect_err("shutdown poll should wait for the outstanding Nexus task");
+        .expect_err("poll should wait for the outstanding Nexus task");
 
+    // Send completion that we know will hang indefinitely before notifying waitiers
     let mut completion =
         Box::pin(worker.complete_nexus_task(create_test_nexus_completion(nexus_task.task_token())));
+
+    // Wait for the completion to start then drop it before notify_waitiers is triggered
+    // Use select so the completion future is polled and completion actually starts
     tokio::select! {
         _ = completion_rpc_started.wait() => {}
         result = completion.as_mut() => {
@@ -1388,11 +1398,13 @@ async fn nexus_shutdown_does_not_hang_when_pending_completion_is_cancelled() {
     }
     drop(completion);
 
-    let poll_result = tokio::time::timeout(Duration::from_secs(1), shutdown_poll.as_mut())
+    // Polling again should now return PollError::ShutDown because the outstanding task map is empty
+    // and waiters should have been notified.
+    let poll_result = tokio::time::timeout(Duration::from_secs(1), poll_future.as_mut())
         .await
         .expect("shutdown poll should finish when a pending completion future is cancelled");
-    assert_matches!(poll_result.unwrap_err(), PollError::ShutDown);
-    drop(shutdown_poll);
+    assert_matches!(poll_result, Err(PollError::ShutDown));
+    drop(poll_future);
 
     worker.shutdown().await;
     worker.finalize_shutdown().await;

--- a/crates/sdk-core/src/core_tests/workers.rs
+++ b/crates/sdk-core/src/core_tests/workers.rs
@@ -1384,11 +1384,11 @@ async fn nexus_shutdown_does_not_hang_when_pending_completion_is_cancelled() {
         .await
         .expect_err("poll should wait for the outstanding Nexus task");
 
-    // Send completion that we know will hang indefinitely before notifying waitiers
+    // Send completion that we know will hang indefinitely before notifying waiters
     let mut completion =
         Box::pin(worker.complete_nexus_task(create_test_nexus_completion(nexus_task.task_token())));
 
-    // Wait for the completion to start then drop it before notify_waitiers is triggered
+    // Wait for the completion to start then drop it before notify_waiters is triggered
     // Use select so the completion future is polled and completion actually starts
     tokio::select! {
         _ = completion_rpc_started.wait() => {}

--- a/crates/sdk-core/src/core_tests/workers.rs
+++ b/crates/sdk-core/src/core_tests/workers.rs
@@ -62,6 +62,7 @@ use temporalio_common::{
             },
         },
     },
+    telemetry::{CoreTelemetry, Logger, TelemetryOptions, telemetry_init},
     worker::WorkerTaskTypes,
 };
 use tokio::sync::{Barrier, Notify, watch};
@@ -1334,6 +1335,16 @@ async fn graceful_shutdown_sends_shutdown_worker_rpc_during_initiate() {
 /// is able to trigger PollShutdown.
 #[tokio::test]
 async fn nexus_shutdown_does_not_hang_when_pending_completion_is_cancelled() {
+    let telemetry = telemetry_init(
+        TelemetryOptions::builder()
+            .logging(Logger::Forward {
+                filter: "OFF,temporalio_sdk_core::worker::nexus=ERROR".to_string(),
+            })
+            .build(),
+    )
+    .unwrap();
+    let _guard = tracing::subscriber::set_default(telemetry.trace_subscriber().unwrap().clone());
+
     let mut client = mock_manual_worker_client();
     let completion_rpc_started = Arc::new(Barrier::new(2));
     let completion_rpc_started_clone = completion_rpc_started.clone();
@@ -1397,6 +1408,18 @@ async fn nexus_shutdown_does_not_hang_when_pending_completion_is_cancelled() {
         }
     }
     drop(completion);
+
+    let logs = telemetry.fetch_buffered_logs();
+    assert!(
+        logs.iter().any(|log| {
+            log.level == tracing::Level::ERROR
+                && log.target == "temporalio_sdk_core::worker::nexus"
+                && log
+                    .message
+                    .starts_with("TaskCompletedGuard triggered notify on drop")
+        }),
+        "expected TaskCompletedGuard error log, got {logs:#?}"
+    );
 
     // Polling again should now return PollError::ShutDown because the outstanding task map is empty
     // and waiters should have been notified.

--- a/crates/sdk-core/src/core_tests/workers.rs
+++ b/crates/sdk-core/src/core_tests/workers.rs
@@ -10,11 +10,14 @@ use crate::{
         self, PollerBehavior,
         client::{
             MockWorkerClient,
-            mocks::{DEFAULT_TEST_CAPABILITIES, DEFAULT_WORKERS_REGISTRY, mock_worker_client},
+            mocks::{
+                DEFAULT_TEST_CAPABILITIES, DEFAULT_WORKERS_REGISTRY, mock_manual_worker_client,
+                mock_worker_client,
+            },
         },
     },
 };
-use futures_util::{stream, stream::StreamExt};
+use futures_util::{FutureExt, future, stream, stream::StreamExt};
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -1324,5 +1327,73 @@ async fn graceful_shutdown_sends_shutdown_worker_rpc_during_initiate() {
         "ShutdownWorker RPC must be called during initiate_shutdown"
     );
 
+    worker.finalize_shutdown().await;
+}
+
+#[tokio::test]
+async fn nexus_shutdown_does_not_hang_when_pending_completion_is_cancelled() {
+    let mut client = mock_manual_worker_client();
+    let completion_rpc_started = Arc::new(Barrier::new(2));
+    let completion_rpc_started_clone = completion_rpc_started.clone();
+    client
+        .expect_complete_nexus_task()
+        .times(1)
+        .returning(move |_, _| {
+            let completion_rpc_started = completion_rpc_started_clone.clone();
+            async move {
+                completion_rpc_started.wait().await;
+                future::pending::<Result<RespondNexusTaskCompletedResponse, tonic::Status>>().await
+            }
+            .boxed()
+        });
+
+    let mut mocks = MocksHolder::from_client_with_custom(
+        client,
+        None::<stream::Empty<PollWorkflowTaskQueueResponse>>,
+        None::<Vec<QueueResponse<PollActivityTaskQueueResponse>>>,
+        Some(vec![QueueResponse::from(create_test_nexus_task(
+            None,
+            Some(nexus::v1::request::Capabilities {
+                temporal_failure_responses: true,
+            }),
+        ))]),
+    );
+    mocks.worker_cfg(|w| {
+        w.task_queue = "nexus-shutdown-cancelled-completion".to_string();
+        w.task_types = WorkerTaskTypes {
+            enable_workflows: false,
+            enable_local_activities: false,
+            enable_remote_activities: false,
+            enable_nexus: true,
+        };
+        w.skip_client_worker_set_check = true;
+    });
+    let worker = mock_worker(mocks);
+
+    let nexus_task = worker.poll_nexus_task().await.unwrap();
+    worker.initiate_shutdown();
+
+    let mut shutdown_poll = Box::pin(worker.poll_nexus_task());
+    tokio::time::timeout(Duration::from_millis(50), shutdown_poll.as_mut())
+        .await
+        .expect_err("shutdown poll should wait for the outstanding Nexus task");
+
+    let mut completion =
+        Box::pin(worker.complete_nexus_task(create_test_nexus_completion(nexus_task.task_token())));
+    tokio::select! {
+        _ = completion_rpc_started.wait() => {}
+        result = completion.as_mut() => {
+            panic!("completion should stay pending, got {result:?}");
+        }
+    }
+    drop(completion);
+
+    let poll_result = tokio::time::timeout(Duration::from_secs(1), shutdown_poll.as_mut())
+        .await
+        .expect("shutdown poll should finish when a pending completion future is cancelled");
+    assert_matches!(poll_result.unwrap_err(), PollError::ShutDown);
+    drop(shutdown_poll);
+
+    worker.shutdown().await;
     worker.finalize_shutdown().await;
 }

--- a/crates/sdk-core/src/worker/nexus.rs
+++ b/crates/sdk-core/src/worker/nexus.rs
@@ -328,9 +328,9 @@ impl NexusManager {
     }
 }
 
-// TaskCompleteNotify is used to ensure that waiters are notified when a task
-// is removed from the outstanding task map even in the event that the running
-// future is dropped.
+/// TaskCompleteNotify is used to ensure that waiters are notified when a task
+/// is removed from the outstanding task map even in the event that the running
+/// future is dropped.
 struct TaskCompletedNotify {
     inner: Option<Arc<Notify>>,
 }

--- a/crates/sdk-core/src/worker/nexus.rs
+++ b/crates/sdk-core/src/worker/nexus.rs
@@ -120,8 +120,7 @@ impl NexusManager {
     ) -> Result<(), CompleteNexusError> {
         let removed = self.outstanding_task_map.lock().remove(&tt);
         if let Some(task_info) = removed {
-            let task_completed_notify =
-                TaskCompletedNotify::new(self.task_completed_notify.clone());
+            let task_completed_notify = TaskCompletedGuard::new(self.task_completed_notify.clone());
             self.metrics
                 .nexus_task_execution_latency(task_info.start_time.elapsed());
             task_info.timeout_task.inspect(|jh| jh.abort());
@@ -331,31 +330,34 @@ impl NexusManager {
 /// TaskCompleteNotify is used to ensure that waiters are notified when a task
 /// is removed from the outstanding task map even in the event that the running
 /// future is dropped.
-struct TaskCompletedNotify {
+struct TaskCompletedGuard {
     inner: Option<Arc<Notify>>,
 }
 
-impl TaskCompletedNotify {
+impl TaskCompletedGuard {
     fn new(notify: Arc<Notify>) -> Self {
         Self {
             inner: Some(notify),
         }
     }
 
-    fn notify_inner(&mut self) {
+    fn notify_waiters(mut self) {
         if let Some(notify) = self.inner.take() {
             notify.notify_waiters();
         }
     }
-
-    fn notify_waiters(mut self) {
-        self.notify_inner();
-    }
 }
 
-impl Drop for TaskCompletedNotify {
+impl Drop for TaskCompletedGuard {
     fn drop(&mut self) {
-        self.notify_inner();
+        if let Some(notify) = self.inner.take() {
+            error!(
+                "TaskCompletedGuard triggered notify on drop. This indicates that the caller has \
+                dropped the future for `complete_task`. \
+                This should not happen. Please file a bug report."
+            );
+            notify.notify_waiters();
+        }
     }
 }
 

--- a/crates/sdk-core/src/worker/nexus.rs
+++ b/crates/sdk-core/src/worker/nexus.rs
@@ -120,6 +120,8 @@ impl NexusManager {
     ) -> Result<(), CompleteNexusError> {
         let removed = self.outstanding_task_map.lock().remove(&tt);
         if let Some(task_info) = removed {
+            let task_completed_notify =
+                TaskCompletedNotify::new(self.task_completed_notify.clone());
             self.metrics
                 .nexus_task_execution_latency(task_info.start_time.elapsed());
             task_info.timeout_task.inspect(|jh| jh.abort());
@@ -294,7 +296,7 @@ impl NexusManager {
                 }
             };
 
-            self.task_completed_notify.notify_waiters();
+            task_completed_notify.notify_waiters();
 
             if let Some(e) = maybe_net_err {
                 if e.code() == tonic::Code::NotFound {
@@ -323,6 +325,37 @@ impl NexusManager {
             return;
         }
         self.poll_returned_shutdown_token.cancelled().await;
+    }
+}
+
+// TaskCompleteNotify is used to ensure that waiters are notified when a task
+// is removed from the outstanding task map even in the event that the running
+// future is dropped.
+struct TaskCompletedNotify {
+    inner: Option<Arc<Notify>>,
+}
+
+impl TaskCompletedNotify {
+    fn new(notify: Arc<Notify>) -> Self {
+        Self {
+            inner: Some(notify),
+        }
+    }
+
+    fn notify_inner(&mut self) {
+        if let Some(notify) = self.inner.take() {
+            notify.notify_waiters();
+        }
+    }
+
+    fn notify_waiters(mut self) {
+        self.notify_inner();
+    }
+}
+
+impl Drop for TaskCompletedNotify {
+    fn drop(&mut self) {
+        self.notify_inner();
     }
 }
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
- Add a guard to notification in complete_nexus_task to ensure that waiters are notified even if the running future is dropped.

## Why?
<!-- Tell your future self why have you made these changes -->

I discovered a bug while testing standalone nexus operations in Python where the nexus worker shutdown would hang indefinitely in some cases. 

The issue exists when Python has called into core with a task completion at the same time that core delivers a task cancellation to Python. The order of events that cause this problem are:

1. Core delivers task for a nexus start operation
2. Python starts to send a task completion for start operation (this triggers an rpc in Core)
3. While the the task delivery is in progress, Core delivers a "cancel_task" to Python
4. Python looks up the asyncio task and cancels it.
5. Py03 bindings drop the Rust future started in step 2 when step 4 happens and before `notify_waiters()` is executed.
6. Nexus task stream goes to exit, but waits forever on notification that was missed.

I've included a fix Python side to shield the task completion future in the [standalone nexus operations PR](https://github.com/temporalio/sdk-python/pull/1461/changes#diff-ae0118ba1d5e950d7ac96e52cd92a8c3a799dee4be92d1301ef5833d84e5ba9dR219) but I think it would be a good idea to apply a fix on the Rust side as well to ensure that if a task is ever removed from the outstanding_task_map then there is always a notification that follows even if the future is dropped.

## Checklist

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Added a test that starts shutdown while a task is in flight, forces the task completion future to drop before `notify_waiters()` is executed and shows that a subsequent poll produces a `PollError::ShutDown` as expected.