### PR TITLE
💥 feat(sdk): remove usage of `anyhow` from public error types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ document as your quick reference when submitting pull requests.
 - If you want to format, don't bother checking first. Just run formatting, and run it by using
   `cargo +nightly fmt`, because some settings require the nightly formatter.
 - Do not extract functions for relatively simple helpers that are only used in one location.
+- Use custom error types leveraging `thiserror` for any public facing error types
 
 
 ## Repo Specific Utilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@ to docs, or any other relevant information.
 
 ### Breaking Changes
 * The `ActivityContext` constructor now requires `ClientOptions`.
+### Breaking Changes
+
+- Rust SDK `ApplicationFailure` and `WorkflowError` APIs now use boxed `std::error::Error` values instead of
+  `anyhow::Error`.

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -316,7 +316,7 @@ impl EncodeFailure for ApplicationFailure {
             cause: self
                 .cause()
                 .map(|cause| Box::new(cause.failure().clone()))
-                .or_else(|| encode_application_failure_cause(self.source_error().as_ref())),
+                .or_else(|| encode_application_failure_cause(self.source_error())),
             failure_info: Some(FailureInfo::ApplicationFailureInfo(
                 ApplicationFailureInfo {
                     r#type: self.type_name().unwrap_or_default().to_owned(),
@@ -773,13 +773,12 @@ mod tests {
             )),
             ..Default::default()
         };
-        let app = ApplicationFailure::new(anyhow::Error::new(ActivityExecutionError::Failed(
-            ActivityFailureError::new(
+        let app =
+            ApplicationFailure::new(ActivityExecutionError::Failed(ActivityFailureError::new(
                 activity_failure.clone(),
                 ActivityFailureInfo::default(),
                 None,
-            ),
-        )));
+            )));
         let converted = convert(OutgoingWorkflowError::Application(Box::new(app)));
         assert!(matches!(
             converted.failure_info,
@@ -797,13 +796,12 @@ mod tests {
             )),
             ..Default::default()
         };
-        let app = ApplicationFailure::new(anyhow::Error::new(ActivityExecutionError::Failed(
-            ActivityFailureError::new(
+        let app =
+            ApplicationFailure::new(ActivityExecutionError::Failed(ActivityFailureError::new(
                 activity_failure.clone(),
                 ActivityFailureInfo::default(),
                 None,
-            ),
-        )));
+            )));
 
         assert!(app.cause().is_none());
 

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -155,7 +155,7 @@ impl From<ProtoApplicationErrorCategory> for ApplicationErrorCategory {
 #[builder(start_fn = builder, state_mod(vis = "pub"))]
 pub struct ApplicationFailure {
     #[builder(start_fn, into)]
-    source: anyhow::Error,
+    source: Box<dyn std::error::Error + Send + Sync>,
     type_name: Option<String>,
     #[builder(default)]
     non_retryable: bool,
@@ -170,7 +170,7 @@ pub struct ApplicationFailure {
 
 impl ApplicationFailure {
     /// Construct a retryable application failure with no extra metadata.
-    pub fn new(source: impl Into<anyhow::Error>) -> Self {
+    pub fn new(source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
         Self {
             source: source.into(),
             type_name: None,
@@ -184,7 +184,7 @@ impl ApplicationFailure {
     }
 
     /// Construct a non-retryable application failure with no extra metadata.
-    pub fn non_retryable(source: impl Into<anyhow::Error>) -> Self {
+    pub fn non_retryable(source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
         Self {
             non_retryable: true,
             ..Self::new(source)
@@ -192,8 +192,8 @@ impl ApplicationFailure {
     }
 
     /// Returns the wrapped source error.
-    pub fn source_error(&self) -> &anyhow::Error {
-        &self.source
+    pub fn source_error(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+        &*self.source as &(dyn std::error::Error + Send + Sync + 'static)
     }
 
     /// Returns the configured application failure type name, if any.
@@ -274,7 +274,7 @@ impl ApplicationFailure {
             .unwrap_or_default();
         let type_name = (!app_info.r#type.is_empty()).then_some(app_info.r#type.clone());
         Self {
-            source: anyhow::anyhow!(failure.message.clone()),
+            source: failure.message.clone().into(),
             type_name,
             non_retryable: app_info.non_retryable,
             next_retry_delay: app_info.next_retry_delay.and_then(|d| d.try_into().ok()),

--- a/crates/sdk/examples/cancellation/workflows.rs
+++ b/crates/sdk/examples/cancellation/workflows.rs
@@ -52,7 +52,7 @@ impl CancellationWorkflow {
 
         temporalio_sdk::workflows::select! {
             result = &mut activity_fut => {
-                let value = result.map_err(|e| anyhow::anyhow!("{e}"))?;
+                let value = result?;
                 Ok(value)
             }
             reason = ctx.cancelled() => {

--- a/crates/sdk/examples/saga/workflows.rs
+++ b/crates/sdk/examples/saga/workflows.rs
@@ -131,9 +131,7 @@ impl BookingActivities {
     pub async fn book_car(_ctx: ActivityContext, trip_id: String) -> Result<String, ActivityError> {
         if trip_id.contains("fail") {
             return Err(ActivityError::application(
-                ApplicationFailure::non_retryable(anyhow::anyhow!(
-                    "Car booking failed for trip {trip_id}"
-                )),
+                ApplicationFailure::non_retryable("Car booking failed for trip {trip_id}"),
             ));
         }
         Ok(format!("car-{trip_id}"))

--- a/crates/sdk/examples/updatable_timer/workflows.rs
+++ b/crates/sdk/examples/updatable_timer/workflows.rs
@@ -1,7 +1,9 @@
 #![allow(unreachable_pub)]
 use std::time::Duration;
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{SyncWorkflowContext, WorkflowContext, WorkflowContextView, WorkflowResult};
+use temporalio_sdk::{
+    ApplicationFailure, SyncWorkflowContext, WorkflowContext, WorkflowContextView, WorkflowResult,
+};
 
 #[workflow]
 pub struct UpdatableTimerWorkflow {
@@ -27,7 +29,7 @@ impl UpdatableTimerWorkflow {
 
             let now_ms = ctx
                 .workflow_time()
-                .ok_or_else(|| anyhow::anyhow!("Did not find workflow time"))?
+                .ok_or_else(|| ApplicationFailure::new("Did not find workflow time"))?
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_millis() as u64;

--- a/crates/workflow/src/runtime/entry.rs
+++ b/crates/workflow/src/runtime/entry.rs
@@ -26,7 +26,7 @@ pub enum WorkflowError {
 
     /// Workflow execution error
     #[error("Workflow execution error: {0}")]
-    Execution(#[from] anyhow::Error),
+    Execution(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl From<WorkflowError> for Failure {
@@ -172,7 +172,7 @@ pub trait ExecutableQuery<Q: QueryDefinition>: WorkflowImplementation {
         converter: &PayloadConverter,
     ) -> Result<Payload, WorkflowError> {
         let input = deserialize_input::<Q::Input>(payloads.payloads.clone(), converter)?;
-        let output = self.handle(ctx, input).map_err(wrap_handler_error)?;
+        let output = self.handle(ctx, input).map_err(WorkflowError::Execution)?;
         serialize_output(&output, converter)
     }
 }
@@ -213,7 +213,7 @@ pub trait ExecutableSyncUpdate<U: UpdateDefinition>: WorkflowImplementation {
                 Ok(payload) => std::future::ready(Ok(payload)).boxed_local(),
                 Err(e) => std::future::ready(Err(e)).boxed_local(),
             },
-            Err(e) => std::future::ready(Err(wrap_handler_error(e))).boxed_local(),
+            Err(e) => std::future::ready(Err(WorkflowError::Execution(e))).boxed_local(),
         }
     }
 
@@ -225,7 +225,7 @@ pub trait ExecutableSyncUpdate<U: UpdateDefinition>: WorkflowImplementation {
         converter: &PayloadConverter,
     ) -> Result<(), WorkflowError> {
         let input = deserialize_input::<U::Input>(payloads.payloads.clone(), converter)?;
-        self.validate(ctx, &input).map_err(wrap_handler_error)
+        self.validate(ctx, &input).map_err(WorkflowError::Execution)
     }
 }
 
@@ -258,7 +258,9 @@ pub trait ExecutableAsyncUpdate<U: UpdateDefinition>: WorkflowImplementation {
         };
         let converter = converter.clone();
         async move {
-            let output = Self::handle(ctx, input).await.map_err(wrap_handler_error)?;
+            let output = Self::handle(ctx, input)
+                .await
+                .map_err(WorkflowError::Execution)?;
             serialize_output(&output, &converter)
         }
         .boxed_local()
@@ -272,7 +274,7 @@ pub trait ExecutableAsyncUpdate<U: UpdateDefinition>: WorkflowImplementation {
         converter: &PayloadConverter,
     ) -> Result<(), WorkflowError> {
         let input = deserialize_input::<U::Input>(payloads.payloads.clone(), converter)?;
-        self.validate(ctx, &input).map_err(wrap_handler_error)
+        self.validate(ctx, &input).map_err(WorkflowError::Execution)
     }
 }
 
@@ -298,11 +300,6 @@ pub(crate) fn serialize_output<O: TemporalSerializable + 'static>(
         converter,
     };
     converter.to_payload(&ctx, output).map_err(Into::into)
-}
-
-/// Wrap a handler error into WorkflowError.
-pub(crate) fn wrap_handler_error(e: Box<dyn std::error::Error + Send + Sync>) -> WorkflowError {
-    WorkflowError::Execution(anyhow::anyhow!(e))
 }
 
 /// Serialize a workflow result value to a payload.

--- a/crates/workflow/src/runtime/instance.rs
+++ b/crates/workflow/src/runtime/instance.rs
@@ -30,6 +30,7 @@ use temporalio_common_wasm::{
         GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
         SerializationContextData,
     },
+    error::ApplicationFailure,
     protos::{
         coresdk::workflow_activation::{
             DoUpdate, QueryWorkflow, SignalWorkflow,
@@ -149,22 +150,32 @@ where
     }
 
     fn rejection_for_missing_update_handler(&self, name: String) -> ActivationJobResult {
-        ActivationJobResult::UpdateRejected(Box::new(self.workflow_error_to_failure(
-            WorkflowError::Execution(anyhow::anyhow!(
-                "No update handler registered for update name {name}"
-            )),
-        )))
+        ActivationJobResult::UpdateRejected(Box::new(self.message_to_failure(format!(
+            "No update handler registered for update name {name}"
+        ))))
     }
 
     fn workflow_error_to_failure(&self, err: WorkflowError) -> Failure {
         use temporalio_common_wasm::error::{OutgoingError, OutgoingWorkflowError};
         let outgoing: OutgoingWorkflowError = match err {
             WorkflowError::PayloadConversion(err) => OutgoingWorkflowError::from(err),
-            WorkflowError::Execution(err) => OutgoingWorkflowError::from(err),
+            WorkflowError::Execution(err) => {
+                OutgoingWorkflowError::Application(Box::new(ApplicationFailure::new(err)))
+            }
         };
         self.base_ctx.data_converter().to_failure(
             &SerializationContextData::Workflow,
             OutgoingError::Workflow(outgoing),
+        )
+    }
+
+    fn message_to_failure(&self, message: String) -> Failure {
+        use temporalio_common_wasm::error::{OutgoingError, OutgoingWorkflowError};
+        self.base_ctx.data_converter().to_failure(
+            &SerializationContextData::Workflow,
+            OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
+                ApplicationFailure::new(message),
+            ))),
         )
     }
 
@@ -260,9 +271,10 @@ where
                 .state(|wf| wf.dispatch_query(view, &query.query_type, &payloads, converter))
             {
                 Some(Ok(payload)) => Ok(payload),
-                None => Err(self.workflow_error_to_failure(WorkflowError::Execution(
-                    anyhow::anyhow!("No query handler for '{}'", query.query_type),
-                ))),
+                None => {
+                    Err(self
+                        .message_to_failure(format!("No query handler for '{}'", query.query_type)))
+                }
                 Some(Err(e)) => Err(self.workflow_error_to_failure(e)),
             },
         }

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -231,6 +231,12 @@ impl From<anyhow::Error> for WorkflowTermination {
     }
 }
 
+impl From<ApplicationFailure> for WorkflowTermination {
+    fn from(value: ApplicationFailure) -> Self {
+        Self::Failed(value.into())
+    }
+}
+
 impl From<temporalio_common_wasm::data_converters::PayloadConversionError> for WorkflowTermination {
     fn from(value: temporalio_common_wasm::data_converters::PayloadConversionError) -> Self {
         Self::Failed(value.into())

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -247,7 +247,11 @@ impl From<crate::runtime::entry::WorkflowError> for WorkflowTermination {
     fn from(value: crate::runtime::entry::WorkflowError) -> Self {
         match value {
             crate::runtime::entry::WorkflowError::PayloadConversion(err) => Self::from(err),
-            crate::runtime::entry::WorkflowError::Execution(err) => Self::from(err),
+            crate::runtime::entry::WorkflowError::Execution(err) => Self::Failed(
+                temporalio_common_wasm::error::OutgoingWorkflowError::Application(Box::new(
+                    ApplicationFailure::new(err),
+                )),
+            ),
         }
     }
 }

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -148,7 +148,7 @@ impl PendingCommandId {
 struct WorkflowRuntimeState {
     host: Rc<dyn WorkflowHost>,
     pending_unblocks: RefCell<HashMap<PendingCommandId, oneshot::Sender<UnblockEvent>>>,
-    forced_wft_failure: RefCell<Option<anyhow::Error>>,
+    forced_wft_failure: RefCell<Option<Box<dyn std::error::Error + Send + Sync>>>,
     progress_made: Cell<bool>,
 }
 
@@ -190,12 +190,12 @@ impl WorkflowRuntimeState {
         true
     }
 
-    fn set_forced_wft_failure(&self, err: anyhow::Error) {
+    fn set_forced_wft_failure(&self, err: Box<dyn std::error::Error + Send + Sync>) {
         *self.forced_wft_failure.borrow_mut() = Some(err);
         self.progress_made.set(true);
     }
 
-    fn take_forced_wft_failure(&self) -> Option<anyhow::Error> {
+    fn take_forced_wft_failure(&self) -> Option<Box<dyn std::error::Error + Send + Sync>> {
         self.forced_wft_failure.borrow_mut().take()
     }
 
@@ -457,7 +457,9 @@ impl BaseWorkflowContext {
         self.inner.runtime.take_progress()
     }
 
-    pub(crate) fn take_forced_wft_failure(&self) -> Option<anyhow::Error> {
+    pub(crate) fn take_forced_wft_failure(
+        &self,
+    ) -> Option<Box<dyn std::error::Error + Send + Sync>> {
         self.inner.runtime.take_forced_wft_failure()
     }
 
@@ -1031,8 +1033,8 @@ impl<W> SyncWorkflowContext<W> {
     }
 
     /// Force a workflow task failure (EX: in order to retry on non-sticky queue)
-    pub fn force_task_fail(&self, with: anyhow::Error) {
-        self.base.inner.runtime.set_forced_wft_failure(with);
+    pub fn force_task_fail(&self, with: impl Into<Box<dyn std::error::Error + Send + Sync>>) {
+        self.base.inner.runtime.set_forced_wft_failure(with.into());
     }
 
     /// Start a nexus operation
@@ -1292,7 +1294,7 @@ impl<W> WorkflowContext<W> {
     }
 
     /// Force a workflow task failure (EX: in order to retry on non-sticky queue)
-    pub fn force_task_fail(&self, with: anyhow::Error) {
+    pub fn force_task_fail(&self, with: impl Into<Box<dyn std::error::Error + Send + Sync>>) {
         self.sync.force_task_fail(with)
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Switch `ApplicationFailure` to be backed by boxed errors
- Switch `WorkflowError` to be backed by boxed errors
- `WorkflowContext::force_task_fail` now works with boxed errors instead of `anyhow`
- Added helper for constructing a `WorkflowTermination` from `ApplicationFailure` (allows `?` to work well in workflow code)
- Cleaned up some examples/tests that still had extra `anyhow` wrapping

These are technically breaking changes, but most code should continue to work without issue as `anyhow::Error` implements `Into<Box<dyn Error + Send + Sync>>`

Each commit is reviewable on its own.

## Why?
Reduce our usage of `anyhow` in public facing APIs

## Checklist
<!--- add/delete as needed --->

1. Closes N/A
2. How was this tested:
Existing tests

3. Any docs updates needed?
Once released we can update docs to no longer have `ApplicationFailure::new(anyhow!("boom"))`
