### PR TITLE
chore: remove unnecessary anyhow wrapping

### DIFF
--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -194,8 +194,7 @@ impl DataConverterTestWorkflow {
                 input,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
 
         Ok(output)
     }
@@ -218,8 +217,7 @@ impl DescribeDataConverterWorkflow {
                 input,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
 
         Ok(output)
     }

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -419,15 +419,13 @@ async fn activity_tasks_from_completion_reserve_slots() {
                 (),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
             ctx.start_activity(
                 FakeAct::act2,
                 (),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
             ctx.state(|wf| wf.complete_token.cancel());
             Ok(())
         }

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -55,7 +55,6 @@ use temporalio_common::{
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, LocalActivityOptions, WorkerOptions, WorkflowContext, WorkflowResult,
-    WorkflowTermination,
     activities::{ActivityContext, ActivityError},
     interceptors::WorkerInterceptor,
 };

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -505,8 +505,7 @@ impl SlowCompletesWf {
                 "hi!".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
             ctx.timer(Duration::from_secs(1)).await;
         }
         Ok(())
@@ -881,8 +880,7 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
                 "hi".to_owned(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
             Ok(())
         }
     }
@@ -956,15 +954,13 @@ async fn history_out_of_order_on_restart() {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
             ctx.start_activity(
                 StdActivities::echo,
                 "hi".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
             ctx.state(|wf| wf.hit_sleep.notify_one());
             ctx.timer(Duration::from_secs(5)).await;
             Ok(())
@@ -987,8 +983,7 @@ async fn history_out_of_order_on_restart() {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
             // Timer is added after restarting workflow
             ctx.timer(Duration::from_secs(1)).await;
             ctx.start_activity(
@@ -996,8 +991,7 @@ async fn history_out_of_order_on_restart() {
                 "hi".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
             ctx.timer(Duration::from_secs(2)).await;
             Ok(())
         }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -72,8 +72,7 @@ impl OneActivityWorkflow {
                 input,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow!("{e}"))?;
+            .await?;
         Ok(r)
     }
 }
@@ -92,8 +91,7 @@ impl MultiArgActivityWorkflow {
                 (input, " world".to_string()),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow!("{e}"))?;
+            .await?;
         Ok(r)
     }
 }
@@ -172,18 +170,19 @@ async fn activity_panics_are_retryable() {
     impl ActivityPanicRetryWorkflow {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<u32> {
-            ctx.start_activity(
-                PanicOnceActivities::panic_once,
-                (),
-                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
-                    .retry_policy(RetryPolicy {
-                        maximum_attempts: 2,
-                        ..Default::default()
-                    })
-                    .build(),
-            )
-            .await
-            .map_err(|e| anyhow!("{e}").into())
+            let result = ctx
+                .start_activity(
+                    PanicOnceActivities::panic_once,
+                    (),
+                    ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                        .retry_policy(RetryPolicy {
+                            maximum_attempts: 2,
+                            ..Default::default()
+                        })
+                        .build(),
+                )
+                .await?;
+            Ok(result)
         }
     }
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -93,7 +93,8 @@ impl HappyParent {
             )
             .await
             .expect("Child should start OK");
-        started.result().await.map_err(|e| anyhow!(e).into())
+        started.result().await?;
+        Ok(())
     }
 }
 
@@ -811,8 +812,7 @@ impl PassChildWorkflowSummaryToMetadata {
                 ..Default::default()
             },
         )
-        .await
-        .map_err(|e| anyhow!(e))?;
+        .await?;
         Ok(())
     }
 }
@@ -920,7 +920,7 @@ impl ParentWf {
                 _ => return Err(anyhow!("Expected start failure").into()),
             }
         }
-        let started = start_res.map_err(|e| anyhow!(e))?;
+        let started = start_res?;
         match (expectation, started.result().await) {
             (Expectation::Success, Ok(_)) => Ok(()),
             (Expectation::Failure, Err(ChildWorkflowExecutionError::Failed(failure))) => {
@@ -1274,13 +1274,9 @@ impl UntypedHappyParent {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(|e| anyhow!(e))?;
-        started
-            .result()
-            .await
-            .map(|_| ())
-            .map_err(|e| anyhow!(e).into())
+            .await?;
+        started.result().await?;
+        Ok(())
     }
 }
 
@@ -1416,8 +1412,7 @@ impl ChildSignalSerializationFailParent {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(|e| anyhow!(e))?;
+            .await?;
 
         let signal_result = started
             .signal(UnserializableSignalChild::bad_signal, AlwaysFailsSerialize)
@@ -1484,8 +1479,7 @@ impl UnitChildParentWf {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(|e| anyhow!(e))?;
+            .await?;
         started.result().await?;
         Ok(())
     }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -57,8 +57,7 @@ impl TimerWfNondeterministic {
                     (),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
                 )
-                .await
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+                .await?;
             }
             _ => panic!("Ran too many times"),
         }
@@ -290,12 +289,10 @@ impl ActivityIdOrTypeChangeWf {
                         ..Default::default()
                     },
                 )
