### PR TITLE
fix(metrics): emit `workflow_type` attribute on `temporal_workflow_task_execution_failed`

### DIFF
--- a/crates/sdk-core/src/telemetry/metrics.rs
+++ b/crates/sdk-core/src/telemetry/metrics.rs
@@ -118,7 +118,7 @@ impl MetricsContext {
         instruments.update_attributes(tm.get_default_attributes());
         Self {
             instruments: Arc::new(instruments),
-            meter: self.meter.clone(),
+            meter: tm,
             in_memory_metrics: self.in_memory_metrics.clone(),
         }
     }

--- a/crates/sdk-core/src/telemetry/metrics.rs
+++ b/crates/sdk-core/src/telemetry/metrics.rs
@@ -1151,6 +1151,19 @@ mod tests {
     impl BufferInstrumentRef for DummyInstrumentRef {}
 
     #[test]
+    fn with_new_attrs_adds_attrs_to_returned_context() {
+        let mc = MetricsContext::no_op();
+        let mc2 = mc.with_new_attrs([MetricKeyValue::new("workflow_type", "my_wf")]);
+        let MetricAttributes::NoOp(labels) = mc2.meter.get_default_attributes() else {
+            panic!("expected no-op metric attributes");
+        };
+        assert_eq!(
+            labels.get("workflow_type").map(String::as_str),
+            Some("my_wf")
+        );
+    }
+
+    #[test]
     fn test_buffered_core_context() {
         let call_buffer = Arc::new(MetricsCallBuffer::new(100));
         let telem_instance = telemetry_init(

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -134,7 +134,6 @@ pub(crate) struct Workflows {
     local_act_mgr: Option<Arc<LocalActivityManager>>,
     ever_polled: AtomicBool,
     default_versioning_behavior: Option<VersioningBehavior>,
-    metrics: MetricsContext,
 }
 
 pub(crate) struct WorkflowBasics {
@@ -177,7 +176,6 @@ impl Workflows {
         let (fetch_tx, fetch_rx) = unbounded_channel();
         let shutdown_tok = basics.shutdown_token.clone();
         let task_queue = basics.worker_config.task_queue.clone();
-        let metrics = basics.metrics.clone();
         let default_versioning_behavior = basics.default_versioning_behavior;
         let extracted_wft_stream = WFTExtractor::build(
             client.clone(),
@@ -269,7 +267,6 @@ impl Workflows {
             local_act_mgr,
             ever_polled: AtomicBool::new(false),
             default_versioning_behavior,
-            metrics,
         }
     }
 
@@ -424,7 +421,7 @@ impl Workflows {
                             );
                             self.handle_activation_failed(run_id, completion_time, new_outcome)
                                 .await;
-                            self.metrics
+                            run_metrics
                                 .with_new_attrs([metrics::failure_reason(
                                     FailureReason::GrpcMessageTooLarge,
                                 )])

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -16,8 +16,9 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    Connection, NamespacedClient, REQUEST_LATENCY_HISTOGRAM_NAME, UntypedQuery, UntypedWorkflow,
-    WorkflowExecutionInfo, WorkflowQueryOptions, WorkflowStartOptions, grpc::WorkflowService,
+    Connection, MESSAGE_TOO_LARGE_KEY, NamespacedClient, REQUEST_LATENCY_HISTOGRAM_NAME,
+    UntypedQuery, UntypedWorkflow, WorkflowExecutionInfo, WorkflowQueryOptions,
+    WorkflowStartOptions, grpc::WorkflowService,
 };
 use temporalio_common::{
     data_converters::RawValue,
@@ -38,6 +39,7 @@ use temporalio_common::{
             common::v1::RetryPolicy,
             enums::v1::{
                 NexusHandlerErrorRetryBehavior, WorkflowIdConflictPolicy, WorkflowIdReusePolicy,
+                WorkflowTaskFailedCause,
             },
             failure::v1::Failure,
             nexus::{
@@ -1751,4 +1753,161 @@ async fn wf_task_latency_recorded_on_dropped_wft() {
     )
     .await
     .unwrap();
+}
+
+#[tokio::test]
+async fn wf_task_execution_failed_metric_includes_workflow_type() {
+    let (telemopts, addr, _aborter) = prom_metrics(None);
+    let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
+    let meter = rt.telemetry().get_temporal_metric_meter().unwrap();
+
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(
+        temporalio_common::protos::temporal::api::enums::v1::EventType::WorkflowExecutionStarted,
+    );
+    t.add_workflow_task_scheduled_and_started();
+
+    let mut mh = MockPollCfg::from_resp_batches(
+        "fake_wf_id",
+        t,
+        [ResponseType::AllHistory, ResponseType::AllHistory],
+        mock_worker_client(),
+    );
+    mh.num_expected_fails = 1;
+    mh.num_expected_completions = Some(0.into());
+
+    let mut mock = build_mock_pollers(mh);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
+    mock.set_temporal_meter(meter);
+    let core = mock_worker(mock);
+
+    let act = core.poll_workflow_activation().await.unwrap();
+    core.complete_workflow_activation(WorkflowActivationCompletion::fail(
+        act.run_id,
+        "test failure".into(),
+        None,
+    ))
+    .await
+    .unwrap();
+    core.handle_eviction().await;
+
+    // The reported WFT failure evicts the run. Consume the replayed activation so the worker can
+    // shut down cleanly without an outstanding workflow task.
+    let act = core.poll_workflow_activation().await.unwrap();
+    core.complete_workflow_activation(WorkflowActivationCompletion::fail(
+        act.run_id,
+        "test failure".into(),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    core.drain_pollers_and_shutdown().await;
+
+    let metric_line = eventually(
+        || {
+            let endpoint = format!("http://{addr}/metrics");
+            async move {
+                let body = get_text(endpoint).await;
+                body.lines()
+                    .find(|l| {
+                        l.starts_with("temporal_workflow_task_execution_failed{")
+                            && l.contains("failure_reason=\"WorkflowError\"")
+                    })
+                    .map(ToString::to_string)
+                    .ok_or_else(|| anyhow!("wf_task_execution_failed metric not found"))
+            }
+        },
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        metric_line.contains("workflow_type=\"default_wf_type\""),
+        "Expected workflow_type label on metric, got: {metric_line}"
+    );
+}
+
+#[tokio::test]
+async fn grpc_message_too_large_wf_task_execution_failed_metric_includes_workflow_type() {
+    let (telemopts, addr, _aborter) = prom_metrics(None);
+    let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
+    let meter = rt.telemetry().get_temporal_metric_meter().unwrap();
+
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(
+        temporalio_common::protos::temporal::api::enums::v1::EventType::WorkflowExecutionStarted,
+    );
+    t.add_workflow_task_scheduled_and_started();
+
+    let mut mh = MockPollCfg::from_resp_batches(
+        "fake_wf_id",
+        t,
+        [ResponseType::AllHistory, ResponseType::AllHistory],
+        mock_worker_client(),
+    );
+    mh.num_expected_fails = 1;
+    let mut times = 1;
+    mh.completion_mock_fn = Some(Box::new(move |_| {
+        if times == 1 {
+            let mut err = tonic::Status::new(
+                tonic::Code::ResourceExhausted,
+                "grpc: received message larger than max",
+            );
+            err.metadata_mut().insert(MESSAGE_TOO_LARGE_KEY, 1.into());
+            times += 1;
+            Err(err)
+        } else {
+            Ok(Default::default())
+        }
+    }));
+    mh.expect_fail_wft_matcher =
+        Box::new(|_, cause, _| *cause == WorkflowTaskFailedCause::GrpcMessageTooLarge);
+
+    let mut mock = build_mock_pollers(mh);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
+    mock.set_temporal_meter(meter);
+    let core = mock_worker(mock);
+
+    let act = core.poll_workflow_activation().await.unwrap();
+    core.complete_workflow_activation(WorkflowActivationCompletion::empty(&act.run_id))
+        .await
+        .unwrap();
+    core.handle_eviction().await;
+
+    // The first completion records the metric and evicts the run. Complete the replayed activation
+    // so the worker has no outstanding workflow task when shutdown drains pollers.
+    let act = core.poll_workflow_activation().await.unwrap();
+    core.complete_execution(&act.run_id).await;
+
+    core.drain_pollers_and_shutdown().await;
+
+    let metric_line = eventually(
+        || {
+            let endpoint = format!("http://{addr}/metrics");
+            async move {
+                let body = get_text(endpoint).await;
+                body.lines()
+                    .find(|l| {
+                        l.starts_with("temporal_workflow_task_execution_failed{")
+                            && l.contains("failure_reason=\"GrpcMessageTooLarge\"")
+                    })
+                    .map(ToString::to_string)
+                    .ok_or_else(|| anyhow!("wf_task_execution_failed metric not found"))
+            }
+        },
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        metric_line.contains("failure_reason=\"GrpcMessageTooLarge\""),
+        "Expected GrpcMessageTooLarge failure reason on metric, got: {metric_line}"
+    );
+    assert!(
+        metric_line.contains("workflow_type=\"default_wf_type\""),
+        "Expected workflow_type label on metric, got: {metric_line}"
+    );
 }

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -272,10 +272,16 @@ async fn oversize_grpc_message() {
     let tq = starter.get_task_queue();
     crate::common::eventually(
         || async {
-            let body = crate::integ_tests::metrics_tests::get_text(format!("http://{addr}/metrics")).await;
-            if body.contains(&format!(
-                "temporal_workflow_task_execution_failed{{failure_reason=\"GrpcMessageTooLarge\",namespace=\"{NAMESPACE}\",service_name=\"temporal-core-sdk\",task_queue=\"{tq}\"}} 1"
-            )) {
+            let body =
+                crate::integ_tests::metrics_tests::get_text(format!("http://{addr}/metrics")).await;
+            if body.lines().any(|line| {
+                line.starts_with("temporal_workflow_task_execution_failed{")
+                    && line.contains("failure_reason=\"GrpcMessageTooLarge\"")
+                    && line.contains(&format!("namespace=\"{NAMESPACE}\""))
+                    && line.contains("service_name=\"temporal-core-sdk\"")
+                    && line.contains(&format!("task_queue=\"{tq}\""))
+                    && line.ends_with(" 1")
+            }) {
                 Ok(())
             } else {
                 Err(())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Actually forward attributes passed to `MetricsContext::with_new_attributes`
- Switch task failures produced by gRPC message too large to use the run metrics instead of worker metrics

First commit adds failing test. Second commit fixes unit & first integration test. Third commit fixes gRPC message too large integration test.

## Why?
First one was straight regression, other one was oversight in initial implementation of gRPC message too large as workflow task failure.

## Checklist
<!--- add/delete as needed --->

1. Closes #1299

2. How was this tested:
- Added unit test to verify `MetricsContext::with_new_attributes` doesn't throw away attributes
- Integration test to verify `workflow_type` is present on `temporal_workflow_task_execution_failed`
- Integration test to verify `workflow_type` is present on `temporal_workflow_task_execution_failed` when task failure is triggered by a gRPC too large

3. Any docs updates needed?
N/A