### PR TITLE
:bookmark: Prefix enum variants with type name

### DIFF
--- a/crates/sdk-core-c-bridge/build.rs
+++ b/crates/sdk-core-c-bridge/build.rs
@@ -5,7 +5,12 @@ use std::env;
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
+    // Prefix every enum's variants with the enum's type name to avoid collisions.
+    let mut config = cbindgen::Config::default();
+    config.enumeration.prefix_with_name = true;
+
     let changed = cbindgen::Builder::new()
+        .with_config(config)
         .with_cpp_compat(true)
         .with_crate(crate_dir)
         .with_pragma_once(true)

--- a/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
+++ b/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
@@ -11,53 +11,53 @@ typedef enum TemporalCoreClientGrpcCompression {
 } TemporalCoreClientGrpcCompression;
 
 typedef enum TemporalCoreRpcService {
-  Workflow = 1,
-  Operator,
-  Cloud,
-  Test,
-  Health,
+  TemporalCoreRpcService_Workflow = 1,
+  TemporalCoreRpcService_Operator,
+  TemporalCoreRpcService_Cloud,
+  TemporalCoreRpcService_Test,
+  TemporalCoreRpcService_Health,
 } TemporalCoreRpcService;
 
 typedef enum TemporalCoreMetricAttributeValueType {
-  String = 1,
-  Int,
-  Float,
-  Bool,
+  TemporalCoreMetricAttributeValueType_String = 1,
+  TemporalCoreMetricAttributeValueType_Int,
+  TemporalCoreMetricAttributeValueType_Float,
+  TemporalCoreMetricAttributeValueType_Bool,
 } TemporalCoreMetricAttributeValueType;
 
 typedef enum TemporalCoreMetricKind {
-  CounterInteger = 1,
-  HistogramInteger,
-  HistogramFloat,
-  HistogramDuration,
-  GaugeInteger,
-  GaugeFloat,
-  UpDownCounterInteger,
+  TemporalCoreMetricKind_CounterInteger = 1,
+  TemporalCoreMetricKind_HistogramInteger,
+  TemporalCoreMetricKind_HistogramFloat,
+  TemporalCoreMetricKind_HistogramDuration,
+  TemporalCoreMetricKind_GaugeInteger,
+  TemporalCoreMetricKind_GaugeFloat,
+  TemporalCoreMetricKind_UpDownCounterInteger,
 } TemporalCoreMetricKind;
 
 typedef enum TemporalCoreForwardedLogLevel {
-  Trace = 0,
-  Debug,
-  Info,
-  Warn,
-  Error,
+  TemporalCoreForwardedLogLevel_Trace = 0,
+  TemporalCoreForwardedLogLevel_Debug,
+  TemporalCoreForwardedLogLevel_Info,
+  TemporalCoreForwardedLogLevel_Warn,
+  TemporalCoreForwardedLogLevel_Error,
 } TemporalCoreForwardedLogLevel;
 
 typedef enum TemporalCoreOpenTelemetryMetricTemporality {
-  Cumulative = 1,
-  Delta,
+  TemporalCoreOpenTelemetryMetricTemporality_Cumulative = 1,
+  TemporalCoreOpenTelemetryMetricTemporality_Delta,
 } TemporalCoreOpenTelemetryMetricTemporality;
 
 typedef enum TemporalCoreOpenTelemetryProtocol {
-  Grpc = 1,
-  Http,
+  TemporalCoreOpenTelemetryProtocol_Grpc = 1,
+  TemporalCoreOpenTelemetryProtocol_Http,
 } TemporalCoreOpenTelemetryProtocol;
 
 typedef enum TemporalCoreSlotKindType {
-  WorkflowSlotKindType,
-  ActivitySlotKindType,
-  LocalActivitySlotKindType,
-  NexusSlotKindType,
+  TemporalCoreSlotKindType_WorkflowSlotKindType,
+  TemporalCoreSlotKindType_ActivitySlotKindType,
+  TemporalCoreSlotKindType_LocalActivitySlotKindType,
+  TemporalCoreSlotKindType_NexusSlotKindType,
 } TemporalCoreSlotKindType;
 
 typedef struct TemporalCoreCancellationToken TemporalCoreCancellationToken;
