### PR TITLE
(CI) Disable caching cargo binaries

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -33,6 +33,7 @@ jobs:
       - run: rustup component add rustfmt clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt --all --check
       - run: cargo doc --workspace --all-features --no-deps
@@ -83,6 +84,7 @@ jobs:
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test -- --include-ignored --nocapture
       - name: Find test executable for cgroup tests
@@ -124,6 +126,7 @@ jobs:
       - run: rustup component add rustfmt clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
           key: msrv
       - run: cargo install cargo-msrv
@@ -186,6 +189,7 @@ jobs:
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo integ-test
 
@@ -211,6 +215,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --features=test-utilities --test cloud_tests
 
@@ -239,6 +244,7 @@ jobs:
           compose-file: ./etc/docker/docker-compose-ci.yaml
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo integ-test docker_
 
@@ -256,6 +262,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build examples
         run: cargo build --examples -p temporalio-sdk --features examples


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Sets `cache-bin: false` option in `Swatinem/rust-cache` GH action to disable caching

## Why?
<!-- Tell your future self why have you made these changes -->
Mitigates macos runner issue: https://github.com/actions/runner-images/issues/14097

Also since we're using `dtolnay/rust-toolchain` action, we shouldn't cache cargo/rustc binaries anyway.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
A similar PR fixed problems in .Net SDK: https://github.com/temporalio/sdk-dotnet/pull/695