### PR TITLE
fix(sdk) 💥 : no longer expose raw proto for application error category

### DIFF
--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -19,9 +19,12 @@ use crate::{
         OutgoingError, OutgoingWorkflowError, ResetWorkflowError, ServerError, TerminatedError,
         TimeoutError,
     },
-    protos::temporal::api::failure::v1::{
-        ActivityFailureInfo, ApplicationFailureInfo, CanceledFailureInfo,
-        ChildWorkflowExecutionFailureInfo, Failure, failure::FailureInfo,
+    protos::temporal::api::{
+        enums::v1::ApplicationErrorCategory as ProtoApplicationErrorCategory,
+        failure::v1::{
+            ActivityFailureInfo, ApplicationFailureInfo, CanceledFailureInfo,
+            ChildWorkflowExecutionFailureInfo, Failure, failure::FailureInfo,
+        },
     },
 };
 
@@ -320,7 +323,7 @@ impl EncodeFailure for ApplicationFailure {
                     non_retryable: self.is_non_retryable(),
                     details,
                     next_retry_delay: self.next_retry_delay().and_then(|d| d.try_into().ok()),
-                    category: self.category() as i32,
+                    category: ProtoApplicationErrorCategory::from(self.category()) as i32,
                 },
             )),
             ..Default::default()
@@ -501,9 +504,9 @@ mod tests {
     use super::*;
     use crate::{
         data_converters::{GenericPayloadConverter, SerializationContext},
+        error::ApplicationErrorCategory,
         protos::temporal::api::{
             common::v1::{Payload, Payloads},
-            enums::v1::ApplicationErrorCategory,
             failure::v1::{
                 ActivityFailureInfo, ChildWorkflowExecutionFailureInfo, NexusHandlerFailureInfo,
                 NexusOperationFailureInfo, ResetWorkflowFailureInfo, ServerFailureInfo,
@@ -649,7 +652,7 @@ mod tests {
         assert_eq!(failure.message, "app boom");
         assert_eq!(info.r#type, "MyType");
         assert!(info.non_retryable);
-        assert_eq!(info.category(), ApplicationErrorCategory::Benign);
+        assert_eq!(info.category(), ProtoApplicationErrorCategory::Benign);
         assert_eq!(info.details.unwrap().payloads[0].data, b"details".to_vec());
     }
 

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -122,6 +122,7 @@ where
 
 /// Categorizes an [`ApplicationFailure`] to hint at how the server and tooling should treat it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
 pub enum ApplicationErrorCategory {
     /// No category was specified.
     #[default]

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -10,7 +10,7 @@ use crate::{
         coresdk::child_workflow::StartChildWorkflowExecutionFailedCause,
         temporal::api::{
             common::v1::{Payload, Payloads},
-            enums::v1::{ApplicationErrorCategory, TimeoutType},
+            enums::v1::{ApplicationErrorCategory as ProtoApplicationErrorCategory, TimeoutType},
             failure::v1::Failure,
         },
     },
@@ -116,6 +116,35 @@ where
     fn from(value: T) -> Self {
         Self {
             repr: FailurePayloadsRepr::Serializable(Box::new(value)),
+        }
+    }
+}
+
+/// Categorizes an [`ApplicationFailure`] to hint at how the server and tooling should treat it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum ApplicationErrorCategory {
+    /// No category was specified.
+    #[default]
+    Unspecified,
+    /// An expected error with little or no severity. Benign errors are logged at a reduced level
+    /// and excluded from error metrics by the server.
+    Benign,
+}
+
+impl From<ApplicationErrorCategory> for ProtoApplicationErrorCategory {
+    fn from(value: ApplicationErrorCategory) -> Self {
+        match value {
+            ApplicationErrorCategory::Unspecified => ProtoApplicationErrorCategory::Unspecified,
+            ApplicationErrorCategory::Benign => ProtoApplicationErrorCategory::Benign,
+        }
+    }
+}
+
+impl From<ProtoApplicationErrorCategory> for ApplicationErrorCategory {
+    fn from(value: ProtoApplicationErrorCategory) -> Self {
+        match value {
+            ProtoApplicationErrorCategory::Unspecified => ApplicationErrorCategory::Unspecified,
+            ProtoApplicationErrorCategory::Benign => ApplicationErrorCategory::Benign,
         }
     }
 }
@@ -248,7 +277,7 @@ impl ApplicationFailure {
             type_name,
             non_retryable: app_info.non_retryable,
             next_retry_delay: app_info.next_retry_delay.and_then(|d| d.try_into().ok()),
-            category: app_info.category(),
+            category: app_info.category().into(),
             details: app_info.details.map(|details| {
                 FailurePayloads::from(DecodablePayloads::new(
                     details.payloads,
@@ -1130,7 +1159,7 @@ mod tests {
         assert_eq!(info.r#type, "MyType");
         assert!(info.non_retryable);
         assert_eq!(info.details, Some(payloads));
-        assert_eq!(info.category(), ApplicationErrorCategory::Benign);
+        assert_eq!(info.category(), ProtoApplicationErrorCategory::Benign);
         assert_eq!(info.next_retry_delay.unwrap().seconds, 3);
     }
 

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -491,14 +491,12 @@ impl Debug for ActivityDefinitions {
 mod test {
     use super::*;
     use rstest::rstest;
-    use temporalio_common::error::ApplicationFailure;
+    use temporalio_common::error::{ApplicationErrorCategory, ApplicationFailure};
 
     #[rstest]
     #[case(true)]
     #[case(false)]
     fn activity_error_conversion_is_not_lossy(#[case] non_retryable: bool) {
-        use temporalio_common::protos::temporal::api::enums::v1::ApplicationErrorCategory;
-
         let original = ApplicationFailure::builder(anyhow::anyhow!("big boom"))
             .type_name("BigBoom".to_owned())
             .non_retryable(non_retryable)

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -2,7 +2,7 @@
 
 pub use crate::workflow_registry::WorkflowRegistrationError;
 pub use temporalio_common::error::{
-    ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
-    ChildWorkflowSignalError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,
-    OutgoingWorkflowError,
+    ActivityExecutionError, ApplicationErrorCategory, ApplicationFailure,
+    ChildWorkflowExecutionError, ChildWorkflowSignalError, ChildWorkflowStartError,
+    OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Create a new SDK type that converts down to the underlying proto for `ApplicationErrorCategory`

## Why?
SDKs general stance is to avoid exposing raw protos to the user unless needed.

Note this is a breaking change for those who were setting categories on application errors.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-rust/issues/1306

2. How was this tested:
👀 

3. Any docs updates needed?
No, did a quick check of the Rust SDK guide and we don't have a code sample for setting the error category.
