### PR TITLE
:boom: Fix possible panic due to LA completing after an eviction

### DIFF
--- a/crates/sdk-core/src/core_tests/workflow_tasks.rs
+++ b/crates/sdk-core/src/core_tests/workflow_tasks.rs
@@ -8,8 +8,8 @@ use crate::{
         WorkflowCachingPolicy::{self, AfterEveryReply, NonSticky},
         build_fake_worker, build_mock_pollers, build_multihist_mock_sg, fanout_tasks,
         gen_assert_and_fail, gen_assert_and_reply, hist_to_poll_resp, mock_worker, poll_and_reply,
-        poll_and_reply_clears_outstanding_evicts, single_hist_mock_sg, start_timer_cmd,
-        test_worker_cfg,
+        poll_and_reply_clears_outstanding_evicts, schedule_local_activity_cmd, single_hist_mock_sg,
+        start_timer_cmd, test_worker_cfg,
     },
     worker::{
         PollerBehavior, SlotMarkUsedContext, SlotReleaseContext, SlotReservationContext,
@@ -33,7 +33,10 @@ use temporalio_client::MESSAGE_TOO_LARGE_KEY;
 use temporalio_common::{
     protos::{
         coresdk::{
-            activity_result::{self as ar, ActivityResolution, activity_resolution},
+            ActivityTaskCompletion,
+            activity_result::{
+                self as ar, ActivityExecutionResult, ActivityResolution, activity_resolution,
+            },
             common::VersioningIntent,
             workflow_activation::{
                 FireTimer, InitializeWorkflow, ResolveActivity, UpdateRandomSeed,
@@ -1399,6 +1402,132 @@ async fn lang_slower_than_wft_timeouts() {
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         start_again.run_id,
         vec![CompleteWorkflowExecution { result: None }.into()],
+    ))
+    .await
+    .unwrap();
+    core.shutdown().await;
+}
+
+#[tokio::test]
+async fn la_resolution_after_wft_not_found_during_eviction() {
+    let wfid = "fake_wf_id";
+    let mut t = TestHistoryBuilder::default();
+    t.add_wfe_started_with_wft_timeout(Duration::from_secs(1));
+    t.add_workflow_task_scheduled_and_started();
+    let first_wft = hist_to_poll_resp(&t, wfid.to_string(), ResponseType::AllHistory).resp;
+    t.add_workflow_task_timed_out();
+    t.add_workflow_task_scheduled_and_started();
+    let second_wft = hist_to_poll_resp(&t, wfid.to_string(), ResponseType::AllHistory).resp;
+
+    let mut mock_cfg = MockPollCfg::from_resp_batches(
+        wfid,
+        t,
+        [ResponseType::Raw(first_wft), ResponseType::Raw(second_wft)],
+        mock_worker_client(),
+    );
+    mock_cfg.make_poll_stream_interminable = true;
+    let mut first_completion = true;
+    mock_cfg.completion_mock_fn = Some(Box::new(move |_| {
+        if first_completion {
+            first_completion = false;
+            Err(tonic::Status::not_found("Workflow task not found."))
+        } else {
+            Ok(Default::default())
+        }
+    }));
+    let mut mock = build_mock_pollers(mock_cfg);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
+    let core = mock_worker(mock);
+    let core = Arc::new(core);
+
+    let activation = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        activation.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
+        }]
+    );
+    let run_id = activation.run_id.clone();
+    let complete_core = core.clone();
+    let complete_activation = tokio::spawn(async move {
+        complete_core
+            .complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+                run_id,
+                vec![
+                    schedule_local_activity_cmd(
+                        1,
+                        "1",
+                        ActivityCancellationType::WaitCancellationCompleted,
+                        Duration::from_secs(30),
+                    ),
+                    start_timer_cmd(1, Duration::from_millis(10)),
+                ],
+            ))
+            .await
+    });
+
+    let act_task = time::timeout(Duration::from_millis(500), core.poll_activity_task())
+        .await
+        .unwrap()
+        .unwrap();
+
+    time::timeout(Duration::from_secs(5), complete_activation)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    let eviction = time::timeout(Duration::from_secs(5), core.poll_workflow_activation())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_matches!(
+        eviction.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::RemoveFromCache(_)),
+        }]
+    );
+    core.complete_workflow_activation(WorkflowActivationCompletion::empty(eviction.run_id))
+        .await
+        .unwrap();
+
+    let replay_activation = time::timeout(Duration::from_secs(5), core.poll_workflow_activation())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_matches!(
+        replay_activation.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(_)),
+        }]
+    );
+
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: act_task.task_token,
+        result: Some(ActivityExecutionResult::cancel_from_details(None)),
+    })
+    .await
+    .unwrap();
+
+    // The stale LA completion should have been dropped by the LA manager when the
+    // eviction activation completed, so it must not produce another activation.
+    assert!(
+        time::timeout(Duration::from_millis(500), core.poll_workflow_activation())
+            .await
+            .is_err()
+    );
+
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+        replay_activation.run_id,
+        vec![
+            schedule_local_activity_cmd(
+                1,
+                "1",
+                ActivityCancellationType::WaitCancellationCompleted,
+                Duration::from_secs(30),
+            ),
+            start_timer_cmd(1, Duration::from_millis(10)),
+        ],
     ))
     .await
     .unwrap();

