### PR TITLE
Fix activity_cancel_delivered_without_heartbeat test

### DIFF
--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -1111,6 +1111,8 @@ pub(crate) fn integ_dev_server_config(
             "--dynamic-config-value".to_owned(),
             "frontend.enableCancelWorkerPollsOnShutdown=true".to_owned(),
             "--dynamic-config-value".to_owned(),
+            "frontend.workerCommandsEnabled=true".to_owned(),
+            "--dynamic-config-value".to_owned(),
             "matching.rps=12000".to_owned(),
             "--search-attribute".to_string(),
             format!("{SEARCH_ATTR_TXT}=Text"),

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -365,6 +365,10 @@ impl CoreWfStarter {
 
     pub(crate) async fn worker(&mut self) -> TestWorker {
         let worker = self.get_worker().await;
+        worker
+            .validate()
+            .await
+            .expect("Worker validation should succeed");
         let client = self.get_client().await;
         let sdk = Worker::new_from_core_options(
             worker,

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -15,8 +15,8 @@ use std::{
 };
 use temporalio_client::{
     Client, ClientOptions, Connection, ConnectionOptions, GrpcCompression, NamespacedClient,
-    RetryOptions, WorkflowFetchHistoryOptions, WorkflowStartOptions, WorkflowTerminateOptions,
-    grpc::WorkflowService,
+    RetryOptions, WorkflowFetchHistoryOptions, WorkflowSignalOptions, WorkflowStartOptions,
+    WorkflowTerminateOptions, grpc::WorkflowService,
 };
 use temporalio_common::{
     ActivityError, UntypedWorkflow,
@@ -41,8 +41,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, CancellableFuture, WorkflowContext, WorkflowResult, WorkflowTermination,
-    activities::ActivityContext,
+    ActivityOptions, CancellableFuture, SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    WorkflowTermination, activities::ActivityContext,
 };
 use tokio::{
     net::TcpListener,
@@ -413,8 +413,11 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat() {
     let mut starter = CoreWfStarter::new_cloud_or_local(wf_name, "")
         .await
         .unwrap();
+    let client = starter.get_client().await;
 
-    struct WaitForCancelActivities {}
+    struct WaitForCancelActivities {
+        client: Client,
+    }
     #[activities]
     impl WaitForCancelActivities {
         #[activity]
@@ -423,6 +426,22 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat() {
             ctx: ActivityContext,
             _: String,
         ) -> Result<String, ActivityError> {
+            self.client
+                .get_workflow_handle::<CancelWithoutHeartbeatWorkflow>(
+                    ctx.info()
+                        .workflow_execution
+                        .as_ref()
+                        .unwrap()
+                        .workflow_id
+                        .clone(),
+                )
+                .signal(
+                    CancelWithoutHeartbeatWorkflow::act_started,
+                    (),
+                    WorkflowSignalOptions::default(),
+                )
+                .await
+                .unwrap();
             ctx.cancelled().await;
             Ok("done".to_string())
         }
@@ -430,7 +449,7 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat() {
 
     starter
         .sdk_config
-        .register_activities(WaitForCancelActivities {});
+        .register_activities(WaitForCancelActivities { client });
     let mut worker = starter.worker().await;
     if !worker
         .core_worker()
@@ -443,7 +462,9 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat() {
 
     #[workflow]
     #[derive(Default)]
-    struct CancelWithoutHeartbeatWorkflow;
+    struct CancelWithoutHeartbeatWorkflow {
+        act_started: bool,
+    }
 
     #[workflow_methods]
     impl CancelWithoutHeartbeatWorkflow {
@@ -462,14 +483,19 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat() {
                     .do_not_eagerly_execute(true)
                     .build(),
             );
-            // Timer needed to ensure the activity is started on a worker before
-            // cancelling, so the cancel goes through the worker commands path.
-            ctx.timer(Duration::from_secs(5)).await;
+            // ensure the activity is started on a worker before cancelling, so the cancel goes
+            // through the worker commands path.
+            ctx.wait_condition(|s| s.act_started).await;
             act_fut.cancel();
             act_fut
                 .await
                 .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
             Ok(())
+        }
+
+        #[signal]
+        fn act_started(&mut self, _ctx: &mut SyncWorkflowContext<Self>) {
+            self.act_started = true;
         }
     }
 

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -458,12 +458,17 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat() {
                         ..Default::default()
                     })
                     .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
+                    // TODO: enable eager dispatch once server supports it for worker commands.
+                    .do_not_eagerly_execute(true)
                     .build(),
             );
-            // Timer needed to avoid cancel-before-sent
-            ctx.timer(Duration::from_millis(10)).await;
+            // Timer needed to ensure the activity is started on a worker before
+            // cancelling, so the cancel goes through the worker commands path.
+            ctx.timer(Duration::from_secs(5)).await;
             act_fut.cancel();
-            let _ = act_fut.await;
+            act_fut
+                .await
+                .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
             Ok(())
         }
     }
@@ -483,7 +488,7 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat() {
         )
         .await
         .unwrap();
-    // Fails with workflow timeout if cancel doesn't work
+    // Fails with workflow timeout if cancel via worker commands doesn't work
     worker.run_until_done().await.unwrap();
     handle.get_result(Default::default()).await.unwrap();
 }


### PR DESCRIPTION
## What
- Moves `validate()` into `CoreWfStarter::worker()` so all integration tests get namespace capabilities populated. Without this, tests checking capabilities like `worker_commands` were silently skipped.

- Disable eager activity dispatch in`activity_cancel_delivered_without_heartbeat` to temporarily workaround a server bug for worker commands -- [server fix](https://github.com/temporalio/temporal/pull/10634).
- In addition, the test fails if the worker did not receive the activity cancel command. Previously, the test would be marked as success.


## How did you test it?
Updated tests