### PR TITLE
💥 feat(sdk): error type for signal external workflow

### DIFF
--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -4,8 +4,8 @@
 mod failure_converter;
 
 pub use failure_converter::{
-    ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint, ChildWorkflowSignalDecodeHint,
-    ChildWorkflowStartDecodeHint, DefaultFailureConverter, FailureConverter, FailureDecodeHint,
+    ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint, ChildWorkflowStartDecodeHint,
+    DefaultFailureConverter, FailureConverter, FailureDecodeHint, WorkflowSignalDecodeHint,
 };
 
 use crate::protos::temporal::api::common::v1::Payload;

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -13,11 +13,11 @@ use super::{PayloadConversionError, PayloadConverter, SerializationContextData};
 use crate::{
     error::{
         ActivityExecutionError, ActivityFailureError, ApplicationFailure, CancelledError,
-        ChildWorkflowExecutionError, ChildWorkflowFailureError, ChildWorkflowSignalError,
-        ChildWorkflowSignalFailureError, ChildWorkflowStartError, IncomingError,
-        IncomingNexusHandlerError, IncomingNexusOperationExecutionError, OutgoingActivityError,
-        OutgoingError, OutgoingWorkflowError, ResetWorkflowError, ServerError, TerminatedError,
-        TimeoutError,
+        ChildWorkflowExecutionError, ChildWorkflowFailureError, ChildWorkflowStartError,
+        IncomingError, IncomingNexusHandlerError, IncomingNexusOperationExecutionError,
+        OutgoingActivityError, OutgoingError, OutgoingWorkflowError, ResetWorkflowError,
+        ServerError, TerminatedError, TimeoutError, WorkflowSignalError,
+        WorkflowSignalFailureError,
     },
     protos::temporal::api::{
         enums::v1::ApplicationErrorCategory as ProtoApplicationErrorCategory,
@@ -148,16 +148,16 @@ impl FailureDecodeHint for ChildWorkflowExecutionDecodeHint {
     }
 }
 
-/// Decode hint for child-workflow signal failures.
+/// Decode hint for workflow signal failures.
 #[derive(Debug, Clone, Copy)]
-pub struct ChildWorkflowSignalDecodeHint;
+pub struct WorkflowSignalDecodeHint;
 
-impl FailureDecodeHint for ChildWorkflowSignalDecodeHint {
-    type Output = ChildWorkflowSignalError;
+impl FailureDecodeHint for WorkflowSignalDecodeHint {
+    type Output = WorkflowSignalError;
 
     fn adapt(self, normalized: IncomingError) -> Self::Output {
         let failure = normalized.failure().clone();
-        ChildWorkflowSignalError::Failed(Box::new(ChildWorkflowSignalFailureError::new(
+        WorkflowSignalError::Failed(Box::new(WorkflowSignalFailureError::new(
             failure, normalized,
         )))
     }
@@ -187,7 +187,7 @@ impl FailureConverter for DefaultFailureConverter {
             OutgoingError::Workflow(OutgoingWorkflowError::ChildWorkflowStart(child)) => {
                 child.encode_failure(payload_converter, context)
             }
-            OutgoingError::Workflow(OutgoingWorkflowError::ChildWorkflowSignal(signal)) => {
+            OutgoingError::Workflow(OutgoingWorkflowError::WorkflowSignal(signal)) => {
                 signal.encode_failure(payload_converter, context)
             }
         };
@@ -223,7 +223,7 @@ enum ClassifiedFailure<'a> {
     ActivityExecution(&'a ActivityExecutionError),
     ChildWorkflowExecution(&'a ChildWorkflowExecutionError),
     ChildWorkflowStart(&'a ChildWorkflowStartError),
-    ChildWorkflowSignal(&'a ChildWorkflowSignalError),
+    WorkflowSignal(&'a WorkflowSignalError),
     Generic(&'a (dyn std::error::Error + 'static)),
 }
 
@@ -247,8 +247,8 @@ impl<'a> ClassifiedFailure<'a> {
             Self::ChildWorkflowExecution(child)
         } else if let Some(child) = err.downcast_ref::<ChildWorkflowStartError>() {
             Self::ChildWorkflowStart(child)
-        } else if let Some(child_signal) = err.downcast_ref::<ChildWorkflowSignalError>() {
-            Self::ChildWorkflowSignal(child_signal)
+        } else if let Some(child_signal) = err.downcast_ref::<WorkflowSignalError>() {
+            Self::WorkflowSignal(child_signal)
         } else {
             Self::Generic(err)
         }
@@ -288,7 +288,7 @@ impl<'a> ClassifiedFailure<'a> {
                 .unwrap_or_else(|converter_error| {
                     encode_failed_error_conversion(child, converter_error)
                 }),
-            Self::ChildWorkflowSignal(signal) => signal
+            Self::WorkflowSignal(signal) => signal
                 .encode_failure(
                     &PayloadConverter::default(),
                     &SerializationContextData::None,
@@ -390,7 +390,7 @@ impl EncodeFailure for ChildWorkflowStartError {
     }
 }
 
-impl EncodeFailure for ChildWorkflowSignalError {
+impl EncodeFailure for WorkflowSignalError {
     fn encode_failure(
         &self,
         _: &PayloadConverter,
@@ -1433,11 +1433,11 @@ mod tests {
             .to_error(
                 &SerializationContextData::Workflow,
                 failure.clone(),
-                ChildWorkflowSignalDecodeHint,
+                WorkflowSignalDecodeHint,
             )
             .unwrap();
 
-        let ChildWorkflowSignalError::Failed(decoded_failure) = decoded else {
+        let WorkflowSignalError::Failed(decoded_failure) = decoded else {
             panic!("expected failed child-workflow signal error");
         };
         assert_eq!(decoded_failure.failure(), &failure);

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -359,9 +359,9 @@ pub enum OutgoingWorkflowError {
     /// A workflow failure sourced from child-workflow start.
     #[error(transparent)]
     ChildWorkflowStart(#[from] Box<ChildWorkflowStartError>),
-    /// A workflow failure sourced from child-workflow signaling.
+    /// A workflow failure sourced from signaling a workflow.
     #[error(transparent)]
-    ChildWorkflowSignal(#[from] Box<ChildWorkflowSignalError>),
+    WorkflowSignal(#[from] Box<WorkflowSignalError>),
 }
 
 impl From<anyhow::Error> for OutgoingWorkflowError {
@@ -400,9 +400,9 @@ impl From<ChildWorkflowStartError> for OutgoingWorkflowError {
     }
 }
 
-impl From<ChildWorkflowSignalError> for OutgoingWorkflowError {
-    fn from(value: ChildWorkflowSignalError) -> Self {
-        Self::ChildWorkflowSignal(Box::new(value))
+impl From<WorkflowSignalError> for OutgoingWorkflowError {
+    fn from(value: WorkflowSignalError) -> Self {
+        Self::WorkflowSignal(Box::new(value))
     }
 }
 
@@ -1023,52 +1023,52 @@ impl ChildWorkflowExecutionError {
     }
 }
 
-/// Error returned when signaling a child workflow fails.
+/// Error returned when signaling a workflow fails.
 #[derive(Debug, thiserror::Error)]
-pub enum ChildWorkflowSignalError {
+pub enum WorkflowSignalError {
     /// The signal delivery failed.
     #[error("Child workflow signal failed: {}", .0.failure().message)]
-    Failed(#[source] Box<ChildWorkflowSignalFailureError>),
+    Failed(#[source] Box<WorkflowSignalFailureError>),
     /// Failed to serialize the signal input payload.
     #[error("Signal payload conversion failed: {0}")]
     Serialization(#[from] PayloadConversionError),
 }
 
-impl ChildWorkflowSignalError {
-    /// Returns the retained top-level child-workflow signal failure proto, if one exists.
+impl WorkflowSignalError {
+    /// Returns the retained top-level workflow signal failure proto, if one exists.
     pub fn failure(&self) -> Option<&Failure> {
         match self {
-            ChildWorkflowSignalError::Failed(err) => Some(err.failure()),
-            ChildWorkflowSignalError::Serialization(_) => None,
+            WorkflowSignalError::Failed(err) => Some(err.failure()),
+            WorkflowSignalError::Serialization(_) => None,
         }
     }
 
-    /// Returns the normalized cause of the child-workflow signal failure, if any.
+    /// Returns the normalized cause of the workflow signal failure, if any.
     pub fn cause(&self) -> Option<&IncomingError> {
         match self {
-            ChildWorkflowSignalError::Failed(err) => err.cause(),
-            ChildWorkflowSignalError::Serialization(_) => None,
+            WorkflowSignalError::Failed(err) => err.cause(),
+            WorkflowSignalError::Serialization(_) => None,
         }
     }
 
     /// Returns the underlying failure reason for wrapper-shaped signal failures.
     pub fn reason(&self) -> Option<&IncomingError> {
         match self {
-            ChildWorkflowSignalError::Failed(err) => Some(err.error()),
-            ChildWorkflowSignalError::Serialization(_) => None,
+            WorkflowSignalError::Failed(err) => Some(err.error()),
+            WorkflowSignalError::Serialization(_) => None,
         }
     }
 }
 
-/// A normalized child-workflow signal failure wrapper.
+/// A normalized workflow signal failure wrapper.
 #[derive(Debug)]
-pub struct ChildWorkflowSignalFailureError {
+pub struct WorkflowSignalFailureError {
     failure: Failure,
     error: Box<IncomingError>,
 }
 
-impl ChildWorkflowSignalFailureError {
-    /// Creates a child-workflow signal failure wrapper.
+impl WorkflowSignalFailureError {
+    /// Creates a workflow signal failure wrapper.
     pub(crate) fn new(failure: Failure, error: IncomingError) -> Self {
         Self {
             failure,
@@ -1081,7 +1081,7 @@ impl ChildWorkflowSignalFailureError {
         &self.failure
     }
 
-    /// Returns the normalized direct cause of the child-workflow signal failure, if any.
+    /// Returns the normalized direct cause of the workflow signal failure, if any.
     pub fn cause(&self) -> Option<&IncomingError> {
         self.error.cause()
     }
@@ -1092,13 +1092,13 @@ impl ChildWorkflowSignalFailureError {
     }
 }
 
-impl std::fmt::Display for ChildWorkflowSignalFailureError {
+impl std::fmt::Display for WorkflowSignalFailureError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.failure.fmt(f)
     }
 }
 
-impl std::error::Error for ChildWorkflowSignalFailureError {
+impl std::error::Error for WorkflowSignalFailureError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.cause()
             .map(|cause| cause as &(dyn std::error::Error + 'static))

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -34,9 +34,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    CancellableFuture, ChildWorkflowExecutionError, ChildWorkflowOptions, ChildWorkflowSignalError,
-    ChildWorkflowStartError, SyncWorkflowContext, WorkflowContext, WorkflowResult,
-    WorkflowTermination,
+    CancellableFuture, ChildWorkflowExecutionError, ChildWorkflowOptions, ChildWorkflowStartError,
+    SyncWorkflowContext, WorkflowContext, WorkflowResult, WorkflowSignalError, WorkflowTermination,
 };
 use temporalio_sdk_core::{
     replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
@@ -1450,10 +1449,7 @@ impl ChildSignalSerializationFailParent {
         let signal_result = started
             .signal(UnserializableSignalChild::bad_signal, AlwaysFailsSerialize)
             .await;
-        assert_matches!(
-            signal_result,
-            Err(ChildWorkflowSignalError::Serialization(_))
-        );
+        assert_matches!(signal_result, Err(WorkflowSignalError::Serialization(_)));
 
         // Cancel child so parent can complete cleanly.
         started.cancel("test done".to_string());

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -388,7 +388,7 @@ impl SignalSerializationFailure {
         let result = handle
             .signal(SignalSerializationFailure::bad_signal, BadSignalInput)
             .await;
-        Ok(result.unwrap_err().message)
+        Ok(result.unwrap_err().to_string())
     }
 
     #[signal]

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -3,6 +3,6 @@
 pub use crate::workflow_registry::WorkflowRegistrationError;
 pub use temporalio_common::error::{
     ActivityExecutionError, ApplicationErrorCategory, ApplicationFailure,
-    ChildWorkflowExecutionError, ChildWorkflowSignalError, ChildWorkflowStartError,
-    OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
+    ChildWorkflowExecutionError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,
+    OutgoingWorkflowError, WorkflowSignalError,
 };

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -83,8 +83,8 @@ pub mod workflows;
 
 pub use crate::error::{
     ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
-    ChildWorkflowSignalError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,
-    OutgoingWorkflowError, WorkflowRegistrationError,
+    ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
+    WorkflowRegistrationError, WorkflowSignalError,
 };
 pub use temporalio_client::Namespace;
 pub use temporalio_workflow::{

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -27,8 +27,8 @@ pub use runtime::model::{TimerResult, WorkflowResult, WorkflowTermination};
 #[doc(hidden)]
 pub use runtime::{SdkWakeGuard, is_sdk_wake};
 pub use temporalio_common_wasm::error::{
-    ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowSignalError,
-    ChildWorkflowStartError,
+    ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
+    WorkflowSignalError,
 };
 pub use workflow_context::{
     ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext, CancellableFuture,

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -10,7 +10,7 @@ use temporalio_common_wasm::{
     WorkflowDefinition,
     error::{
         ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
-        ChildWorkflowSignalError,
+        WorkflowSignalError,
     },
     protos::{
         coresdk::{
@@ -268,8 +268,8 @@ impl From<ChildWorkflowExecutionError> for WorkflowTermination {
     }
 }
 
-impl From<ChildWorkflowSignalError> for WorkflowTermination {
-    fn from(value: ChildWorkflowSignalError) -> Self {
+impl From<WorkflowSignalError> for WorkflowTermination {
+    fn from(value: WorkflowSignalError) -> Self {
         Self::Failed(value.into())
     }
 }

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -38,9 +38,9 @@ use temporalio_common_wasm::{
     ActivityDefinition, SignalDefinition, WorkflowDefinition,
     data_converters::{
         ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
-        ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter,
-        PayloadConversionError, PayloadConverter, SerializationContext, SerializationContextData,
-        TemporalDeserializable, WorkflowSignalDecodeHint,
+        ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter, PayloadConverter,
+        SerializationContext, SerializationContextData, TemporalDeserializable,
+        WorkflowSignalDecodeHint,
     },
     error::{
         ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
@@ -2220,8 +2220,8 @@ impl ExternalWorkflowHandle {
         &self,
         signal: S,
         input: S::Input,
-    ) -> impl CancellableFuture<SignalExternalWfResult> + 'static {
-        let payload_converter = self.base_ctx.inner.data_converter.payload_converter();
+    ) -> impl CancellableFuture<Result<(), WorkflowSignalError>> + 'static {
+        let payload_converter = self.base_ctx.data_converter().payload_converter();
         let ctx = SerializationContext {
             data: &SerializationContextData::Workflow,
             converter: payload_converter,
@@ -2229,7 +2229,7 @@ impl ExternalWorkflowHandle {
         let payloads = match payload_converter.to_payloads(&ctx, &input) {
             Ok(p) => p,
             Err(e) => {
-                return SignalExternalFut::SerializationError(Some(e));
+                return SignalChildFut::eager(e.into());
             }
         };
         let signal = Signal::new(S::name(&signal), payloads);
@@ -2240,7 +2240,10 @@ impl ExternalWorkflowHandle {
                 run_id: self.run_id.clone().unwrap_or_default(),
             },
         );
-        SignalExternalFut::Running(self.base_ctx.clone().send_signal_wf(target, signal))
+        SignalChildFut::Running {
+            inner: self.base_ctx.clone().send_signal_wf(target, signal),
+            data_converter: self.base_ctx.data_converter().clone(),
+        }
     }
 
     /// Request cancellation of the external workflow.
@@ -2274,61 +2277,6 @@ impl ExternalWorkflowHandle {
             .into(),
         );
         cmd
-    }
-}
-
-enum SignalExternalFut<F> {
-    Running(F),
-    SerializationError(Option<PayloadConversionError>),
-    Done,
-}
-
-impl<F: Unpin> Unpin for SignalExternalFut<F> {}
-
-impl<F> Future for SignalExternalFut<F>
-where
-    F: Future<Output = SignalExternalWfResult> + Unpin,
-{
-    type Output = SignalExternalWfResult;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-        match this {
-            SignalExternalFut::Running(inner) => {
-                let result = std::task::ready!(Pin::new(inner).poll(cx));
-                *this = SignalExternalFut::Done;
-                Poll::Ready(result)
-            }
-            SignalExternalFut::SerializationError(e) => {
-                let err = e.take().expect("polled after completion");
-                *this = SignalExternalFut::Done;
-                Poll::Ready(Err(Failure {
-                    message: format!("Failed to serialize signal input: {err}"),
-                    ..Default::default()
-                }))
-            }
-            SignalExternalFut::Done => panic!("polled after completion"),
-        }
-    }
-}
-
-impl<F> FusedFuture for SignalExternalFut<F>
-where
-    F: Future<Output = SignalExternalWfResult> + Unpin,
-{
-    fn is_terminated(&self) -> bool {
-        matches!(self, SignalExternalFut::Done)
-    }
-}
-
-impl<F> CancellableFuture<SignalExternalWfResult> for SignalExternalFut<F>
-where
-    F: CancellableFuture<SignalExternalWfResult> + Unpin,
-{
-    fn cancel(&self) {
-        if let SignalExternalFut::Running(inner) = self {
-            inner.cancel()
-        }
     }
 }
 

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -38,13 +38,13 @@ use temporalio_common_wasm::{
     ActivityDefinition, SignalDefinition, WorkflowDefinition,
     data_converters::{
         ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
-        ChildWorkflowSignalDecodeHint, ChildWorkflowStartDecodeHint, DataConverter,
-        GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
-        SerializationContextData, TemporalDeserializable,
+        ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter,
+        PayloadConversionError, PayloadConverter, SerializationContext, SerializationContextData,
+        TemporalDeserializable, WorkflowSignalDecodeHint,
     },
     error::{
-        ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowSignalError,
-        ChildWorkflowStartError,
+        ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
+        WorkflowSignalError,
     },
     protos::{
         coresdk::{
@@ -2066,7 +2066,7 @@ where
 enum SignalChildFut<F> {
     /// Immediate error (e.g., signal input serialization failure). Resolves on first poll.
     Errored {
-        error: Option<ChildWorkflowSignalError>,
+        error: Option<WorkflowSignalError>,
     },
     Running {
         inner: F,
@@ -2076,7 +2076,7 @@ enum SignalChildFut<F> {
 }
 
 impl<F> SignalChildFut<F> {
-    fn eager(err: ChildWorkflowSignalError) -> Self {
+    fn eager(err: WorkflowSignalError) -> Self {
         Self::Errored { error: Some(err) }
     }
 }
@@ -2087,7 +2087,7 @@ impl<F> Future for SignalChildFut<F>
 where
     F: Future<Output = SignalExternalWfResult> + Unpin,
 {
-    type Output = Result<(), ChildWorkflowSignalError>;
+    type Output = Result<(), WorkflowSignalError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -2104,7 +2104,7 @@ where
                 Poll::Ready(Err(failure)) => Poll::Ready(Err(data_converter.to_error(
                     &SerializationContextData::Workflow,
                     failure,
-                    ChildWorkflowSignalDecodeHint,
+                    WorkflowSignalDecodeHint,
                 )?)),
             },
             SignalChildFut::Terminated => panic!("polled after termination"),
@@ -2125,7 +2125,7 @@ where
     }
 }
 
-impl<F> CancellableFuture<Result<(), ChildWorkflowSignalError>> for SignalChildFut<F>
+impl<F> CancellableFuture<Result<(), WorkflowSignalError>> for SignalChildFut<F>
 where
     F: CancellableFuture<SignalExternalWfResult> + Unpin,
 {
@@ -2168,7 +2168,7 @@ where
         &self,
         signal: S,
         input: S::Input,
-    ) -> impl CancellableFuture<Result<(), ChildWorkflowSignalError>> + 'static {
+    ) -> impl CancellableFuture<Result<(), WorkflowSignalError>> + 'static {
         let payload_converter = self.common.data_converter.payload_converter();
         let ctx = SerializationContext {
             data: &SerializationContextData::Workflow,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Rename `ChildWorkflowSignalError` -> `WorkflowSignalError`
- Switch `ExternalWorkflowHandle::signal` to use same machinery as signaling child workflow instead of `SignalExternalFut`

## Why?
- No `Failure` as error types

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Updated test expect error instead of raw failure

3. Any docs updates needed?
N/A