--- a/crates/sdk-core/src/worker/activities/local_activities.rs
+++ b/crates/sdk-core/src/worker/activities/local_activities.rs
@@ -406,9 +406,9 @@ impl LocalActivityManager {
     /// Returns the next pending local-activity related action, or None if shutdown has initiated
     /// and there are no more remaining actions to take.
     pub(crate) async fn next_pending(&self) -> Option<NextPendingLAAction> {
-        let (new_or_retry, permit) = match self.rcvs.lock().await.next().await? {
-            NewOrCancel::Cancel(c) => {
-                return match c {
+        loop {
+            let (new_or_retry, permit) = match self.rcvs.lock().await.next().await? {
+                NewOrCancel::Cancel(c) => match c {
                     CancelOrTimeout::Cancel(c) => {
                         if self
                             .dat
@@ -416,11 +416,10 @@ impl LocalActivityManager {
                             .outstanding_activity_tasks
                             .contains_key(c.task_token.as_slice())
                         {
-                            Some(NextPendingLAAction::Dispatch(c))
-                        } else {
-                            // Don't dispatch cancels for things we've already stopped tracking
-                            None
+                            return Some(NextPendingLAAction::Dispatch(c));
                         }
+                        // Don't dispatch cancels for things we've already stopped tracking
+                        continue;
                     }
                     CancelOrTimeout::Timeout { run_id, resolution } => {
                         let tt = self
@@ -434,124 +433,123 @@ impl LocalActivityManager {
                             .as_ref()
                             .map(|lai| lai.task_token.clone());
                         if let Some(task_token) = tt {
-                            Some(NextPendingLAAction::Autocomplete(
+                            return Some(NextPendingLAAction::Autocomplete(
                                 self.complete(&task_token, resolution.result),
-                            ))
-                        } else {
-                            // This timeout is for a no-longer-tracked activity, so, whatever
-                            None
+                            ));
                         }
+                        // This timeout is for a no-longer-tracked activity, so, whatever
+                        continue;
                     }
-                };
+                },
+                NewOrCancel::New(n, perm) => (n, perm),
+            };
+
+            // It is important that there are no await points after receiving from the channel, as
+            // it would mean dropping this future would cause us to drop the activity request.
+            let (new_la, attempt) = match new_or_retry {
+                NewOrRetry::New(n) => {
+                    let explicit_attempt_num_or_1 = n.schedule_cmd.attempt.max(1);
+                    (n, explicit_attempt_num_or_1)
+                }
+                NewOrRetry::Retry { in_flight, attempt } => (in_flight, attempt),
+            };
+            let la_info_for_in_flight_map = new_la.clone();
+            let id = ExecutingLAId {
+                run_id: new_la.workflow_exec_info.run_id.clone(),
+                seq_num: new_la.schedule_cmd.seq,
+            };
+            let orig_sched_time = new_la.schedule_cmd.original_schedule_time;
+            let sa = new_la.schedule_cmd;
+
+            let mut dat = self.dat.lock();
+            if !dat.la_info.contains_key(&id) {
+                debug!(id=?id, "Dropping invalidated local activity request");
+                continue;
             }
-            NewOrCancel::New(n, perm) => (n, perm),
-        };
+            // If this request originated from a local backoff task, clear the entry for it. We
+            // don't await the handle because we know it must already be done, and there's no
+            // meaningful value.
+            dat.la_info
+                .get_mut(&id)
+                .map(|lai| lai.backing_off_task.take());
 
-        // It is important that there are no await points after receiving from the channel, as
-        // it would mean dropping this future would cause us to drop the activity request.
-        let (new_la, attempt) = match new_or_retry {
-            NewOrRetry::New(n) => {
-                let explicit_attempt_num_or_1 = n.schedule_cmd.attempt.max(1);
-                (n, explicit_attempt_num_or_1)
-            }
-            NewOrRetry::Retry { in_flight, attempt } => (in_flight, attempt),
-        };
-        let la_info_for_in_flight_map = new_la.clone();
-        let id = ExecutingLAId {
-            run_id: new_la.workflow_exec_info.run_id.clone(),
-            seq_num: new_la.schedule_cmd.seq,
-        };
-        let orig_sched_time = new_la.schedule_cmd.original_schedule_time;
-        let sa = new_la.schedule_cmd;
-
-        let mut dat = self.dat.lock();
-        if !dat.la_info.contains_key(&id) {
-            debug!(id=?id, "Dropping invalidated local activity request");
-            return None;
-        }
-        // If this request originated from a local backoff task, clear the entry for it. We
-        // don't await the handle because we know it must already be done, and there's no
-        // meaningful value.
-        dat.la_info
-            .get_mut(&id)
-            .map(|lai| lai.backing_off_task.take());
-
-        // If this task sat in the queue for too long, return a timeout for it instead
-        if let Some(s2s) = sa.schedule_to_start_timeout.as_ref() {
-            let sat_for = new_la.schedule_time.elapsed().unwrap_or_default();
-            if sat_for > *s2s {
-                return Some(NextPendingLAAction::Autocomplete(
-                    LACompleteAction::Report {
-                        run_id: new_la.workflow_exec_info.run_id,
-                        resolution: LocalActivityResolution {
-                            seq: sa.seq,
-                            result: LocalActivityExecutionResult::timeout(
-                                TimeoutType::ScheduleToStart,
-                            ),
-                            runtime: sat_for,
-                            attempt,
-                            backoff: None,
-                            original_schedule_time: orig_sched_time,
+            // If this task sat in the queue for too long, return a timeout for it instead
+            if let Some(s2s) = sa.schedule_to_start_timeout.as_ref() {
+                let sat_for = new_la.schedule_time.elapsed().unwrap_or_default();
+                if sat_for > *s2s {
+                    return Some(NextPendingLAAction::Autocomplete(
+                        LACompleteAction::Report {
+                            run_id: new_la.workflow_exec_info.run_id,
+                            resolution: LocalActivityResolution {
+                                seq: sa.seq,
+                                result: LocalActivityExecutionResult::timeout(
+                                    TimeoutType::ScheduleToStart,
+                                ),
+                                runtime: sat_for,
+                                attempt,
+                                backoff: None,
+                                original_schedule_time: orig_sched_time,
+                            },
+                            task: None,
                         },
-                        task: None,
-                    },
-                ));
+                    ));
+                }
             }
-        }
 
-        let la_info = dat.la_info.get_mut(&id).expect("Activity must exist");
-        let tt = la_info.task_token.clone();
-        if let Some(to) = la_info.timeout_bag.as_mut() {
-            to.mark_started();
-        }
-        dat.outstanding_activity_tasks.insert(
-            tt.clone(),
-            LocalInFlightActInfo {
-                la_info: la_info_for_in_flight_map,
-                dispatch_time: Instant::now(),
-                attempt,
-                _permit: permit.into_used(LocalActivitySlotInfo {
-                    activity_type: sa.activity_type.clone(),
-                }),
-            },
-        );
+            let la_info = dat.la_info.get_mut(&id).expect("Activity must exist");
+            let tt = la_info.task_token.clone();
+            if let Some(to) = la_info.timeout_bag.as_mut() {
+                to.mark_started();
+            }
+            dat.outstanding_activity_tasks.insert(
+                tt.clone(),
+                LocalInFlightActInfo {
+                    la_info: la_info_for_in_flight_map,
+                    dispatch_time: Instant::now(),
+                    attempt,
+                    _permit: permit.into_used(LocalActivitySlotInfo {
+                        activity_type: sa.activity_type.clone(),
+                    }),
+                },
+            );
 
-        let (schedule_to_close, start_to_close) = sa.close_timeouts.into_sched_and_start();
-        self.metrics
-            .with_new_attrs([
-                activity_type(sa.activity_type.clone()),
-                workflow_type(new_la.workflow_type.clone()),
-            ])
-            .la_executed();
-        Some(NextPendingLAAction::Dispatch(ActivityTask {
-            task_token: tt.0,
-            variant: Some(activity_task::Variant::Start(Start {
-                workflow_namespace: self.namespace.clone(),
-                workflow_type: new_la.workflow_type,
-                workflow_execution: Some(new_la.workflow_exec_info),
-                activity_id: sa.activity_id,
-                activity_type: sa.activity_type,
-                header_fields: sa.headers,
-                input: sa.arguments,
-                heartbeat_details: vec![],
-                scheduled_time: Some(new_la.schedule_time.into()),
-                current_attempt_scheduled_time: Some(new_la.schedule_time.into()),
-                started_time: Some(SystemTime::now().into()),
-                attempt,
-                schedule_to_close_timeout: schedule_to_close
-                    .unwrap_or(Duration::ZERO)
-                    .try_into()
-                    .ok(),
-                start_to_close_timeout: start_to_close
-                    .or(schedule_to_close)
-                    .and_then(|t| t.try_into().ok()),
-                heartbeat_timeout: None,
-                retry_policy: Some(sa.retry_policy.into()),
-                priority: Some(Default::default()),
-                is_local: true,
-                run_id: String::new(),
-            })),
-        }))
+            let (schedule_to_close, start_to_close) = sa.close_timeouts.into_sched_and_start();
+            self.metrics
+                .with_new_attrs([
+                    activity_type(sa.activity_type.clone()),
+                    workflow_type(new_la.workflow_type.clone()),
+                ])
+                .la_executed();
+            return Some(NextPendingLAAction::Dispatch(ActivityTask {
+                task_token: tt.0,
+                variant: Some(activity_task::Variant::Start(Start {
+                    workflow_namespace: self.namespace.clone(),
+                    workflow_type: new_la.workflow_type,
+                    workflow_execution: Some(new_la.workflow_exec_info),
+                    activity_id: sa.activity_id,
+                    activity_type: sa.activity_type,
+                    header_fields: sa.headers,
+                    input: sa.arguments,
+                    heartbeat_details: vec![],
+                    scheduled_time: Some(new_la.schedule_time.into()),
+                    current_attempt_scheduled_time: Some(new_la.schedule_time.into()),
+                    started_time: Some(SystemTime::now().into()),
+                    attempt,
+                    schedule_to_close_timeout: schedule_to_close
+                        .unwrap_or(Duration::ZERO)
+                        .try_into()
+                        .ok(),
+                    start_to_close_timeout: start_to_close
+                        .or(schedule_to_close)
+                        .and_then(|t| t.try_into().ok()),
+                    heartbeat_timeout: None,
+                    retry_policy: Some(sa.retry_policy.into()),
+                    priority: Some(Default::default()),
+                    is_local: true,
+                    run_id: String::new(),
+                })),
+            }));
+        }
     }
 
     /// Mark a local activity as having completed
@@ -1101,29 +1099,53 @@ mod tests {
     async fn invalidate_drops_queued_activity() {
         let lam = LocalActivityManager::test(5);
         let run_id = "run_id";
-        lam.enqueue([NewLocalAct {
-            schedule_cmd: ValidScheduleLA {
-                seq: 1,
-                activity_id: 1.to_string(),
-                ..Default::default()
-            },
-            workflow_type: "".to_string(),
-            workflow_exec_info: WorkflowExecution {
-                workflow_id: "".to_string(),
-                run_id: run_id.to_string(),
-            },
-            schedule_time: SystemTime::now(),
-        }
-        .into()]);
+        let other_run_id = "other_run_id";
+        lam.enqueue([
+            NewLocalAct {
+                schedule_cmd: ValidScheduleLA {
+                    seq: 1,
+                    activity_id: 1.to_string(),
+                    ..Default::default()
+                },
+                workflow_type: "".to_string(),
+                workflow_exec_info: WorkflowExecution {
+                    workflow_id: "".to_string(),
+                    run_id: run_id.to_string(),
+                },
+                schedule_time: SystemTime::now(),
+            }
+            .into(),
+            NewLocalAct {
+                schedule_cmd: ValidScheduleLA {
+                    seq: 1,
+                    activity_id: 2.to_string(),
+                    ..Default::default()
+                },
+                workflow_type: "".to_string(),
+                workflow_exec_info: WorkflowExecution {
+                    workflow_id: "".to_string(),
+                    run_id: other_run_id.to_string(),
+                },
+                schedule_time: SystemTime::now(),
+            }
+            .into(),
+        ]);
 
         lam.enqueue([LocalActRequest::InvalidateRun(run_id.to_string())]);
-        assert!(
-            tokio::time::timeout(Duration::from_millis(100), lam.next_pending())
-                .await
-                .unwrap()
-                .is_none()
+        let next = tokio::time::timeout(Duration::from_millis(100), lam.next_pending())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_matches!(
+            next.variant.unwrap(),
+            activity_task::Variant::Start(Start {
+                activity_id,
+                workflow_execution: Some(WorkflowExecution { run_id, .. }),
+                ..
+            }) if activity_id == "2" && run_id == other_run_id
         );
-        assert_eq!(lam.num_outstanding(), 0);
+        assert_eq!(lam.num_outstanding(), 1);
     }
 
     #[tokio::test]

--- a/crates/sdk-core/src/worker/activities/local_activities.rs
+++ b/crates/sdk-core/src/worker/activities/local_activities.rs
@@ -137,6 +137,8 @@ pub(crate) enum LocalActRequest {
     Cancel(ExecutingLAId),
     #[from(ignore)]
     CancelAllInRun(String),
+    #[from(ignore)]
+    InvalidateRun(String),
     StartHeartbeatTimeout {
         send_on_elapse: HeartbeatTimeoutMsg,
         deadline: Instant,
@@ -297,9 +299,7 @@ impl LocalActivityManager {
                     let tt = dlock.gen_next_token();
                     match dlock.la_info.entry(id) {
                         Entry::Occupied(o) => {
-                            // Do not queue local activities which are in fact already executing.
-                            // This can happen during evictions.
-                            debug!(
+                            dbg_panic!(
                                 "Tried to queue already-executing local activity {:?}",
                                 o.key()
                             );
@@ -368,6 +368,24 @@ impl LocalActivityManager {
                             immediate_resolutions.push(immediate_res);
                         }
                     }
+                }
+                LocalActRequest::InvalidateRun(run_id) => {
+                    debug!(run_id=%run_id, "Invalidating all local activities for run");
+                    let mut dlock = self.dat.lock();
+                    dlock
+                        .outstanding_activity_tasks
+                        .retain(|_, info| info.la_info.workflow_exec_info.run_id != run_id);
+                    dlock.la_info.retain(|id, info| {
+                        if id.run_id == run_id {
+                            if let Some(backoff_task) = info.backing_off_task.as_ref() {
+                                backoff_task.abort();
+                            }
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    self.set_shutdown_complete_if_ready(&mut dlock);
                 }
                 LocalActRequest::IndicateWorkflowTaskCompleted(run_id) => {
                     let mut dlock = self.dat.lock();
@@ -447,6 +465,10 @@ impl LocalActivityManager {
         let sa = new_la.schedule_cmd;
 
         let mut dat = self.dat.lock();
+        if !dat.la_info.contains_key(&id) {
+            debug!(id=?id, "Dropping invalidated local activity request");
+            return None;
+        }
         // If this request originated from a local backoff task, clear the entry for it. We
         // don't await the handle because we know it must already be done, and there's no
         // meaningful value.
@@ -977,7 +999,6 @@ impl Drop for TimeoutBag {
 mod tests {
     use super::*;
     use crate::{prost_dur, protosext::LACloseTimeouts, retry_logic::ValidatedRetryPolicy};
-    use futures_util::FutureExt;
     use temporalio_common::protos::temporal::api::{
         common::v1::RetryPolicy,
         failure::v1::{ApplicationFailureInfo, Failure, failure::FailureInfo},
@@ -1074,6 +1095,35 @@ mod tests {
                 lam.complete(&tt, LocalActivityExecutionResult::Completed(Default::default()));
             } => (),
         };
+    }
+
+    #[tokio::test]
+    async fn invalidate_drops_queued_activity() {
+        let lam = LocalActivityManager::test(5);
+        let run_id = "run_id";
+        lam.enqueue([NewLocalAct {
+            schedule_cmd: ValidScheduleLA {
+                seq: 1,
+                activity_id: 1.to_string(),
+                ..Default::default()
+            },
+            workflow_type: "".to_string(),
+            workflow_exec_info: WorkflowExecution {
+                workflow_id: "".to_string(),
+                run_id: run_id.to_string(),
+            },
+            schedule_time: SystemTime::now(),
+        }
+        .into()]);
+
+        lam.enqueue([LocalActRequest::InvalidateRun(run_id.to_string())]);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), lam.next_pending())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(lam.num_outstanding(), 0);
     }
 
     #[tokio::test]
@@ -1363,7 +1413,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn idempotency_enforced() {
+    #[should_panic(expected = "Tried to queue already-executing local activity")]
+    async fn duplicate_local_activity_queue_panics() {
         let lam = LocalActivityManager::test(10);
         let new_la = NewLocalAct {
             schedule_cmd: ValidScheduleLA {
@@ -1378,18 +1429,7 @@ mod tests {
             },
             schedule_time: SystemTime::now(),
         };
-        // Verify only one will get queued
-        lam.enqueue([new_la.clone().into(), new_la.clone().into()]);
-        lam.next_pending().await.unwrap().unwrap();
-        assert_eq!(lam.num_outstanding(), 1);
-        // There should be nothing else in the queue
-        assert!(lam.rcvs.lock().await.next().now_or_never().is_none());
-
-        // Verify that if we now enqueue the same act again, after the task is outstanding, we still
-        // don't add it.
-        lam.enqueue([new_la.into()]);
-        assert_eq!(lam.num_outstanding(), 1);
-        assert!(lam.rcvs.lock().await.next().now_or_never().is_none());
+        lam.enqueue([new_la.clone().into(), new_la.into()]);
     }
 
     #[tokio::test]

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -675,6 +675,14 @@ impl ManagedRun {
         } else {
             false
         };
+        if evict && let Some(sink) = self.local_activity_request_sink.as_deref() {
+            let immediate_resolutions = sink.sink_reqs(vec![LocalActRequest::InvalidateRun(
+                self.wfm.machines.run_id.clone(),
+            )]);
+            if !immediate_resolutions.is_empty() {
+                dbg_panic!("Invalidating local activities should not produce resolutions");
+            }
+        }
         let buffered = if evict {
             mem::take(&mut self.task_buffer)
         } else {
@@ -904,6 +912,15 @@ impl ManagedRun {
         }
 
         if !self.activation_is_eviction() && self.trying_to_evict.is_none() {
+            let outstanding_las = self.wfm.machines.outstanding_local_activity_count();
+            if outstanding_las > 0 && self.config.max_cached_workflows == 0 {
+                warn!(
+                    run_id=%info.run_id,
+                    reason=?info.reason,
+                    outstanding_local_activities=outstanding_las,
+                    "Eviction requested while local activities are still in flight; local activities when using max_cached_workflows=0 are likely to be dropped or retried"
+                );
+            }
             debug!(run_id=%info.run_id, reason=%info.message, "Eviction requested");
             // If we've requested an eviction because of failure related reasons then we want to
             // delete any pending queries, since handling them no longer makes sense. Evictions

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -782,33 +782,6 @@ async fn schedule_to_close_timeout_across_timer_backoff(#[case] cached: bool) {
     assert_eq!(3, num_attempts.load(Ordering::Relaxed));
 }
 
-#[rstest::rstest]
-#[tokio::test]
-async fn eviction_wont_make_local_act_get_dropped(#[values(true, false)] short_wft_timeout: bool) {
-    let wf_name = format!("eviction_wont_make_local_act_get_dropped_{short_wft_timeout}");
-    let mut starter = CoreWfStarter::new(&wf_name);
-    starter.sdk_config.max_cached_workflows = 0_usize;
-    starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    worker
-        .register_workflow::<LocalActThenTimerThenWait>()
-        .unwrap();
-
-    let task_queue = starter.get_task_queue().to_owned();
-    let opts = if short_wft_timeout {
-        WorkflowStartOptions::new(task_queue, wf_name.clone())
-            .task_timeout(Duration::from_secs(1))
-            .build()
-    } else {
-        WorkflowStartOptions::new(task_queue, wf_name.clone()).build()
-    };
-    worker
-        .submit_workflow(LocalActThenTimerThenWait::run, (), opts)
-        .await
-        .unwrap();
-    worker.run_until_done().await.unwrap();
-}
-
 #[tokio::test]
 async fn timer_backoff_concurrent_with_non_timer_backoff() {
     let wf_name = "timer_backoff_concurrent_with_non_timer_backoff";


### PR DESCRIPTION
## What was changed
This changes local activity eviction semantics so local activities are invalidated when their
  owning workflow run instance is evicted, rather than allowing them to survive and potentially
  be adopted by a later replay of the same RunID.

  The old behavior was timing-dependent: an in-flight LA completion could arrive after eviction
  while the workflow was replaying, but before replay had recreated the corresponding local
  activity machine. In that state, the completion no longer had a valid owner, yet Core could try
  to apply it to the new workflow-machine instance, causing nondeterminism or corrupting WFT/
  activation bookkeeping. If the completion happened to arrive later, after replay recreated the
  LA command, it could appear to work, but that relied on an accidental race rather than a sound
  ownership model.

  This also makes duplicate local activity queueing an invariant violation instead of silently
  suppressing it, and warns when eviction is requested while local activities are still in
  flight, which is especially problematic with max_cached_workflows = 0.

> [!WARNING]
> It's probably important to call this one out in release notes, as it's possible there are people out there semi-depending on the behavior that accidentally worked. This is probably only likely in situations where they have the cache off. They should not have the cache off. This is not actually a breaking change, though.

## Why?
Bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-rust/issues/1230
2. How was this tested:
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
