### PR TITLE
fix(macros): drop anyhow dependency from workflow_methods expansion

### DIFF
--- a/crates/macros/src/workflow_definitions.rs
+++ b/crates/macros/src/workflow_definitions.rs
@@ -1012,7 +1012,7 @@ impl WorkflowMethodsDefinition {
                 let result = #run_call;
                 match result {
                     Ok(value) => ::temporalio_sdk::workflows::serialize_result(value, &ctx.payload_converter())
-                        .map_err(|e| ::temporalio_sdk::WorkflowTermination::from(::anyhow::Error::new(e))),
+                        .map_err(::temporalio_sdk::WorkflowTermination::from),
                     Err(e) => Err(e),
                 }
             }.boxed_local()

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1281,6 +1281,15 @@ impl From<temporalio_common::data_converters::PayloadConversionError> for Workfl
     }
 }
 
+impl From<workflows::WorkflowError> for WorkflowTermination {
+    fn from(err: workflows::WorkflowError) -> Self {
+        match err {
+            workflows::WorkflowError::PayloadConversion(e) => Self::from(e),
+            workflows::WorkflowError::Execution(e) => Self::from(e),
+        }
+    }
+}
+
 impl From<ActivityExecutionError> for WorkflowTermination {
     fn from(value: ActivityExecutionError) -> Self {
         Self::Failed(value.into())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

The `#[workflow_methods]` macro previously expanded to code that referenced `::anyhow::Error` directly:

```rust
.map_err(|e| ::temporalio_sdk::WorkflowTermination::from(::anyhow::Error::new(e)))
```

This forced every downstream crate using the proc-macro workflow API to add a direct `anyhow` dependency, even when its application code did not use `anyhow`.

This PR:

1. Adds `impl From<workflows::WorkflowError> for WorkflowTermination` in `crates/sdk/src/lib.rs`. It dispatches on the existing `WorkflowError` variants and delegates to the already-present `From<PayloadConversionError>` / `From<anyhow::Error>` impls, so semantics are preserved.
2. Replaces the `anyhow::Error::new(e)` construction in the macro with the function reference `::temporalio_sdk::WorkflowTermination::from`, removing the `::anyhow::` path from the generated code.

## Why?

`anyhow` is an implementation detail of the SDK. Leaking it through macro expansion forces user crates that intentionally avoid `anyhow` (e.g. those using typed errors) to take a direct dependency on it just to get `#[workflow_methods]` to compile. The SDK already exposes the conversions we need via `WorkflowTermination`, so the macro can produce equivalent code without naming `anyhow`.

## Checklist

1. Closes #1245

2. How was this tested:
   - `cargo check --workspace --all-targets`
   - `cargo lint`
   - `cargo test -p temporalio-macros`
   - `cargo test -p temporalio-sdk --lib`

3. Any docs updates needed?
   N/A — no public API change beyond an additional `From` impl for `WorkflowTermination`.