@@ -570,9 +570,9 @@ typedef struct TemporalCoreLegacyBuildIdBasedStrategy {
 } TemporalCoreLegacyBuildIdBasedStrategy;
 
 typedef enum TemporalCoreWorkerVersioningStrategy_Tag {
-  None,
-  DeploymentBased,
-  LegacyBuildIdBased,
+  TemporalCoreWorkerVersioningStrategy_None,
+  TemporalCoreWorkerVersioningStrategy_DeploymentBased,
+  TemporalCoreWorkerVersioningStrategy_LegacyBuildIdBased,
 } TemporalCoreWorkerVersioningStrategy_Tag;
 
 typedef struct TemporalCoreWorkerVersioningStrategy {
@@ -625,37 +625,37 @@ typedef uintptr_t (*TemporalCoreCustomSlotSupplierTryReserveCallback)(const stru
                                                                       void *user_data);
 
 typedef enum TemporalCoreSlotInfo_Tag {
-  WorkflowSlotInfo,
-  ActivitySlotInfo,
-  LocalActivitySlotInfo,
-  NexusSlotInfo,
+  TemporalCoreSlotInfo_WorkflowSlotInfo,
+  TemporalCoreSlotInfo_ActivitySlotInfo,
+  TemporalCoreSlotInfo_LocalActivitySlotInfo,
+  TemporalCoreSlotInfo_NexusSlotInfo,
 } TemporalCoreSlotInfo_Tag;
 
-typedef struct TemporalCoreWorkflowSlotInfo_Body {
+typedef struct TemporalCoreSlotInfo_TemporalCoreWorkflowSlotInfo_Body {
   struct TemporalCoreByteArrayRef workflow_type;
   bool is_sticky;
-} TemporalCoreWorkflowSlotInfo_Body;
+} TemporalCoreSlotInfo_TemporalCoreWorkflowSlotInfo_Body;
 
-typedef struct TemporalCoreActivitySlotInfo_Body {
+typedef struct TemporalCoreSlotInfo_TemporalCoreActivitySlotInfo_Body {
   struct TemporalCoreByteArrayRef activity_type;
-} TemporalCoreActivitySlotInfo_Body;
+} TemporalCoreSlotInfo_TemporalCoreActivitySlotInfo_Body;
 
-typedef struct TemporalCoreLocalActivitySlotInfo_Body {
+typedef struct TemporalCoreSlotInfo_TemporalCoreLocalActivitySlotInfo_Body {
   struct TemporalCoreByteArrayRef activity_type;
-} TemporalCoreLocalActivitySlotInfo_Body;
+} TemporalCoreSlotInfo_TemporalCoreLocalActivitySlotInfo_Body;
 
-typedef struct TemporalCoreNexusSlotInfo_Body {
+typedef struct TemporalCoreSlotInfo_TemporalCoreNexusSlotInfo_Body {
   struct TemporalCoreByteArrayRef operation;
   struct TemporalCoreByteArrayRef service;
-} TemporalCoreNexusSlotInfo_Body;
+} TemporalCoreSlotInfo_TemporalCoreNexusSlotInfo_Body;
 
 typedef struct TemporalCoreSlotInfo {
   TemporalCoreSlotInfo_Tag tag;
   union {
-    TemporalCoreWorkflowSlotInfo_Body workflow_slot_info;
-    TemporalCoreActivitySlotInfo_Body activity_slot_info;
-    TemporalCoreLocalActivitySlotInfo_Body local_activity_slot_info;
-    TemporalCoreNexusSlotInfo_Body nexus_slot_info;
+    TemporalCoreSlotInfo_TemporalCoreWorkflowSlotInfo_Body workflow_slot_info;
+    TemporalCoreSlotInfo_TemporalCoreActivitySlotInfo_Body activity_slot_info;
+    TemporalCoreSlotInfo_TemporalCoreLocalActivitySlotInfo_Body local_activity_slot_info;
+    TemporalCoreSlotInfo_TemporalCoreNexusSlotInfo_Body nexus_slot_info;
   };
 } TemporalCoreSlotInfo;
 
@@ -750,9 +750,9 @@ typedef struct TemporalCoreCustomSlotSupplierCallbacksImpl {
 } TemporalCoreCustomSlotSupplierCallbacksImpl;
 
 typedef enum TemporalCoreSlotSupplier_Tag {
-  FixedSize,
-  ResourceBased,
-  Custom,
+  TemporalCoreSlotSupplier_FixedSize,
+  TemporalCoreSlotSupplier_ResourceBased,
+  TemporalCoreSlotSupplier_Custom,
 } TemporalCoreSlotSupplier_Tag;
 
 typedef struct TemporalCoreSlotSupplier {

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -56,7 +56,6 @@ pub struct ConnectionOptions {
     pub grpc_compression: ClientGrpcCompression,
 }
 
-/// cbindgen:prefix-with-name=true
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub enum ClientGrpcCompression {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Generate C bridge enum variants with type name prefix

## Why?

Avoid collisions when enums have the same variant name.

## Checklist
<!--- add/delete as needed --->

1. Closes #1318 