### PR TITLE
c-bridge: drop worker Arc clone before waking lang to fix finalize_shutdown race

### DIFF
--- a/crates/sdk-core-c-bridge/src/worker.rs
+++ b/crates/sdk-core-c-bridge/src/worker.rs
@@ -625,6 +625,10 @@ pub extern "C" fn temporal_core_worker_validate(
                 .into_raw()
                 .cast_const(),
         };
+        // Drop our worker clone before waking lang: finalize_shutdown() takes
+        // sole ownership via Arc::try_unwrap, which fails if this clone is still
+        // alive when the woken thread calls it. (notify-after-release)
+        drop(core_worker);
         unsafe {
             callback(user_data.into(), fail);
         }
@@ -688,6 +692,10 @@ pub extern "C" fn temporal_core_worker_poll_workflow_activation(
                     .cast_const(),
             ),
         };
+        // Drop our worker clone before waking lang: finalize_shutdown() takes
+        // sole ownership via Arc::try_unwrap, which fails if this clone is still
+        // alive when the woken thread calls it. (notify-after-release)
+        drop(core_worker);
         unsafe {
             callback(user_data.into(), success, fail);
         }
@@ -722,6 +730,10 @@ pub extern "C" fn temporal_core_worker_poll_activity_task(
                     .cast_const(),
             ),
         };
+        // Drop our worker clone before waking lang: finalize_shutdown() takes
+        // sole ownership via Arc::try_unwrap, which fails if this clone is still
+        // alive when the woken thread calls it. (notify-after-release)
+        drop(core_worker);
         unsafe {
             callback(user_data.into(), success, fail);
         }
@@ -756,6 +768,10 @@ pub extern "C" fn temporal_core_worker_poll_nexus_task(
                     .cast_const(),
             ),
         };
+        // Drop our worker clone before waking lang: finalize_shutdown() takes
+        // sole ownership via Arc::try_unwrap, which fails if this clone is still
+        // alive when the woken thread calls it. (notify-after-release)
+        drop(core_worker);
         unsafe {
             callback(user_data.into(), success, fail);
         }
@@ -798,6 +814,10 @@ pub extern "C" fn temporal_core_worker_complete_workflow_activation(
                 .into_raw()
                 .cast_const(),
         };
+        // Drop our worker clone before waking lang: finalize_shutdown() takes
+        // sole ownership via Arc::try_unwrap, which fails if this clone is still
+        // alive when the woken thread calls it. (notify-after-release)
+        drop(core_worker);
         unsafe {
             callback(user_data.into(), fail);
         }
@@ -840,6 +860,10 @@ pub extern "C" fn temporal_core_worker_complete_activity_task(
                 .into_raw()
                 .cast_const(),
         };
+        // Drop our worker clone before waking lang: finalize_shutdown() takes
+        // sole ownership via Arc::try_unwrap, which fails if this clone is still
+        // alive when the woken thread calls it. (notify-after-release)
+        drop(core_worker);
         unsafe {
             callback(user_data.into(), fail);
         }
@@ -882,6 +906,10 @@ pub extern "C" fn temporal_core_worker_complete_nexus_task(
                 .into_raw()
                 .cast_const(),
         };
+        // Drop our worker clone before waking lang: finalize_shutdown() takes
+        // sole ownership via Arc::try_unwrap, which fails if this clone is still
+        // alive when the woken thread calls it. (notify-after-release)
+        drop(core_worker);
         unsafe {
             callback(user_data.into(), fail);
         }


### PR DESCRIPTION
## Problem

`temporal_core_worker_finalize_shutdown` takes sole ownership of the worker via `Arc::try_unwrap(worker.worker.take().unwrap())`:

```rust
let core_worker = match Arc::try_unwrap(worker.worker.take().unwrap()) {
    Ok(core_worker) => core_worker,
    Err(arc) => { /* "Cannot finalize, expected 1 reference, got {N}" */ return; }
};
core_worker.finalize_shutdown().await;
```

But every poll/complete/validate FFI fn clones that `Arc` into a spawned Tokio task and drops the clone only at **task-scope end — after** invoking the completion callback that wakes the foreign (lang) thread:

```rust
let core_worker = worker.worker.as_ref().unwrap().clone();
worker.runtime.core.tokio_handle().spawn(async move {
    let (success, fail) = match core_worker.poll_workflow_activation().await { ... };
    unsafe { callback(user_data.into(), success, fail); } // wakes lang...
}); // ...core_worker dropped only HERE, after the wake
```

So when lang reacts to a poll returning shutdown by calling `finalize_shutdown`, the poll task's clone may still be alive (`strong_count == 2`), `try_unwrap` returns `Err`, and finalize fails. Because the worker is already `take()`n out of the `Option`, it is spent and the call cannot be retried. This is timing-dependent: it surfaces intermittently under load (e.g. CI), not on a quiet machine.

## Fix

Drop the worker clone as soon as the await result is in hand and **before** invoking the callback (notify-after-release ordering), in all seven spawning fns (`validate`, `poll_workflow_activation`, `poll_activity_task`, `poll_nexus_task`, `complete_workflow_activation`, `complete_activity_task`, `complete_nexus_task`). The woken lang thread is then guaranteed to observe sole ownership.

Pure reordering — no added synchronization, no behavior change on the success path. `+28 −0`, one file.

## Validation

Found and fixed while building a PHP SDK on this C bridge. Reproduced as intermittent `finalize_shutdown` failures on CI; with this change the worker create/poll/shutdown lifecycle and the full workflow/activity/cancellation integration suite pass deterministically against a live dev server.
