### PR TITLE
Add activity execution interceptors

### DIFF
--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -5,6 +5,7 @@ use crate::common::{
 };
 use anyhow::anyhow;
 use assert_matches::assert_matches;
+use futures_util::{FutureExt, future::BoxFuture};
 use std::{
     sync::{
         Arc, Mutex,
@@ -49,8 +50,8 @@ use temporalio_sdk::{
     WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
     interceptors::{
-        ActivityExecutionInput, ActivityExecutionNext, ActivityInterceptor,
-        ActivityInterceptorWithNext,
+        ActivityInboundInterceptor, ActivityInboundInterceptorNext,
+        ActivityInboundInterceptorWithNext, ExecuteActivityInput, ExecuteActivityOutput,
     },
 };
 use temporalio_sdk_core::{
@@ -120,61 +121,66 @@ struct ActivityInterceptorRecords {
     records: Mutex<Vec<ActivityInterceptorRecord>>,
 }
 
-struct RecordingActivityInterceptor {
+struct RecordingActivityInboundInterceptor {
     interceptor: &'static str,
     records: Arc<ActivityInterceptorRecords>,
 }
 
-#[async_trait::async_trait]
-impl ActivityInterceptor for RecordingActivityInterceptor {
-    async fn execute_activity(
-        &self,
-        input: ActivityExecutionInput,
-        next: ActivityExecutionNext<'_>,
-    ) -> temporalio_sdk::interceptors::ActivityExecutionOutput {
-        let info = input.context().info();
-        let activity_type = info.activity_type.clone();
-        let workflow_type = info.workflow_type.clone();
-        let is_local = info.is_local;
-        self.records
-            .records
-            .lock()
-            .unwrap()
-            .push(ActivityInterceptorRecord {
-                interceptor: self.interceptor,
-                phase: ActivityInterceptorPhase::Before,
-                activity_type: activity_type.clone(),
-                workflow_type: workflow_type.clone(),
-                is_local,
-                input: input.downcast_ref::<String>().cloned(),
-                output: None,
-                status: None,
-            });
-        let result = next.run(input).await;
-        self.records
-            .records
-            .lock()
-            .unwrap()
-            .push(ActivityInterceptorRecord {
-                interceptor: self.interceptor,
-                phase: ActivityInterceptorPhase::After,
-                activity_type,
-                workflow_type,
-                is_local,
-                input: None,
-                output: result
-                    .as_ref()
-                    .ok()
-                    .and_then(|output| output.downcast_ref::<String>())
-                    .cloned(),
-                status: Some(activity_execution_output_status(&result)),
-            });
-        result
+impl ActivityInboundInterceptor for RecordingActivityInboundInterceptor {
+    fn execute_activity<'a, 'b>(
+        &'a self,
+        input: ExecuteActivityInput,
+        next: ActivityInboundInterceptorNext<'b>,
+    ) -> BoxFuture<'a, ExecuteActivityOutput>
+    where
+        'b: 'a,
+    {
+        async move {
+            let info = input.activity_info();
+            let activity_type = info.activity_type.clone();
+            let workflow_type = info.workflow_type.clone();
+            let is_local = info.is_local;
+            self.records
+                .records
+                .lock()
+                .unwrap()
+                .push(ActivityInterceptorRecord {
+                    interceptor: self.interceptor,
+                    phase: ActivityInterceptorPhase::Before,
+                    activity_type: activity_type.clone(),
+                    workflow_type: workflow_type.clone(),
+                    is_local,
+                    input: input.args_ref::<String>().cloned(),
+                    output: None,
+                    status: None,
+                });
+            let result = next.run(input).await;
+            self.records
+                .records
+                .lock()
+                .unwrap()
+                .push(ActivityInterceptorRecord {
+                    interceptor: self.interceptor,
+                    phase: ActivityInterceptorPhase::After,
+                    activity_type,
+                    workflow_type,
+                    is_local,
+                    input: None,
+                    output: result
+                        .as_ref()
+                        .ok()
+                        .and_then(|output| output.downcast_ref::<String>())
+                        .cloned(),
+                    status: Some(activity_execution_output_status(&result)),
+                });
+            result
+        }
+        .boxed()
     }
 }
 
 fn activity_execution_output_status(
-    result: &temporalio_sdk::interceptors::ActivityExecutionOutput,
+    result: &temporalio_sdk::interceptors::ExecuteActivityOutput,
 ) -> &'static str {
     match result {
         Ok(_) => "completed",
@@ -265,15 +271,17 @@ async fn activity_interceptor_wraps_activity_execution() {
 
     let records = Arc::new(ActivityInterceptorRecords::default());
     let mut interceptor =
-        ActivityInterceptorWithNext::new(Box::new(RecordingActivityInterceptor {
+        ActivityInboundInterceptorWithNext::new(Box::new(RecordingActivityInboundInterceptor {
             interceptor: "outer",
             records: records.clone(),
         }));
-    interceptor.set_next(Box::new(RecordingActivityInterceptor {
+    interceptor.set_next(Box::new(RecordingActivityInboundInterceptor {
         interceptor: "inner",
         records: records.clone(),
     }));
-    worker.inner_mut().set_activity_interceptor(interceptor);
+    worker
+        .inner_mut()
+        .set_activity_inbound_interceptor(interceptor);
 
     let input = "hello from input!".to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -349,7 +357,7 @@ async fn activity_interceptor_wraps_local_activity_execution() {
     let records = Arc::new(ActivityInterceptorRecords::default());
     worker
         .inner_mut()
-        .set_activity_interceptor(RecordingActivityInterceptor {
+        .set_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "local",
             records: records.clone(),
         });
@@ -393,6 +401,53 @@ async fn activity_interceptor_wraps_local_activity_execution() {
             },
         ]
     );
+}
+
+struct MutatingActivityInboundInterceptor;
+
+impl ActivityInboundInterceptor for MutatingActivityInboundInterceptor {
+    fn execute_activity<'a, 'b>(
+        &'a self,
+        mut input: ExecuteActivityInput,
+        next: ActivityInboundInterceptorNext<'b>,
+    ) -> BoxFuture<'a, ExecuteActivityOutput>
+    where
+        'b: 'a,
+    {
+        if let Some(input) = input.args_mut::<String>() {
+            input.push_str(" mutated");
+        }
+        next.run(input)
+    }
+}
+
+#[tokio::test]
+async fn activity_inbound_interceptor_can_mutate_activity_input() {
+    let wf_name = OneActivityWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<OneActivityWorkflow>();
+    let mut worker = starter.worker().await;
+
+    worker
+        .inner_mut()
+        .set_activity_inbound_interceptor(MutatingActivityInboundInterceptor);
+
+    let input = "hello from input!".to_string();
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            OneActivityWorkflow::run,
+            input,
+            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    let r = handle.get_result(Default::default()).await.unwrap();
+    assert_eq!(r, "hello from input! mutated");
 }
 
 #[tokio::test]
@@ -443,7 +498,7 @@ async fn activity_interceptor_observes_activity_error() {
     let records = Arc::new(ActivityInterceptorRecords::default());
     worker
         .inner_mut()
-        .set_activity_interceptor(RecordingActivityInterceptor {
+        .set_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "failure",
             records: records.clone(),
         });
@@ -539,7 +594,7 @@ async fn activity_interceptor_observes_activity_panic() {
     let records = Arc::new(ActivityInterceptorRecords::default());
     worker
         .inner_mut()
-        .set_activity_interceptor(RecordingActivityInterceptor {
+        .set_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "panic",
             records: records.clone(),
         });

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use assert_matches::assert_matches;
 use std::{
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
     time::Duration,
@@ -45,8 +45,13 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityExecutionError, ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult,
+    ActivityExecutionError, ActivityOptions, CancellableFuture, LocalActivityOptions,
+    WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
+    interceptors::{
+        ActivityExecutionInput, ActivityExecutionNext, ActivityInterceptor,
+        ActivityInterceptorWithNext,
+    },
 };
 use temporalio_sdk_core::{
     PollerBehavior, prost_dur,
@@ -74,6 +79,108 @@ impl OneActivityWorkflow {
             )
             .await?;
         Ok(r)
+    }
+}
+
+#[workflow]
+#[derive(Default)]
+struct OneLocalActivityWorkflow;
+
+#[workflow_methods]
+impl OneLocalActivityWorkflow {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<String> {
+        let r = ctx
+            .start_local_activity(StdActivities::echo, input, LocalActivityOptions::default())
+            .await?;
+        Ok(r)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ActivityInterceptorPhase {
+    Before,
+    After,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ActivityInterceptorRecord {
+    interceptor: &'static str,
+    phase: ActivityInterceptorPhase,
+    activity_type: String,
+    workflow_type: String,
+    is_local: bool,
+    input: Option<String>,
+    output: Option<String>,
+    status: Option<&'static str>,
+}
+
+#[derive(Default)]
+struct ActivityInterceptorRecords {
+    records: Mutex<Vec<ActivityInterceptorRecord>>,
+}
+
+struct RecordingActivityInterceptor {
+    interceptor: &'static str,
+    records: Arc<ActivityInterceptorRecords>,
+}
+
+#[async_trait::async_trait]
+impl ActivityInterceptor for RecordingActivityInterceptor {
+    async fn execute_activity(
+        &self,
+        input: ActivityExecutionInput,
+        next: ActivityExecutionNext<'_>,
+    ) -> temporalio_sdk::interceptors::ActivityExecutionOutput {
+        let info = input.context().info();
+        let activity_type = info.activity_type.clone();
+        let workflow_type = info.workflow_type.clone();
+        let is_local = info.is_local;
+        self.records
+            .records
+            .lock()
+            .unwrap()
+            .push(ActivityInterceptorRecord {
+                interceptor: self.interceptor,
+                phase: ActivityInterceptorPhase::Before,
+                activity_type: activity_type.clone(),
+                workflow_type: workflow_type.clone(),
+                is_local,
+                input: input.downcast_ref::<String>().cloned(),
+                output: None,
+                status: None,
+            });
+        let result = next.run(input).await;
+        self.records
+            .records
+            .lock()
+            .unwrap()
+            .push(ActivityInterceptorRecord {
+                interceptor: self.interceptor,
+                phase: ActivityInterceptorPhase::After,
+                activity_type,
+                workflow_type,
+                is_local,
+                input: None,
+                output: result
+                    .as_ref()
+                    .ok()
+                    .and_then(|output| output.downcast_ref::<String>())
+                    .cloned(),
+                status: Some(activity_execution_output_status(&result)),
+            });
+        result
+    }
+}
+
+fn activity_execution_output_status(
+    result: &temporalio_sdk::interceptors::ActivityExecutionOutput,
+) -> &'static str {
+    match result {
+        Ok(_) => "completed",
+        Err(ActivityError::Application(_)) => "failed",
+        Err(ActivityError::Cancelled { .. }) => "cancelled",
+        Err(ActivityError::WillCompleteAsync) => "will_complete_async",
     }
 }
 
@@ -144,6 +251,337 @@ async fn one_activity_only() {
     worker.run_until_done().await.unwrap();
     let r = handle.get_result(Default::default()).await.unwrap();
     assert_eq!(r, input);
+}
+
+#[tokio::test]
+async fn activity_interceptor_wraps_activity_execution() {
+    let wf_name = OneActivityWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<OneActivityWorkflow>();
+    let mut worker = starter.worker().await;
+
+    let records = Arc::new(ActivityInterceptorRecords::default());
+    let mut interceptor =
+        ActivityInterceptorWithNext::new(Box::new(RecordingActivityInterceptor {
+            interceptor: "outer",
+            records: records.clone(),
+        }));
+    interceptor.set_next(Box::new(RecordingActivityInterceptor {
+        interceptor: "inner",
+        records: records.clone(),
+    }));
+    worker.inner_mut().set_activity_interceptor(interceptor);
+
+    let input = "hello from input!".to_string();
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            OneActivityWorkflow::run,
+            input.clone(),
+            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    let r = handle.get_result(Default::default()).await.unwrap();
+    assert_eq!(r, input);
+
+    assert_eq!(
+        records.records.lock().unwrap().as_slice(),
+        &[
+            ActivityInterceptorRecord {
+                interceptor: "outer",
+                phase: ActivityInterceptorPhase::Before,
+                activity_type: "StdActivities::echo".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: false,
+                input: Some(input.clone()),
+                output: None,
+                status: None,
+            },
+            ActivityInterceptorRecord {
+                interceptor: "inner",
+                phase: ActivityInterceptorPhase::Before,
+                activity_type: "StdActivities::echo".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: false,
+                input: Some(input.clone()),
+                output: None,
+                status: None,
+            },
+            ActivityInterceptorRecord {
+                interceptor: "inner",
+                phase: ActivityInterceptorPhase::After,
+                activity_type: "StdActivities::echo".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: false,
+                input: None,
+                output: Some(input.clone()),
+                status: Some("completed"),
+            },
+            ActivityInterceptorRecord {
+                interceptor: "outer",
+                phase: ActivityInterceptorPhase::After,
+                activity_type: "StdActivities::echo".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: false,
+                input: None,
+                output: Some(input.clone()),
+                status: Some("completed"),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn activity_interceptor_wraps_local_activity_execution() {
+    let wf_name = OneLocalActivityWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<OneLocalActivityWorkflow>();
+    let mut worker = starter.worker().await;
+
+    let records = Arc::new(ActivityInterceptorRecords::default());
+    worker
+        .inner_mut()
+        .set_activity_interceptor(RecordingActivityInterceptor {
+            interceptor: "local",
+            records: records.clone(),
+        });
+
+    let input = "hello from local input!".to_string();
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            OneLocalActivityWorkflow::run,
+            input.clone(),
+            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    let r = handle.get_result(Default::default()).await.unwrap();
+    assert_eq!(r, input);
+
+    assert_eq!(
+        records.records.lock().unwrap().as_slice(),
+        &[
+            ActivityInterceptorRecord {
+                interceptor: "local",
+                phase: ActivityInterceptorPhase::Before,
+                activity_type: "StdActivities::echo".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: true,
+                input: Some(input.clone()),
+                output: None,
+                status: None,
+            },
+            ActivityInterceptorRecord {
+                interceptor: "local",
+                phase: ActivityInterceptorPhase::After,
+                activity_type: "StdActivities::echo".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: true,
+                input: None,
+                output: Some(input.clone()),
+                status: Some("completed"),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn activity_interceptor_observes_activity_error() {
+    struct FailingActivities;
+
+    #[activities]
+    impl FailingActivities {
+        #[activity]
+        async fn fail(_ctx: ActivityContext, input: String) -> Result<String, ActivityError> {
+            Err(anyhow!("failed input: {input}").into())
+        }
+    }
+
+    #[workflow]
+    #[derive(Default)]
+    struct ActivityFailureWorkflow;
+
+    #[workflow_methods]
+    impl ActivityFailureWorkflow {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<()> {
+            let result: Result<String, ActivityExecutionError> = ctx
+                .start_activity(
+                    FailingActivities::fail,
+                    input,
+                    ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                        .retry_policy(RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        })
+                        .build(),
+                )
+                .await;
+            assert!(result.is_err());
+            Ok(())
+        }
+    }
+
+    let wf_name = ActivityFailureWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.register_activities(FailingActivities);
+    starter
+        .sdk_config
+        .register_workflow::<ActivityFailureWorkflow>();
+    let mut worker = starter.worker().await;
+
+    let records = Arc::new(ActivityInterceptorRecords::default());
+    worker
+        .inner_mut()
+        .set_activity_interceptor(RecordingActivityInterceptor {
+            interceptor: "failure",
+            records: records.clone(),
+        });
+
+    let input = "bad input".to_string();
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            ActivityFailureWorkflow::run,
+            input.clone(),
+            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    handle.get_result(Default::default()).await.unwrap();
+
+    assert_eq!(
+        records.records.lock().unwrap().as_slice(),
+        &[
+            ActivityInterceptorRecord {
+                interceptor: "failure",
+                phase: ActivityInterceptorPhase::Before,
+                activity_type: "FailingActivities::fail".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: false,
+                input: Some(input),
+                output: None,
+                status: None,
+            },
+            ActivityInterceptorRecord {
+                interceptor: "failure",
+                phase: ActivityInterceptorPhase::After,
+                activity_type: "FailingActivities::fail".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: false,
+                input: None,
+                output: None,
+                status: Some("failed"),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn activity_interceptor_observes_activity_panic() {
+    struct PanickingActivities;
+
+    #[activities]
+    impl PanickingActivities {
+        #[activity]
+        async fn panic_activity(
+            _ctx: ActivityContext,
+            input: String,
+        ) -> Result<String, ActivityError> {
+            panic!("panic input: {input}");
+        }
+    }
+
+    #[workflow]
+    #[derive(Default)]
+    struct ActivityPanicWorkflow;
+
+    #[workflow_methods]
+    impl ActivityPanicWorkflow {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<()> {
+            let result: Result<String, ActivityExecutionError> = ctx
+                .start_activity(
+                    PanickingActivities::panic_activity,
+                    input,
+                    ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                        .retry_policy(RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        })
+                        .build(),
+                )
+                .await;
+            assert!(result.is_err());
+            Ok(())
+        }
+    }
+
+    let wf_name = ActivityPanicWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.register_activities(PanickingActivities);
+    starter
+        .sdk_config
+        .register_workflow::<ActivityPanicWorkflow>();
+    let mut worker = starter.worker().await;
+
+    let records = Arc::new(ActivityInterceptorRecords::default());
+    worker
+        .inner_mut()
+        .set_activity_interceptor(RecordingActivityInterceptor {
+            interceptor: "panic",
+            records: records.clone(),
+        });
+
+    let input = "panic input".to_string();
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            ActivityPanicWorkflow::run,
+            input.clone(),
+            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    handle.get_result(Default::default()).await.unwrap();
+
+    assert_eq!(
+        records.records.lock().unwrap().as_slice(),
+        &[
+            ActivityInterceptorRecord {
+                interceptor: "panic",
+                phase: ActivityInterceptorPhase::Before,
+                activity_type: "PanickingActivities::panic_activity".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: false,
+                input: Some(input),
+                output: None,
+                status: None,
+            },
+            ActivityInterceptorRecord {
+                interceptor: "panic",
+                phase: ActivityInterceptorPhase::After,
+                activity_type: "PanickingActivities::panic_activity".to_owned(),
+                workflow_type: wf_name.to_owned(),
+                is_local: false,
+                input: None,
+                output: None,
+                status: Some("failed"),
+            },
+        ]
+    );
 }
 
 #[tokio::test]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -5,7 +5,7 @@ use crate::common::{
 };
 use anyhow::anyhow;
 use assert_matches::assert_matches;
-use futures_util::{FutureExt, future::BoxFuture};
+use futures_util::FutureExt;
 use std::{
     sync::{
         Arc, Mutex,
@@ -50,8 +50,8 @@ use temporalio_sdk::{
     WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
     interceptors::{
-        ActivityInboundInterceptor, ActivityInboundInterceptorNext,
-        ActivityInboundInterceptorWithNext, ExecuteActivityInput, ExecuteActivityOutput,
+        ActivityInboundInterceptor, ExecuteActivityInput, ExecuteActivityOutput,
+        ExecuteActivityResult, Next,
     },
 };
 use temporalio_sdk_core::{
@@ -127,14 +127,11 @@ struct RecordingActivityInboundInterceptor {
 }
 
 impl ActivityInboundInterceptor for RecordingActivityInboundInterceptor {
-    fn execute_activity<'a, 'b>(
+    fn execute_activity<'a>(
         &'a self,
         input: ExecuteActivityInput,
-        next: ActivityInboundInterceptorNext<'b>,
-    ) -> BoxFuture<'a, ExecuteActivityOutput>
-    where
-        'b: 'a,
-    {
+        next: Next<'a, ExecuteActivityInput, ExecuteActivityOutput<'a>>,
+    ) -> ExecuteActivityOutput<'a> {
         async move {
             let info = input.activity_info();
             let activity_type = info.activity_type.clone();
@@ -171,7 +168,7 @@ impl ActivityInboundInterceptor for RecordingActivityInboundInterceptor {
                         .ok()
                         .and_then(|output| output.downcast_ref::<String>())
                         .cloned(),
-                    status: Some(activity_execution_output_status(&result)),
+                    status: Some(activity_execution_result_status(&result)),
                 });
             result
         }
@@ -179,9 +176,7 @@ impl ActivityInboundInterceptor for RecordingActivityInboundInterceptor {
     }
 }
 
-fn activity_execution_output_status(
-    result: &temporalio_sdk::interceptors::ExecuteActivityOutput,
-) -> &'static str {
+fn activity_execution_result_status(result: &ExecuteActivityResult) -> &'static str {
     match result {
         Ok(_) => "completed",
         Err(ActivityError::Application(_)) => "failed",
@@ -262,7 +257,7 @@ async fn one_activity_only() {
 #[tokio::test]
 async fn activity_interceptor_wraps_activity_execution() {
     let wf_name = OneActivityWorkflow::name();
-    let mut starter = CoreWfStarter::new(wf_name);
+    let mut starter = CoreWfStarter::new("activity_interceptor_wraps_activity_execution");
     starter.sdk_config.register_activities(StdActivities);
     starter
         .sdk_config
@@ -270,18 +265,18 @@ async fn activity_interceptor_wraps_activity_execution() {
     let mut worker = starter.worker().await;
 
     let records = Arc::new(ActivityInterceptorRecords::default());
-    let mut interceptor =
-        ActivityInboundInterceptorWithNext::new(Box::new(RecordingActivityInboundInterceptor {
-            interceptor: "outer",
-            records: records.clone(),
-        }));
-    interceptor.set_next(Box::new(RecordingActivityInboundInterceptor {
-        interceptor: "inner",
-        records: records.clone(),
-    }));
     worker
         .inner_mut()
-        .set_activity_inbound_interceptor(interceptor);
+        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+            interceptor: "outer",
+            records: records.clone(),
+        });
+    worker
+        .inner_mut()
+        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+            interceptor: "inner",
+            records: records.clone(),
+        });
 
     let input = "hello from input!".to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -289,7 +284,7 @@ async fn activity_interceptor_wraps_activity_execution() {
         .submit_workflow(
             OneActivityWorkflow::run,
             input.clone(),
-            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+            WorkflowStartOptions::new(task_queue.clone(), task_queue).build(),
         )
         .await
         .unwrap();
@@ -347,7 +342,7 @@ async fn activity_interceptor_wraps_activity_execution() {
 #[tokio::test]
 async fn activity_interceptor_wraps_local_activity_execution() {
     let wf_name = OneLocalActivityWorkflow::name();
-    let mut starter = CoreWfStarter::new(wf_name);
+    let mut starter = CoreWfStarter::new("activity_interceptor_wraps_local_activity_execution");
     starter.sdk_config.register_activities(StdActivities);
     starter
         .sdk_config
@@ -357,7 +352,7 @@ async fn activity_interceptor_wraps_local_activity_execution() {
     let records = Arc::new(ActivityInterceptorRecords::default());
     worker
         .inner_mut()
-        .set_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "local",
             records: records.clone(),
         });
@@ -368,7 +363,7 @@ async fn activity_interceptor_wraps_local_activity_execution() {
         .submit_workflow(
             OneLocalActivityWorkflow::run,
             input.clone(),
-            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+            WorkflowStartOptions::new(task_queue.clone(), task_queue).build(),
         )
         .await
         .unwrap();
@@ -406,14 +401,11 @@ async fn activity_interceptor_wraps_local_activity_execution() {
 struct MutatingActivityInboundInterceptor;
 
 impl ActivityInboundInterceptor for MutatingActivityInboundInterceptor {
-    fn execute_activity<'a, 'b>(
+    fn execute_activity<'a>(
         &'a self,
         mut input: ExecuteActivityInput,
-        next: ActivityInboundInterceptorNext<'b>,
-    ) -> BoxFuture<'a, ExecuteActivityOutput>
-    where
-        'b: 'a,
-    {
+        next: Next<'a, ExecuteActivityInput, ExecuteActivityOutput<'a>>,
+    ) -> ExecuteActivityOutput<'a> {
         if let Some(input) = input.args_mut::<String>() {
             input.push_str(" mutated");
         }
@@ -423,8 +415,7 @@ impl ActivityInboundInterceptor for MutatingActivityInboundInterceptor {
 
 #[tokio::test]
 async fn activity_inbound_interceptor_can_mutate_activity_input() {
-    let wf_name = OneActivityWorkflow::name();
-    let mut starter = CoreWfStarter::new(wf_name);
+    let mut starter = CoreWfStarter::new("activity_inbound_interceptor_can_mutate_activity_input");
     starter.sdk_config.register_activities(StdActivities);
     starter
         .sdk_config
@@ -433,7 +424,7 @@ async fn activity_inbound_interceptor_can_mutate_activity_input() {
 
     worker
         .inner_mut()
-        .set_activity_inbound_interceptor(MutatingActivityInboundInterceptor);
+        .add_activity_inbound_interceptor(MutatingActivityInboundInterceptor);
 
     let input = "hello from input!".to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -441,7 +432,7 @@ async fn activity_inbound_interceptor_can_mutate_activity_input() {
         .submit_workflow(
             OneActivityWorkflow::run,
             input,
-            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+            WorkflowStartOptions::new(task_queue.clone(), task_queue).build(),
         )
         .await
         .unwrap();
@@ -488,7 +479,7 @@ async fn activity_interceptor_observes_activity_error() {
     }
 
     let wf_name = ActivityFailureWorkflow::name();
-    let mut starter = CoreWfStarter::new(wf_name);
+    let mut starter = CoreWfStarter::new("activity_interceptor_observes_activity_error");
     starter.sdk_config.register_activities(FailingActivities);
     starter
         .sdk_config
@@ -498,7 +489,7 @@ async fn activity_interceptor_observes_activity_error() {
     let records = Arc::new(ActivityInterceptorRecords::default());
     worker
         .inner_mut()
-        .set_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "failure",
             records: records.clone(),
         });
@@ -509,7 +500,7 @@ async fn activity_interceptor_observes_activity_error() {
         .submit_workflow(
             ActivityFailureWorkflow::run,
             input.clone(),
-            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+            WorkflowStartOptions::new(task_queue.clone(), task_queue).build(),
         )
         .await
         .unwrap();
@@ -584,7 +575,7 @@ async fn activity_interceptor_observes_activity_panic() {
     }
 
     let wf_name = ActivityPanicWorkflow::name();
-    let mut starter = CoreWfStarter::new(wf_name);
+    let mut starter = CoreWfStarter::new("activity_interceptor_observes_activity_panic");
     starter.sdk_config.register_activities(PanickingActivities);
     starter
         .sdk_config
@@ -594,7 +585,7 @@ async fn activity_interceptor_observes_activity_panic() {
     let records = Arc::new(ActivityInterceptorRecords::default());
     worker
         .inner_mut()
-        .set_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "panic",
             records: records.clone(),
         });
@@ -605,7 +596,7 @@ async fn activity_interceptor_observes_activity_panic() {
         .submit_workflow(
             ActivityPanicWorkflow::run,
             input.clone(),
-            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+            WorkflowStartOptions::new(task_queue.clone(), task_queue).build(),
         )
         .await
         .unwrap();

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -93,6 +93,16 @@ path = "examples/activity_heartbeating/starter.rs"
 required-features = ["examples"]
 
 [[example]]
+name = "activity-interceptor-worker"
+path = "examples/activity_interceptor/worker.rs"
+required-features = ["examples"]
+
+[[example]]
+name = "activity-interceptor-starter"
+path = "examples/activity_interceptor/starter.rs"
+required-features = ["examples"]
+
+[[example]]
 name = "timer-examples-worker"
 path = "examples/timer_examples/worker.rs"
 required-features = ["examples"]

--- a/crates/sdk/examples/README.md
+++ b/crates/sdk/examples/README.md
@@ -31,7 +31,7 @@ See each example's README for details and expected output.
 
 - [Hello World](hello_world/) — Basic workflow that calls a single activity
 - [Activity Heartbeating](activity_heartbeating/) — Long-running activity with heartbeating and resume-on-retry
-- [Activity Interceptor](activity_interceptor/) — Wrapping activity execution and inspecting typed inputs/outputs
+- [Activity Inbound Interceptor](activity_interceptor/) — Wrapping inbound activity execution and inspecting typed inputs/outputs
 - [Timer Examples](timer_examples/) — Workflow timers, racing timers against activities, and timer cancellation
 - [Message Passing](message_passing/) — Signals, queries, and updates on a workflow
 - [Child Workflows](child_workflows/) — Starting and collecting results from child workflows

--- a/crates/sdk/examples/README.md
+++ b/crates/sdk/examples/README.md
@@ -31,6 +31,7 @@ See each example's README for details and expected output.
 
 - [Hello World](hello_world/) — Basic workflow that calls a single activity
 - [Activity Heartbeating](activity_heartbeating/) — Long-running activity with heartbeating and resume-on-retry
+- [Activity Interceptor](activity_interceptor/) — Wrapping activity execution and inspecting typed inputs/outputs
 - [Timer Examples](timer_examples/) — Workflow timers, racing timers against activities, and timer cancellation
 - [Message Passing](message_passing/) — Signals, queries, and updates on a workflow
 - [Child Workflows](child_workflows/) — Starting and collecting results from child workflows

--- a/crates/sdk/examples/activity_interceptor/README.md
+++ b/crates/sdk/examples/activity_interceptor/README.md
@@ -1,7 +1,7 @@
-# Activity Interceptor
+# Activity Inbound Interceptor
 
-Demonstrates wrapping activity execution with an interceptor that logs decoded activity inputs and
-outputs.
+Demonstrates wrapping inbound activity execution with an interceptor that logs decoded activity
+inputs and outputs.
 
 Run the worker first, then start the workflow in another terminal:
 

--- a/crates/sdk/examples/activity_interceptor/README.md
+++ b/crates/sdk/examples/activity_interceptor/README.md
@@ -1,0 +1,14 @@
+# Activity Interceptor
+
+Demonstrates wrapping activity execution with an interceptor that logs decoded activity inputs and
+outputs.
+
+Run the worker first, then start the workflow in another terminal:
+
+```bash
+cargo run --features examples --example activity-interceptor-worker
+cargo run --features examples --example activity-interceptor-starter
+```
+
+Expected worker output includes logs for the matched `greet` activity input and output, plus a
+generic log for the other activity type.

--- a/crates/sdk/examples/activity_interceptor/starter.rs
+++ b/crates/sdk/examples/activity_interceptor/starter.rs
@@ -1,0 +1,33 @@
+mod workflows;
+
+use temporalio_client::{
+    Client, ClientOptions, Connection, WorkflowGetResultOptions, WorkflowStartOptions,
+    envconfig::LoadClientConfigProfileOptions,
+};
+use workflows::ActivityInterceptorWorkflow;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (conn_opts, client_opts) =
+        ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
+    let connection = Connection::connect(conn_opts).await?;
+    let client = Client::new(connection, client_opts)?;
+
+    let handle = client
+        .start_workflow(
+            ActivityInterceptorWorkflow::run,
+            "Temporal".to_string(),
+            WorkflowStartOptions::new("activity-interceptor", "activity-interceptor-workflow-id")
+                .build(),
+        )
+        .await?;
+
+    println!("Started workflow, run_id: {:?}", handle.run_id());
+
+    let result = handle
+        .get_result(WorkflowGetResultOptions::default())
+        .await?;
+    println!("Workflow result: {result}");
+
+    Ok(())
+}

--- a/crates/sdk/examples/activity_interceptor/worker.rs
+++ b/crates/sdk/examples/activity_interceptor/worker.rs
@@ -1,5 +1,6 @@
 mod workflows;
 
+use futures_util::{FutureExt, future::BoxFuture};
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
@@ -7,7 +8,8 @@ use temporalio_common::telemetry::TelemetryOptions;
 use temporalio_sdk::{
     Worker, WorkerOptions,
     interceptors::{
-        ActivityExecutionInput, ActivityExecutionNext, ActivityExecutionOutput, ActivityInterceptor,
+        ActivityInboundInterceptor, ActivityInboundInterceptorNext, ExecuteActivityInput,
+        ExecuteActivityOutput,
     },
 };
 use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
@@ -17,39 +19,44 @@ use workflows::{
 
 struct LoggingActivityInterceptor;
 
-#[async_trait::async_trait]
-impl ActivityInterceptor for LoggingActivityInterceptor {
-    async fn execute_activity(
-        &self,
-        input: ActivityExecutionInput,
-        next: ActivityExecutionNext<'_>,
-    ) -> ActivityExecutionOutput {
-        let activity_type = input.context().info().activity_type.clone();
-        match activity_type.as_str() {
-            name if name == GreetingActivities::greet.name() => {
-                if let Some(request) = input.downcast_ref::<GreetingRequest>() {
-                    println!("greet input: {request:?}");
+impl ActivityInboundInterceptor for LoggingActivityInterceptor {
+    fn execute_activity<'a, 'b>(
+        &'a self,
+        input: ExecuteActivityInput,
+        next: ActivityInboundInterceptorNext<'b>,
+    ) -> BoxFuture<'a, ExecuteActivityOutput>
+    where
+        'b: 'a,
+    {
+        async move {
+            let activity_type = input.activity_info().activity_type.clone();
+            match activity_type.as_str() {
+                name if name == GreetingActivities::greet.name() => {
+                    if let Some(request) = input.args_ref::<GreetingRequest>() {
+                        println!("greet input: {request:?}");
+                    }
                 }
+                other => println!("running activity: {other}"),
             }
-            other => println!("running activity: {other}"),
-        }
 
-        let result = next.run(input).await;
+            let result = next.run(input).await;
 
-        match activity_type.as_str() {
-            name if name == GreetingActivities::greet.name() => {
-                if let Ok(output) = &result
-                    && let Some(response) = output.downcast_ref::<GreetingResponse>()
-                {
-                    println!("greet output: {response:?}");
+            match activity_type.as_str() {
+                name if name == GreetingActivities::greet.name() => {
+                    if let Ok(output) = &result
+                        && let Some(response) = output.downcast_ref::<GreetingResponse>()
+                    {
+                        println!("greet output: {response:?}");
+                    }
                 }
+                _ => {}
             }
-            _ => {}
+            if let Err(err) = &result {
+                println!("activity {activity_type} failed: {err:?}");
+            }
+            result
         }
-        if let Err(err) = &result {
-            println!("activity {activity_type} failed: {err:?}");
-        }
-        result
+        .boxed()
     }
 }
 
@@ -71,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build();
 
     let mut worker = Worker::new(&runtime, client, worker_options)?;
-    worker.set_activity_interceptor(LoggingActivityInterceptor);
+    worker.set_activity_inbound_interceptor(LoggingActivityInterceptor);
     println!("Worker started on task queue: activity-interceptor");
     worker.run().await?;
 

--- a/crates/sdk/examples/activity_interceptor/worker.rs
+++ b/crates/sdk/examples/activity_interceptor/worker.rs
@@ -1,0 +1,79 @@
+mod workflows;
+
+use temporalio_client::{
+    Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
+};
+use temporalio_common::telemetry::TelemetryOptions;
+use temporalio_sdk::{
+    Worker, WorkerOptions,
+    interceptors::{
+        ActivityExecutionInput, ActivityExecutionNext, ActivityExecutionOutput, ActivityInterceptor,
+    },
+};
+use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use workflows::{
+    ActivityInterceptorWorkflow, GreetingActivities, GreetingRequest, GreetingResponse,
+};
+
+struct LoggingActivityInterceptor;
+
+#[async_trait::async_trait]
+impl ActivityInterceptor for LoggingActivityInterceptor {
+    async fn execute_activity(
+        &self,
+        input: ActivityExecutionInput,
+        next: ActivityExecutionNext<'_>,
+    ) -> ActivityExecutionOutput {
+        let activity_type = input.context().info().activity_type.clone();
+        match activity_type.as_str() {
+            name if name == GreetingActivities::greet.name() => {
+                if let Some(request) = input.downcast_ref::<GreetingRequest>() {
+                    println!("greet input: {request:?}");
+                }
+            }
+            other => println!("running activity: {other}"),
+        }
+
+        let result = next.run(input).await;
+
+        match activity_type.as_str() {
+            name if name == GreetingActivities::greet.name() => {
+                if let Ok(output) = &result
+                    && let Some(response) = output.downcast_ref::<GreetingResponse>()
+                {
+                    println!("greet output: {response:?}");
+                }
+            }
+            _ => {}
+        }
+        if let Err(err) = &result {
+            println!("activity {activity_type} failed: {err:?}");
+        }
+        result
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let runtime = CoreRuntime::new_assume_tokio(
+        RuntimeOptions::builder()
+            .telemetry_options(TelemetryOptions::builder().build())
+            .build()?,
+    )?;
+    let (conn_opts, client_opts) =
+        ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
+    let connection = Connection::connect(conn_opts).await?;
+    let client = Client::new(connection, client_opts)?;
+
+    let worker_options = WorkerOptions::new("activity-interceptor")
+        .register_workflow::<ActivityInterceptorWorkflow>()
+        .register_activities(GreetingActivities)
+        .build();
+
+    let mut worker = Worker::new(&runtime, client, worker_options)?;
+    worker.set_activity_interceptor(LoggingActivityInterceptor);
+    println!("Worker started on task queue: activity-interceptor");
+    worker.run().await?;
+
+    Ok(())
+}

--- a/crates/sdk/examples/activity_interceptor/worker.rs
+++ b/crates/sdk/examples/activity_interceptor/worker.rs
@@ -1,16 +1,13 @@
 mod workflows;
 
-use futures_util::{FutureExt, future::BoxFuture};
+use futures_util::FutureExt;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
 use temporalio_common::telemetry::TelemetryOptions;
 use temporalio_sdk::{
     Worker, WorkerOptions,
-    interceptors::{
-        ActivityInboundInterceptor, ActivityInboundInterceptorNext, ExecuteActivityInput,
-        ExecuteActivityOutput,
-    },
+    interceptors::{ActivityInboundInterceptor, ExecuteActivityInput, ExecuteActivityOutput, Next},
 };
 use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
 use workflows::{
@@ -20,14 +17,11 @@ use workflows::{
 struct LoggingActivityInterceptor;
 
 impl ActivityInboundInterceptor for LoggingActivityInterceptor {
-    fn execute_activity<'a, 'b>(
+    fn execute_activity<'a>(
         &'a self,
         input: ExecuteActivityInput,
-        next: ActivityInboundInterceptorNext<'b>,
-    ) -> BoxFuture<'a, ExecuteActivityOutput>
-    where
-        'b: 'a,
-    {
+        next: Next<'a, ExecuteActivityInput, ExecuteActivityOutput<'a>>,
+    ) -> ExecuteActivityOutput<'a> {
         async move {
             let activity_type = input.activity_info().activity_type.clone();
             match activity_type.as_str() {
@@ -38,9 +32,7 @@ impl ActivityInboundInterceptor for LoggingActivityInterceptor {
                 }
                 other => println!("running activity: {other}"),
             }
-
             let result = next.run(input).await;
-
             match activity_type.as_str() {
                 name if name == GreetingActivities::greet.name() => {
                     if let Ok(output) = &result
@@ -78,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build();
 
     let mut worker = Worker::new(&runtime, client, worker_options)?;
-    worker.set_activity_inbound_interceptor(LoggingActivityInterceptor);
+    worker.add_activity_inbound_interceptor(LoggingActivityInterceptor);
     println!("Worker started on task queue: activity-interceptor");
     worker.run().await?;
 

--- a/crates/sdk/examples/activity_interceptor/workflows.rs
+++ b/crates/sdk/examples/activity_interceptor/workflows.rs
@@ -1,0 +1,69 @@
+#![allow(unreachable_pub)]
+
+use std::time::Duration;
+use temporalio_macros::{activities, workflow, workflow_methods};
+use temporalio_sdk::{
+    ActivityOptions, WorkflowContext, WorkflowResult,
+    activities::{ActivityContext, ActivityError},
+};
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct GreetingRequest {
+    pub name: String,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct GreetingResponse {
+    pub message: String,
+}
+
+#[workflow]
+#[derive(Default)]
+pub struct ActivityInterceptorWorkflow;
+
+#[workflow_methods]
+impl ActivityInterceptorWorkflow {
+    #[run]
+    pub async fn run(ctx: &mut WorkflowContext<Self>, name: String) -> WorkflowResult<String> {
+        let greet = ctx
+            .start_activity(
+                GreetingActivities::greet,
+                GreetingRequest { name: name.clone() },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
+            )
+            .await?;
+        let shout = ctx
+            .start_activity(
+                GreetingActivities::shout,
+                GreetingRequest { name },
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
+            )
+            .await?;
+        Ok(format!("{} {}", greet.message, shout.message))
+    }
+}
+
+pub struct GreetingActivities;
+
+#[activities]
+impl GreetingActivities {
+    #[activity]
+    pub async fn greet(
+        _ctx: ActivityContext,
+        request: GreetingRequest,
+    ) -> Result<GreetingResponse, ActivityError> {
+        Ok(GreetingResponse {
+            message: format!("Hello, {}!", request.name),
+        })
+    }
+
+    #[activity]
+    pub async fn shout(
+        _ctx: ActivityContext,
+        request: GreetingRequest,
+    ) -> Result<GreetingResponse, ActivityError> {
+        Ok(GreetingResponse {
+            message: format!("HELLO, {}!", request.name.to_uppercase()),
+        })
+    }
+}

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -50,17 +50,19 @@ pub use temporalio_macros::activities;
 use crate::{
     OutgoingActivityError, OutgoingError,
     interceptors::{
-        ActivityExecutionInput, ActivityExecutionNext, ActivityExecutionOutput,
-        ActivityExecutionValue, ActivityInterceptor,
+        ActivityExecutionValue, ActivityInboundInterceptor, ActivityInboundInterceptorNext,
+        ExecuteActivityInput, ExecuteActivityOutput,
     },
     panic_formatter,
 };
-use futures_util::{FutureExt, future::BoxFuture};
+use futures_util::{
+    FutureExt,
+    future::{BoxFuture, ready},
+};
 use prost_types::{Duration, Timestamp};
 use std::{
     collections::HashMap,
     fmt::Debug,
-    future::Future,
     panic::AssertUnwindSafe,
     sync::Arc,
     time::{Duration as StdDuration, SystemTime},
@@ -194,6 +196,10 @@ impl ActivityContext {
     /// Get headers attached to this activity
     pub fn headers(&self) -> &HashMap<String, Payload> {
         &self.header_fields
+    }
+
+    pub(crate) fn headers_mut(&mut self) -> &mut HashMap<String, Payload> {
+        &mut self.header_fields
     }
 }
 
@@ -354,8 +360,8 @@ pub(crate) type ActivityInvocation = Arc<
             Vec<Payload>,
             DataConverter,
             ActivityContext,
-            Option<Arc<dyn ActivityInterceptor>>,
-        ) -> BoxFuture<'static, ActivityExecutionOutput>
+            Option<Arc<dyn ActivityInboundInterceptor>>,
+        ) -> BoxFuture<'static, ExecuteActivityOutput>
         + Send
         + Sync,
 >;
@@ -400,9 +406,9 @@ impl ActivityDefinitions {
     {
         self.activities.insert(
             AD::name(),
-            Arc::new(move |payloads, dc, c, activity_interceptor| {
+            Arc::new(move |payloads, dc, c, activity_inbound_interceptor| {
                 let instance = instance.clone();
-                catch_activity_panic(async move {
+                async move {
                     // Codec application happens at the SDK/Core boundary, so activity
                     // implementations work with the payload converter directly.
                     let pc = dc.payload_converter();
@@ -411,13 +417,23 @@ impl ActivityDefinitions {
                         converter: pc,
                     };
                     let input: AD::Input = pc.from_payloads(&ctx, payloads)?;
-                    let input = ActivityExecutionInput::new(c, Box::new(input));
-                    let next = activity_execution_next::<AD>(instance);
-                    match activity_interceptor {
-                        Some(interceptor) => interceptor.execute_activity(input, next).await,
-                        None => next.run(input).await,
+                    let input = ExecuteActivityInput::new(c, Box::new(input));
+                    let next = activity_inbound_interceptor_next::<AD>(instance);
+                    let activity_execution = match activity_inbound_interceptor {
+                        Some(interceptor) => {
+                            async move { interceptor.execute_activity(input, next).await }.boxed()
+                        }
+                        None => next.run(input),
+                    };
+                    match AssertUnwindSafe(activity_execution).catch_unwind().await {
+                        Ok(output) => output,
+                        Err(panic) => Err(ApplicationFailure::new(anyhow::anyhow!(
+                            "Activity function panicked: {}",
+                            panic_formatter(panic)
+                        ))
+                        .into()),
                     }
-                })
+                }
                 .boxed()
             }),
         );
@@ -433,66 +449,48 @@ impl ActivityDefinitions {
     }
 }
 
-fn activity_execution_next<AD>(instance: Arc<AD::Implementer>) -> ActivityExecutionNext<'static>
+fn activity_inbound_interceptor_next<AD>(
+    instance: Arc<AD::Implementer>,
+) -> ActivityInboundInterceptorNext<'static>
 where
     AD: ActivityDefinition + ExecutableActivity,
     AD::Input: Send + Sync,
     AD::Output: Send + Sync,
 {
-    ActivityExecutionNext::new(move |input| {
-        catch_activity_panic(async move {
-            let (activity_context, input) = input.into_parts();
-            let input = *input
-                .downcast::<AD::Input>()
-                .expect("activity interceptor returned input with wrong concrete type");
-            AD::execute(Some(instance), activity_context, input)
+    ActivityInboundInterceptorNext::new(move |input| {
+        let (activity_context, args) = input.into_parts();
+        let args = match args.downcast::<AD::Input>() {
+            Ok(args) => args,
+            Err(_) => {
+                return ready(Err(ApplicationFailure::new(anyhow::anyhow!(
+                    "Activity inbound interceptor returned arguments with wrong concrete type for activity {}",
+                    AD::name()
+                ))
+                .into()))
+                .boxed();
+            }
+        };
+
+        async move {
+            match AssertUnwindSafe(AD::execute(Some(instance), activity_context, *args))
+                .catch_unwind()
                 .await
-                .map(|output| Box::new(output) as Box<dyn ActivityExecutionValue>)
-        })
+            {
+                Ok(result) => {
+                    result.map(|output| Box::new(output) as Box<dyn ActivityExecutionValue>)
+                }
+                Err(panic) => Err(ApplicationFailure::new(anyhow::anyhow!(
+                    "Activity function panicked: {}",
+                    panic_formatter(panic)
+                ))
+                .into()),
+            }
+        }
         .boxed()
     })
 }
 
-pub(crate) fn activity_execution_output_to_core(
-    dc: &DataConverter,
-    output: ActivityExecutionOutput,
-) -> ActivityExecutionResult {
-    match output {
-        Ok(output) => {
-            // Codec application happens at the SDK/Core boundary, so activity implementations work
-            // with the payload converter directly.
-            let pc = dc.payload_converter();
-            let ctx = SerializationContext {
-                data: &SerializationContextData::Activity,
-                converter: pc,
-            };
-            match output.serialize_payload(&ctx) {
-                Ok(payload) => ActivityExecutionResult::ok(payload),
-                Err(err) => activity_error_to_core_result(dc, err.into()),
-            }
-        }
-        Err(err) => activity_error_to_core_result(dc, err),
-    }
-}
-
-async fn catch_activity_panic(
-    future: impl Future<Output = ActivityExecutionOutput>,
-) -> ActivityExecutionOutput {
-    match AssertUnwindSafe(future).catch_unwind().await {
-        Ok(output) => output,
-        Err(panic) => Err(activity_panic_to_execution_error(panic)),
-    }
-}
-
-fn activity_panic_to_execution_error(panic: Box<dyn std::any::Any + Send>) -> ActivityError {
-    ApplicationFailure::new(anyhow::anyhow!(
-        "Activity function panicked: {}",
-        panic_formatter(panic)
-    ))
-    .into()
-}
-
-fn activity_error_to_core_result(
+pub(crate) fn activity_error_to_core_result(
     dc: &DataConverter,
     err: ActivityError,
 ) -> ActivityExecutionResult {

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -47,11 +47,21 @@
 #[doc(inline)]
 pub use temporalio_macros::activities;
 
+use crate::{
+    OutgoingActivityError, OutgoingError,
+    interceptors::{
+        ActivityExecutionInput, ActivityExecutionNext, ActivityExecutionOutput,
+        ActivityExecutionValue, ActivityInterceptor,
+    },
+    panic_formatter,
+};
 use futures_util::{FutureExt, future::BoxFuture};
 use prost_types::{Duration, Timestamp};
 use std::{
     collections::HashMap,
     fmt::Debug,
+    future::Future,
+    panic::AssertUnwindSafe,
     sync::Arc,
     time::{Duration as StdDuration, SystemTime},
 };
@@ -63,7 +73,7 @@ use temporalio_common::{
     },
     error::{ApplicationFailure, FailurePayloads},
     protos::{
-        coresdk::{ActivityHeartbeat, activity_task},
+        coresdk::{ActivityHeartbeat, activity_result::ActivityExecutionResult, activity_task},
         temporal::api::common::v1::{Payload, RetryPolicy, WorkflowExecution},
         utilities::TryIntoOrNone,
     },
@@ -344,7 +354,8 @@ pub(crate) type ActivityInvocation = Arc<
             Vec<Payload>,
             DataConverter,
             ActivityContext,
-        ) -> BoxFuture<'static, Result<Payload, ActivityError>>
+            Option<Arc<dyn ActivityInterceptor>>,
+        ) -> BoxFuture<'static, ActivityExecutionOutput>
         + Send
         + Sync,
 >;
@@ -384,27 +395,29 @@ impl ActivityDefinitions {
     pub fn register_activity<AD>(&mut self, instance: Arc<AD::Implementer>) -> &mut Self
     where
         AD: ActivityDefinition + ExecutableActivity,
+        AD::Input: Send + Sync,
         AD::Output: Send + Sync,
     {
         self.activities.insert(
             AD::name(),
-            Arc::new(move |payloads, dc, c| {
+            Arc::new(move |payloads, dc, c, activity_interceptor| {
                 let instance = instance.clone();
-                let dc = dc.clone();
-                async move {
-                    // Use PayloadConverter (not DataConverter) since the codec is applied
-                    // at the SDK/Core boundary by the visitor, not here.
+                catch_activity_panic(async move {
+                    // Codec application happens at the SDK/Core boundary, so activity
+                    // implementations work with the payload converter directly.
                     let pc = dc.payload_converter();
                     let ctx = SerializationContext {
                         data: &SerializationContextData::Activity,
                         converter: pc,
                     };
-                    let deserialized: AD::Input = pc
-                        .from_payloads(&ctx, payloads)
-                        .map_err(ActivityError::from)?;
-                    let result = AD::execute(Some(instance), c, deserialized).await?;
-                    pc.to_payload(&ctx, &result).map_err(ActivityError::from)
-                }
+                    let input: AD::Input = pc.from_payloads(&ctx, payloads)?;
+                    let input = ActivityExecutionInput::new(c, Box::new(input));
+                    let next = activity_execution_next::<AD>(instance);
+                    match activity_interceptor {
+                        Some(interceptor) => interceptor.execute_activity(input, next).await,
+                        None => next.run(input).await,
+                    }
+                })
                 .boxed()
             }),
         );
@@ -417,6 +430,82 @@ impl ActivityDefinitions {
 
     pub(crate) fn get(&self, act_type: &str) -> Option<ActivityInvocation> {
         self.activities.get(act_type).cloned()
+    }
+}
+
+fn activity_execution_next<AD>(instance: Arc<AD::Implementer>) -> ActivityExecutionNext<'static>
+where
+    AD: ActivityDefinition + ExecutableActivity,
+    AD::Input: Send + Sync,
+    AD::Output: Send + Sync,
+{
+    ActivityExecutionNext::new(move |input| {
+        catch_activity_panic(async move {
+            let (activity_context, input) = input.into_parts();
+            let input = *input
+                .downcast::<AD::Input>()
+                .expect("activity interceptor returned input with wrong concrete type");
+            AD::execute(Some(instance), activity_context, input)
+                .await
+                .map(|output| Box::new(output) as Box<dyn ActivityExecutionValue>)
+        })
+        .boxed()
+    })
+}
+
+pub(crate) fn activity_execution_output_to_core(
+    dc: &DataConverter,
+    output: ActivityExecutionOutput,
+) -> ActivityExecutionResult {
+    match output {
+        Ok(output) => {
+            // Codec application happens at the SDK/Core boundary, so activity implementations work
+            // with the payload converter directly.
+            let pc = dc.payload_converter();
+            let ctx = SerializationContext {
+                data: &SerializationContextData::Activity,
+                converter: pc,
+            };
+            match output.serialize_payload(&ctx) {
+                Ok(payload) => ActivityExecutionResult::ok(payload),
+                Err(err) => activity_error_to_core_result(dc, err.into()),
+            }
+        }
+        Err(err) => activity_error_to_core_result(dc, err),
+    }
+}
+
+async fn catch_activity_panic(
+    future: impl Future<Output = ActivityExecutionOutput>,
+) -> ActivityExecutionOutput {
+    match AssertUnwindSafe(future).catch_unwind().await {
+        Ok(output) => output,
+        Err(panic) => Err(activity_panic_to_execution_error(panic)),
+    }
+}
+
+fn activity_panic_to_execution_error(panic: Box<dyn std::any::Any + Send>) -> ActivityError {
+    ApplicationFailure::new(anyhow::anyhow!(
+        "Activity function panicked: {}",
+        panic_formatter(panic)
+    ))
+    .into()
+}
+
+fn activity_error_to_core_result(
+    dc: &DataConverter,
+    err: ActivityError,
+) -> ActivityExecutionResult {
+    match err {
+        ActivityError::Application(app) => ActivityExecutionResult::fail(dc.to_failure(
+            &SerializationContextData::Activity,
+            OutgoingError::Activity(OutgoingActivityError::Application(app)),
+        )),
+        ActivityError::Cancelled { details } => ActivityExecutionResult::cancel(dc.to_failure(
+            &SerializationContextData::Activity,
+            OutgoingError::Activity(OutgoingActivityError::Cancelled { details }),
+        )),
+        ActivityError::WillCompleteAsync => ActivityExecutionResult::will_complete_async(),
     }
 }
 

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -50,8 +50,8 @@ pub use temporalio_macros::activities;
 use crate::{
     OutgoingActivityError, OutgoingError,
     interceptors::{
-        ActivityExecutionValue, ActivityInboundInterceptor, ActivityInboundInterceptorNext,
-        ExecuteActivityInput, ExecuteActivityOutput,
+        ActivityExecutionValue, ActivityInboundInterceptor, ExecuteActivityInput,
+        ExecuteActivityOutput, Next,
     },
     panic_formatter,
 };
@@ -360,11 +360,26 @@ pub(crate) type ActivityInvocation = Arc<
             Vec<Payload>,
             DataConverter,
             ActivityContext,
-            Option<Arc<dyn ActivityInboundInterceptor>>,
-        ) -> BoxFuture<'static, ExecuteActivityOutput>
+            Vec<Arc<dyn ActivityInboundInterceptor>>,
+        ) -> ExecuteActivityOutput<'static>
         + Send
         + Sync,
 >;
+
+fn call_execute_activity<'a>(
+    interceptors: &'a [Arc<dyn ActivityInboundInterceptor>],
+    input: ExecuteActivityInput,
+    next: Next<'a, ExecuteActivityInput, ExecuteActivityOutput<'a>>,
+) -> ExecuteActivityOutput<'a> {
+    if let Some((first, rest)) = interceptors.split_first() {
+        first.execute_activity(
+            input,
+            Next::new(move |input| call_execute_activity(rest, input, next)),
+        )
+    } else {
+        next.run(input)
+    }
+}
 
 #[doc(hidden)]
 pub trait ActivityImplementer {
@@ -406,7 +421,7 @@ impl ActivityDefinitions {
     {
         self.activities.insert(
             AD::name(),
-            Arc::new(move |payloads, dc, c, activity_inbound_interceptor| {
+            Arc::new(move |payloads, dc, c, activity_inbound_interceptors| {
                 let instance = instance.clone();
                 async move {
                     // Codec application happens at the SDK/Core boundary, so activity
@@ -418,13 +433,9 @@ impl ActivityDefinitions {
                     };
                     let input: AD::Input = pc.from_payloads(&ctx, payloads)?;
                     let input = ExecuteActivityInput::new(c, Box::new(input));
-                    let next = activity_inbound_interceptor_next::<AD>(instance);
-                    let activity_execution = match activity_inbound_interceptor {
-                        Some(interceptor) => {
-                            async move { interceptor.execute_activity(input, next).await }.boxed()
-                        }
-                        None => next.run(input),
-                    };
+                    let leaf = activity_inbound_base::<AD>(instance);
+                    let activity_execution =
+                        call_execute_activity(&activity_inbound_interceptors, input, leaf);
                     match AssertUnwindSafe(activity_execution).catch_unwind().await {
                         Ok(output) => output,
                         Err(panic) => Err(ApplicationFailure::new(anyhow::anyhow!(
@@ -449,45 +460,47 @@ impl ActivityDefinitions {
     }
 }
 
-fn activity_inbound_interceptor_next<AD>(
+fn activity_inbound_base<'a, AD>(
     instance: Arc<AD::Implementer>,
-) -> ActivityInboundInterceptorNext<'static>
+) -> Next<'a, ExecuteActivityInput, ExecuteActivityOutput<'a>>
 where
     AD: ActivityDefinition + ExecutableActivity,
     AD::Input: Send + Sync,
     AD::Output: Send + Sync,
 {
-    ActivityInboundInterceptorNext::new(move |input| {
-        let (activity_context, args) = input.into_parts();
-        let args = match args.downcast::<AD::Input>() {
-            Ok(args) => args,
-            Err(_) => {
-                return ready(Err(ApplicationFailure::new(anyhow::anyhow!(
+    Next::new(
+        move |input: ExecuteActivityInput| -> ExecuteActivityOutput<'a> {
+            let (activity_context, args) = input.into_parts();
+            let args = match args.downcast::<AD::Input>() {
+                Ok(args) => args,
+                Err(_) => {
+                    return ready(Err(ApplicationFailure::new(anyhow::anyhow!(
                     "Activity inbound interceptor returned arguments with wrong concrete type for activity {}",
                     AD::name()
                 ))
                 .into()))
                 .boxed();
-            }
-        };
-
-        async move {
-            match AssertUnwindSafe(AD::execute(Some(instance), activity_context, *args))
-                .catch_unwind()
-                .await
-            {
-                Ok(result) => {
-                    result.map(|output| Box::new(output) as Box<dyn ActivityExecutionValue>)
                 }
-                Err(panic) => Err(ApplicationFailure::new(anyhow::anyhow!(
-                    "Activity function panicked: {}",
-                    panic_formatter(panic)
-                ))
-                .into()),
+            };
+
+            async move {
+                match AssertUnwindSafe(AD::execute(Some(instance), activity_context, *args))
+                    .catch_unwind()
+                    .await
+                {
+                    Ok(result) => {
+                        result.map(|output| Box::new(output) as Box<dyn ActivityExecutionValue>)
+                    }
+                    Err(panic) => Err(ApplicationFailure::new(anyhow::anyhow!(
+                        "Activity function panicked: {}",
+                        panic_formatter(panic)
+                    ))
+                    .into()),
+                }
             }
-        }
-        .boxed()
-    })
+            .boxed()
+        },
+    )
 }
 
 pub(crate) fn activity_error_to_core_result(

--- a/crates/sdk/src/interceptors.rs
+++ b/crates/sdk/src/interceptors.rs
@@ -1,15 +1,50 @@
 //! User-definable interceptors are defined in this module
 
-use crate::Worker;
-use anyhow::bail;
-use std::sync::{Arc, OnceLock};
-use temporalio_common::protos::{
-    coresdk::{
-        workflow_activation::{WorkflowActivation, remove_from_cache::EvictionReason},
-        workflow_completion::WorkflowActivationCompletion,
-    },
-    temporal::api::common::v1::Payload,
+use crate::{
+    Worker,
+    activities::{ActivityContext, ActivityError},
 };
+use anyhow::bail;
+use futures_util::future::BoxFuture;
+use std::{
+    any::Any,
+    sync::{Arc, OnceLock},
+};
+use temporalio_common::{
+    data_converters::{
+        GenericPayloadConverter, PayloadConversionError, SerializationContext, TemporalSerializable,
+    },
+    protos::{
+        coresdk::{
+            workflow_activation::{WorkflowActivation, remove_from_cache::EvictionReason},
+            workflow_completion::WorkflowActivationCompletion,
+        },
+        temporal::api::common::v1::Payload,
+    },
+};
+
+mod activity_execution_value {
+    use super::*;
+
+    pub trait Sealed {
+        fn to_activity_payload(
+            &self,
+            context: &SerializationContext<'_>,
+        ) -> Result<Payload, PayloadConversionError>;
+    }
+
+    impl<T> Sealed for T
+    where
+        T: Any + TemporalSerializable + Send + Sync,
+    {
+        fn to_activity_payload(
+            &self,
+            context: &SerializationContext<'_>,
+        ) -> Result<Payload, PayloadConversionError> {
+            context.converter.to_payload(context, self)
+        }
+    }
+}
 
 /// Implementors can intercept certain actions that happen within the Worker.
 ///
@@ -28,6 +63,102 @@ pub trait WorkerInterceptor {
         _activation: &WorkflowActivation,
     ) -> Result<(), anyhow::Error> {
         Ok(())
+    }
+}
+
+/// Activity execution data passed to [`ActivityInterceptor::execute_activity`].
+#[non_exhaustive]
+pub struct ActivityExecutionInput {
+    context: ActivityContext,
+    input: Box<dyn Any + Send + Sync>,
+}
+
+impl ActivityExecutionInput {
+    pub(crate) fn new(context: ActivityContext, input: Box<dyn Any + Send + Sync>) -> Self {
+        Self { context, input }
+    }
+
+    pub(crate) fn into_parts(self) -> (ActivityContext, Box<dyn Any + Send + Sync>) {
+        (self.context, self.input)
+    }
+
+    /// Context for the activity execution.
+    pub fn context(&self) -> &ActivityContext {
+        &self.context
+    }
+
+    /// Attempt to access the decoded activity input as a concrete type.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        self.input.downcast_ref()
+    }
+}
+
+/// Type-erased activity output returned from [`ActivityExecutionNext::run`].
+pub trait ActivityExecutionValue:
+    Any + TemporalSerializable + Send + Sync + activity_execution_value::Sealed
+{
+    /// Access this value as [`Any`] for type-specific inspection.
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T> ActivityExecutionValue for T
+where
+    T: Any + TemporalSerializable + Send + Sync,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl dyn ActivityExecutionValue {
+    /// Attempt to access the activity output as a concrete type.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        self.as_any().downcast_ref()
+    }
+
+    pub(crate) fn serialize_payload(
+        &self,
+        context: &SerializationContext<'_>,
+    ) -> Result<Payload, PayloadConversionError> {
+        self.to_activity_payload(context)
+    }
+}
+
+/// Output of an activity execution returned from [`ActivityExecutionNext::run`].
+pub type ActivityExecutionOutput = Result<Box<dyn ActivityExecutionValue>, ActivityError>;
+
+/// The next activity execution step in an interceptor chain.
+pub struct ActivityExecutionNext<'a> {
+    run: Box<
+        dyn FnOnce(ActivityExecutionInput) -> BoxFuture<'a, ActivityExecutionOutput> + Send + 'a,
+    >,
+}
+
+impl<'a> ActivityExecutionNext<'a> {
+    pub(crate) fn new(
+        run: impl FnOnce(ActivityExecutionInput) -> BoxFuture<'a, ActivityExecutionOutput> + Send + 'a,
+    ) -> Self {
+        Self { run: Box::new(run) }
+    }
+
+    /// Run the next interceptor or the activity implementation.
+    pub async fn run(self, input: ActivityExecutionInput) -> ActivityExecutionOutput {
+        (self.run)(input).await
+    }
+}
+
+/// Implementors can intercept activity execution.
+///
+/// Advanced usage only.
+#[async_trait::async_trait]
+pub trait ActivityInterceptor: Send + Sync {
+    /// Wrap activity execution.
+    async fn execute_activity(
+        &self,
+        input: ActivityExecutionInput,
+        next: ActivityExecutionNext<'_>,
+    ) -> ActivityExecutionOutput {
+        next.run(input).await
     }
 }
 
@@ -72,6 +203,44 @@ impl WorkerInterceptor for InterceptorWithNext {
             next.on_workflow_activation(a).await?;
         }
         Ok(())
+    }
+}
+
+/// Supports the composition of activity interceptors.
+pub struct ActivityInterceptorWithNext {
+    inner: Box<dyn ActivityInterceptor>,
+    next: Option<Box<ActivityInterceptorWithNext>>,
+}
+
+impl ActivityInterceptorWithNext {
+    /// Create from an existing interceptor, can be used to initialize a chain of interceptors.
+    pub fn new(inner: Box<dyn ActivityInterceptor>) -> Self {
+        Self { inner, next: None }
+    }
+
+    /// Sets the next interceptor, and then returns that interceptor, wrapped by
+    /// [ActivityInterceptorWithNext]. You can keep calling this method on it to extend the chain.
+    pub fn set_next(&mut self, next: Box<dyn ActivityInterceptor>) -> &mut Self {
+        self.next.insert(Box::new(Self::new(next)))
+    }
+}
+
+#[async_trait::async_trait]
+impl ActivityInterceptor for ActivityInterceptorWithNext {
+    async fn execute_activity(
+        &self,
+        input: ActivityExecutionInput,
+        next: ActivityExecutionNext<'_>,
+    ) -> ActivityExecutionOutput {
+        let chain_next = ActivityExecutionNext::new(move |input| {
+            Box::pin(async move {
+                match self.next.as_deref() {
+                    Some(next_interceptor) => next_interceptor.execute_activity(input, next).await,
+                    None => next.run(input).await,
+                }
+            })
+        });
+        self.inner.execute_activity(input, chain_next).await
     }
 }
 

--- a/crates/sdk/src/interceptors.rs
+++ b/crates/sdk/src/interceptors.rs
@@ -2,12 +2,13 @@
 
 use crate::{
     Worker,
-    activities::{ActivityContext, ActivityError},
+    activities::{ActivityContext, ActivityError, ActivityInfo},
 };
 use anyhow::bail;
-use futures_util::future::BoxFuture;
+use futures_util::{FutureExt, future::BoxFuture};
 use std::{
     any::Any,
+    collections::HashMap,
     sync::{Arc, OnceLock},
 };
 use temporalio_common::{
@@ -66,34 +67,49 @@ pub trait WorkerInterceptor {
     }
 }
 
-/// Activity execution data passed to [`ActivityInterceptor::execute_activity`].
+/// Activity execution data passed to [`ActivityInboundInterceptor::execute_activity`].
 #[non_exhaustive]
-pub struct ActivityExecutionInput {
+pub struct ExecuteActivityInput {
     context: ActivityContext,
-    input: Box<dyn Any + Send + Sync>,
+    args: Box<dyn Any + Send + Sync>,
 }
 
-impl ActivityExecutionInput {
-    pub(crate) fn new(context: ActivityContext, input: Box<dyn Any + Send + Sync>) -> Self {
-        Self { context, input }
+impl ExecuteActivityInput {
+    pub(crate) fn new(context: ActivityContext, args: Box<dyn Any + Send + Sync>) -> Self {
+        Self { context, args }
     }
 
     pub(crate) fn into_parts(self) -> (ActivityContext, Box<dyn Any + Send + Sync>) {
-        (self.context, self.input)
+        (self.context, self.args)
     }
 
-    /// Context for the activity execution.
-    pub fn context(&self) -> &ActivityContext {
-        &self.context
+    /// Information about the activity execution.
+    pub fn activity_info(&self) -> &ActivityInfo {
+        self.context.info()
     }
 
-    /// Attempt to access the decoded activity input as a concrete type.
-    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        self.input.downcast_ref()
+    /// Headers attached to this activity.
+    pub fn headers(&self) -> &HashMap<String, Payload> {
+        self.context.headers()
+    }
+
+    /// Mutably access headers attached to this activity.
+    pub fn headers_mut(&mut self) -> &mut HashMap<String, Payload> {
+        self.context.headers_mut()
+    }
+
+    /// Attempt to access the decoded activity arguments as a concrete type.
+    pub fn args_ref<T: Any>(&self) -> Option<&T> {
+        self.args.downcast_ref()
+    }
+
+    /// Attempt to mutably access the decoded activity arguments as a concrete type.
+    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.args.downcast_mut()
     }
 }
 
-/// Type-erased activity output returned from [`ActivityExecutionNext::run`].
+/// Type-erased activity output returned from [`ActivityInboundInterceptorNext::run`].
 pub trait ActivityExecutionValue:
     Any + TemporalSerializable + Send + Sync + activity_execution_value::Sealed
 {
@@ -124,41 +140,41 @@ impl dyn ActivityExecutionValue {
     }
 }
 
-/// Output of an activity execution returned from [`ActivityExecutionNext::run`].
-pub type ActivityExecutionOutput = Result<Box<dyn ActivityExecutionValue>, ActivityError>;
+/// Output of an activity execution returned from [`ActivityInboundInterceptorNext::run`].
+pub type ExecuteActivityOutput = Result<Box<dyn ActivityExecutionValue>, ActivityError>;
 
 /// The next activity execution step in an interceptor chain.
-pub struct ActivityExecutionNext<'a> {
-    run: Box<
-        dyn FnOnce(ActivityExecutionInput) -> BoxFuture<'a, ActivityExecutionOutput> + Send + 'a,
-    >,
+pub struct ActivityInboundInterceptorNext<'a> {
+    run: Box<dyn FnOnce(ExecuteActivityInput) -> BoxFuture<'a, ExecuteActivityOutput> + Send + 'a>,
 }
 
-impl<'a> ActivityExecutionNext<'a> {
+impl<'a> ActivityInboundInterceptorNext<'a> {
     pub(crate) fn new(
-        run: impl FnOnce(ActivityExecutionInput) -> BoxFuture<'a, ActivityExecutionOutput> + Send + 'a,
+        run: impl FnOnce(ExecuteActivityInput) -> BoxFuture<'a, ExecuteActivityOutput> + Send + 'a,
     ) -> Self {
         Self { run: Box::new(run) }
     }
 
     /// Run the next interceptor or the activity implementation.
-    pub async fn run(self, input: ActivityExecutionInput) -> ActivityExecutionOutput {
-        (self.run)(input).await
+    pub fn run(self, input: ExecuteActivityInput) -> BoxFuture<'a, ExecuteActivityOutput> {
+        (self.run)(input)
     }
 }
 
 /// Implementors can intercept activity execution.
 ///
 /// Advanced usage only.
-#[async_trait::async_trait]
-pub trait ActivityInterceptor: Send + Sync {
+pub trait ActivityInboundInterceptor: Send + Sync {
     /// Wrap activity execution.
-    async fn execute_activity(
-        &self,
-        input: ActivityExecutionInput,
-        next: ActivityExecutionNext<'_>,
-    ) -> ActivityExecutionOutput {
-        next.run(input).await
+    fn execute_activity<'a, 'b>(
+        &'a self,
+        input: ExecuteActivityInput,
+        next: ActivityInboundInterceptorNext<'b>,
+    ) -> BoxFuture<'a, ExecuteActivityOutput>
+    where
+        'b: 'a,
+    {
+        async move { next.run(input).await }.boxed()
     }
 }
 
@@ -206,33 +222,35 @@ impl WorkerInterceptor for InterceptorWithNext {
     }
 }
 
-/// Supports the composition of activity interceptors.
-pub struct ActivityInterceptorWithNext {
-    inner: Box<dyn ActivityInterceptor>,
-    next: Option<Box<ActivityInterceptorWithNext>>,
+/// Supports the composition of activity inbound interceptors.
+pub struct ActivityInboundInterceptorWithNext {
+    inner: Box<dyn ActivityInboundInterceptor>,
+    next: Option<Box<ActivityInboundInterceptorWithNext>>,
 }
 
-impl ActivityInterceptorWithNext {
+impl ActivityInboundInterceptorWithNext {
     /// Create from an existing interceptor, can be used to initialize a chain of interceptors.
-    pub fn new(inner: Box<dyn ActivityInterceptor>) -> Self {
+    pub fn new(inner: Box<dyn ActivityInboundInterceptor>) -> Self {
         Self { inner, next: None }
     }
 
     /// Sets the next interceptor, and then returns that interceptor, wrapped by
-    /// [ActivityInterceptorWithNext]. You can keep calling this method on it to extend the chain.
-    pub fn set_next(&mut self, next: Box<dyn ActivityInterceptor>) -> &mut Self {
+    /// [ActivityInboundInterceptorWithNext]. You can keep calling this method on it to extend the chain.
+    pub fn set_next(&mut self, next: Box<dyn ActivityInboundInterceptor>) -> &mut Self {
         self.next.insert(Box::new(Self::new(next)))
     }
 }
 
-#[async_trait::async_trait]
-impl ActivityInterceptor for ActivityInterceptorWithNext {
-    async fn execute_activity(
-        &self,
-        input: ActivityExecutionInput,
-        next: ActivityExecutionNext<'_>,
-    ) -> ActivityExecutionOutput {
-        let chain_next = ActivityExecutionNext::new(move |input| {
+impl ActivityInboundInterceptor for ActivityInboundInterceptorWithNext {
+    fn execute_activity<'a, 'b>(
+        &'a self,
+        input: ExecuteActivityInput,
+        next: ActivityInboundInterceptorNext<'b>,
+    ) -> BoxFuture<'a, ExecuteActivityOutput>
+    where
+        'b: 'a,
+    {
+        let chain_next = ActivityInboundInterceptorNext::new(move |input| {
             Box::pin(async move {
                 match self.next.as_deref() {
                     Some(next_interceptor) => next_interceptor.execute_activity(input, next).await,
@@ -240,7 +258,7 @@ impl ActivityInterceptor for ActivityInterceptorWithNext {
                 }
             })
         });
-        self.inner.execute_activity(input, chain_next).await
+        self.inner.execute_activity(input, chain_next)
     }
 }
 

--- a/crates/sdk/src/interceptors.rs
+++ b/crates/sdk/src/interceptors.rs
@@ -5,7 +5,7 @@ use crate::{
     activities::{ActivityContext, ActivityError, ActivityInfo},
 };
 use anyhow::bail;
-use futures_util::{FutureExt, future::BoxFuture};
+use futures_util::future::BoxFuture;
 use std::{
     any::Any,
     collections::HashMap,
@@ -67,6 +67,24 @@ pub trait WorkerInterceptor {
     }
 }
 
+/// Continuation for an interceptor operation.
+///
+/// Interceptor implementations call [`Next::run`] to invoke the next step of the chain.
+pub struct Next<'a, I, O> {
+    inner: Box<dyn FnOnce(I) -> O + Send + 'a>,
+}
+
+impl<'a, I, O> Next<'a, I, O> {
+    pub(crate) fn new(f: impl FnOnce(I) -> O + Send + 'a) -> Self {
+        Self { inner: Box::new(f) }
+    }
+
+    /// Continue the call chain with the provided input.
+    pub fn run(self, input: I) -> O {
+        (self.inner)(input)
+    }
+}
+
 /// Activity execution data passed to [`ActivityInboundInterceptor::execute_activity`].
 #[non_exhaustive]
 pub struct ExecuteActivityInput {
@@ -109,7 +127,7 @@ impl ExecuteActivityInput {
     }
 }
 
-/// Type-erased activity output returned from [`ActivityInboundInterceptorNext::run`].
+/// Type-erased activity output carried through the activity interceptor chain.
 pub trait ActivityExecutionValue:
     Any + TemporalSerializable + Send + Sync + activity_execution_value::Sealed
 {
@@ -140,41 +158,23 @@ impl dyn ActivityExecutionValue {
     }
 }
 
-/// Output of an activity execution returned from [`ActivityInboundInterceptorNext::run`].
-pub type ExecuteActivityOutput = Result<Box<dyn ActivityExecutionValue>, ActivityError>;
+/// Result of an activity execution carried through the interceptor chain.
+pub type ExecuteActivityResult = Result<Box<dyn ActivityExecutionValue>, ActivityError>;
 
-/// The next activity execution step in an interceptor chain.
-pub struct ActivityInboundInterceptorNext<'a> {
-    run: Box<dyn FnOnce(ExecuteActivityInput) -> BoxFuture<'a, ExecuteActivityOutput> + Send + 'a>,
-}
+/// Future produced by activity inbound interceptors.
+pub type ExecuteActivityOutput<'a> = BoxFuture<'a, ExecuteActivityResult>;
 
-impl<'a> ActivityInboundInterceptorNext<'a> {
-    pub(crate) fn new(
-        run: impl FnOnce(ExecuteActivityInput) -> BoxFuture<'a, ExecuteActivityOutput> + Send + 'a,
-    ) -> Self {
-        Self { run: Box::new(run) }
-    }
-
-    /// Run the next interceptor or the activity implementation.
-    pub fn run(self, input: ExecuteActivityInput) -> BoxFuture<'a, ExecuteActivityOutput> {
-        (self.run)(input)
-    }
-}
-
-/// Implementors can intercept activity execution.
+/// Inbound interceptor for activity calls coming from the server.
 ///
-/// Advanced usage only.
-pub trait ActivityInboundInterceptor: Send + Sync {
-    /// Wrap activity execution.
-    fn execute_activity<'a, 'b>(
+/// Must be implemented by inbound activity interceptors.
+pub trait ActivityInboundInterceptor: Send + Sync + 'static {
+    /// Called to invoke the activity.
+    fn execute_activity<'a>(
         &'a self,
         input: ExecuteActivityInput,
-        next: ActivityInboundInterceptorNext<'b>,
-    ) -> BoxFuture<'a, ExecuteActivityOutput>
-    where
-        'b: 'a,
-    {
-        async move { next.run(input).await }.boxed()
+        next: Next<'a, ExecuteActivityInput, ExecuteActivityOutput<'a>>,
+    ) -> ExecuteActivityOutput<'a> {
+        next.run(input)
     }
 }
 
@@ -219,46 +219,6 @@ impl WorkerInterceptor for InterceptorWithNext {
             next.on_workflow_activation(a).await?;
         }
         Ok(())
-    }
-}
-
-/// Supports the composition of activity inbound interceptors.
-pub struct ActivityInboundInterceptorWithNext {
-    inner: Box<dyn ActivityInboundInterceptor>,
-    next: Option<Box<ActivityInboundInterceptorWithNext>>,
-}
-
-impl ActivityInboundInterceptorWithNext {
-    /// Create from an existing interceptor, can be used to initialize a chain of interceptors.
-    pub fn new(inner: Box<dyn ActivityInboundInterceptor>) -> Self {
-        Self { inner, next: None }
-    }
-
-    /// Sets the next interceptor, and then returns that interceptor, wrapped by
-    /// [ActivityInboundInterceptorWithNext]. You can keep calling this method on it to extend the chain.
-    pub fn set_next(&mut self, next: Box<dyn ActivityInboundInterceptor>) -> &mut Self {
-        self.next.insert(Box::new(Self::new(next)))
-    }
-}
-
-impl ActivityInboundInterceptor for ActivityInboundInterceptorWithNext {
-    fn execute_activity<'a, 'b>(
-        &'a self,
-        input: ExecuteActivityInput,
-        next: ActivityInboundInterceptorNext<'b>,
-    ) -> BoxFuture<'a, ExecuteActivityOutput>
-    where
-        'b: 'a,
-    {
-        let chain_next = ActivityInboundInterceptorNext::new(move |input| {
-            Box::pin(async move {
-                match self.next.as_deref() {
-                    Some(next_interceptor) => next_interceptor.execute_activity(input, next).await,
-                    None => next.run(input).await,
-                }
-            })
-        });
-        self.inner.execute_activity(input, chain_next)
     }
 }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -114,9 +114,9 @@ pub use workflow_context::{
 use crate::{
     activities::{
         ActivityContext, ActivityDefinitions, ActivityImplementer, ExecutableActivity,
-        activity_execution_output_to_core,
+        activity_error_to_core_result,
     },
-    interceptors::{ActivityInterceptor, WorkerInterceptor},
+    interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
     workflow_context::{
         ChildWfCommon, NexusUnblockData, PendingChildWorkflow, StartedNexusOperation,
     },
@@ -138,13 +138,13 @@ use std::{
 use temporalio_client::{Client, NamespacedClient};
 use temporalio_common::{
     ActivityDefinition, WorkflowDefinition,
-    data_converters::{DataConverter, SerializationContextData},
+    data_converters::{DataConverter, SerializationContext, SerializationContextData},
     payload_visitor::{decode_payloads, encode_payloads},
     protos::{
         TaskToken,
         coresdk::{
             ActivityTaskCompletion, AsJsonPayloadExt,
-            activity_result::ActivityResolution,
+            activity_result::{ActivityExecutionResult, ActivityResolution},
             activity_task::{ActivityTask, activity_task},
             child_workflow::ChildWorkflowResult,
             nexus::NexusOperationResult,
@@ -439,7 +439,7 @@ struct CommonWorker {
     worker: Arc<CoreWorker>,
     task_queue: String,
     worker_interceptor: Option<Box<dyn WorkerInterceptor>>,
-    activity_interceptor: Option<Arc<dyn ActivityInterceptor>>,
+    activity_inbound_interceptor: Option<Arc<dyn ActivityInboundInterceptor>>,
     data_converter: DataConverter,
 }
 
@@ -516,7 +516,7 @@ impl Worker {
                 task_queue: worker.get_config().task_queue.clone(),
                 worker,
                 worker_interceptor: None,
-                activity_interceptor: None,
+                activity_inbound_interceptor: None,
                 data_converter,
             },
             workflow_half: WorkflowHalf {
@@ -735,7 +735,7 @@ impl Worker {
                             common.worker.clone(),
                             common.task_queue.clone(),
                             common.data_converter.clone(),
-                            common.activity_interceptor.clone(),
+                            common.activity_inbound_interceptor.clone(),
                             activity,
                         )?;
                     }
@@ -757,9 +757,12 @@ impl Worker {
         self.common.worker_interceptor = Some(Box::new(interceptor));
     }
 
-    /// Set an [ActivityInterceptor].
-    pub fn set_activity_interceptor(&mut self, interceptor: impl ActivityInterceptor + 'static) {
-        self.common.activity_interceptor = Some(Arc::new(interceptor));
+    /// Set an [ActivityInboundInterceptor], replacing any existing activity inbound interceptor.
+    pub fn set_activity_inbound_interceptor(
+        &mut self,
+        interceptor: impl ActivityInboundInterceptor + 'static,
+    ) {
+        self.common.activity_inbound_interceptor = Some(Arc::new(interceptor));
     }
 
     /// Turns this rust worker into a new worker with all the same workflows and activities
@@ -927,7 +930,7 @@ impl ActivityHalf {
         worker: Arc<CoreWorker>,
         task_queue: String,
         data_converter: DataConverter,
-        activity_interceptor: Option<Arc<dyn ActivityInterceptor>>,
+        activity_inbound_interceptor: Option<Arc<dyn ActivityInboundInterceptor>>,
         activity: ActivityTask,
     ) -> Result<(), anyhow::Error> {
         match activity.variant {
@@ -962,11 +965,28 @@ impl ActivityHalf {
                                 .record("temporalWorkflowID", &info.workflow_id)
                                 .record("temporalRunID", &info.run_id);
                         }
-                        (act_fn)(args, data_converter, ctx, activity_interceptor).await
+                        (act_fn)(args, data_converter, ctx, activity_inbound_interceptor).await
                     }
                     .instrument(span);
                     let result = act_fut.await;
-                    let result = activity_execution_output_to_core(&codec_data_converter, result);
+                    let result = match result {
+                        Ok(output) => {
+                            // Codec application happens at the SDK/Core boundary, so activity
+                            // implementations work with the payload converter directly.
+                            let pc = codec_data_converter.payload_converter();
+                            let ctx = SerializationContext {
+                                data: &SerializationContextData::Activity,
+                                converter: pc,
+                            };
+                            match output.serialize_payload(&ctx) {
+                                Ok(payload) => ActivityExecutionResult::ok(payload),
+                                Err(err) => {
+                                    activity_error_to_core_result(&codec_data_converter, err.into())
+                                }
+                            }
+                        }
+                        Err(err) => activity_error_to_core_result(&codec_data_converter, err),
+                    };
                     let mut completion = ActivityTaskCompletion {
                         task_token,
                         result: Some(result),

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -113,10 +113,10 @@ pub use workflow_context::{
 
 use crate::{
     activities::{
-        ActivityContext, ActivityDefinitions, ActivityError, ActivityImplementer,
-        ExecutableActivity,
+        ActivityContext, ActivityDefinitions, ActivityImplementer, ExecutableActivity,
+        activity_execution_output_to_core,
     },
-    interceptors::WorkerInterceptor,
+    interceptors::{ActivityInterceptor, WorkerInterceptor},
     workflow_context::{
         ChildWfCommon, NexusUnblockData, PendingChildWorkflow, StartedNexusOperation,
     },
@@ -132,7 +132,6 @@ use std::{
     fmt::{Debug, Display, Formatter},
     future::Future,
     marker::PhantomData,
-    panic::AssertUnwindSafe,
     sync::Arc,
     time::Duration,
 };
@@ -145,7 +144,7 @@ use temporalio_common::{
         TaskToken,
         coresdk::{
             ActivityTaskCompletion, AsJsonPayloadExt,
-            activity_result::{ActivityExecutionResult, ActivityResolution},
+            activity_result::ActivityResolution,
             activity_task::{ActivityTask, activity_task},
             child_workflow::ChildWorkflowResult,
             nexus::NexusOperationResult,
@@ -294,6 +293,7 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     pub fn register_activity<AD>(mut self, instance: Arc<AD::Implementer>) -> Self
     where
         AD: ActivityDefinition + ExecutableActivity,
+        AD::Input: Send + Sync,
         AD::Output: Send + Sync,
     {
         self.activities.register_activity::<AD>(instance);
@@ -350,6 +350,7 @@ impl WorkerOptions {
     pub fn register_activity<AD>(&mut self, instance: Arc<AD::Implementer>) -> &mut Self
     where
         AD: ActivityDefinition + ExecutableActivity,
+        AD::Input: Send + Sync,
         AD::Output: Send + Sync,
     {
         self.activities.register_activity::<AD>(instance);
@@ -438,6 +439,7 @@ struct CommonWorker {
     worker: Arc<CoreWorker>,
     task_queue: String,
     worker_interceptor: Option<Box<dyn WorkerInterceptor>>,
+    activity_interceptor: Option<Arc<dyn ActivityInterceptor>>,
     data_converter: DataConverter,
 }
 
@@ -514,6 +516,7 @@ impl Worker {
                 task_queue: worker.get_config().task_queue.clone(),
                 worker,
                 worker_interceptor: None,
+                activity_interceptor: None,
                 data_converter,
             },
             workflow_half: WorkflowHalf {
@@ -559,6 +562,7 @@ impl Worker {
     pub fn register_activity<AD>(&mut self, instance: Arc<AD::Implementer>) -> &mut Self
     where
         AD: ActivityDefinition + ExecutableActivity,
+        AD::Input: Send + Sync,
         AD::Output: Send + Sync,
     {
         self.activity_half
@@ -731,6 +735,7 @@ impl Worker {
                             common.worker.clone(),
                             common.task_queue.clone(),
                             common.data_converter.clone(),
+                            common.activity_interceptor.clone(),
                             activity,
                         )?;
                     }
@@ -750,6 +755,11 @@ impl Worker {
     /// Set a [WorkerInterceptor]
     pub fn set_worker_interceptor(&mut self, interceptor: impl WorkerInterceptor + 'static) {
         self.common.worker_interceptor = Some(Box::new(interceptor));
+    }
+
+    /// Set an [ActivityInterceptor].
+    pub fn set_activity_interceptor(&mut self, interceptor: impl ActivityInterceptor + 'static) {
+        self.common.activity_interceptor = Some(Arc::new(interceptor));
     }
 
     /// Turns this rust worker into a new worker with all the same workflows and activities
@@ -917,6 +927,7 @@ impl ActivityHalf {
         worker: Arc<CoreWorker>,
         task_queue: String,
         data_converter: DataConverter,
+        activity_interceptor: Option<Arc<dyn ActivityInterceptor>>,
         activity: ActivityTask,
     ) -> Result<(), anyhow::Error> {
         match activity.variant {
@@ -942,7 +953,6 @@ impl ActivityHalf {
 
                 let (ctx, args) =
                     ActivityContext::new(worker.clone(), ct, task_queue, task_token.clone(), start);
-                let activity_data_converter = data_converter.clone();
                 let codec_data_converter = data_converter.clone();
 
                 tokio::spawn(async move {
@@ -952,47 +962,11 @@ impl ActivityHalf {
                                 .record("temporalWorkflowID", &info.workflow_id)
                                 .record("temporalRunID", &info.run_id);
                         }
-                        (act_fn)(args, activity_data_converter, ctx).await
+                        (act_fn)(args, data_converter, ctx, activity_interceptor).await
                     }
                     .instrument(span);
-                    let output = AssertUnwindSafe(act_fut).catch_unwind().await;
-                    let activity_context = SerializationContextData::Activity;
-                    let result = match output {
-                        Err(e) => ActivityExecutionResult::fail(
-                            data_converter.to_failure(
-                                &activity_context,
-                                OutgoingError::Activity(OutgoingActivityError::Application(
-                                    ApplicationFailure::new(anyhow!(
-                                        "Activity function panicked: {}",
-                                        panic_formatter(e)
-                                    ))
-                                    .into(),
-                                )),
-                            ),
-                        ),
-                        Ok(Ok(p)) => ActivityExecutionResult::ok(p),
-                        Ok(Err(err)) => match err {
-                            ActivityError::Application(app) => {
-                                ActivityExecutionResult::fail(data_converter.to_failure(
-                                    &activity_context,
-                                    OutgoingError::Activity(OutgoingActivityError::Application(
-                                        app,
-                                    )),
-                                ))
-                            }
-                            ActivityError::Cancelled { details } => {
-                                ActivityExecutionResult::cancel(data_converter.to_failure(
-                                    &activity_context,
-                                    OutgoingError::Activity(OutgoingActivityError::Cancelled {
-                                        details,
-                                    }),
-                                ))
-                            }
-                            ActivityError::WillCompleteAsync => {
-                                ActivityExecutionResult::will_complete_async()
-                            }
-                        },
-                    };
+                    let result = act_fut.await;
+                    let result = activity_execution_output_to_core(&codec_data_converter, result);
                     let mut completion = ActivityTaskCompletion {
                         task_token,
                         result: Some(result),
@@ -1376,7 +1350,7 @@ mod tests {
     #[activities]
     impl MyActivities {
         #[activity]
-        async fn my_activity(_ctx: ActivityContext) -> Result<(), ActivityError> {
+        async fn my_activity(_ctx: ActivityContext) -> Result<(), activities::ActivityError> {
             Ok(())
         }
 
@@ -1385,7 +1359,7 @@ mod tests {
             self: Arc<Self>,
             _ctx: ActivityContext,
             _: String,
-        ) -> Result<(), ActivityError> {
+        ) -> Result<(), activities::ActivityError> {
             Ok(())
         }
     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -439,7 +439,7 @@ struct CommonWorker {
     worker: Arc<CoreWorker>,
     task_queue: String,
     worker_interceptor: Option<Box<dyn WorkerInterceptor>>,
-    activity_inbound_interceptor: Option<Arc<dyn ActivityInboundInterceptor>>,
+    activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
     data_converter: DataConverter,
 }
 
@@ -516,7 +516,7 @@ impl Worker {
                 task_queue: worker.get_config().task_queue.clone(),
                 worker,
                 worker_interceptor: None,
-                activity_inbound_interceptor: None,
+                activity_inbound_interceptors: Vec::new(),
                 data_converter,
             },
             workflow_half: WorkflowHalf {
@@ -735,7 +735,7 @@ impl Worker {
                             common.worker.clone(),
                             common.task_queue.clone(),
                             common.data_converter.clone(),
-                            common.activity_inbound_interceptor.clone(),
+                            common.activity_inbound_interceptors.clone(),
                             activity,
                         )?;
                     }
@@ -757,12 +757,15 @@ impl Worker {
         self.common.worker_interceptor = Some(Box::new(interceptor));
     }
 
-    /// Set an [ActivityInboundInterceptor], replacing any existing activity inbound interceptor.
-    pub fn set_activity_inbound_interceptor(
+    /// Append an [ActivityInboundInterceptor] to the chain. Interceptors run in the order they
+    /// are added, outer-most first.
+    pub fn add_activity_inbound_interceptor(
         &mut self,
-        interceptor: impl ActivityInboundInterceptor + 'static,
+        interceptor: impl ActivityInboundInterceptor,
     ) {
-        self.common.activity_inbound_interceptor = Some(Arc::new(interceptor));
+        self.common
+            .activity_inbound_interceptors
+            .push(Arc::new(interceptor));
     }
 
     /// Turns this rust worker into a new worker with all the same workflows and activities
@@ -930,7 +933,7 @@ impl ActivityHalf {
         worker: Arc<CoreWorker>,
         task_queue: String,
         data_converter: DataConverter,
-        activity_inbound_interceptor: Option<Arc<dyn ActivityInboundInterceptor>>,
+        activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
         activity: ActivityTask,
     ) -> Result<(), anyhow::Error> {
         match activity.variant {
@@ -965,7 +968,7 @@ impl ActivityHalf {
                                 .record("temporalWorkflowID", &info.workflow_id)
                                 .record("temporalRunID", &info.run_id);
                         }
-                        (act_fn)(args, data_converter, ctx, activity_inbound_interceptor).await
+                        (act_fn)(args, data_converter, ctx, activity_inbound_interceptors).await
                     }
                     .instrument(span);
                     let result = act_fut.await;
@@ -1363,6 +1366,7 @@ impl PrintablePanicType for EndPrintingAttempts {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::activities::ActivityError;
     use temporalio_macros::{activities, workflow, workflow_methods};
 
     struct MyActivities {}
@@ -1370,7 +1374,7 @@ mod tests {
     #[activities]
     impl MyActivities {
         #[activity]
-        async fn my_activity(_ctx: ActivityContext) -> Result<(), activities::ActivityError> {
+        async fn my_activity(_ctx: ActivityContext) -> Result<(), ActivityError> {
             Ok(())
         }
 
@@ -1379,7 +1383,7 @@ mod tests {
             self: Arc<Self>,
             _ctx: ActivityContext,
             _: String,
-        ) -> Result<(), activities::ActivityError> {
+        ) -> Result<(), ActivityError> {
             Ok(())
         }
     }

--- a/crates/sdk/src/workflows.rs
+++ b/crates/sdk/src/workflows.rs
@@ -56,8 +56,7 @@
 ///
 /// ```no_run
 /// use std::time::Duration;
-/// use temporalio_sdk::workflows::select;
-/// use temporalio_sdk::WorkflowContext;
+/// use temporalio_sdk::{WorkflowContext, workflows::select};
 ///
 /// # async fn hidden(ctx: &mut WorkflowContext<()>) {
 /// select! {


### PR DESCRIPTION
## What was changed

Introduce an ActivityInterceptor API for wrapping Rust SDK activity execution. Interceptors receive ActivityExecutionInput, can inspect the ActivityContext and decoded typed input, call ActivityExecutionNext::run, and then inspect the typed activity output or execution error before completion is reported back to Core.

This adds:

- ActivityInterceptor, ActivityExecutionInput, ActivityExecutionNext, ActivityExecutionOutput, and ActivityExecutionValue
- ActivityInterceptorWithNext for composing interceptor chains
- Worker::set_activity_interceptor for installing an activity interceptor on a worker
- an SDK example showing typed input/output logging from an interceptor

## Why?

The existing activity hooks were too narrow for SDK-level middleware because they could not wrap the actual activity call or observe both decoded inputs and typed outputs around execution.

This change moves activity result conversion to after interceptor execution, so normal completions, failures, cancellations, WillCompleteAsync, panics, local activities, and remote activities all flow through the same execution wrapper. That gives interceptors a stable boundary for logging, metrics, tracing, policy enforcement, and other middleware without requiring activity call sites to change.

## Testing

Added integration coverage for:

- chained activity interceptor ordering
- remote activity input/output inspection
- local activity interception
- activity failure observation
- activity panic observation

Also added a runnable activity_interceptor SDK example.