### PR TITLE
Make TLS backend feature-selectable in sdk-core and client

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["development-tools"]
 readme = "README.md"
 
 [features]
-default = ["envconfig"]
+default = ["envconfig", "tls-ring"]
+tls-ring = ["tonic/tls-ring"]
+tls-aws-lc = ["tonic/tls-aws-lc"]
 telemetry = ["dep:opentelemetry"]
 core-based-sdk = []
 envconfig = ["temporalio-common/envconfig"]
@@ -42,7 +44,7 @@ tokio = { version = "1.47", default-features = false, features = [
   "sync",
   "time",
 ] }
-tonic = { workspace = true, default-features = false, features = ["tls-ring", "tls-native-roots", "channel"] }
+tonic = { workspace = true, default-features = false, features = ["tls-native-roots", "channel"] }
 tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 url = "2.5"

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -16,7 +16,9 @@ rust-version = "1.88.0"
 [lib]
 
 [features]
-default = ["envconfig", "prometheus"]
+default = ["envconfig", "prometheus", "tls-ring"]
+tls-ring = ["temporalio-client/tls-ring"]
+tls-aws-lc = ["temporalio-client/tls-aws-lc"]
 envconfig = ["temporalio-client/envconfig", "temporalio-common/envconfig"]
 prometheus = ["temporalio-common/prometheus"]
 otel = [
@@ -102,7 +104,6 @@ tokio = { version = "1.47", default-features = false, features = [
 tokio-util = { version = "0.7", features = ["io", "io-util"] }
 tokio-stream = { version = "0.1", default-features = false }
 tonic = { workspace = true, default-features = false, features = [
-  "tls-ring",
   "tls-native-roots",
   "transport",
   "codegen",


### PR DESCRIPTION
The hard-coded `tonic = { features = ["tls-ring", ...] }` in sdk-core and client forces ring on every consumer. Some users ban ring entirely (e.g. those standardised on aws-lc-rs for FIPS or supply-chain reasons) and cannot depend on temporalio-sdk because of this single line.

Add `tls-ring` and `tls-aws-lc` as crate features in both crates. `tls-ring` remains the default so upstream behaviour is unchanged. Downstream users can opt out:

```toml
[dependencies]
temporalio-sdk-core = {
    version = "0.4",
    default-features = false,
    features = ["envconfig", "prometheus", "tls-aws-lc"],
}
```

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
