### PR TITLE
Rename master to main for API deps

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -58,6 +58,7 @@ jobs:
           - os: ubuntu-latest
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
+            timeoutMinutes: 30
           - os: macos-arm
             runsOn: macos-14
           - os: macos-intel

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ equivalent.
 This repo uses a subtree for upstream protobuf files. The path `crates/protos/protos/api_upstream`
 is a subtree. To update it, use:
 
-`git pull --squash --rebase=false -s subtree -X subtree=crates/protos/protos/api_upstream ssh://git@github.com/temporalio/api.git master --allow-unrelated-histories`
+`git pull --squash --rebase=false -s subtree -X subtree=crates/protos/protos/api_upstream ssh://git@github.com/temporalio/api.git main --allow-unrelated-histories`
 
 Do not question why this git command is the way it is. It is not our place to interpret git's ways.
 This same approach can be taken for updating `crates/protos/protos/api_cloud_upstream` from the

--- a/arch_docs/diagrams/README.md
+++ b/arch_docs/diagrams/README.md
@@ -6,5 +6,5 @@ They can be embedded into those documents two ways:
   https://stackoverflow.com/questions/32203610/how-to-integrate-uml-diagrams-into-gitlab-or-github
 * By pasting them into https://www.planttext.com/ and then embedding the resulting SVG link
 
-The first technique has the problem that the PR won't show changes, since it's always from master.
+The first technique has the problem that the PR won't show changes, since it's always from main.
 The second has the problem that you have to update it by hand. Pick your poison.

--- a/crates/protos/protos/api_upstream/.github/workflows/create-release.yml
+++ b/crates/protos/protos/api_upstream/.github/workflows/create-release.yml
@@ -6,7 +6,7 @@ on:
       branch:
         description: "Branch to be tagged"
         required: true
-        default: master
+        default: main
       tag:
         description: "Tag for new version (v1.23.4)"
         required: true
@@ -90,7 +90,7 @@ jobs:
   check-compatibility-sdk-go:
     needs: prepare-inputs
     if: ${{ github.event.inputs.skip_sdk_check == false || github.event.inputs.skip_sdk_check == 'false' }}
-    uses: temporalio/api-go/.github/workflows/check-sdk-compat.yml@master
+    uses: temporalio/api-go/.github/workflows/check-sdk-compat.yml@main
     with:
       sdk_ref: latest
       api_ref: ${{ needs.prepare-inputs.outputs.api_go_commit_sha }}
@@ -134,7 +134,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.create-release.result == 'success'
-    uses: temporalio/api-go/.github/workflows/create-release.yml@master
+    uses: temporalio/api-go/.github/workflows/create-release.yml@main
     with:
       ref: ${{ needs.prepare-inputs.outputs.api_go_commit_sha }}
       tag: ${{ github.event.inputs.tag }}

--- a/crates/protos/protos/api_upstream/.github/workflows/push-to-buf.yml
+++ b/crates/protos/protos/api_upstream/.github/workflows/push-to-buf.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v**'
     branches:
-      - master
+      - main
 permissions:
   contents: read
 jobs:

--- a/crates/protos/protos/api_upstream/.github/workflows/trigger-api-go-delete-release.yml
+++ b/crates/protos/protos/api_upstream/.github/workflows/trigger-api-go-delete-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trigger-api-go-delete-release:
-    uses: temporalio/api-go/.github/workflows/delete-release.yml@master
+    uses: temporalio/api-go/.github/workflows/delete-release.yml@main
     with:
       tag: ${{ github.event.release.tag_name }}
       api_commit_sha: ${{ github.event.release.target_commitish }}

--- a/crates/protos/protos/api_upstream/.github/workflows/trigger-api-go-publish-release.yml
+++ b/crates/protos/protos/api_upstream/.github/workflows/trigger-api-go-publish-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trigger-api-go-publish-release:
-    uses: temporalio/api-go/.github/workflows/publish-release.yml@master
+    uses: temporalio/api-go/.github/workflows/publish-release.yml@main
     with:
       tag: ${{ github.event.release.tag_name }}
       api_commit_sha: ${{ github.event.release.target_commitish }}

--- a/crates/protos/protos/api_upstream/.github/workflows/trigger-api-go-update.yml
+++ b/crates/protos/protos/api_upstream/.github/workflows/trigger-api-go-update.yml
@@ -3,13 +3,13 @@ name: 'Trigger api-go Update'
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch in api-go repo to trigger update protos (default: master)"
+        description: "Branch in api-go repo to trigger update protos (default: main)"
         required: true
-        default: master
+        default: main
 
 jobs:
   notify:

--- a/crates/protos/protos/api_upstream/Makefile
+++ b/crates/protos/protos/api_upstream/Makefile
@@ -76,7 +76,7 @@ http-api-docs:
 ##### Plugins & tools #####
 grpc-install:
 	@printf $(COLOR) "Install/update protoc and plugins..."
-	@go install go.temporal.io/api/cmd/protogen@master
+	@go install go.temporal.io/api/cmd/protogen@main
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest
@@ -118,8 +118,8 @@ buf-lint: $(STAMPDIR)/buf-mod-prune
 	(cd $(PROTO_ROOT) && buf lint)
 
 buf-breaking:
-	@printf $(COLOR) "Run buf breaking changes check against master branch..."	
-	@(cd $(PROTO_ROOT) && buf breaking --against 'https://github.com/temporalio/api.git#branch=master')
+	@printf $(COLOR) "Run buf breaking changes check against main branch..."
+	@(cd $(PROTO_ROOT) && buf breaking --against 'https://github.com/temporalio/api.git#branch=main')
 
 nexus-rpc-yaml: nexus-rpc-yaml-install
 	printf $(COLOR) "Generate nexus/temporal-proto-models-nexusrpc.yaml..."

--- a/crates/protos/protos/testsrv_upstream/Makefile
+++ b/crates/protos/protos/testsrv_upstream/Makefile
@@ -64,8 +64,8 @@ buf-lint:
 	(cd $(PROTO_ROOT) && buf lint)
 
 buf-breaking:
-#	@printf $(COLOR) "Run buf breaking changes check against master branch..."
-#	@(cd $(PROTO_ROOT) && buf breaking --against '../../../../.git#branch=master')
+#	@printf $(COLOR) "Run buf breaking changes check against main branch..."
+#	@(cd $(PROTO_ROOT) && buf breaking --against '../../../../.git#branch=main')
 
 ##### Clean #####
 clean:


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Renamed `master` to `main` for all API deps

## Why?
Default branch for `api` repo got renamed from `master` to `main`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Branch-name and documentation updates plus a CI timeout tweak; no runtime or security logic changes.
> 
> **Overview**
> Updates branch references from **`master`** to **`main`** across the repo and the vendored **`api_upstream`** subtree, matching Temporal’s **`api`** (and related **`api-go`**) default branch rename.
> 
> **Docs and CI:** `README.md` subtree pull instructions, arch diagram notes, and **`per-pr`** unit-test matrix now use **`main`**; **`ubuntu-arm`** jobs get an explicit **30-minute** timeout like other slow runners.
> 
> **Upstream subtree (`api_upstream`):** GitHub Actions (release, Buf push, api-go triggers) default branches, workflow refs (`@main`), and Makefile targets (`protogen@main`, `buf breaking` against **`main`**) are aligned. **`testsrv_upstream`** Makefile comments for buf-breaking were updated the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c1926481425ac03015f41e77696159f74846b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->