### PR TITLE
 Add grpc-status trailers to fake gRPC responses

### DIFF
--- a/crates/client/src/callback_based.rs
+++ b/crates/client/src/callback_based.rs
@@ -4,7 +4,7 @@
 use anyhow::anyhow;
 use bytes::{BufMut, BytesMut};
 use futures_util::{future::BoxFuture, stream};
-use http::{HeaderMap, Request, Response};
+use http::{HeaderMap, HeaderValue, Request, Response};
 use http_body_util::{BodyExt, StreamBody, combinators::BoxBody};
 use hyper::body::{Bytes, Frame};
 use std::{
@@ -104,9 +104,12 @@ impl Service<Request<tonic::body::Body>> for CallbackBasedGrpcService {
                     let mut body_prepend = BytesMut::with_capacity(5);
                     body_prepend.put_u8(0); // 0 means no compression
                     body_prepend.put_u32(success.proto.len() as u32);
+                    let mut trailers = HeaderMap::new();
+                    trailers.insert("grpc-status", HeaderValue::from_static("0"));
                     let stream = stream::iter(vec![
                         Ok::<_, Status>(Frame::data(Bytes::from(body_prepend))),
                         Ok::<_, Status>(Frame::data(Bytes::from(success.proto))),
+                        Ok::<_, Status>(Frame::trailers(trailers)),
                     ]);
                     let stream_body = StreamBody::new(stream);
                     let full_body = BoxBody::new(stream_body).boxed();

--- a/crates/sdk-core/tests/integ_tests/client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/client_tests.rs
@@ -5,8 +5,12 @@ use crate::common::{
     http_proxy::HttpProxy,
 };
 use assert_matches::assert_matches;
-use futures_util::FutureExt;
-use http_body_util::Full;
+use futures_util::{FutureExt, stream};
+use http_body_util::{BodyExt, StreamBody, combinators::BoxBody};
+use hyper::{
+    body::{Bytes, Frame},
+    http::{HeaderMap, HeaderValue},
+};
 use prost::Message;
 use std::{
     collections::HashMap,
@@ -538,14 +542,18 @@ where
         .encode(&mut buf)
         .expect("failed to encode response message");
 
-    // Props to o3-mini for giving me a cheap way to make a grpc response
     let mut frame = Vec::with_capacity(5 + buf.len());
     frame.push(0);
     let len = buf.len() as u32;
     frame.extend_from_slice(&len.to_be_bytes());
     frame.extend_from_slice(&buf);
-    let full_body = Full::new(frame.into());
-    let body = Body::new(full_body);
+    let mut trailers = HeaderMap::new();
+    trailers.insert("grpc-status", HeaderValue::from_static("0"));
+    let stream = stream::iter(vec![
+        Ok::<_, Status>(Frame::data(Bytes::from(frame))),
+        Ok::<_, Status>(Frame::trailers(trailers)),
+    ]);
+    let body = Body::new(BoxBody::new(StreamBody::new(stream)).boxed());
 
     // Build the HTTP response with the required gRPC headers.
     Response::builder()


### PR DESCRIPTION
## What was changed
updated the two fake-success response builders to stream a final trailer frame containing `grpc-status: 0`

## Why?
tonic version bumped, https://github.com/hyperium/tonic/pull/2543

Our fake gRPC success responses are malformed, they send HTTP 200 plus a framed protobuf body, but they do not send the required final grpc-status: 0 trailer. Newer tonic correctly treats that as an invalid/truncated gRPC response, so tests fail with missing grpc-status trailer.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how synthetic success responses are constructed by adding a standard gRPC trailer, with minimal impact beyond test/fake transports.
> 
> **Overview**
> Updates the callback-based gRPC service and integration-test fake server helpers to stream a final trailers frame containing `grpc-status: 0` after successful response data.
> 
> This replaces previous “data-only” success bodies with `StreamBody`/`Frame`-based bodies so responses are well-formed under newer `tonic` validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99cd542688d733035c1f6466314beec258fbf411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->