### PR TITLE
Bump Windows unit test job to 20 minutes

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -53,6 +53,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-arm, macos-intel, macos-arm, windows-latest]
         include:
           - os: windows-latest
+            timeoutMinutes: 20
           - os: ubuntu-latest
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Extend Windows unit test job to 20 minutes.

## Why?

Starting with https://github.com/temporalio/sdk-rust/commit/c57f825ff4a312d084773498fceeca9eef853607, the Windows unit test job has been timing out frequently. This commit and later do not have any obvious changes that would have caused the drastic uptick in job execution time. It's possible that the runner is just slower or maybe the Rust cache is empty. Extend the timeout by 5 minutes to see if this can be mitigated for now.
