### PR TITLE
feat: payload limits validation visitor

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -77,6 +77,7 @@ tonic = { workspace = true, default-features = false, features = [
   "transport",
   "codegen",
 ] }
+prost = { workspace = true }
 tracing = "0.1"
 # TODO [rust-sdk-branch]: Is it reasonable to make this optional?
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -36,8 +36,12 @@ fn generate_payload_visitor(
     File::open(descriptor_path)?.read_to_end(&mut descriptor_bytes)?;
     let descriptor_set = FileDescriptorSet::decode(&descriptor_bytes[..])?;
 
-    let mut generator = PayloadVisitorGenerator::new();
-    generator.process_descriptors(&descriptor_set);
+    let model = PayloadModel::build(&descriptor_set);
+    let mut generator = PayloadVisitorGenerator {
+        model,
+        message_fields: HashMap::new(),
+    };
+    generator.build_field_infos();
 
     let output_path = out_dir.join("payload_visitor_impl.rs");
     let mut file = File::create(&output_path)?;
@@ -87,50 +91,36 @@ struct OneofVariant {
     name: String,
 }
 
-/// Generator for PayloadVisitable implementations.
-struct PayloadVisitorGenerator {
+struct PayloadModel {
     /// Maps fully qualified message names to their descriptors
     messages: HashMap<String, DescriptorProto>,
-    /// Messages that contain Payloads (directly or transitively)
+    /// Message names that contain Payloads (directly or transitively)
     payload_containing: HashSet<String>,
     /// Types currently being checked (for cycle detection)
     checking: HashSet<String>,
     /// Types that have been checked and don't contain payloads
     not_payload_containing: HashSet<String>,
-    /// The payload fields for each message
-    message_fields: HashMap<String, Vec<PayloadFieldInfo>>,
 }
 
-impl PayloadVisitorGenerator {
-    fn new() -> Self {
-        Self {
+impl PayloadModel {
+    fn build(descriptor_set: &FileDescriptorSet) -> Self {
+        let mut model = Self {
             messages: HashMap::new(),
             payload_containing: HashSet::new(),
             checking: HashSet::new(),
             not_payload_containing: HashSet::new(),
-            message_fields: HashMap::new(),
-        }
-    }
-
-    fn process_descriptors(&mut self, descriptor_set: &FileDescriptorSet) {
-        // First pass: collect all message types
+        };
         for file in &descriptor_set.file {
             let package = file.package.as_deref().unwrap_or("");
             for msg in &file.message_type {
-                self.collect_messages(package, msg);
+                model.collect_messages(package, msg);
             }
         }
-
-        // Second pass: find payload-containing types
-        let all_names: Vec<String> = self.messages.keys().cloned().collect();
+        let all_names: Vec<String> = model.messages.keys().cloned().collect();
         for name in &all_names {
-            self.check_contains_payload(name);
+            model.check_contains_payload(name);
         }
-
-        // Third pass: build field info for payload-containing types
-        for name in self.payload_containing.clone() {
-            self.build_field_info(&name);
-        }
+        model
     }
 
     fn collect_messages(&mut self, package: &str, msg: &DescriptorProto) {
@@ -207,54 +197,32 @@ impl PayloadVisitorGenerator {
         msg: &DescriptorProto,
         field: &FieldDescriptorProto,
     ) -> bool {
-        if is_message_type(field) {
-            let type_name = field.type_name.as_deref().unwrap_or("");
-            let type_name = type_name.trim_start_matches('.');
-
-            // Check if this is a map type
-            if let Some(nested) = msg.nested_type.iter().find(|n| {
-                is_map_entry(&n.options)
-                    && n.name.as_deref()
-                        == Some(&Self::to_map_entry_name(
-                            field.name.as_deref().unwrap_or(""),
-                        ))
-            }) {
-                // It's a map - check the value type
-                if let Some(value_field) = nested
-                    .field
-                    .iter()
-                    .find(|f| f.name.as_deref() == Some("value"))
-                {
-                    let value_type = value_field
-                        .type_name
-                        .as_deref()
-                        .unwrap_or("")
-                        .trim_start_matches('.');
-                    return self.check_contains_payload(value_type);
-                }
-            }
-
-            return self.check_contains_payload(type_name);
+        if !is_message_type(field) {
+            return false;
         }
-
-        false
+        // For a map, follow the value type; otherwise the field's own message type.
+        let target = match map_value_type(msg, field) {
+            Some(value_type) => value_type,
+            None => field
+                .type_name
+                .as_deref()
+                .unwrap_or("")
+                .trim_start_matches('.'),
+        };
+        self.check_contains_payload(target)
     }
+}
 
-    fn to_map_entry_name(field_name: &str) -> String {
-        let mut result = String::new();
-        let mut capitalize_next = true;
-        for c in field_name.chars() {
-            if c == '_' {
-                capitalize_next = true;
-            } else if capitalize_next {
-                result.push(c.to_ascii_uppercase());
-                capitalize_next = false;
-            } else {
-                result.push(c);
-            }
+struct PayloadVisitorGenerator {
+    model: PayloadModel,
+    message_fields: HashMap<String, Vec<PayloadFieldInfo>>,
+}
+
+impl PayloadVisitorGenerator {
+    fn build_field_infos(&mut self) {
+        for name in self.model.payload_containing.clone() {
+            self.build_field_info(&name);
         }
-        result.push_str("Entry");
-        result
     }
 
     fn build_field_info(&mut self, name: &str) {
@@ -267,7 +235,7 @@ impl PayloadVisitorGenerator {
             return;
         }
 
-        let msg = match self.messages.get(name) {
+        let msg = match self.model.messages.get(name) {
             Some(m) => m.clone(),
             None => return,
         };
@@ -307,7 +275,7 @@ impl PayloadVisitorGenerator {
                         .as_deref()
                         .unwrap_or("")
                         .trim_start_matches('.');
-                    if self.payload_containing.contains(type_name) {
+                    if self.model.payload_containing.contains(type_name) {
                         variants.push(OneofVariant {
                             name: field.name.clone().unwrap_or_default(),
                         });
@@ -340,79 +308,30 @@ impl PayloadVisitorGenerator {
         let field_name = field.name.as_deref().unwrap_or("");
         let proto_path = format!("{}.{}", parent_name, field_name);
 
-        if !is_message_type(field) {
-            return None;
-        }
-
-        let type_name = field
-            .type_name
-            .as_deref()
-            .unwrap_or("")
-            .trim_start_matches('.');
-
-        // Check if it's a map
-        if let Some(nested) = parent_msg.nested_type.iter().find(|n| {
-            is_map_entry(&n.options)
-                && n.name.as_deref() == Some(&Self::to_map_entry_name(field_name))
-        }) {
-            let value_field = nested
-                .field
-                .iter()
-                .find(|f| f.name.as_deref() == Some("value"))?;
-            let value_type = value_field
-                .type_name
-                .as_deref()
-                .unwrap_or("")
-                .trim_start_matches('.');
-
-            if !self.payload_containing.contains(value_type) {
-                return None;
-            }
-
-            if value_type == "temporal.api.common.v1.Payload" {
-                return Some(PayloadFieldInfo {
-                    name: field_name.to_string(),
-                    proto_path,
-                    kind: PayloadFieldKind::MapPayload,
-                });
-            } else {
-                return Some(PayloadFieldInfo {
-                    name: field_name.to_string(),
-                    proto_path,
-                    kind: PayloadFieldKind::MapNestedMessage,
-                });
-            }
-        }
-
-        if !self.payload_containing.contains(type_name) {
-            return None;
-        }
-
-        let is_repeated = is_repeated(field);
-
-        if type_name == "temporal.api.common.v1.Payload" {
-            Some(PayloadFieldInfo {
-                name: field_name.to_string(),
-                proto_path,
-                kind: if is_repeated {
-                    PayloadFieldKind::RepeatedPayload
+        let kind = match field_shape(&self.model, parent_msg, field)? {
+            FieldShape::Map(value_type) => {
+                if value_type == "temporal.api.common.v1.Payload" {
+                    PayloadFieldKind::MapPayload
                 } else {
-                    PayloadFieldKind::SinglePayload
-                },
-            })
-        } else if type_name == "temporal.api.common.v1.Payloads" {
-            Some(PayloadFieldInfo {
-                name: field_name.to_string(),
-                proto_path,
-                kind: PayloadFieldKind::PayloadsMessage,
-            })
-        } else {
-            Some(PayloadFieldInfo {
-                name: field_name.to_string(),
-                proto_path,
-                kind: PayloadFieldKind::NestedMessage,
-            })
-        }
+                    PayloadFieldKind::MapNestedMessage
+                }
+            }
+            FieldShape::Single(t) => match t.as_str() {
+                "temporal.api.common.v1.Payload" => PayloadFieldKind::SinglePayload,
+                "temporal.api.common.v1.Payloads" => PayloadFieldKind::PayloadsMessage,
+                _ => PayloadFieldKind::NestedMessage,
+            },
+            FieldShape::Repeated(t) => match t.as_str() {
+                "temporal.api.common.v1.Payload" => PayloadFieldKind::RepeatedPayload,
+                "temporal.api.common.v1.Payloads" => PayloadFieldKind::PayloadsMessage,
+                _ => PayloadFieldKind::NestedMessage,
+            },
+        };
+        Some(PayloadFieldInfo {
+            name: field_name.to_string(),
+            proto_path,
+            kind,
+        })
     }
 
     fn generate(&self) -> String {
@@ -420,7 +339,7 @@ impl PayloadVisitorGenerator {
         output.push_str("// Generated from descriptors.bin - DO NOT EDIT\n\n");
 
         // Generate impls for each payload-containing type
-        for name in self.payload_containing.iter() {
+        for name in self.model.payload_containing.iter() {
             if name == "temporal.api.common.v1.Payload" || name == "temporal.api.common.v1.Payloads"
             {
                 continue;
@@ -435,7 +354,7 @@ impl PayloadVisitorGenerator {
     }
 
     fn generate_impl(&self, proto_name: &str, fields: &[PayloadFieldInfo]) -> String {
-        let rust_path = self.proto_to_rust_path(proto_name);
+        let rust_path = proto_to_rust_path(proto_name);
 
         let mut impl_body = String::new();
 
@@ -470,7 +389,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
         proto_path: &str,
         kind: &PayloadFieldKind,
     ) -> String {
-        let rust_field = Self::to_snake_case(field_name);
+        let rust_field = to_snake_case(field_name);
 
         match kind {
             PayloadFieldKind::SinglePayload => {
@@ -535,7 +454,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
             PayloadFieldKind::NestedMessage => {
                 // Check if the field in the parent is repeated
                 let parent_name = proto_path.rsplit_once('.').map(|(p, _)| p).unwrap_or("");
-                let is_field_repeated = if let Some(msg) = self.messages.get(parent_name) {
+                let is_field_repeated = if let Some(msg) = self.model.messages.get(parent_name) {
                     msg.field
                         .iter()
                         .any(|f| f.name.as_deref() == Some(field_name) && is_repeated(f))
@@ -569,14 +488,14 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
                 // Compute the parent proto name from the proto_path
                 let parent_proto_name = proto_path.rsplit_once('.').map(|(p, _)| p).unwrap_or("");
                 // Get the full rust path to the oneof enum
-                let enum_path = self.proto_to_rust_oneof_enum_path(parent_proto_name, oneof_name);
+                let enum_path = proto_to_rust_oneof_enum_path(parent_proto_name, oneof_name);
                 // The field in the struct is snake_case of the oneof field name
-                let rust_field = Self::to_snake_case(oneof_name);
+                let rust_field = to_snake_case(oneof_name);
 
                 let mut arms = String::new();
 
                 for variant in variants {
-                    let variant_name = Self::to_pascal_case(&variant.name);
+                    let variant_name = to_pascal_case(&variant.name);
                     arms.push_str(&format!(
                         "                {enum_path}::{variant}(msg) => msg.visit_payloads_mut(visitor).await,\n",
                         enum_path = enum_path,
@@ -608,75 +527,92 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
             }
         }
     }
+}
 
-    fn proto_to_rust_path(&self, proto_name: &str) -> String {
-        let parts: Vec<&str> = proto_name.split('.').collect();
-        let mut rust_parts = Vec::new();
+fn to_map_entry_name(field_name: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = true;
+    for c in field_name.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c);
+        }
+    }
+    result.push_str("Entry");
+    result
+}
 
-        // Handle the package -> module mapping
-        for (i, part) in parts.iter().enumerate() {
-            if i == parts.len() - 1 {
-                // Last part is the type name - keep PascalCase
-                rust_parts.push((*part).to_string());
-            } else {
-                // Package parts become snake_case modules
-                rust_parts.push(Self::to_snake_case(part));
+fn proto_to_rust_path(proto_name: &str) -> String {
+    let parts: Vec<&str> = proto_name.split('.').collect();
+    let mut rust_parts = Vec::new();
+
+    // Handle the package -> module mapping
+    for (i, part) in parts.iter().enumerate() {
+        if i == parts.len() - 1 {
+            // Last part is the type name - keep PascalCase
+            rust_parts.push((*part).to_string());
+        } else {
+            // Package parts become snake_case modules
+            rust_parts.push(to_snake_case(part));
+        }
+    }
+
+    // The protos module structure
+    let path = rust_parts.join("::");
+
+    // Map to the actual crate paths
+    format!("crate::protos::{}", path)
+}
+
+fn proto_to_rust_oneof_enum_path(parent_proto_name: &str, oneof_name: &str) -> String {
+    let parts: Vec<&str> = parent_proto_name.split('.').collect();
+    let mut rust_parts = Vec::new();
+
+    // All parts become snake_case modules (struct name becomes a module containing the enum)
+    for part in parts.iter() {
+        rust_parts.push(to_snake_case(part));
+    }
+
+    let module_path = rust_parts.join("::");
+    // The enum name is PascalCase of the oneof field name
+    let enum_name = to_pascal_case(oneof_name);
+
+    format!("crate::protos::{}::{}", module_path, enum_name)
+}
+
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c.is_uppercase() {
+            if i > 0 {
+                result.push('_');
             }
+            result.push(c.to_ascii_lowercase());
+        } else {
+            result.push(c);
         }
-
-        // The protos module structure
-        let path = rust_parts.join("::");
-
-        // Map to the actual crate paths
-        format!("crate::protos::{}", path)
     }
+    result
+}
 
-    fn proto_to_rust_oneof_enum_path(&self, parent_proto_name: &str, oneof_name: &str) -> String {
-        let parts: Vec<&str> = parent_proto_name.split('.').collect();
-        let mut rust_parts = Vec::new();
-
-        // All parts become snake_case modules (struct name becomes a module containing the enum)
-        for part in parts.iter() {
-            rust_parts.push(Self::to_snake_case(part));
+fn to_pascal_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = true;
+    for c in s.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c);
         }
-
-        let module_path = rust_parts.join("::");
-        // The enum name is PascalCase of the oneof field name
-        let enum_name = Self::to_pascal_case(oneof_name);
-
-        format!("crate::protos::{}::{}", module_path, enum_name)
     }
-
-    fn to_snake_case(s: &str) -> String {
-        let mut result = String::new();
-        for (i, c) in s.chars().enumerate() {
-            if c.is_uppercase() {
-                if i > 0 {
-                    result.push('_');
-                }
-                result.push(c.to_ascii_lowercase());
-            } else {
-                result.push(c);
-            }
-        }
-        result
-    }
-
-    fn to_pascal_case(s: &str) -> String {
-        let mut result = String::new();
-        let mut capitalize_next = true;
-        for c in s.chars() {
-            if c == '_' {
-                capitalize_next = true;
-            } else if capitalize_next {
-                result.push(c.to_ascii_uppercase());
-                capitalize_next = false;
-            } else {
-                result.push(c);
-            }
-        }
-        result
-    }
+    result
 }
 
 fn is_message_type(field: &FieldDescriptorProto) -> bool {
@@ -693,22 +629,83 @@ fn is_map_entry(options: &Option<MessageOptions>) -> bool {
         .is_some_and(|o| o.map_entry.unwrap_or(false))
 }
 
+/// If `field` is a proto map, the fully-qualified name of its value type (leading `.` trimmed).
+/// `None` if the field isn't a map.
+fn map_value_type<'a>(
+    parent_msg: &'a DescriptorProto,
+    field: &FieldDescriptorProto,
+) -> Option<&'a str> {
+    let entry_name = to_map_entry_name(field.name.as_deref().unwrap_or(""));
+    let entry = parent_msg
+        .nested_type
+        .iter()
+        .find(|n| is_map_entry(&n.options) && n.name.as_deref() == Some(&entry_name))?;
+    let value = entry
+        .field
+        .iter()
+        .find(|f| f.name.as_deref() == Some("value"))?;
+    Some(
+        value
+            .type_name
+            .as_deref()
+            .unwrap_or("")
+            .trim_start_matches('.'),
+    )
+}
+
+/// The payload-relevant structural shape of a single (non-oneof) field, carrying the
+/// fully-qualified target type. `None` for non-message fields and for message fields whose target
+/// isn't payload-containing — both generators ignore those. The *terminal-vs-recurse* decision and
+/// any measurement strategy are left to each generator, since they draw that boundary differently.
+enum FieldShape {
+    Single(String),
+    Repeated(String),
+    Map(String),
+}
+
+fn field_shape(
+    model: &PayloadModel,
+    parent_msg: &DescriptorProto,
+    field: &FieldDescriptorProto,
+) -> Option<FieldShape> {
+    if !is_message_type(field) {
+        return None;
+    }
+    if let Some(value_type) = map_value_type(parent_msg, field) {
+        return model
+            .payload_containing
+            .contains(value_type)
+            .then(|| FieldShape::Map(value_type.to_string()));
+    }
+    let type_name = field
+        .type_name
+        .as_deref()
+        .unwrap_or("")
+        .trim_start_matches('.');
+    if !model.payload_containing.contains(type_name) {
+        return None;
+    }
+    Some(if is_repeated(field) {
+        FieldShape::Repeated(type_name.to_string())
+    } else {
+        FieldShape::Single(type_name.to_string())
+    })
+}
+
 // ===========================================================================
 // Payload-limits validator generator
 //
-// Emits `PayloadLimitsValidatable` impls for the closure of outbound gRPC request
-// messages, dispatching each payload-bearing *leaf* field through a hand-authored
-// decision tables (`*_FIELDS`, grouped by class) mapping `(message.field)` -> limit class.
-// The *measurement strategy* is derived mechanically from each field's proto shape;
-// the table only records the specified class decision (blob / memo / not).
+// The decision table (`*_FIELDS`, grouped by class) records only the limit class per
+// `(message.field)`; the measurement strategy is derived mechanically from each field's
+// proto shape, so editing the table never means re-deciding how a field is measured.
 //
 // Any payload-bearing leaf field that is missing from the table -- or any stale table
 // entry no longer produced by the descriptor walk -- fails the build. This is the
 // compile-time forcing function: a proto change cannot land until classified here.
 // ===========================================================================
 
-/// Fully-qualified proto names whose value is a *measurable unit* the server checks as a whole.
-/// The generator stops recursion at these and emits a table-driven leaf check at the parent field.
+/// The generator stops recursion at these types and emits a table-driven leaf check at the parent
+/// field, rather than descending into their inner payload fields.
 const TERMINAL_LEAVES: &[&str] = &[
     "temporal.api.common.v1.Payload",
     "temporal.api.common.v1.Payloads",
@@ -739,8 +736,7 @@ const EXTRA_WHOLE_MESSAGE_LEAVES: &[&str] = &[
 //
 // Roots are derived automatically from the proto service definitions (every `temporal.api.*` RPC
 // *input* message; see `service_request_roots`), so a new RPC/request can't be silently missed — its
-// payload fields become unclassified and fail the build until added below. The measurement strategy
-// is derived mechanically from the field's proto shape.
+// payload fields become unclassified and fail the build until added below.
 const BLOB_FIELDS: &[&str] = &[
     "temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes.result",
     "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.input",
@@ -881,7 +877,6 @@ fn service_request_roots(descriptor_set: &FileDescriptorSet) -> Vec<String> {
     roots
 }
 
-/// Which limit a validated field is checked against — mirrors the runtime `LimitClass`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LimitClass {
     Blob,
@@ -889,7 +884,6 @@ enum LimitClass {
 }
 
 impl LimitClass {
-    /// The generated runtime `LimitClass` token.
     fn token(self) -> &'static str {
         match self {
             Self::Blob => "crate::payload_limits::LimitClass::Blob",
@@ -898,25 +892,19 @@ impl LimitClass {
     }
 }
 
-/// How a field is classified in the decision table. A validated field carries its [`LimitClass`] and
-/// whether an over-limit is enforced as an error (warn + error) or warning-only — kept separate, as
-/// the runtime sink does. `NotValidated` fields emit no check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FieldPolicy {
     Validated {
         class: LimitClass,
+        /// When false, an over-limit is reported warning-only (never escalated to an error).
         enforce_error: bool,
     },
     NotValidated,
 }
 
-/// What a (non-oneof) field resolves to for limit purposes.
 enum Target {
-    /// A measurable leaf requiring a table entry at the field's proto path.
     Leaf(LeafKind),
-    /// A payload-containing nested message to recurse into.
     Struct(StructShape, String),
-    /// Not payload-bearing; ignored.
     Skip,
 }
 
@@ -955,24 +943,14 @@ fn generate_payload_limits_validator(
     File::open(descriptor_path)?.read_to_end(&mut descriptor_bytes)?;
     let descriptor_set = FileDescriptorSet::decode(&descriptor_bytes[..])?;
 
-    // Reuse the visitor generator's first two passes for message collection + payload reachability.
-    let mut base = PayloadVisitorGenerator::new();
-    for file in &descriptor_set.file {
-        let package = file.package.as_deref().unwrap_or("");
-        for msg in &file.message_type {
-            base.collect_messages(package, msg);
-        }
-    }
-    let all_names: Vec<String> = base.messages.keys().cloned().collect();
-    for name in &all_names {
-        base.check_contains_payload(name);
-    }
+    // Reuse the visitor generator's message collection + payload reachability.
+    let mut model = PayloadModel::build(&descriptor_set);
 
     // Force the owners of extra whole-message leaves to be treated as validatable, so the closure
     // walk recurses into them (e.g. RespondWorkflowTaskCompletedRequest.messages -> Message.body).
     for path in EXTRA_WHOLE_MESSAGE_LEAVES {
         if let Some((owner, _)) = path.rsplit_once('.') {
-            base.payload_containing.insert(owner.to_string());
+            model.payload_containing.insert(owner.to_string());
         }
     }
 
@@ -982,7 +960,7 @@ fn generate_payload_limits_validator(
 
     // Compute the closure of structural messages reachable from the service request roots.
     let roots = service_request_roots(&descriptor_set);
-    let to_generate = limits_closure(&base, &roots);
+    let to_generate = limits_closure(&model, &roots);
 
     let mut output = String::new();
     output.push_str("// Generated from descriptors.bin - DO NOT EDIT\n");
@@ -992,7 +970,7 @@ fn generate_payload_limits_validator(
     generate_names.sort();
     for name in &generate_names {
         output.push_str(&generate_limits_impl(
-            &base,
+            &model,
             name,
             &table,
             &mut used_keys,
@@ -1038,7 +1016,6 @@ fn generate_payload_limits_validator(
     Ok(())
 }
 
-/// Load the decision table: `field proto path -> FieldPolicy`.
 fn load_payload_limits_table() -> Result<HashMap<String, FieldPolicy>, Box<dyn std::error::Error>> {
     let blob = Validated {
         class: LimitClass::Blob,
@@ -1069,22 +1046,22 @@ fn load_payload_limits_table() -> Result<HashMap<String, FieldPolicy>, Box<dyn s
 
 /// BFS from the roots, following payload-containing structural fields, collecting the message types
 /// that need a generated `PayloadLimitsValidatable` impl (excludes terminal leaf types).
-fn limits_closure(base: &PayloadVisitorGenerator, roots: &[String]) -> HashSet<String> {
+fn limits_closure(model: &PayloadModel, roots: &[String]) -> HashSet<String> {
     let mut result = HashSet::new();
     let mut queue: Vec<String> = roots.to_vec();
     while let Some(name) = queue.pop() {
         if TERMINAL_LEAVES.contains(&name.as_str()) || result.contains(&name) {
             continue;
         }
-        let Some(msg) = base.messages.get(&name) else {
+        let Some(msg) = model.messages.get(&name) else {
             continue;
         };
-        if !base.payload_containing.contains(&name) {
+        if !model.payload_containing.contains(&name) {
             continue;
         }
         result.insert(name.clone());
         for field in &msg.field {
-            if let Target::Struct(_, ty) = classify_field(base, msg, field) {
+            if let Target::Struct(_, ty) = classify_field(model, msg, field) {
                 queue.push(ty);
             } else if is_message_type(field) {
                 // Oneof variants are message-typed; enqueue payload-containing structural variants.
@@ -1094,7 +1071,7 @@ fn limits_closure(base: &PayloadVisitorGenerator, roots: &[String]) -> HashSet<S
                     .unwrap_or("")
                     .trim_start_matches('.')
                     .to_string();
-                if base.payload_containing.contains(&ty) && !TERMINAL_LEAVES.contains(&ty.as_str())
+                if model.payload_containing.contains(&ty) && !TERMINAL_LEAVES.contains(&ty.as_str())
                 {
                     queue.push(ty);
                 }
@@ -1104,86 +1081,56 @@ fn limits_closure(base: &PayloadVisitorGenerator, roots: &[String]) -> HashSet<S
     result
 }
 
-/// Classify a (non-map-handling-aside) field into a leaf check or a structural recursion.
 fn classify_field(
-    base: &PayloadVisitorGenerator,
+    model: &PayloadModel,
     parent_msg: &DescriptorProto,
     field: &FieldDescriptorProto,
 ) -> Target {
-    if !is_message_type(field) {
+    let Some(shape) = field_shape(model, parent_msg, field) else {
         return Target::Skip;
-    }
-    let field_name = field.name.as_deref().unwrap_or("");
-    let type_name = field
-        .type_name
-        .as_deref()
-        .unwrap_or("")
-        .trim_start_matches('.');
-
-    // Map fields: classified by their value type.
-    if let Some(nested) = parent_msg.nested_type.iter().find(|n| {
-        is_map_entry(&n.options)
-            && n.name.as_deref() == Some(&PayloadVisitorGenerator::to_map_entry_name(field_name))
-    }) {
-        let value_field = nested
-            .field
-            .iter()
-            .find(|f| f.name.as_deref() == Some("value"));
-        let value_type = value_field
-            .and_then(|f| f.type_name.as_deref())
-            .unwrap_or("")
-            .trim_start_matches('.');
-        return match value_type {
+    };
+    match shape {
+        FieldShape::Map(value_type) => match value_type.as_str() {
             "temporal.api.common.v1.Payload" => Target::Leaf(LeafKind::MapPayload),
             "temporal.api.common.v1.Payloads" => Target::Leaf(LeafKind::MapPayloads),
-            other if base.payload_containing.contains(other) => {
-                Target::Struct(StructShape::Map, other.to_string())
-            }
-            _ => Target::Skip,
-        };
-    }
-
-    if !base.payload_containing.contains(type_name) {
-        return Target::Skip;
-    }
-
-    let repeated = is_repeated(field);
-    match type_name {
-        "temporal.api.common.v1.Payload" => Target::Leaf(if repeated {
-            LeafKind::RepeatedPayload
-        } else {
-            LeafKind::SinglePayload
-        }),
-        "temporal.api.common.v1.Payloads" => Target::Leaf(LeafKind::SinglePayloads),
-        "temporal.api.common.v1.Memo" => Target::Leaf(LeafKind::SingleMemo),
-        "temporal.api.common.v1.Header" => Target::Leaf(LeafKind::SingleHeader),
-        "temporal.api.common.v1.SearchAttributes" => Target::Leaf(LeafKind::SingleSearchAttributes),
-        "temporal.api.failure.v1.Failure" => Target::Leaf(if repeated {
-            LeafKind::RepeatedWholeMessage
-        } else {
-            LeafKind::WholeMessage
-        }),
-        other => Target::Struct(
-            if repeated {
-                StructShape::Repeated
-            } else {
-                StructShape::Single
-            },
-            other.to_string(),
-        ),
+            other => Target::Struct(StructShape::Map, other.to_string()),
+        },
+        FieldShape::Single(type_name) => match terminal_leaf_kind(&type_name, false) {
+            Some(kind) => Target::Leaf(kind),
+            None => Target::Struct(StructShape::Single, type_name),
+        },
+        FieldShape::Repeated(type_name) => match terminal_leaf_kind(&type_name, true) {
+            Some(kind) => Target::Leaf(kind),
+            None => Target::Struct(StructShape::Repeated, type_name),
+        },
     }
 }
 
+/// The leaf measurement kind for a `TERMINAL_LEAVES` type, or `None` for any other (recurse-into)
+/// message. `repeated` only changes Payload and Failure, the two that have a per-element form.
+fn terminal_leaf_kind(type_name: &str, repeated: bool) -> Option<LeafKind> {
+    Some(match type_name {
+        "temporal.api.common.v1.Payload" if repeated => LeafKind::RepeatedPayload,
+        "temporal.api.common.v1.Payload" => LeafKind::SinglePayload,
+        "temporal.api.common.v1.Payloads" => LeafKind::SinglePayloads,
+        "temporal.api.common.v1.Memo" => LeafKind::SingleMemo,
+        "temporal.api.common.v1.Header" => LeafKind::SingleHeader,
+        "temporal.api.common.v1.SearchAttributes" => LeafKind::SingleSearchAttributes,
+        "temporal.api.failure.v1.Failure" if repeated => LeafKind::RepeatedWholeMessage,
+        "temporal.api.failure.v1.Failure" => LeafKind::WholeMessage,
+        _ => return None,
+    })
+}
+
 fn generate_limits_impl(
-    base: &PayloadVisitorGenerator,
+    model: &PayloadModel,
     proto_name: &str,
     table: &HashMap<String, FieldPolicy>,
     used_keys: &mut HashSet<String>,
     unclassified: &mut Vec<String>,
 ) -> String {
-    let conv = PayloadVisitorGenerator::new();
-    let rust_path = conv.proto_to_rust_path(proto_name);
-    let msg = &base.messages[proto_name];
+    let rust_path = proto_to_rust_path(proto_name);
+    let msg = &model.messages[proto_name];
 
     let mut body = String::new();
 
@@ -1198,8 +1145,8 @@ fn generate_limits_impl(
         }
         let field_name = field.name.as_deref().unwrap_or("");
         let proto_path = format!("{proto_name}.{field_name}");
-        let rust_field = PayloadVisitorGenerator::to_snake_case(field_name);
-        match classify_field(base, msg, field) {
+        let rust_field = to_snake_case(field_name);
+        match classify_field(model, msg, field) {
             Target::Leaf(kind) => {
                 body.push_str(&emit_leaf(
                     &proto_path,
@@ -1233,22 +1180,14 @@ fn generate_limits_impl(
                 .as_deref()
                 .unwrap_or("")
                 .trim_start_matches('.');
-            if !is_message_type(field) || !base.payload_containing.contains(type_name) {
+            if !is_message_type(field) || !model.payload_containing.contains(type_name) {
                 continue;
             }
             payload_variants += 1;
-            let variant = PayloadVisitorGenerator::to_pascal_case(var_field);
-            let enum_path = conv.proto_to_rust_oneof_enum_path(proto_name, oneof_name);
-            if TERMINAL_LEAVES.contains(&type_name) {
+            let variant = to_pascal_case(var_field);
+            let enum_path = proto_to_rust_oneof_enum_path(proto_name, oneof_name);
+            if let Some(kind) = terminal_leaf_kind(type_name, false) {
                 let proto_path = format!("{proto_name}.{var_field}");
-                let kind = match type_name {
-                    "temporal.api.common.v1.Payloads" => LeafKind::SinglePayloads,
-                    "temporal.api.common.v1.Payload" => LeafKind::SinglePayload,
-                    "temporal.api.common.v1.Memo" => LeafKind::SingleMemo,
-                    "temporal.api.common.v1.Header" => LeafKind::SingleHeader,
-                    "temporal.api.failure.v1.Failure" => LeafKind::WholeMessage,
-                    _ => LeafKind::SingleSearchAttributes,
-                };
                 let check =
                     oneof_leaf_check(&proto_path, var_field, kind, table, used_keys, unclassified);
                 arms.push_str(&format!(
@@ -1263,7 +1202,7 @@ fn generate_limits_impl(
         if payload_variants == 0 {
             continue;
         }
-        let rust_field = PayloadVisitorGenerator::to_snake_case(oneof_name);
+        let rust_field = to_snake_case(oneof_name);
         // A catch-all is needed unless every variant is payload-bearing.
         let catch_all = if payload_variants < variants.len() {
             "                _ => {}\n"
@@ -1283,7 +1222,7 @@ fn generate_limits_impl(
         if owner != proto_name {
             continue;
         }
-        let rust_field = PayloadVisitorGenerator::to_snake_case(field_name);
+        let rust_field = to_snake_case(field_name);
         body.push_str(&emit_leaf(
             path,
             field_name,
@@ -1307,14 +1246,11 @@ impl crate::payload_limits::PayloadLimitsValidatable for {rust_path} {{
 
 /// Whether this field is the synthetic representation of a proto map (and thus not a real oneof).
 fn is_map_field(parent_msg: &DescriptorProto, field: &FieldDescriptorProto) -> bool {
-    let field_name = field.name.as_deref().unwrap_or("");
-    parent_msg.nested_type.iter().any(|n| {
-        is_map_entry(&n.options)
-            && n.name.as_deref() == Some(&PayloadVisitorGenerator::to_map_entry_name(field_name))
-    })
+    map_value_type(parent_msg, field).is_some()
 }
 
-/// Resolve the classification for a leaf path, recording usage / lack of classification.
+/// Records the lookup as a used table key (or as unclassified, which fails the build) as a side
+/// effect, so the caller need not track table coverage itself.
 fn leaf_class(
     proto_path: &str,
     table: &HashMap<String, FieldPolicy>,
@@ -1333,7 +1269,8 @@ fn leaf_class(
     }
 }
 
-/// The size expression for a leaf, given the name of the accessor binding already in scope.
+/// `accessor` must name a binding already in scope in the emitted code; the returned expression
+/// references it.
 fn leaf_size_expr(kind: LeafKind, accessor: &str) -> String {
     match kind {
         LeafKind::SinglePayloads => format!("crate::payload_limits::payloads_size({accessor})"),
@@ -1364,7 +1301,6 @@ fn leaf_size_expr(kind: LeafKind, accessor: &str) -> String {
     }
 }
 
-/// Emit a leaf check for a regular (non-oneof) field.
 fn emit_leaf(
     proto_path: &str,
     proto_field: &str,
@@ -1411,7 +1347,8 @@ fn emit_leaf(
     }
 }
 
-/// Emit a leaf check inside a oneof match arm, where the variant payload is bound to `inner`.
+/// The emitted check references a binding named `inner`, which the enclosing oneof match arm must
+/// bind to the variant payload.
 fn oneof_leaf_check(
     proto_path: &str,
     proto_field: &str,
@@ -1443,8 +1380,6 @@ fn effective_kind(kind: LeafKind, class: LimitClass) -> LeafKind {
     }
 }
 
-/// Emit a structural recursion for a regular (non-oneof) field, pushing a path segment (proto field
-/// name, plus index/key for repeated/map fields) around the descent.
 fn emit_struct(rust_field: &str, proto_field: &str, shape: StructShape) -> String {
     match shape {
         StructShape::Single => format!(

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -695,7 +695,7 @@ fn is_map_entry(options: &Option<MessageOptions>) -> bool {
 //
 // Emits `PayloadLimitsValidatable` impls for the closure of outbound gRPC request
 // messages, dispatching each payload-bearing *leaf* field through a hand-authored
-// decision table (`PAYLOAD_LIMITS_TABLE`) that maps `(message.field)` -> limit class.
+// decision tables (`*_FIELDS`, grouped by class) mapping `(message.field)` -> limit class.
 // The *measurement strategy* is derived mechanically from each field's proto shape;
 // the table only records the specified class decision (blob / memo / not).
 //
@@ -727,390 +727,125 @@ const EXTRA_WHOLE_MESSAGE_LEAVES: &[&str] = &[
     "temporal.api.protocol.v1.Message.body",
 ];
 
-// Payload-limits decision table — THE source of truth for how the SDK mirrors the server's
+// Payload-limits decision tables — THE source of truth for how the SDK mirrors the server's
 // payload/memo size checks.
-//
-// Each entry maps a payload-bearing leaf field (`<fully.qualified.Message>.<field>`) to the
-// server-enforced limit policy ([`LimitClass`]):
 //   - Blob          blob (payload) size limit, warn + error
 //   - Memo          memo size limit, warn + error
 //   - BlobWarn      blob limit, warning only
 //   - NotValidated  the server does not enforce a *replicable* limit on this field
 //
-// The validated closure's roots are derived automatically from the proto service definitions (every
-// `temporal.api.*` RPC *input* message; see `service_request_roots`), so a new RPC/request cannot be
-// silently missed — its payload fields become unclassified and fail the build until added here.
-//
-// The measurement strategy is derived mechanically from the field's proto shape.
-const PAYLOAD_LIMITS_TABLE: &[(&str, LimitClass)] = &[
-    // ============================== Blob (payload) limit, warn + error ==========================
-    (
-        "temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes.result",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.command.v1.FailWorkflowExecutionCommandAttributes.failure",
-        LimitClass::Blob,
-    ), // whole Failure proto
-    // Data-sum of the memo's fields (not whole-Memo); the server's merged-memo check is not replicable.
-    (
-        "temporal.api.command.v1.ModifyWorkflowPropertiesCommandAttributes.upserted_memo",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.command.v1.RecordMarkerCommandAttributes.details",
-        LimitClass::Blob,
-    ), // map<string,Payloads> sum
-    (
-        "temporal.api.command.v1.ScheduleActivityTaskCommandAttributes.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.command.v1.ScheduleNexusOperationCommandAttributes.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.command.v1.UpsertWorkflowSearchAttributesCommandAttributes.search_attributes",
-        LimitClass::Blob,
-    ), // indexed_fields data-sum
-    ("temporal.api.protocol.v1.Message.body", LimitClass::Blob), // whole Any body; see EXTRA_WHOLE_MESSAGE_LEAVES
-    (
-        "temporal.api.query.v1.WorkflowQuery.query_args",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflow.v1.NewWorkflowExecutionInfo.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatByIdRequest.details",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatRequest.details",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondActivityTaskCanceledByIdRequest.details",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest.details",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondActivityTaskCompletedByIdRequest.result",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest.result",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.signal_input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartActivityExecutionRequest.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartNexusOperationExecutionRequest.input",
-        LimitClass::Blob,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.input",
-        LimitClass::Blob,
-    ),
-    // ============================== Memo limit, warn + error ====================================
-    (
-        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.memo",
-        LimitClass::Memo,
-    ),
-    (
-        "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.memo",
-        LimitClass::Memo,
-    ),
-    (
-        "temporal.api.workflow.v1.NewWorkflowExecutionInfo.memo",
-        LimitClass::Memo,
-    ),
-    (
-        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.memo",
-        LimitClass::Memo,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.memo",
-        LimitClass::Memo,
-    ),
-    // ============================== Warning only ================================================
-    // Failure responses.
-    (
-        "temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdRequest.failure",
-        LimitClass::BlobWarn,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdRequest.last_heartbeat_details",
-        LimitClass::BlobWarn,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest.failure",
-        LimitClass::BlobWarn,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest.last_heartbeat_details",
-        LimitClass::BlobWarn,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondNexusTaskFailedRequest.failure",
-        LimitClass::BlobWarn,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest.failure",
-        LimitClass::BlobWarn,
-    ),
-    // Query results.
-    (
-        "temporal.api.query.v1.WorkflowQueryResult.answer",
-        LimitClass::BlobWarn,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest.query_result",
-        LimitClass::BlobWarn,
-    ),
-    // ============================== Not validated ===============================================
+// Roots are derived automatically from the proto service definitions (every `temporal.api.*` RPC
+// *input* message; see `service_request_roots`), so a new RPC/request can't be silently missed — its
+// payload fields become unclassified and fail the build until added below. The measurement strategy
+// is derived mechanically from the field's proto shape.
+const BLOB_FIELDS: &[&str] = &[
+    "temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes.result",
+    "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.input",
+    "temporal.api.command.v1.FailWorkflowExecutionCommandAttributes.failure", // whole Failure proto
+    "temporal.api.command.v1.ModifyWorkflowPropertiesCommandAttributes.upserted_memo", // memo fields data-sum
+    "temporal.api.command.v1.RecordMarkerCommandAttributes.details", // map<string,Payloads> sum
+    "temporal.api.command.v1.ScheduleActivityTaskCommandAttributes.input",
+    "temporal.api.command.v1.ScheduleNexusOperationCommandAttributes.input",
+    "temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes.input",
+    "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.input",
+    "temporal.api.command.v1.UpsertWorkflowSearchAttributesCommandAttributes.search_attributes", // indexed_fields data-sum
+    "temporal.api.protocol.v1.Message.body", // whole Any body; see EXTRA_WHOLE_MESSAGE_LEAVES
+    "temporal.api.query.v1.WorkflowQuery.query_args",
+    "temporal.api.workflow.v1.NewWorkflowExecutionInfo.input",
+    "temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatByIdRequest.details",
+    "temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatRequest.details",
+    "temporal.api.workflowservice.v1.RespondActivityTaskCanceledByIdRequest.details",
+    "temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest.details",
+    "temporal.api.workflowservice.v1.RespondActivityTaskCompletedByIdRequest.result",
+    "temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest.result",
+    "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.input",
+    "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.signal_input",
+    "temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest.input",
+    "temporal.api.workflowservice.v1.StartActivityExecutionRequest.input",
+    "temporal.api.workflowservice.v1.StartNexusOperationExecutionRequest.input",
+    "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.input",
+];
+
+const MEMO_FIELDS: &[&str] = &[
+    "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.memo",
+    "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.memo",
+    "temporal.api.workflow.v1.NewWorkflowExecutionInfo.memo",
+    "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.memo",
+    "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.memo",
+];
+
+// Warn-only: the SDK warns but never proactively fails the task (failure responses; query results).
+const BLOB_WARN_FIELDS: &[&str] = &[
+    "temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdRequest.failure",
+    "temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdRequest.last_heartbeat_details",
+    "temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest.failure",
+    "temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest.last_heartbeat_details",
+    "temporal.api.workflowservice.v1.RespondNexusTaskFailedRequest.failure",
+    "temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest.failure",
+    "temporal.api.query.v1.WorkflowQueryResult.answer",
+    "temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest.query_result",
+];
+
+const NOT_VALIDATED_FIELDS: &[&str] = &[
     // Headers: server records a HeaderSize metric only.
-    (
-        "temporal.api.batch.v1.BatchOperationSignal.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.RecordMarkerCommandAttributes.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.ScheduleActivityTaskCommandAttributes.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.query.v1.WorkflowQuery.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.update.v1.Input.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflow.v1.NewWorkflowExecutionInfo.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflow.v1.PostResetOperation.SignalWorkflow.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartActivityExecutionRequest.header",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.header",
-        LimitClass::NotValidated,
-    ),
-    // Search attributes: separate SA limits; the server's check merges with the workflow's existing
-    // SAs, which the SDK doesn't have, so it's not replicable.
-    (
-        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflow.v1.NewWorkflowExecutionInfo.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.CreateScheduleRequest.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartActivityExecutionRequest.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartNexusOperationExecutionRequest.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.UpdateScheduleRequest.search_attributes",
-        LimitClass::NotValidated,
-    ),
-    // Internal carry-over fields the SDK does not author / the server does not size-check here.
-    (
-        "temporal.api.command.v1.CancelWorkflowExecutionCommandAttributes.details",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.failure",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.last_completion_result",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.command.v1.RecordMarkerCommandAttributes.failure",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.continued_failure",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.last_completion_result",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.TerminateWorkflowExecutionRequest.details",
-        LimitClass::NotValidated,
-    ), // not size-checked
-    // Dedicated size limits the server enforces but the SDK can't replicate: not blob/memo, and not
-    // exposed via DescribeNamespace.
-    //   - UserMetadata summary/details: dedicated limits enforced only on the nexus-start path; the
-    //     workflow/command user_metadata reached here isn't size-checked anyway.
-    //   - Nexus EndpointSpec.description: Operator Create/UpdateNexusEndpoint checks it against
-    //     `maxDescriptionSize` (the cloud variant is cloud-only).
-    (
-        "temporal.api.sdk.v1.UserMetadata.details",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.sdk.v1.UserMetadata.summary",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.nexus.v1.EndpointSpec.description",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.cloud.nexus.v1.EndpointSpec.description",
-        LimitClass::NotValidated,
-    ),
-    // Update input args: frontend records a metric only — enforced later, on delivery, via the
-    // protocol Message.body check above.
-    (
-        "temporal.api.update.v1.Input.args",
-        LimitClass::NotValidated,
-    ),
+    "temporal.api.batch.v1.BatchOperationSignal.header",
+    "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.header",
+    "temporal.api.command.v1.RecordMarkerCommandAttributes.header",
+    "temporal.api.command.v1.ScheduleActivityTaskCommandAttributes.header",
+    "temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes.header",
+    "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.header",
+    "temporal.api.query.v1.WorkflowQuery.header",
+    "temporal.api.update.v1.Input.header",
+    "temporal.api.workflow.v1.NewWorkflowExecutionInfo.header",
+    "temporal.api.workflow.v1.PostResetOperation.SignalWorkflow.header",
+    "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.header",
+    "temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest.header",
+    "temporal.api.workflowservice.v1.StartActivityExecutionRequest.header",
+    "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.header",
+    // Search attributes: separate non-replicable SA limit (server merges with the workflow's existing SAs).
+    "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.search_attributes",
+    "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.search_attributes",
+    "temporal.api.workflow.v1.NewWorkflowExecutionInfo.search_attributes",
+    "temporal.api.workflowservice.v1.CreateScheduleRequest.search_attributes",
+    "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.search_attributes",
+    "temporal.api.workflowservice.v1.StartActivityExecutionRequest.search_attributes",
+    "temporal.api.workflowservice.v1.StartNexusOperationExecutionRequest.search_attributes",
+    "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.search_attributes",
+    "temporal.api.workflowservice.v1.UpdateScheduleRequest.search_attributes",
+    // Internal carry-over fields the SDK doesn't author / the server doesn't size-check here.
+    "temporal.api.command.v1.CancelWorkflowExecutionCommandAttributes.details",
+    "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.failure",
+    "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.last_completion_result",
+    "temporal.api.command.v1.RecordMarkerCommandAttributes.failure",
+    "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.continued_failure",
+    "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.last_completion_result",
+    "temporal.api.workflowservice.v1.TerminateWorkflowExecutionRequest.details",
+    // Dedicated, non-fetchable limits (not blob/memo, not in DescribeNamespace): UserMetadata
+    // (nexus-start only); Nexus EndpointSpec.description (maxDescriptionSize; cloud variant cloud-only).
+    "temporal.api.sdk.v1.UserMetadata.details",
+    "temporal.api.sdk.v1.UserMetadata.summary",
+    "temporal.api.nexus.v1.EndpointSpec.description",
+    "temporal.api.cloud.nexus.v1.EndpointSpec.description",
+    // Update input args: frontend records a metric only — enforced on delivery via Message.body.
+    "temporal.api.update.v1.Input.args",
     // Query/nexus failures and the nexus sync response payload: not size-checked on these paths.
-    (
-        "temporal.api.nexus.v1.StartOperationResponse.Sync.payload",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.nexus.v1.StartOperationResponse.failure",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.query.v1.WorkflowQueryResult.failure",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest.failure",
-        LimitClass::NotValidated,
-    ),
-    // Schedules: server sums memo.Size() + action.input.Size() vs the blob limit — a cross-field
-    // aggregate the per-field model can't express (deferred to a Custom validator). The action input
-    // is still blob-checked individually via NewWorkflowExecutionInfo.input.
-    (
-        "temporal.api.workflowservice.v1.CreateScheduleRequest.memo",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.UpdateScheduleRequest.memo",
-        LimitClass::NotValidated,
-    ),
-    // Enforced downstream, not at the request that carries them: the signal input is blob-checked
-    // per target when the batch/reset fans out to a signal, not at StartBatchOperation / reset.
-    (
-        "temporal.api.batch.v1.BatchOperationSignal.input",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflow.v1.PostResetOperation.SignalWorkflow.input",
-        LimitClass::NotValidated,
-    ),
+    "temporal.api.nexus.v1.StartOperationResponse.Sync.payload",
+    "temporal.api.nexus.v1.StartOperationResponse.failure",
+    "temporal.api.query.v1.WorkflowQueryResult.failure",
+    "temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest.failure",
+    // Schedules: server sums memo + action.input vs blob — cross-field aggregate (Custom, deferred).
+    "temporal.api.workflowservice.v1.CreateScheduleRequest.memo",
+    "temporal.api.workflowservice.v1.UpdateScheduleRequest.memo",
+    // Enforced downstream: signal input is blob-checked per target on batch/reset fan-out.
+    "temporal.api.batch.v1.BatchOperationSignal.input",
+    "temporal.api.workflow.v1.PostResetOperation.SignalWorkflow.input",
     // Not size-checked by the server.
-    (
-        "temporal.api.batch.v1.BatchOperationTermination.details",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.deployment.v1.UpdateDeploymentMetadata.upsert_entries",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.workflowservice.v1.UpdateWorkerDeploymentVersionMetadataRequest.upsert_entries",
-        LimitClass::NotValidated,
-    ),
+    "temporal.api.batch.v1.BatchOperationTermination.details",
+    "temporal.api.deployment.v1.UpdateDeploymentMetadata.upsert_entries",
+    "temporal.api.workflowservice.v1.UpdateWorkerDeploymentVersionMetadataRequest.upsert_entries",
     // Cloud-only API; not handled by the OSS server.
-    (
-        "temporal.api.compute.v1.ComputeProvider.details",
-        LimitClass::NotValidated,
-    ),
-    (
-        "temporal.api.compute.v1.ComputeScaler.details",
-        LimitClass::NotValidated,
-    ),
+    "temporal.api.compute.v1.ComputeProvider.details",
+    "temporal.api.compute.v1.ComputeScaler.details",
 ];
 
 /// The roots of the validated closure are derived automatically from the proto service definitions:
@@ -1244,7 +979,7 @@ fn generate_payload_limits_validator(
 
     let mut output = String::new();
     output.push_str("// Generated from descriptors.bin - DO NOT EDIT\n");
-    output.push_str("// Payload-limits validators. Edit PAYLOAD_LIMITS_TABLE in build.rs to classify fields.\n\n");
+    output.push_str("// Payload-limits validators. Edit the *_FIELDS tables in build.rs to classify fields.\n\n");
 
     let mut generate_names: Vec<String> = to_generate.into_iter().collect();
     generate_names.sort();
@@ -1264,15 +999,13 @@ fn generate_payload_limits_validator(
         unclassified.dedup();
         let list = unclassified
             .iter()
-            .map(|p| {
-                format!("    (\"{p}\", LimitClass::Blob),  // or Memo / BlobWarn / NotValidated")
-            })
+            .map(|p| format!("    \"{p}\","))
             .collect::<Vec<_>>()
             .join("\n");
         return Err(format!(
-            "payload-limits: {} payload-bearing field(s) are not classified in PAYLOAD_LIMITS_TABLE \
-             (crates/common/build.rs). Add an entry per field (the server-enforced limit class), \
-             e.g.:\n{}\n",
+            "payload-limits: {} payload-bearing field(s) are not classified. Add each to the right \
+             *_FIELDS list (BLOB_FIELDS / MEMO_FIELDS / BLOB_WARN_FIELDS / NOT_VALIDATED_FIELDS) in \
+             crates/common/build.rs:\n{}\n",
             unclassified.len(),
             list
         )
@@ -1285,7 +1018,7 @@ fn generate_payload_limits_validator(
         let mut stale: Vec<String> = stale.into_iter().cloned().collect();
         stale.sort();
         return Err(format!(
-            "payload-limits: {} stale entr(y/ies) in PAYLOAD_LIMITS_TABLE (crates/common/build.rs) \
+            "payload-limits: {} stale entr(y/ies) in the *_FIELDS tables (crates/common/build.rs) \
              no longer correspond to a payload-bearing field; remove them:\n    {}\n",
             stale.len(),
             stale.join("\n    ")
@@ -1300,9 +1033,20 @@ fn generate_payload_limits_validator(
 
 /// Load the decision table: `field proto path -> limit class`.
 fn load_payload_limits_table() -> Result<HashMap<String, LimitClass>, Box<dyn std::error::Error>> {
+    use std::iter::repeat;
+    let entries = BLOB_FIELDS
+        .iter()
+        .zip(repeat(LimitClass::Blob))
+        .chain(MEMO_FIELDS.iter().zip(repeat(LimitClass::Memo)))
+        .chain(BLOB_WARN_FIELDS.iter().zip(repeat(LimitClass::BlobWarn)))
+        .chain(
+            NOT_VALIDATED_FIELDS
+                .iter()
+                .zip(repeat(LimitClass::NotValidated)),
+        );
     let mut map = HashMap::new();
-    for (path, class) in PAYLOAD_LIMITS_TABLE {
-        if map.insert((*path).to_string(), *class).is_some() {
+    for (path, class) in entries {
+        if map.insert((*path).to_string(), class).is_some() {
             return Err(format!("payload-limits: duplicate table entry for `{path}`").into());
         }
     }

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     generate_payload_visitor(&out, &descriptor_file)?;
+    generate_payload_limits_validator(&out, &descriptor_file)?;
     Ok(())
 }
 
@@ -687,4 +688,1011 @@ fn is_map_entry(options: &Option<MessageOptions>) -> bool {
     options
         .as_ref()
         .is_some_and(|o| o.map_entry.unwrap_or(false))
+}
+
+// ===========================================================================
+// Payload-limits validator generator (sibling of the payload-visitor generator)
+//
+// Emits `PayloadLimitsValidatable` impls for the closure of outbound gRPC request
+// messages, dispatching each payload-bearing *leaf* field through a hand-authored
+// decision table (`PAYLOAD_LIMITS_TABLE`) that maps `(message.field)` -> limit class.
+// The *measurement strategy* is derived mechanically from each field's proto shape;
+// the table only records the specified class decision (blob / memo / not).
+//
+// Any payload-bearing leaf field that is missing from the table -- or any stale table
+// entry no longer produced by the descriptor walk -- fails the build. This is the
+// compile-time forcing function: a proto change cannot land until classified here.
+// ===========================================================================
+
+/// Fully-qualified proto names whose value is a *measurable unit* the server checks as a whole.
+/// The generator stops recursion at these and emits a table-driven leaf check at the parent field.
+const TERMINAL_LEAVES: &[&str] = &[
+    "temporal.api.common.v1.Payload",
+    "temporal.api.common.v1.Payloads",
+    "temporal.api.common.v1.Memo",
+    "temporal.api.common.v1.Header",
+    "temporal.api.common.v1.SearchAttributes",
+    // The server size-checks a Failure as a whole proto (e.g. FailWorkflowExecution), so we measure
+    // it as one unit rather than decomposing it into its inner payload fields.
+    "temporal.api.failure.v1.Failure",
+];
+
+/// Field paths the server size-checks as a whole serialized sub-message even though the field is
+/// not itself payload-bearing — so payload-reachability never reaches them. Measured via
+/// `message_size` (the server's `proto.Size`), classified via the table like any other leaf. The
+/// owning message is forced into the validated closure so parents recurse into it.
+const EXTRA_WHOLE_MESSAGE_LEAVES: &[&str] = &[
+    // protocol Message body (google.protobuf.Any): the server blob-checks `proto.Size(message.Body)`
+    // when processing update messages and fails the WFT on exceed (handleMessage).
+    "temporal.api.protocol.v1.Message.body",
+];
+
+// Payload-limits decision table — THE source of truth for how the SDK mirrors the server's
+// payload/memo size checks.
+//
+// Each entry maps a payload-bearing leaf field (`<fully.qualified.Message>.<field>`) to the
+// server-enforced limit policy ([`LimitClass`]):
+//   - Blob          blob (payload) size limit, warn + error
+//   - Memo          memo size limit, warn + error
+//   - BlobWarn      blob limit, warning only
+//   - NotValidated  the server does not enforce a *replicable* limit on this field
+//
+// The validated closure's roots are derived automatically from the proto service definitions (every
+// `temporal.api.*` RPC *input* message; see `service_request_roots`), so a new RPC/request cannot be
+// silently missed — its payload fields become unclassified and fail the build until added here.
+//
+// The measurement strategy is derived mechanically from the field's proto shape.
+const PAYLOAD_LIMITS_TABLE: &[(&str, LimitClass)] = &[
+    // ============================== Blob (payload) limit, warn + error ==========================
+    (
+        "temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes.result",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.command.v1.FailWorkflowExecutionCommandAttributes.failure",
+        LimitClass::Blob,
+    ), // whole Failure proto
+    // Data-sum of the memo's fields (not whole-Memo); the server's merged-memo check is not replicable.
+    (
+        "temporal.api.command.v1.ModifyWorkflowPropertiesCommandAttributes.upserted_memo",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.command.v1.RecordMarkerCommandAttributes.details",
+        LimitClass::Blob,
+    ), // map<string,Payloads> sum
+    (
+        "temporal.api.command.v1.ScheduleActivityTaskCommandAttributes.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.command.v1.ScheduleNexusOperationCommandAttributes.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.command.v1.UpsertWorkflowSearchAttributesCommandAttributes.search_attributes",
+        LimitClass::Blob,
+    ), // indexed_fields data-sum
+    ("temporal.api.protocol.v1.Message.body", LimitClass::Blob), // whole Any body; see EXTRA_WHOLE_MESSAGE_LEAVES
+    (
+        "temporal.api.query.v1.WorkflowQuery.query_args",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflow.v1.NewWorkflowExecutionInfo.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatByIdRequest.details",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatRequest.details",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondActivityTaskCanceledByIdRequest.details",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest.details",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondActivityTaskCompletedByIdRequest.result",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest.result",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.signal_input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartActivityExecutionRequest.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartNexusOperationExecutionRequest.input",
+        LimitClass::Blob,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.input",
+        LimitClass::Blob,
+    ),
+    // ============================== Memo limit, warn + error ====================================
+    (
+        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.memo",
+        LimitClass::Memo,
+    ),
+    (
+        "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.memo",
+        LimitClass::Memo,
+    ),
+    (
+        "temporal.api.workflow.v1.NewWorkflowExecutionInfo.memo",
+        LimitClass::Memo,
+    ),
+    (
+        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.memo",
+        LimitClass::Memo,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.memo",
+        LimitClass::Memo,
+    ),
+    // ============================== Warning only ================================================
+    // Failure responses.
+    (
+        "temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdRequest.failure",
+        LimitClass::BlobWarn,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdRequest.last_heartbeat_details",
+        LimitClass::BlobWarn,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest.failure",
+        LimitClass::BlobWarn,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest.last_heartbeat_details",
+        LimitClass::BlobWarn,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondNexusTaskFailedRequest.failure",
+        LimitClass::BlobWarn,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest.failure",
+        LimitClass::BlobWarn,
+    ),
+    // Query results.
+    (
+        "temporal.api.query.v1.WorkflowQueryResult.answer",
+        LimitClass::BlobWarn,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest.query_result",
+        LimitClass::BlobWarn,
+    ),
+    // ============================== Not validated ===============================================
+    // Headers: server records a HeaderSize metric only.
+    (
+        "temporal.api.batch.v1.BatchOperationSignal.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.RecordMarkerCommandAttributes.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.ScheduleActivityTaskCommandAttributes.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.query.v1.WorkflowQuery.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.update.v1.Input.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflow.v1.NewWorkflowExecutionInfo.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflow.v1.PostResetOperation.SignalWorkflow.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartActivityExecutionRequest.header",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.header",
+        LimitClass::NotValidated,
+    ),
+    // Search attributes: separate SA limits; the server's check merges with the workflow's existing
+    // SAs, which the SDK doesn't have, so it's not replicable.
+    (
+        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflow.v1.NewWorkflowExecutionInfo.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.CreateScheduleRequest.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartActivityExecutionRequest.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartNexusOperationExecutionRequest.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.UpdateScheduleRequest.search_attributes",
+        LimitClass::NotValidated,
+    ),
+    // Internal carry-over fields the SDK does not author / the server does not size-check here.
+    (
+        "temporal.api.command.v1.CancelWorkflowExecutionCommandAttributes.details",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.failure",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes.last_completion_result",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.command.v1.RecordMarkerCommandAttributes.failure",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.continued_failure",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest.last_completion_result",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.TerminateWorkflowExecutionRequest.details",
+        LimitClass::NotValidated,
+    ), // not size-checked
+    // Dedicated size limits the server enforces but the SDK can't replicate: not blob/memo, and not
+    // exposed via DescribeNamespace.
+    //   - UserMetadata summary/details: dedicated limits enforced only on the nexus-start path; the
+    //     workflow/command user_metadata reached here isn't size-checked anyway.
+    //   - Nexus EndpointSpec.description: Operator Create/UpdateNexusEndpoint checks it against
+    //     `maxDescriptionSize` (the cloud variant is cloud-only).
+    (
+        "temporal.api.sdk.v1.UserMetadata.details",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.sdk.v1.UserMetadata.summary",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.nexus.v1.EndpointSpec.description",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.cloud.nexus.v1.EndpointSpec.description",
+        LimitClass::NotValidated,
+    ),
+    // Update input args: frontend records a metric only — enforced later, on delivery, via the
+    // protocol Message.body check above.
+    (
+        "temporal.api.update.v1.Input.args",
+        LimitClass::NotValidated,
+    ),
+    // Query/nexus failures and the nexus sync response payload: not size-checked on these paths.
+    (
+        "temporal.api.nexus.v1.StartOperationResponse.Sync.payload",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.nexus.v1.StartOperationResponse.failure",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.query.v1.WorkflowQueryResult.failure",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest.failure",
+        LimitClass::NotValidated,
+    ),
+    // Schedules: server sums memo.Size() + action.input.Size() vs the blob limit — a cross-field
+    // aggregate the per-field model can't express (deferred to a Custom validator). The action input
+    // is still blob-checked individually via NewWorkflowExecutionInfo.input.
+    (
+        "temporal.api.workflowservice.v1.CreateScheduleRequest.memo",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.UpdateScheduleRequest.memo",
+        LimitClass::NotValidated,
+    ),
+    // Enforced downstream, not at the request that carries them: the signal input is blob-checked
+    // per target when the batch/reset fans out to a signal, not at StartBatchOperation / reset.
+    (
+        "temporal.api.batch.v1.BatchOperationSignal.input",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflow.v1.PostResetOperation.SignalWorkflow.input",
+        LimitClass::NotValidated,
+    ),
+    // Not size-checked by the server.
+    (
+        "temporal.api.batch.v1.BatchOperationTermination.details",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.deployment.v1.UpdateDeploymentMetadata.upsert_entries",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.workflowservice.v1.UpdateWorkerDeploymentVersionMetadataRequest.upsert_entries",
+        LimitClass::NotValidated,
+    ),
+    // Cloud-only API; not handled by the OSS server.
+    (
+        "temporal.api.compute.v1.ComputeProvider.details",
+        LimitClass::NotValidated,
+    ),
+    (
+        "temporal.api.compute.v1.ComputeScaler.details",
+        LimitClass::NotValidated,
+    ),
+];
+
+/// The roots of the validated closure are derived automatically from the proto service definitions:
+/// every RPC *input* (request) message of every `temporal.api.*` service. This guarantees a new RPC
+/// or request message cannot be silently missed — its payload fields become unclassified and fail
+/// the build until the table is updated. We use RPC inputs (not all messages) because the SDK only
+/// ever *sends* requests; responses/history are received, never transmitted, so they need no limits.
+fn service_request_roots(descriptor_set: &FileDescriptorSet) -> Vec<String> {
+    let mut roots = Vec::new();
+    for file in &descriptor_set.file {
+        // Only Temporal API services (WorkflowService, OperatorService); excludes internal coresdk.
+        if !file
+            .package
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("temporal.api.")
+        {
+            continue;
+        }
+        for service in &file.service {
+            for method in &service.method {
+                if let Some(input) = method.input_type.as_deref() {
+                    roots.push(input.trim_start_matches('.').to_string());
+                }
+            }
+        }
+    }
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+/// The limit policy a payload field is subject to, per the decision table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LimitClass {
+    /// Blob limit, warn + error.
+    Blob,
+    /// Memo limit, warn + error.
+    Memo,
+    /// Blob limit, warning only.
+    BlobWarn,
+    /// The server does not enforce a (replicable) limit on this field; recorded explicitly.
+    NotValidated,
+}
+
+impl LimitClass {
+    /// The generated `(LimitClass token, enforce_error)` pair, or `None` for `NotValidated`.
+    fn token(self) -> Option<(&'static str, bool)> {
+        match self {
+            Self::Blob => Some(("crate::payload_limits::LimitClass::Blob", true)),
+            Self::Memo => Some(("crate::payload_limits::LimitClass::Memo", true)),
+            Self::BlobWarn => Some(("crate::payload_limits::LimitClass::Blob", false)),
+            Self::NotValidated => None,
+        }
+    }
+}
+
+/// What a (non-oneof) field resolves to for limit purposes.
+enum Target {
+    /// A measurable leaf requiring a table entry at the field's proto path.
+    Leaf(LeafKind),
+    /// A payload-containing nested message to recurse into.
+    Struct(StructShape, String),
+    /// Not payload-bearing; ignored.
+    Skip,
+}
+
+#[derive(Clone, Copy)]
+enum LeafKind {
+    SinglePayloads,
+    SinglePayload,
+    RepeatedPayload,
+    SingleMemo,
+    /// A `Memo` validated against the *blob* limit: measured as the data-sum of its `fields`, the
+    /// way the server checks e.g. `ModifyWorkflowProperties.upserted_memo` (whereas a memo-classed
+    /// `Memo` keeps whole-proto `memo_size`).
+    MemoFieldsDataSum,
+    SingleHeader,
+    SingleSearchAttributes,
+    MapPayload,
+    MapPayloads,
+    /// A whole message measured by its serialized proto size (e.g. Failure).
+    WholeMessage,
+    /// A repeated whole message, summed (e.g. repeated Failure).
+    RepeatedWholeMessage,
+}
+
+#[derive(Clone, Copy)]
+enum StructShape {
+    Single,
+    Repeated,
+    Map,
+}
+
+fn generate_payload_limits_validator(
+    out_dir: &Path,
+    descriptor_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut descriptor_bytes = Vec::new();
+    File::open(descriptor_path)?.read_to_end(&mut descriptor_bytes)?;
+    let descriptor_set = FileDescriptorSet::decode(&descriptor_bytes[..])?;
+
+    // Reuse the visitor generator's first two passes for message collection + payload reachability.
+    let mut base = PayloadVisitorGenerator::new();
+    for file in &descriptor_set.file {
+        let package = file.package.as_deref().unwrap_or("");
+        for msg in &file.message_type {
+            base.collect_messages(package, msg);
+        }
+    }
+    let all_names: Vec<String> = base.messages.keys().cloned().collect();
+    for name in &all_names {
+        base.check_contains_payload(name);
+    }
+
+    // Force the owners of extra whole-message leaves to be treated as validatable, so the closure
+    // walk recurses into them (e.g. RespondWorkflowTaskCompletedRequest.messages -> Message.body).
+    for path in EXTRA_WHOLE_MESSAGE_LEAVES {
+        if let Some((owner, _)) = path.rsplit_once('.') {
+            base.payload_containing.insert(owner.to_string());
+        }
+    }
+
+    let table = load_payload_limits_table()?;
+    let mut used_keys: HashSet<String> = HashSet::new();
+    let mut unclassified: Vec<String> = Vec::new();
+
+    // Compute the closure of structural messages reachable from the service request roots.
+    let roots = service_request_roots(&descriptor_set);
+    let to_generate = limits_closure(&base, &roots);
+
+    let mut output = String::new();
+    output.push_str("// Generated from descriptors.bin - DO NOT EDIT\n");
+    output.push_str("// Payload-limits validators. Edit PAYLOAD_LIMITS_TABLE in build.rs to classify fields.\n\n");
+
+    let mut generate_names: Vec<String> = to_generate.into_iter().collect();
+    generate_names.sort();
+    for name in &generate_names {
+        output.push_str(&generate_limits_impl(
+            &base,
+            name,
+            &table,
+            &mut used_keys,
+            &mut unclassified,
+        ));
+    }
+
+    // Fail the build on any unclassified leaf field (forces an explicit decision on proto changes).
+    if !unclassified.is_empty() {
+        unclassified.sort();
+        unclassified.dedup();
+        let list = unclassified
+            .iter()
+            .map(|p| {
+                format!("    (\"{p}\", LimitClass::Blob),  // or Memo / BlobWarn / NotValidated")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(format!(
+            "payload-limits: {} payload-bearing field(s) are not classified in PAYLOAD_LIMITS_TABLE \
+             (crates/common/build.rs). Add an entry per field (the server-enforced limit class), \
+             e.g.:\n{}\n",
+            unclassified.len(),
+            list
+        )
+        .into());
+    }
+
+    // Fail the build on stale table entries (a field that no longer exists in the proto closure).
+    let stale: Vec<&String> = table.keys().filter(|k| !used_keys.contains(*k)).collect();
+    if !stale.is_empty() {
+        let mut stale: Vec<String> = stale.into_iter().cloned().collect();
+        stale.sort();
+        return Err(format!(
+            "payload-limits: {} stale entr(y/ies) in PAYLOAD_LIMITS_TABLE (crates/common/build.rs) \
+             no longer correspond to a payload-bearing field; remove them:\n    {}\n",
+            stale.len(),
+            stale.join("\n    ")
+        )
+        .into());
+    }
+
+    let output_path = out_dir.join("payload_limits_impl.rs");
+    File::create(&output_path)?.write_all(output.as_bytes())?;
+    Ok(())
+}
+
+/// Load the decision table: `field proto path -> limit class`.
+fn load_payload_limits_table() -> Result<HashMap<String, LimitClass>, Box<dyn std::error::Error>> {
+    let mut map = HashMap::new();
+    for (path, class) in PAYLOAD_LIMITS_TABLE {
+        if map.insert((*path).to_string(), *class).is_some() {
+            return Err(format!("payload-limits: duplicate table entry for `{path}`").into());
+        }
+    }
+    Ok(map)
+}
+
+/// BFS from the roots, following payload-containing structural fields, collecting the message types
+/// that need a generated `PayloadLimitsValidatable` impl (excludes terminal leaf types).
+fn limits_closure(base: &PayloadVisitorGenerator, roots: &[String]) -> HashSet<String> {
+    let mut result = HashSet::new();
+    let mut queue: Vec<String> = roots.to_vec();
+    while let Some(name) = queue.pop() {
+        if TERMINAL_LEAVES.contains(&name.as_str()) || result.contains(&name) {
+            continue;
+        }
+        let Some(msg) = base.messages.get(&name) else {
+            continue;
+        };
+        if !base.payload_containing.contains(&name) {
+            continue;
+        }
+        result.insert(name.clone());
+        for field in &msg.field {
+            if let Target::Struct(_, ty) = classify_field(base, msg, field) {
+                queue.push(ty);
+            } else if is_message_type(field) {
+                // Oneof variants are message-typed; enqueue payload-containing structural variants.
+                let ty = field
+                    .type_name
+                    .as_deref()
+                    .unwrap_or("")
+                    .trim_start_matches('.')
+                    .to_string();
+                if base.payload_containing.contains(&ty) && !TERMINAL_LEAVES.contains(&ty.as_str())
+                {
+                    queue.push(ty);
+                }
+            }
+        }
+    }
+    result
+}
+
+/// Classify a (non-map-handling-aside) field into a leaf check or a structural recursion.
+fn classify_field(
+    base: &PayloadVisitorGenerator,
+    parent_msg: &DescriptorProto,
+    field: &FieldDescriptorProto,
+) -> Target {
+    if !is_message_type(field) {
+        return Target::Skip;
+    }
+    let field_name = field.name.as_deref().unwrap_or("");
+    let type_name = field
+        .type_name
+        .as_deref()
+        .unwrap_or("")
+        .trim_start_matches('.');
+
+    // Map fields: classified by their value type.
+    if let Some(nested) = parent_msg.nested_type.iter().find(|n| {
+        is_map_entry(&n.options)
+            && n.name.as_deref() == Some(&PayloadVisitorGenerator::to_map_entry_name(field_name))
+    }) {
+        let value_field = nested
+            .field
+            .iter()
+            .find(|f| f.name.as_deref() == Some("value"));
+        let value_type = value_field
+            .and_then(|f| f.type_name.as_deref())
+            .unwrap_or("")
+            .trim_start_matches('.');
+        return match value_type {
+            "temporal.api.common.v1.Payload" => Target::Leaf(LeafKind::MapPayload),
+            "temporal.api.common.v1.Payloads" => Target::Leaf(LeafKind::MapPayloads),
+            other if base.payload_containing.contains(other) => {
+                Target::Struct(StructShape::Map, other.to_string())
+            }
+            _ => Target::Skip,
+        };
+    }
+
+    if !base.payload_containing.contains(type_name) {
+        return Target::Skip;
+    }
+
+    let repeated = is_repeated(field);
+    match type_name {
+        "temporal.api.common.v1.Payload" => Target::Leaf(if repeated {
+            LeafKind::RepeatedPayload
+        } else {
+            LeafKind::SinglePayload
+        }),
+        "temporal.api.common.v1.Payloads" => Target::Leaf(LeafKind::SinglePayloads),
+        "temporal.api.common.v1.Memo" => Target::Leaf(LeafKind::SingleMemo),
+        "temporal.api.common.v1.Header" => Target::Leaf(LeafKind::SingleHeader),
+        "temporal.api.common.v1.SearchAttributes" => Target::Leaf(LeafKind::SingleSearchAttributes),
+        "temporal.api.failure.v1.Failure" => Target::Leaf(if repeated {
+            LeafKind::RepeatedWholeMessage
+        } else {
+            LeafKind::WholeMessage
+        }),
+        other => Target::Struct(
+            if repeated {
+                StructShape::Repeated
+            } else {
+                StructShape::Single
+            },
+            other.to_string(),
+        ),
+    }
+}
+
+fn generate_limits_impl(
+    base: &PayloadVisitorGenerator,
+    proto_name: &str,
+    table: &HashMap<String, LimitClass>,
+    used_keys: &mut HashSet<String>,
+    unclassified: &mut Vec<String>,
+) -> String {
+    let conv = PayloadVisitorGenerator::new();
+    let rust_path = conv.proto_to_rust_path(proto_name);
+    let msg = &base.messages[proto_name];
+
+    let mut body = String::new();
+
+    // Group oneof fields; handle regular fields directly.
+    let mut oneof_fields: HashMap<i32, Vec<&FieldDescriptorProto>> = HashMap::new();
+    for field in &msg.field {
+        if let Some(oneof_index) = field.oneof_index
+            && !is_map_field(msg, field)
+        {
+            oneof_fields.entry(oneof_index).or_default().push(field);
+            continue;
+        }
+        let field_name = field.name.as_deref().unwrap_or("");
+        let proto_path = format!("{proto_name}.{field_name}");
+        let rust_field = PayloadVisitorGenerator::to_snake_case(field_name);
+        match classify_field(base, msg, field) {
+            Target::Leaf(kind) => {
+                body.push_str(&emit_leaf(
+                    &proto_path,
+                    field_name,
+                    &rust_field,
+                    kind,
+                    table,
+                    used_keys,
+                    unclassified,
+                ));
+            }
+            Target::Struct(shape, _) => {
+                body.push_str(&emit_struct(&rust_field, field_name, shape));
+            }
+            Target::Skip => {}
+        }
+    }
+
+    // Oneofs: recurse into payload-containing structural variants; leaf variants get a table check.
+    let mut oneof_indices: Vec<i32> = oneof_fields.keys().copied().collect();
+    oneof_indices.sort();
+    for idx in oneof_indices {
+        let variants = &oneof_fields[&idx];
+        let oneof_name = msg.oneof_decl[idx as usize].name.as_deref().unwrap_or("");
+        let mut arms = String::new();
+        let mut payload_variants = 0usize;
+        for field in variants {
+            let var_field = field.name.as_deref().unwrap_or("");
+            let type_name = field
+                .type_name
+                .as_deref()
+                .unwrap_or("")
+                .trim_start_matches('.');
+            if !is_message_type(field) || !base.payload_containing.contains(type_name) {
+                continue;
+            }
+            payload_variants += 1;
+            let variant = PayloadVisitorGenerator::to_pascal_case(var_field);
+            let enum_path = conv.proto_to_rust_oneof_enum_path(proto_name, oneof_name);
+            if TERMINAL_LEAVES.contains(&type_name) {
+                let proto_path = format!("{proto_name}.{var_field}");
+                let kind = match type_name {
+                    "temporal.api.common.v1.Payloads" => LeafKind::SinglePayloads,
+                    "temporal.api.common.v1.Payload" => LeafKind::SinglePayload,
+                    "temporal.api.common.v1.Memo" => LeafKind::SingleMemo,
+                    "temporal.api.common.v1.Header" => LeafKind::SingleHeader,
+                    "temporal.api.failure.v1.Failure" => LeafKind::WholeMessage,
+                    _ => LeafKind::SingleSearchAttributes,
+                };
+                let check =
+                    oneof_leaf_check(&proto_path, var_field, kind, table, used_keys, unclassified);
+                arms.push_str(&format!(
+                    "                {enum_path}::{variant}(inner) => {{ {check} }}\n"
+                ));
+            } else {
+                arms.push_str(&format!(
+                    "                {enum_path}::{variant}(inner) => {{\n                    sink.enter(\"{var_field}\", crate::payload_limits::FieldIndexer::None);\n                    crate::payload_limits::PayloadLimitsValidatable::validate_payload_limits(inner, sink);\n                    sink.exit();\n                }}\n"
+                ));
+            }
+        }
+        if payload_variants == 0 {
+            continue;
+        }
+        let rust_field = PayloadVisitorGenerator::to_snake_case(oneof_name);
+        // A catch-all is needed unless every variant is payload-bearing.
+        let catch_all = if payload_variants < variants.len() {
+            "                _ => {}\n"
+        } else {
+            ""
+        };
+        body.push_str(&format!(
+            "        if let Some(oneof) = &self.{rust_field} {{\n            match oneof {{\n{arms}{catch_all}            }}\n        }}\n"
+        ));
+    }
+
+    // Extra whole-message leaves: non-payload fields the server size-checks as a sub-message.
+    for path in EXTRA_WHOLE_MESSAGE_LEAVES {
+        let Some((owner, field_name)) = path.rsplit_once('.') else {
+            continue;
+        };
+        if owner != proto_name {
+            continue;
+        }
+        let rust_field = PayloadVisitorGenerator::to_snake_case(field_name);
+        body.push_str(&emit_leaf(
+            path,
+            field_name,
+            &rust_field,
+            LeafKind::WholeMessage,
+            table,
+            used_keys,
+            unclassified,
+        ));
+    }
+
+    format!(
+        r#"#[allow(deprecated, unused_variables, clippy::collapsible_if, clippy::collapsible_match, clippy::single_match)]
+impl crate::payload_limits::PayloadLimitsValidatable for {rust_path} {{
+    fn validate_payload_limits(&self, sink: &mut dyn crate::payload_limits::PayloadLimitSink) {{
+{body}    }}
+}}
+"#
+    )
+}
+
+/// Whether this field is the synthetic representation of a proto map (and thus not a real oneof).
+fn is_map_field(parent_msg: &DescriptorProto, field: &FieldDescriptorProto) -> bool {
+    let field_name = field.name.as_deref().unwrap_or("");
+    parent_msg.nested_type.iter().any(|n| {
+        is_map_entry(&n.options)
+            && n.name.as_deref() == Some(&PayloadVisitorGenerator::to_map_entry_name(field_name))
+    })
+}
+
+/// Resolve the table class for a leaf path, recording usage / lack of classification.
+fn leaf_class(
+    proto_path: &str,
+    table: &HashMap<String, LimitClass>,
+    used_keys: &mut HashSet<String>,
+    unclassified: &mut Vec<String>,
+) -> Option<LimitClass> {
+    match table.get(proto_path) {
+        Some(class) => {
+            used_keys.insert(proto_path.to_string());
+            Some(*class)
+        }
+        None => {
+            unclassified.push(proto_path.to_string());
+            None
+        }
+    }
+}
+
+/// The size expression for a leaf, given the name of the accessor binding already in scope.
+fn leaf_size_expr(kind: LeafKind, accessor: &str) -> String {
+    match kind {
+        LeafKind::SinglePayloads => format!("crate::payload_limits::payloads_size({accessor})"),
+        LeafKind::SinglePayload => format!("crate::payload_limits::payload_size({accessor})"),
+        LeafKind::SingleMemo => format!("crate::payload_limits::memo_size({accessor})"),
+        LeafKind::MemoFieldsDataSum => {
+            format!("crate::payload_limits::map_payload_data_sum({accessor}.fields.iter())")
+        }
+        LeafKind::SingleHeader => {
+            format!("crate::payload_limits::map_payload_data_sum({accessor}.fields.iter())")
+        }
+        LeafKind::SingleSearchAttributes => {
+            format!("crate::payload_limits::map_payload_data_sum({accessor}.indexed_fields.iter())")
+        }
+        LeafKind::RepeatedPayload => {
+            format!("{accessor}.iter().map(crate::payload_limits::payload_size).sum::<usize>()")
+        }
+        LeafKind::MapPayload => {
+            format!("crate::payload_limits::map_payload_data_sum({accessor}.iter())")
+        }
+        LeafKind::MapPayloads => {
+            format!("crate::payload_limits::map_payloads_sum({accessor}.iter())")
+        }
+        LeafKind::WholeMessage => format!("crate::payload_limits::message_size({accessor})"),
+        LeafKind::RepeatedWholeMessage => {
+            format!("{accessor}.iter().map(crate::payload_limits::message_size).sum::<usize>()")
+        }
+    }
+}
+
+/// Emit a leaf check for a regular (non-oneof) field.
+fn emit_leaf(
+    proto_path: &str,
+    proto_field: &str,
+    rust_field: &str,
+    kind: LeafKind,
+    table: &HashMap<String, LimitClass>,
+    used_keys: &mut HashSet<String>,
+    unclassified: &mut Vec<String>,
+) -> String {
+    let Some(class) = leaf_class(proto_path, table, used_keys, unclassified) else {
+        return String::new();
+    };
+    let kind = effective_kind(kind, class);
+    let Some((class_token, enforce)) = class.token() else {
+        return String::new(); // NotValidated
+    };
+    match kind {
+        // Optional message singulars: guard on Some.
+        LeafKind::SinglePayloads
+        | LeafKind::SinglePayload
+        | LeafKind::SingleMemo
+        | LeafKind::MemoFieldsDataSum
+        | LeafKind::SingleHeader
+        | LeafKind::SingleSearchAttributes
+        | LeafKind::WholeMessage => {
+            let size = leaf_size_expr(kind, "inner");
+            format!(
+                "        if let Some(inner) = &self.{rust_field} {{\n            sink.check(\"{proto_field}\", {class_token}, {size}, {enforce});\n        }}\n"
+            )
+        }
+        // Repeated / map: always present (empty -> 0, harmless).
+        LeafKind::RepeatedPayload
+        | LeafKind::RepeatedWholeMessage
+        | LeafKind::MapPayload
+        | LeafKind::MapPayloads => {
+            let accessor = format!("self.{rust_field}");
+            let size = leaf_size_expr(kind, &accessor);
+            format!("        sink.check(\"{proto_field}\", {class_token}, {size}, {enforce});\n")
+        }
+    }
+}
+
+/// Emit a leaf check inside a oneof match arm, where the variant payload is bound to `inner`.
+fn oneof_leaf_check(
+    proto_path: &str,
+    proto_field: &str,
+    kind: LeafKind,
+    table: &HashMap<String, LimitClass>,
+    used_keys: &mut HashSet<String>,
+    unclassified: &mut Vec<String>,
+) -> String {
+    let Some(class) = leaf_class(proto_path, table, used_keys, unclassified) else {
+        return String::new();
+    };
+    let kind = effective_kind(kind, class);
+    let Some((class_token, enforce)) = class.token() else {
+        return String::new();
+    };
+    let size = leaf_size_expr(kind, "inner");
+    format!("sink.check(\"{proto_field}\", {class_token}, {size}, {enforce});")
+}
+
+/// Adjust a leaf's measurement for its classified limit. A `Memo` validated against the *blob*
+/// limit is measured as the data-sum of its `fields` (the way the server checks
+/// `ModifyWorkflowProperties.upserted_memo`); a memo-classed `Memo` keeps whole-proto `memo_size`.
+fn effective_kind(kind: LeafKind, class: LimitClass) -> LeafKind {
+    match (kind, class) {
+        (LeafKind::SingleMemo, LimitClass::Blob | LimitClass::BlobWarn) => {
+            LeafKind::MemoFieldsDataSum
+        }
+        _ => kind,
+    }
+}
+
+/// Emit a structural recursion for a regular (non-oneof) field, pushing a path segment (proto field
+/// name, plus index/key for repeated/map fields) around the descent.
+fn emit_struct(rust_field: &str, proto_field: &str, shape: StructShape) -> String {
+    match shape {
+        StructShape::Single => format!(
+            "        if let Some(inner) = &self.{rust_field} {{\n            sink.enter(\"{proto_field}\", crate::payload_limits::FieldIndexer::None);\n            crate::payload_limits::PayloadLimitsValidatable::validate_payload_limits(inner, sink);\n            sink.exit();\n        }}\n"
+        ),
+        StructShape::Repeated => format!(
+            "        for (idx, inner) in self.{rust_field}.iter().enumerate() {{\n            sink.enter(\"{proto_field}\", crate::payload_limits::FieldIndexer::Index(idx));\n            crate::payload_limits::PayloadLimitsValidatable::validate_payload_limits(inner, sink);\n            sink.exit();\n        }}\n"
+        ),
+        StructShape::Map => format!(
+            "        for (key, inner) in self.{rust_field}.iter() {{\n            sink.enter(\"{proto_field}\", crate::payload_limits::FieldIndexer::Key(key));\n            crate::payload_limits::PayloadLimitsValidatable::validate_payload_limits(inner, sink);\n            sink.exit();\n        }}\n"
+        ),
+    }
 }

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -8,8 +8,11 @@ use std::{
     env,
     fs::File,
     io::{Read, Write},
+    iter::repeat,
     path::Path,
 };
+
+use FieldPolicy::{NotValidated, Validated};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-env-changed=DEP_TEMPORALIO_PROTOS_DESCRIPTOR_PATH");
@@ -728,11 +731,11 @@ const EXTRA_WHOLE_MESSAGE_LEAVES: &[&str] = &[
 ];
 
 // Payload-limits decision tables — THE source of truth for how the SDK mirrors the server's
-// payload/memo size checks.
-//   - Blob          blob (payload) size limit, warn + error
-//   - Memo          memo size limit, warn + error
-//   - BlobWarn      blob limit, warning only
-//   - NotValidated  the server does not enforce a *replicable* limit on this field
+// payload/memo size checks. Fields are grouped by policy (the loader maps each list to a
+// `FieldPolicy`):
+//   - BLOB_FIELDS / MEMO_FIELDS  blob / memo limit, warn + error
+//   - BLOB_WARN_FIELDS           blob limit, warning only (enforce_error = false)
+//   - NOT_VALIDATED_FIELDS       the server enforces no replicable limit on the field
 //
 // Roots are derived automatically from the proto service definitions (every `temporal.api.*` RPC
 // *input* message; see `service_request_roots`), so a new RPC/request can't be silently missed — its
@@ -878,29 +881,33 @@ fn service_request_roots(descriptor_set: &FileDescriptorSet) -> Vec<String> {
     roots
 }
 
-/// The limit policy a payload field is subject to, per the decision table.
+/// Which limit a validated field is checked against — mirrors the runtime `LimitClass`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LimitClass {
-    /// Blob limit, warn + error.
     Blob,
-    /// Memo limit, warn + error.
     Memo,
-    /// Blob limit, warning only.
-    BlobWarn,
-    /// The server does not enforce a (replicable) limit on this field; recorded explicitly.
-    NotValidated,
 }
 
 impl LimitClass {
-    /// The generated `(LimitClass token, enforce_error)` pair, or `None` for `NotValidated`.
-    fn token(self) -> Option<(&'static str, bool)> {
+    /// The generated runtime `LimitClass` token.
+    fn token(self) -> &'static str {
         match self {
-            Self::Blob => Some(("crate::payload_limits::LimitClass::Blob", true)),
-            Self::Memo => Some(("crate::payload_limits::LimitClass::Memo", true)),
-            Self::BlobWarn => Some(("crate::payload_limits::LimitClass::Blob", false)),
-            Self::NotValidated => None,
+            Self::Blob => "crate::payload_limits::LimitClass::Blob",
+            Self::Memo => "crate::payload_limits::LimitClass::Memo",
         }
     }
+}
+
+/// How a field is classified in the decision table. A validated field carries its [`LimitClass`] and
+/// whether an over-limit is enforced as an error (warn + error) or warning-only — kept separate, as
+/// the runtime sink does. `NotValidated` fields emit no check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldPolicy {
+    Validated {
+        class: LimitClass,
+        enforce_error: bool,
+    },
+    NotValidated,
 }
 
 /// What a (non-oneof) field resolves to for limit purposes.
@@ -1031,22 +1038,29 @@ fn generate_payload_limits_validator(
     Ok(())
 }
 
-/// Load the decision table: `field proto path -> limit class`.
-fn load_payload_limits_table() -> Result<HashMap<String, LimitClass>, Box<dyn std::error::Error>> {
-    use std::iter::repeat;
+/// Load the decision table: `field proto path -> FieldPolicy`.
+fn load_payload_limits_table() -> Result<HashMap<String, FieldPolicy>, Box<dyn std::error::Error>> {
+    let blob = Validated {
+        class: LimitClass::Blob,
+        enforce_error: true,
+    };
+    let memo = Validated {
+        class: LimitClass::Memo,
+        enforce_error: true,
+    };
+    let blob_warn = Validated {
+        class: LimitClass::Blob,
+        enforce_error: false,
+    };
     let entries = BLOB_FIELDS
         .iter()
-        .zip(repeat(LimitClass::Blob))
-        .chain(MEMO_FIELDS.iter().zip(repeat(LimitClass::Memo)))
-        .chain(BLOB_WARN_FIELDS.iter().zip(repeat(LimitClass::BlobWarn)))
-        .chain(
-            NOT_VALIDATED_FIELDS
-                .iter()
-                .zip(repeat(LimitClass::NotValidated)),
-        );
+        .zip(repeat(blob))
+        .chain(MEMO_FIELDS.iter().zip(repeat(memo)))
+        .chain(BLOB_WARN_FIELDS.iter().zip(repeat(blob_warn)))
+        .chain(NOT_VALIDATED_FIELDS.iter().zip(repeat(NotValidated)));
     let mut map = HashMap::new();
-    for (path, class) in entries {
-        if map.insert((*path).to_string(), class).is_some() {
+    for (path, classification) in entries {
+        if map.insert((*path).to_string(), classification).is_some() {
             return Err(format!("payload-limits: duplicate table entry for `{path}`").into());
         }
     }
@@ -1163,7 +1177,7 @@ fn classify_field(
 fn generate_limits_impl(
     base: &PayloadVisitorGenerator,
     proto_name: &str,
-    table: &HashMap<String, LimitClass>,
+    table: &HashMap<String, FieldPolicy>,
     used_keys: &mut HashSet<String>,
     unclassified: &mut Vec<String>,
 ) -> String {
@@ -1300,17 +1314,17 @@ fn is_map_field(parent_msg: &DescriptorProto, field: &FieldDescriptorProto) -> b
     })
 }
 
-/// Resolve the table class for a leaf path, recording usage / lack of classification.
+/// Resolve the classification for a leaf path, recording usage / lack of classification.
 fn leaf_class(
     proto_path: &str,
-    table: &HashMap<String, LimitClass>,
+    table: &HashMap<String, FieldPolicy>,
     used_keys: &mut HashSet<String>,
     unclassified: &mut Vec<String>,
-) -> Option<LimitClass> {
+) -> Option<FieldPolicy> {
     match table.get(proto_path) {
-        Some(class) => {
+        Some(classification) => {
             used_keys.insert(proto_path.to_string());
-            Some(*class)
+            Some(*classification)
         }
         None => {
             unclassified.push(proto_path.to_string());
@@ -1356,17 +1370,19 @@ fn emit_leaf(
     proto_field: &str,
     rust_field: &str,
     kind: LeafKind,
-    table: &HashMap<String, LimitClass>,
+    table: &HashMap<String, FieldPolicy>,
     used_keys: &mut HashSet<String>,
     unclassified: &mut Vec<String>,
 ) -> String {
-    let Some(class) = leaf_class(proto_path, table, used_keys, unclassified) else {
-        return String::new();
+    let Some(FieldPolicy::Validated {
+        class,
+        enforce_error,
+    }) = leaf_class(proto_path, table, used_keys, unclassified)
+    else {
+        return String::new(); // unclassified (build fails) or NotValidated (no check)
     };
     let kind = effective_kind(kind, class);
-    let Some((class_token, enforce)) = class.token() else {
-        return String::new(); // NotValidated
-    };
+    let class_token = class.token();
     match kind {
         // Optional message singulars: guard on Some.
         LeafKind::SinglePayloads
@@ -1378,7 +1394,7 @@ fn emit_leaf(
         | LeafKind::WholeMessage => {
             let size = leaf_size_expr(kind, "inner");
             format!(
-                "        if let Some(inner) = &self.{rust_field} {{\n            sink.check(\"{proto_field}\", {class_token}, {size}, {enforce});\n        }}\n"
+                "        if let Some(inner) = &self.{rust_field} {{\n            sink.check(\"{proto_field}\", {class_token}, {size}, {enforce_error});\n        }}\n"
             )
         }
         // Repeated / map: always present (empty -> 0, harmless).
@@ -1388,7 +1404,9 @@ fn emit_leaf(
         | LeafKind::MapPayloads => {
             let accessor = format!("self.{rust_field}");
             let size = leaf_size_expr(kind, &accessor);
-            format!("        sink.check(\"{proto_field}\", {class_token}, {size}, {enforce});\n")
+            format!(
+                "        sink.check(\"{proto_field}\", {class_token}, {size}, {enforce_error});\n"
+            )
         }
     }
 }
@@ -1398,19 +1416,21 @@ fn oneof_leaf_check(
     proto_path: &str,
     proto_field: &str,
     kind: LeafKind,
-    table: &HashMap<String, LimitClass>,
+    table: &HashMap<String, FieldPolicy>,
     used_keys: &mut HashSet<String>,
     unclassified: &mut Vec<String>,
 ) -> String {
-    let Some(class) = leaf_class(proto_path, table, used_keys, unclassified) else {
+    let Some(FieldPolicy::Validated {
+        class,
+        enforce_error,
+    }) = leaf_class(proto_path, table, used_keys, unclassified)
+    else {
         return String::new();
     };
     let kind = effective_kind(kind, class);
-    let Some((class_token, enforce)) = class.token() else {
-        return String::new();
-    };
+    let class_token = class.token();
     let size = leaf_size_expr(kind, "inner");
-    format!("sink.check(\"{proto_field}\", {class_token}, {size}, {enforce});")
+    format!("sink.check(\"{proto_field}\", {class_token}, {size}, {enforce_error});")
 }
 
 /// Adjust a leaf's measurement for its classified limit. A `Memo` validated against the *blob*
@@ -1418,9 +1438,7 @@ fn oneof_leaf_check(
 /// `ModifyWorkflowProperties.upserted_memo`); a memo-classed `Memo` keeps whole-proto `memo_size`.
 fn effective_kind(kind: LeafKind, class: LimitClass) -> LeafKind {
     match (kind, class) {
-        (LeafKind::SingleMemo, LimitClass::Blob | LimitClass::BlobWarn) => {
-            LeafKind::MemoFieldsDataSum
-        }
+        (LeafKind::SingleMemo, LimitClass::Blob) => LeafKind::MemoFieldsDataSum,
         _ => kind,
     }
 }

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -691,7 +691,7 @@ fn is_map_entry(options: &Option<MessageOptions>) -> bool {
 }
 
 // ===========================================================================
-// Payload-limits validator generator (sibling of the payload-visitor generator)
+// Payload-limits validator generator
 //
 // Emits `PayloadLimitsValidatable` impls for the closure of outbound gRPC request
 // messages, dispatching each payload-bearing *leaf* field through a hand-authored

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -11,6 +11,8 @@ extern crate tracing;
 pub mod envconfig;
 #[doc(hidden)]
 pub mod fsm_trait;
+#[doc(hidden)]
+pub mod payload_limits;
 pub mod payload_visitor;
 pub mod protos;
 pub mod telemetry;

--- a/crates/common/src/payload_limits.rs
+++ b/crates/common/src/payload_limits.rs
@@ -1,8 +1,8 @@
 //! Payload/memo size-limit validation infrastructure.
 //!
 //! Mirrors the size checks the Temporal server enforces. The per-(message, field) policy is
-//! generated from the proto descriptors against the hand-authored `PAYLOAD_LIMITS_TABLE` in
-//! `build.rs`; adding or removing a payload-bearing field fails the build until the table is updated.
+//! generated from the proto descriptors against the hand-authored `*_FIELDS` tables in
+//! `build.rs`; adding or removing a payload-bearing field fails the build until they're updated.
 //!
 //! Size is the serialized proto size (`encoded_len()`), except for the map-aggregate helpers that
 //! mirror the server's `len(key) + …` accounting (`map_payloads_sum` / `map_payload_data_sum`).

--- a/crates/common/src/payload_limits.rs
+++ b/crates/common/src/payload_limits.rs
@@ -1,0 +1,655 @@
+//! Payload/memo size-limit validation infrastructure.
+//!
+//! Mirrors the size checks the Temporal server enforces. The per-(message, field) policy is
+//! generated from the proto descriptors against the hand-authored `PAYLOAD_LIMITS_TABLE` in
+//! `build.rs`; adding or removing a payload-bearing field fails the build until the table is updated.
+//!
+//! Size is the serialized proto size (`encoded_len()`), except for the map-aggregate helpers that
+//! mirror the server's `len(key) + …` accounting (`map_payloads_sum` / `map_payload_data_sum`).
+//!
+//! Generated `PayloadLimitsValidatable` impls report each field's size and class to a
+//! `PayloadLimitSink`. `validate_payload_limits` is a sink that logs warnings and returns the first
+//! error-level violation.
+
+use crate::protos::temporal::api::common::v1::{Memo, Payload, Payloads};
+use prost::Message;
+
+/// Default warning threshold for blob (payload) sizes: 512 KiB.
+pub const DEFAULT_BLOB_SIZE_WARN: usize = 512 * 1024;
+/// Default warning threshold for memo sizes: 2 KiB.
+pub const DEFAULT_MEMO_SIZE_WARN: usize = 2 * 1024;
+
+/// Which server-enforced size limit a payload field is subject to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitClass {
+    /// Subject to the blob (payload) size limit.
+    Blob,
+    /// Subject to the memo size limit.
+    Memo,
+}
+
+/// How a nested field is addressed within its parent.
+#[derive(Debug, Clone, Copy)]
+pub enum FieldIndexer<'a> {
+    /// A singular field.
+    None,
+    /// The `n`-th element of a repeated field.
+    Index(usize),
+    /// A map entry with the given key.
+    Key(&'a str),
+}
+
+/// Path of proto field names to the field being validated; proto names make it language-agnostic.
+/// A helper sinks can embed to track location across `enter`/`exit`.
+#[derive(Debug, Clone, Default)]
+struct PayloadPath {
+    segments: Vec<String>,
+}
+
+impl PayloadPath {
+    fn push(&mut self, name: &str, indexer: FieldIndexer) {
+        self.segments.push(match indexer {
+            FieldIndexer::None => name.to_string(),
+            FieldIndexer::Index(index) => format!("{name}[{index}]"),
+            FieldIndexer::Key(key) => format!("{name}[{key}]"),
+        });
+    }
+    fn pop(&mut self) {
+        self.segments.pop();
+    }
+    /// The full path to a leaf field with proto name `field_name`.
+    fn leaf(&self, field_name: &str) -> String {
+        if self.segments.is_empty() {
+            field_name.to_string()
+        } else {
+            format!("{}.{}", self.segments.join("."), field_name)
+        }
+    }
+}
+
+/// Receives one callback per validated payload field, with the field's size as the server measures
+/// it. Implementors decide how to handle warnings and errors.
+///
+/// The generated traversal calls `enter`/`exit` around each nested message so the sink can track a
+/// field's location for `check`.
+pub trait PayloadLimitSink {
+    /// Called for each validated payload field. `field_name` is the leaf field's proto name; `size`
+    /// is the field's size in bytes for the given [`LimitClass`]. When `enforce_error` is `false`,
+    /// the field may warn but must not produce an error-level violation.
+    fn check(
+        &mut self,
+        field_name: &'static str,
+        class: LimitClass,
+        size: usize,
+        enforce_error: bool,
+    );
+
+    /// Enter a nested-message field `name`, addressed within its parent by `indexer`.
+    fn enter(&mut self, name: &'static str, indexer: FieldIndexer);
+
+    /// Leave the most recently entered nested field.
+    fn exit(&mut self);
+}
+
+/// Implemented via codegen for every outbound request message that transitively contains validated
+/// payload fields.
+pub trait PayloadLimitsValidatable {
+    /// Reports each validated payload field's size and class to `sink`.
+    fn validate_payload_limits(&self, sink: &mut dyn PayloadLimitSink);
+}
+
+/// Serialized size of a [`Payloads`] message, as the server measures it.
+pub fn payloads_size(payloads: &Payloads) -> usize {
+    payloads.encoded_len()
+}
+
+/// Serialized size of a single [`Payload`], as the server measures it.
+pub fn payload_size(payload: &Payload) -> usize {
+    payload.encoded_len()
+}
+
+/// Serialized size of a [`Memo`] message, as the server measures it.
+pub fn memo_size(memo: &Memo) -> usize {
+    memo.encoded_len()
+}
+
+/// Serialized size of an arbitrary proto message, as the server measures it. Used for messages the
+/// server checks as a whole rather than per-payload-field (e.g. `Failure`).
+pub fn message_size<M: Message>(message: &M) -> usize {
+    message.encoded_len()
+}
+
+/// Aggregate size of a marker-style `map<string, Payloads>`, mirroring the server's
+/// `sum(len(key) + payloads.Size())` accounting (e.g. `RecordMarkerCommandAttributes.details`).
+pub fn map_payloads_sum<'a, K>(entries: impl IntoIterator<Item = (&'a K, &'a Payloads)>) -> usize
+where
+    K: AsRef<str> + 'a,
+{
+    entries
+        .into_iter()
+        .map(|(k, v)| k.as_ref().len() + v.encoded_len())
+        .sum()
+}
+
+/// Aggregate size of a search-attribute-style `map<string, Payload>`, mirroring the server's
+/// `sum(len(key) + len(payload.data))` accounting — note the server counts the **raw data** length
+/// here, not the serialized payload size (e.g. `UpsertWorkflowSearchAttributes.indexed_fields`).
+pub fn map_payload_data_sum<'a, K>(entries: impl IntoIterator<Item = (&'a K, &'a Payload)>) -> usize
+where
+    K: AsRef<str> + 'a,
+{
+    entries
+        .into_iter()
+        .map(|(k, v)| k.as_ref().len() + v.data.len())
+        .sum()
+}
+
+/// Warn/error thresholds for both limit classes. An error threshold of `None` disables error
+/// enforcement for that class (warnings only).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PayloadLimits {
+    /// Blob warning threshold (bytes).
+    pub blob_warn: usize,
+    /// Blob error threshold (bytes), or `None` to warn only.
+    pub blob_error: Option<usize>,
+    /// Memo warning threshold (bytes).
+    pub memo_warn: usize,
+    /// Memo error threshold (bytes), or `None` to warn only.
+    pub memo_error: Option<usize>,
+}
+
+impl Default for PayloadLimits {
+    fn default() -> Self {
+        Self {
+            blob_warn: DEFAULT_BLOB_SIZE_WARN,
+            blob_error: None,
+            memo_warn: DEFAULT_MEMO_SIZE_WARN,
+            memo_error: None,
+        }
+    }
+}
+
+impl PayloadLimits {
+    /// The default warning thresholds with no error enforcement.
+    pub fn warn_only() -> Self {
+        Self::default()
+    }
+
+    /// Returns the `(warn, error)` thresholds for a given class.
+    fn thresholds(&self, class: LimitClass) -> (usize, Option<usize>) {
+        match class {
+            LimitClass::Blob => (self.blob_warn, self.blob_error),
+            LimitClass::Memo => (self.memo_warn, self.memo_error),
+        }
+    }
+}
+
+/// A payload field whose size exceeded one of its configured thresholds (warning or error).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PayloadLimitViolation {
+    /// Path of proto field names from the root message
+    /// (e.g. `commands[2].schedule_activity_task_command_attributes.input`).
+    pub path: String,
+    /// Which limit class the threshold belongs to.
+    pub class: LimitClass,
+    /// The field's measured size in bytes.
+    pub size: usize,
+    /// The threshold that was exceeded (warning threshold for warnings, error threshold for errors).
+    pub limit: usize,
+}
+
+impl std::fmt::Display for PayloadLimitViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "payload field `{}` size {} bytes exceeds the {:?} limit of {} bytes",
+            self.path, self.size, self.class, self.limit
+        )
+    }
+}
+
+impl std::error::Error for PayloadLimitViolation {}
+
+/// A [`PayloadLimitSink`] that collects violations without logging or policy decisions.
+///
+/// Each checked field is sorted into [`warnings`](Self::warnings) or [`errors`](Self::errors): a
+/// field over its error threshold (when `enforce_error` and an error threshold are set) is an error;
+/// otherwise a field over its warning threshold is a warning.
+#[derive(Debug, Clone, Default)]
+pub struct CollectingSink {
+    limits: PayloadLimits,
+    path: PayloadPath,
+    /// Fields that exceeded their warning threshold (but not an enforced error threshold).
+    pub warnings: Vec<PayloadLimitViolation>,
+    /// Fields that exceeded their enforced error threshold.
+    pub errors: Vec<PayloadLimitViolation>,
+}
+
+impl CollectingSink {
+    /// A new collector that classifies fields against `limits`.
+    pub fn new(limits: PayloadLimits) -> Self {
+        Self {
+            limits,
+            ..Default::default()
+        }
+    }
+}
+
+impl PayloadLimitSink for CollectingSink {
+    fn check(
+        &mut self,
+        field_name: &'static str,
+        class: LimitClass,
+        size: usize,
+        enforce_error: bool,
+    ) {
+        let (warn, error) = self.limits.thresholds(class);
+        if enforce_error
+            && let Some(error) = error
+            && size > error
+        {
+            self.errors.push(PayloadLimitViolation {
+                path: self.path.leaf(field_name),
+                class,
+                size,
+                limit: error,
+            });
+        } else if size > warn {
+            self.warnings.push(PayloadLimitViolation {
+                path: self.path.leaf(field_name),
+                class,
+                size,
+                limit: warn,
+            });
+        }
+    }
+
+    fn enter(&mut self, name: &'static str, indexer: FieldIndexer) {
+        self.path.push(name, indexer);
+    }
+    fn exit(&mut self) {
+        self.path.pop();
+    }
+}
+
+/// Validate a message's payload fields against `limits`.
+///
+/// If any field exceeded its error threshold, logs the error(s) and returns the first one without
+/// logging warnings; otherwise logs each warning and returns `None`. With no error thresholds set,
+/// there are never errors, so this only warns and always returns `None`.
+pub fn validate_payload_limits<M: PayloadLimitsValidatable + ?Sized>(
+    msg: &M,
+    limits: &PayloadLimits,
+) -> Option<PayloadLimitViolation> {
+    let mut sink = CollectingSink::new(*limits);
+    msg.validate_payload_limits(&mut sink);
+
+    if !sink.errors.is_empty() {
+        for error in &sink.errors {
+            error!(
+                payload_path = error.path.as_str(),
+                payload_size = error.size,
+                error_limit = error.limit,
+                ?error.class,
+                "Payload size exceeds the error limit"
+            );
+        }
+        return sink.errors.into_iter().next();
+    }
+
+    for warning in &sink.warnings {
+        warn!(
+            payload_path = warning.path.as_str(),
+            payload_size = warning.size,
+            warn_limit = warning.limit,
+            ?warning.class,
+            "Payload size exceeds the warning limit"
+        );
+    }
+    None
+}
+
+// Include the generated PayloadLimitsValidatable implementations.
+include!(concat!(env!("OUT_DIR"), "/payload_limits_impl.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn payload(data: &[u8]) -> Payload {
+        Payload {
+            metadata: HashMap::new(),
+            data: data.to_vec(),
+            external_payloads: vec![],
+        }
+    }
+
+    #[test]
+    fn map_payload_data_sum_counts_key_and_raw_data() {
+        let mut m: HashMap<String, Payload> = HashMap::new();
+        m.insert("ab".to_string(), payload(&[0u8; 10]));
+        m.insert("cde".to_string(), payload(&[0u8; 20]));
+        // (2 + 10) + (3 + 20) = 35
+        assert_eq!(map_payload_data_sum(m.iter()), 35);
+    }
+
+    use crate::protos::temporal::api::sdk::v1::UserMetadata;
+    use crate::protos::temporal::api::workflowservice::v1::{
+        RespondActivityTaskFailedRequest, RespondWorkflowTaskCompletedRequest,
+        StartWorkflowExecutionRequest,
+    };
+
+    /// A sink that records the path of each visited field (order is not significant).
+    #[derive(Default)]
+    struct RecordingSink {
+        path: PayloadPath,
+        visited: Vec<String>,
+    }
+    impl PayloadLimitSink for RecordingSink {
+        fn check(&mut self, field_name: &'static str, _: LimitClass, _: usize, _: bool) {
+            self.visited.push(self.path.leaf(field_name));
+        }
+        fn enter(&mut self, name: &'static str, indexer: FieldIndexer) {
+            self.path.push(name, indexer);
+        }
+        fn exit(&mut self) {
+            self.path.pop();
+        }
+    }
+    impl RecordingSink {
+        /// The visited paths, sorted for order-independent comparison. Not deduped, so a field
+        /// visited more than once would still show up as a duplicate.
+        fn sorted(&self) -> Vec<String> {
+            let mut v = self.visited.clone();
+            v.sort();
+            v
+        }
+    }
+
+    fn memo_with_key_value(key: &str, data_len: usize) -> Memo {
+        let mut fields = HashMap::new();
+        fields.insert(key.to_string(), payload(&vec![0u8; data_len]));
+        Memo { fields }
+    }
+
+    fn payloads(total_data: usize) -> Payloads {
+        Payloads {
+            payloads: vec![payload(&vec![0u8; total_data])],
+        }
+    }
+
+    fn worker_limits(blob_error: usize, memo_error: usize) -> PayloadLimits {
+        PayloadLimits {
+            blob_warn: 10,
+            blob_error: Some(blob_error),
+            memo_warn: 10,
+            memo_error: Some(memo_error),
+        }
+    }
+
+    #[test]
+    fn blob_field_over_error_limit_is_reported() {
+        let req = StartWorkflowExecutionRequest {
+            input: Some(payloads(1000)),
+            ..Default::default()
+        };
+        let violation =
+            validate_payload_limits(&req, &worker_limits(100, 100)).expect("should error");
+        assert_eq!(violation.class, LimitClass::Blob);
+        assert_eq!(violation.path, "input");
+        assert!(violation.size > 100);
+    }
+
+    #[test]
+    fn memo_field_uses_memo_limit() {
+        // A memo larger than the memo error limit but under the blob error limit must still error,
+        // proving the memo class routes to the memo threshold.
+        let req = StartWorkflowExecutionRequest {
+            memo: Some(memo_with_key_value("k", 50)),
+            ..Default::default()
+        };
+        let limits = PayloadLimits {
+            blob_warn: 10,
+            blob_error: Some(1_000_000),
+            memo_warn: 10,
+            memo_error: Some(20),
+        };
+        let violation = validate_payload_limits(&req, &limits).expect("memo should error");
+        assert_eq!(violation.class, LimitClass::Memo);
+        assert_eq!(violation.path, "memo");
+    }
+
+    #[test]
+    fn warn_only_classified_field_never_errors() {
+        // RespondActivityTaskFailed.failure is classified warn-only (enforce_error = false), so even
+        // with worker error limits a huge failure does not produce an error-level violation.
+        let req = RespondActivityTaskFailedRequest {
+            failure: Some(crate::protos::temporal::api::failure::v1::Failure {
+                message: "x".repeat(10_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(validate_payload_limits(&req, &worker_limits(100, 100)).is_none());
+    }
+
+    #[test]
+    fn under_limit_is_ok() {
+        let req = StartWorkflowExecutionRequest {
+            input: Some(payloads(5)),
+            ..Default::default()
+        };
+        assert!(validate_payload_limits(&req, &worker_limits(100_000, 100_000)).is_none());
+    }
+
+    #[test]
+    fn blob_classed_memo_is_measured_as_fields_data_sum() {
+        use crate::protos::temporal::api::command::v1::ModifyWorkflowPropertiesCommandAttributes;
+        // upserted_memo is classified `blob`, so it is measured as the data-sum of its fields
+        // (the server's line-1386 check), NOT whole-Memo proto size.
+        let mut fields = HashMap::new();
+        fields.insert("ab".to_string(), payload(&[0u8; 10]));
+        fields.insert("cde".to_string(), payload(&[0u8; 20]));
+        let attr = ModifyWorkflowPropertiesCommandAttributes {
+            upserted_memo: Some(Memo { fields }),
+        };
+        // data-sum = (2 + 10) + (3 + 20) = 35. blob_error = 30 -> errors; classified as Blob.
+        let violation = validate_payload_limits(&attr, &worker_limits(30, 1_000_000))
+            .expect("blob fields-data-sum should error");
+        assert_eq!(violation.class, LimitClass::Blob);
+        assert_eq!(violation.path, "upserted_memo");
+        assert_eq!(violation.size, 35);
+    }
+
+    #[test]
+    fn marker_details_map_is_measured_as_payloads_sum() {
+        use crate::protos::temporal::api::command::v1::RecordMarkerCommandAttributes;
+        // details is a map<string, Payloads>, measured as sum(len(key) + payloads.Size()).
+        let mut details = HashMap::new();
+        details.insert("marker".to_string(), payloads(1000));
+        let attr = RecordMarkerCommandAttributes {
+            details,
+            ..Default::default()
+        };
+        let violation =
+            validate_payload_limits(&attr, &worker_limits(100, 100)).expect("map-sum should error");
+        assert_eq!(violation.class, LimitClass::Blob);
+        assert_eq!(violation.path, "details");
+    }
+
+    #[test]
+    fn single_payload_field_is_measured_as_payload_size() {
+        use crate::protos::temporal::api::command::v1::ScheduleNexusOperationCommandAttributes;
+        // ScheduleNexusOperation.input is a single Payload (not Payloads).
+        let attr = ScheduleNexusOperationCommandAttributes {
+            input: Some(payload(&[0u8; 1000])),
+            ..Default::default()
+        };
+        let violation = validate_payload_limits(&attr, &worker_limits(100, 100))
+            .expect("single payload should error");
+        assert_eq!(violation.class, LimitClass::Blob);
+        assert_eq!(violation.path, "input");
+    }
+
+    #[test]
+    fn whole_failure_is_measured_as_message_size() {
+        use crate::protos::temporal::api::command::v1::FailWorkflowExecutionCommandAttributes;
+        // FailWorkflowExecution.failure is blob-classed and measured as the whole Failure proto size.
+        let attr = FailWorkflowExecutionCommandAttributes {
+            failure: Some(crate::protos::temporal::api::failure::v1::Failure {
+                message: "x".repeat(1000),
+                ..Default::default()
+            }),
+        };
+        let violation = validate_payload_limits(&attr, &worker_limits(100, 100))
+            .expect("whole-failure should error");
+        assert_eq!(violation.class, LimitClass::Blob);
+        assert_eq!(violation.path, "failure");
+    }
+
+    // --- CollectingSink: classification, independent of logging/early-return ---------------------
+
+    #[test]
+    fn collecting_sink_classifies_error_vs_warning() {
+        // worker_limits(100, 100): blob_warn = 10, blob_error = Some(100).
+        let mut sink = CollectingSink::new(worker_limits(100, 100));
+        sink.check("over_error", LimitClass::Blob, 200, true);
+        sink.check("over_warn", LimitClass::Blob, 50, true);
+        sink.check("under_warn", LimitClass::Blob, 5, true);
+
+        assert_eq!(sink.errors.len(), 1);
+        assert_eq!(sink.errors[0].path, "over_error");
+        assert_eq!(sink.errors[0].limit, 100);
+        assert_eq!(sink.warnings.len(), 1);
+        assert_eq!(sink.warnings[0].path, "over_warn");
+        assert_eq!(sink.warnings[0].limit, 10);
+    }
+
+    #[test]
+    fn collecting_sink_warn_only_field_never_errors() {
+        let mut sink = CollectingSink::new(worker_limits(100, 100));
+        // enforce_error = false: even way over the error threshold, this is a warning.
+        sink.check("warn_only", LimitClass::Blob, 5000, false);
+        assert!(sink.errors.is_empty());
+        assert_eq!(sink.warnings.len(), 1);
+        assert_eq!(sink.warnings[0].path, "warn_only");
+    }
+
+    #[test]
+    fn collecting_sink_no_error_limit_only_warns() {
+        let mut sink = CollectingSink::new(PayloadLimits::warn_only());
+        sink.check("big", LimitClass::Blob, DEFAULT_BLOB_SIZE_WARN + 1, true);
+        assert!(sink.errors.is_empty());
+        assert_eq!(sink.warnings.len(), 1);
+        assert_eq!(sink.warnings[0].path, "big");
+    }
+
+    #[test]
+    fn collecting_sink_routes_memo_to_memo_limit() {
+        let mut sink = CollectingSink::new(worker_limits(1_000_000, 20));
+        // Same size: blob is fine (huge blob limit) but memo errors (tiny memo limit).
+        sink.check("blob_field", LimitClass::Blob, 100, true);
+        sink.check("memo_field", LimitClass::Memo, 100, true);
+        assert_eq!(sink.errors.len(), 1);
+        assert_eq!(sink.errors[0].class, LimitClass::Memo);
+        assert_eq!(sink.errors[0].path, "memo_field");
+    }
+
+    // --- Which fields get visited (visit order is not significant) -------------------------------
+
+    #[test]
+    fn visits_validated_fields_and_skips_not_validated() {
+        let req = StartWorkflowExecutionRequest {
+            input: Some(payloads(1)),
+            memo: Some(memo_with_key_value("k", 1)),
+            // `header` is classified not_validated, so it is never visited...
+            header: Some(crate::protos::temporal::api::common::v1::Header {
+                fields: {
+                    let mut fields = HashMap::new();
+                    fields.insert("h".to_string(), payload(&[1]));
+                    fields
+                },
+            }),
+            // ...and `user_metadata` is recursed into, but its summary/details are not_validated
+            // (the server enforces dedicated limits only in the nexus path), so nothing is visited.
+            user_metadata: Some(UserMetadata {
+                summary: Some(payload(&[1])),
+                details: Some(payload(&[1])),
+            }),
+            ..Default::default()
+        };
+        let mut sink = RecordingSink::default();
+        req.validate_payload_limits(&mut sink);
+        assert_eq!(sink.sorted(), vec!["input", "memo"]);
+    }
+
+    #[test]
+    fn visits_only_present_fields() {
+        // Only `input` is set; memo / user_metadata / search_attributes etc. are absent and must
+        // not be visited.
+        let req = StartWorkflowExecutionRequest {
+            input: Some(payloads(1)),
+            ..Default::default()
+        };
+        let mut sink = RecordingSink::default();
+        req.validate_payload_limits(&mut sink);
+        assert_eq!(sink.sorted(), vec!["input"]);
+    }
+
+    #[test]
+    fn visits_payload_fields_of_each_command() {
+        use crate::protos::temporal::api::command::v1::{
+            Command, CompleteWorkflowExecutionCommandAttributes,
+            ScheduleActivityTaskCommandAttributes, command::Attributes,
+        };
+        let req = RespondWorkflowTaskCompletedRequest {
+            commands: vec![
+                Command {
+                    attributes: Some(Attributes::ScheduleActivityTaskCommandAttributes(
+                        ScheduleActivityTaskCommandAttributes {
+                            input: Some(payloads(1)),
+                            ..Default::default()
+                        },
+                    )),
+                    ..Default::default()
+                },
+                Command {
+                    attributes: Some(Attributes::CompleteWorkflowExecutionCommandAttributes(
+                        CompleteWorkflowExecutionCommandAttributes {
+                            result: Some(payloads(1)),
+                        },
+                    )),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let mut sink = RecordingSink::default();
+        req.validate_payload_limits(&mut sink);
+        assert_eq!(
+            sink.sorted(),
+            vec![
+                "commands[0].schedule_activity_task_command_attributes.input",
+                "commands[1].complete_workflow_execution_command_attributes.result",
+            ]
+        );
+    }
+
+    #[test]
+    fn visits_protocol_message_body() {
+        // Message.body is a google.protobuf.Any (not payload-bearing), reached only because Message
+        // is a forced whole-message leaf and the parent recurses into `messages`.
+        use crate::protos::temporal::api::protocol::v1::Message;
+        let req = RespondWorkflowTaskCompletedRequest {
+            messages: vec![Message {
+                body: Some(Default::default()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let mut sink = RecordingSink::default();
+        req.validate_payload_limits(&mut sink);
+        assert_eq!(sink.sorted(), vec!["messages[0].body"]);
+    }
+}

--- a/crates/common/src/payload_limits.rs
+++ b/crates/common/src/payload_limits.rs
@@ -317,6 +317,20 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    use crate::protos::temporal::api::command::v1::{
+        Command, CompleteWorkflowExecutionCommandAttributes,
+        FailWorkflowExecutionCommandAttributes, ModifyWorkflowPropertiesCommandAttributes,
+        RecordMarkerCommandAttributes, ScheduleActivityTaskCommandAttributes,
+        ScheduleNexusOperationCommandAttributes, command::Attributes,
+    };
+    use crate::protos::temporal::api::failure::v1::Failure;
+    use crate::protos::temporal::api::protocol::v1::Message;
+    use crate::protos::temporal::api::sdk::v1::UserMetadata;
+    use crate::protos::temporal::api::workflowservice::v1::{
+        RespondActivityTaskFailedRequest, RespondWorkflowTaskCompletedRequest,
+        StartWorkflowExecutionRequest,
+    };
+
     fn payload(data: &[u8]) -> Payload {
         Payload {
             metadata: HashMap::new(),
@@ -333,12 +347,6 @@ mod tests {
         // (2 + 10) + (3 + 20) = 35
         assert_eq!(map_payload_data_sum(m.iter()), 35);
     }
-
-    use crate::protos::temporal::api::sdk::v1::UserMetadata;
-    use crate::protos::temporal::api::workflowservice::v1::{
-        RespondActivityTaskFailedRequest, RespondWorkflowTaskCompletedRequest,
-        StartWorkflowExecutionRequest,
-    };
 
     /// A sink that records the path of each visited field (order is not significant).
     #[derive(Default)]
@@ -425,7 +433,7 @@ mod tests {
         // RespondActivityTaskFailed.failure is classified warn-only (enforce_error = false), so even
         // with worker error limits a huge failure does not produce an error-level violation.
         let req = RespondActivityTaskFailedRequest {
-            failure: Some(crate::protos::temporal::api::failure::v1::Failure {
+            failure: Some(Failure {
                 message: "x".repeat(10_000),
                 ..Default::default()
             }),
@@ -445,7 +453,6 @@ mod tests {
 
     #[test]
     fn blob_classed_memo_is_measured_as_fields_data_sum() {
-        use crate::protos::temporal::api::command::v1::ModifyWorkflowPropertiesCommandAttributes;
         // upserted_memo is classified `blob`, so it is measured as the data-sum of its fields
         // (the server's line-1386 check), NOT whole-Memo proto size.
         let mut fields = HashMap::new();
@@ -464,7 +471,6 @@ mod tests {
 
     #[test]
     fn marker_details_map_is_measured_as_payloads_sum() {
-        use crate::protos::temporal::api::command::v1::RecordMarkerCommandAttributes;
         // details is a map<string, Payloads>, measured as sum(len(key) + payloads.Size()).
         let mut details = HashMap::new();
         details.insert("marker".to_string(), payloads(1000));
@@ -480,7 +486,6 @@ mod tests {
 
     #[test]
     fn single_payload_field_is_measured_as_payload_size() {
-        use crate::protos::temporal::api::command::v1::ScheduleNexusOperationCommandAttributes;
         // ScheduleNexusOperation.input is a single Payload (not Payloads).
         let attr = ScheduleNexusOperationCommandAttributes {
             input: Some(payload(&[0u8; 1000])),
@@ -494,10 +499,9 @@ mod tests {
 
     #[test]
     fn whole_failure_is_measured_as_message_size() {
-        use crate::protos::temporal::api::command::v1::FailWorkflowExecutionCommandAttributes;
         // FailWorkflowExecution.failure is blob-classed and measured as the whole Failure proto size.
         let attr = FailWorkflowExecutionCommandAttributes {
-            failure: Some(crate::protos::temporal::api::failure::v1::Failure {
+            failure: Some(Failure {
                 message: "x".repeat(1000),
                 ..Default::default()
             }),
@@ -599,10 +603,6 @@ mod tests {
 
     #[test]
     fn visits_payload_fields_of_each_command() {
-        use crate::protos::temporal::api::command::v1::{
-            Command, CompleteWorkflowExecutionCommandAttributes,
-            ScheduleActivityTaskCommandAttributes, command::Attributes,
-        };
         let req = RespondWorkflowTaskCompletedRequest {
             commands: vec![
                 Command {
@@ -640,7 +640,6 @@ mod tests {
     fn visits_protocol_message_body() {
         // Message.body is a google.protobuf.Any (not payload-bearing), reached only because Message
         // is a forced whole-message leaf and the parent recurses into `messages`.
-        use crate::protos::temporal::api::protocol::v1::Message;
         let req = RespondWorkflowTaskCompletedRequest {
             messages: vec![Message {
                 body: Some(Default::default()),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add a SDK-internal, build-time generated payload/memo limit visitor:
- Generated from proto service definitions (every `temporal.api.*` rpc input message)
- Emits `PayloadLimitsValidatable` implementations to report each payload-bearing field size and classification to a `PayloadLimitsSink` implementation.
- Consumes the `PAYLOAD_LIMITS_TABLE` in `build.rs` to map each payload-bearing message and field combination to a classification. The build will fail if there are any missing or stale entries. This allows us to classify new combinations as they are added to the API. Initial classification answers built from inspection of `temporal/temporal` repository.
- Algorithm terminates at `Payload`, `Payloads`, `Memo`, `Failure`, `Any`, `SearchAttributes`, and `Header` leaf fields.
- APIs:
  - `PayloadLimitSink` receives callbacks from visitor to consume the size and classification information for each visited message and field combination.
  - `validation_payload_limits` func to log errors and warnings and returns the first error-level `PayloadLimitViolation`. Each violation carries a proto-field-name path that is relative to the root message.

Approximately 370 lines of `build.rs` is the classification table itself.
Approximately 300 lines of `payload_limits.rs` is tests.

## Why?

Create a foundational element that will be later integrated to allow clients and workers to validate payload limits and proactively issue WFT / AT failures.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: New unit tests
1. Any docs updates needed? No