-                .await
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+                .await?;
             } else {
                 ctx.start_local_activity(StdActivities::no_op, (), Default::default())
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    .await?;
             }
         } else if id_change {
             ctx.start_activity(
@@ -305,16 +302,14 @@ impl ActivityIdOrTypeChangeWf {
                     .activity_id("I'm bad and wrong!".to_string())
                     .build(),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
         } else {
             ctx.start_activity(
                 StdActivities::no_op,
                 (),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
         }
         Ok(())
     }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -48,7 +48,6 @@ use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityExecutionError, ActivityOptions, ApplicationFailure, CancellableFuture,
     LocalActivityOptions, WorkflowContext, WorkflowContextView, WorkflowResult,
-    WorkflowTermination,
     activities::{ActivityContext, ActivityError},
     interceptors::{FailOnNondeterminismInterceptor, WorkerInterceptor},
 };

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -81,8 +81,7 @@ impl OneLocalActivityWf {
             "hi!".to_string(),
             LocalActivityOptions::default(),
         )
-        .await
-        .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+        .await?;
         assert!(initial_workflow_time < ctx.workflow_time().unwrap());
         Ok(())
     }
@@ -1128,8 +1127,7 @@ async fn long_local_activity_with_update(
                 Duration::from_secs(6),
                 LocalActivityOptions::default(),
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
             Ok(ctx.state(|wf| wf.update_counter))
         }
 
@@ -1273,8 +1271,7 @@ impl LocalActivityWithSummaryWf {
                 ..Default::default()
             },
         )
-        .await
-        .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+        .await?;
         Ok(())
     }
 }
@@ -1440,8 +1437,7 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
                 "hi".to_string(),
                 LocalActivityOptions::default(),
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
             Ok(())
         }
     }
@@ -1662,8 +1658,7 @@ async fn local_act_null_result() {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
-                .await
-                .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+                .await?;
             Ok(())
         }
     }
@@ -1699,8 +1694,7 @@ async fn local_act_command_immediately_follows_la_marker() {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
-                .await
-                .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+                .await?;
             ctx.timer(Duration::from_secs(1)).await;
             Ok(())
         }
@@ -2319,8 +2313,7 @@ async fn resolved_las_not_recorded_if_wft_fails_many_times() {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
             panic!()
         }
     }
@@ -2870,11 +2863,9 @@ impl TwoLaWf {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
         ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
         Ok(())
     }
 }
@@ -3007,12 +2998,10 @@ impl LaTimerLaWf {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
         ctx.timer(Duration::from_secs(5)).await;
         ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
         Ok(())
     }
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
@@ -152,8 +152,7 @@ impl ResetRandomseedWf {
                 "hi!".to_string(),
                 LocalActivityOptions::default(),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
         }
         ctx.wait_condition(|s| s.post_fail_received).await;
         ctx.state(|wf| wf.notify.notify_one());

--- a/crates/sdk/examples/activity_heartbeating/workflows.rs
+++ b/crates/sdk/examples/activity_heartbeating/workflows.rs
@@ -52,8 +52,7 @@ impl HeartbeatingWorkflow {
                     .heartbeat_timeout(Duration::from_secs(5))
                     .build(),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
         Ok(result)
     }
 }

--- a/crates/sdk/examples/cancellation/workflows.rs
+++ b/crates/sdk/examples/cancellation/workflows.rs
@@ -64,8 +64,7 @@ impl CancellationWorkflow {
                         (),
                         ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
                     )
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    .await?;
 
                 Ok(format!("Cancelled (reason={reason}), {cleanup_result}"))
             }

--- a/crates/sdk/examples/hello_world/workflows.rs
+++ b/crates/sdk/examples/hello_world/workflows.rs
@@ -20,8 +20,7 @@ impl HelloWorldWorkflow {
                 name,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
         Ok(greeting)
     }
 }

--- a/crates/sdk/examples/local_activities/workflows.rs
+++ b/crates/sdk/examples/local_activities/workflows.rs
@@ -33,8 +33,7 @@ impl LocalActivitiesWorkflow {
                 name.clone(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
 
         let local_result = ctx
             .start_local_activity(
@@ -45,8 +44,7 @@ impl LocalActivitiesWorkflow {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
 
         Ok((remote_result, local_result))
     }

--- a/crates/sdk/examples/polling/workflows.rs
+++ b/crates/sdk/examples/polling/workflows.rs
@@ -34,8 +34,7 @@ impl PollingWorkflow {
         for attempt in 1..=max_attempts {
             let is_ready = ctx
                 .start_activity(PollingActivities::check_condition, attempt, activity_opts())
-                .await
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+                .await?;
 
             if is_ready {
                 return Ok(format!("Condition met on attempt {attempt}"));

--- a/crates/sdk/examples/schedules/workflows.rs
+++ b/crates/sdk/examples/schedules/workflows.rs
@@ -30,8 +30,7 @@ impl ScheduledWorkflow {
                 name,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .await?;
         Ok(greeting)
     }
 }

--- a/crates/sdk/examples/timer_examples/workflows.rs
+++ b/crates/sdk/examples/timer_examples/workflows.rs
@@ -37,7 +37,7 @@ impl TimerWorkflow {
                 100u64,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(30)),
             ) => {
-                result.map_err(|e| anyhow::anyhow!("{e}"))?;
+                result?;
                 "activity"
             }
         };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Remove a bunch of `map_err(|e| anyhow::anyhow!(e))` from our test workflows and examples.

## Why?
#1226 made all of this manual wrapping in `anyhow` no longer necessary since we now have first class conversions between our error types.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
`rustc`

3. Any docs updates needed?
N/A
