### PR TITLE
Feature-select OTLP exporter TLS backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ to docs, or any other relevant information.
 * `client()` and `workflow_handle()` helpers to `ActivityContext` for easily obtaining a Temporal client
 * Exposed `backoff_start_interval` when continuing as new, which will delay the first task of the
   continued workflow by the configured interval.
+* The `tls-ring` / `tls-aws-lc` features now also select the TLS crypto backend for the OTLP metric
+  exporter (in addition to the gRPC service client). Previously the OTLP exporter hardcoded the `ring`
+  backend regardless of the selected feature, which prevented producing a `ring`-free, `aws-lc-rs`-only
+  (FIPS-capable) build. Building with `--no-default-features --features tls-aws-lc,otel` now yields a
+  dependency tree free of `ring`.
 
 ### Breaking Changes
 * The `ActivityContext` constructor now requires `ClientOptions`.

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -13,7 +13,17 @@ categories = ["development-tools"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:reqwest"]
+tls-ring = [
+  "opentelemetry-otlp?/tls-ring",
+  "opentelemetry-otlp?/reqwest-rustls",
+  "tonic/tls-native-roots",
+]
+tls-aws-lc = [
+  "opentelemetry-otlp?/tls-aws-lc",
+  "tonic/tls-native-roots",
+  "reqwest?/rustls-tls-native-roots-no-provider",
+]
 prometheus = [
   "dep:prometheus",
   "dep:hyper",
@@ -55,13 +65,12 @@ opentelemetry_sdk = { version = "0.31", default-features = false, features = [
 opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "tokio",
   "metrics",
-  "tls-roots",
   "http-proto",
   "grpc-tonic",
   "reqwest-blocking-client",
-  "reqwest-rustls",
 ], optional = true }
 parking_lot = { version = "0.12" }
+reqwest = { version = "0.12", default-features = false, optional = true }
 prometheus = { version = "0.14", optional = true, default-features = false }
 ringbuf = { version = "0.5", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -17,8 +17,19 @@ rust-version = "1.88.0"
 
 [features]
 default = ["envconfig", "prometheus", "tls-ring"]
-tls-ring = ["temporalio-client/tls-ring"]
-tls-aws-lc = ["temporalio-client/tls-aws-lc"]
+tls-ring = [
+  "temporalio-client/tls-ring",
+  "temporalio-common/tls-ring",
+  "opentelemetry-otlp?/tls-ring",
+  "opentelemetry-otlp?/reqwest-rustls",
+  "tonic/tls-native-roots",
+]
+tls-aws-lc = [
+  "temporalio-client/tls-aws-lc",
+  "temporalio-common/tls-aws-lc",
+  "opentelemetry-otlp?/tls-aws-lc",
+  "tonic/tls-native-roots",
+]
 envconfig = ["temporalio-client/envconfig", "temporalio-common/envconfig"]
 prometheus = ["temporalio-common/prometheus"]
 otel = [
@@ -67,11 +78,9 @@ opentelemetry_sdk = { version = "0.31", default-features = false, features = [
 opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "tokio",
   "metrics",
-  "tls-roots",
   "http-proto",
   "grpc-tonic",
   "reqwest-blocking-client",
-  "reqwest-rustls",
 ], optional = true }
 parking_lot = { version = "0.12" }
 pid = "4.0"


### PR DESCRIPTION
## What was changed

[PR #1274](https://github.com/temporalio/sdk-rust/pull/1274) made the TLS crypto backend
feature-selectable (`tls-ring` / `tls-aws-lc`) for the gRPC service client. This extends
that to the OTLP metric exporter. Previously `opentelemetry-otlp` hardcoded `tls-roots` +
`reqwest-rustls`, which always pulled in `ring`. Those are removed and replaced with
feature-gated wiring (`tls-ring` keeps today's behavior; `tls-aws-lc` routes the exporter
through `aws-lc-rs`), using `opentelemetry-otlp` 0.31.1's own `tls-ring`/`tls-aws-lc`
features.

## Why?

#1274 covered the gRPC path, but the OTLP exporter still hardcoded `ring`, so a
`ring`-free, `aws-lc-rs`-only build (required for FIPS-capable deployments) wasn't
possible. Building with `--no-default-features --features tls-aws-lc,otel` now yields a
dependency tree free of `ring`.

## Checklist

1. Closes  (no issue)<!-- add issue number here -->

2. How was this tested:

   - `cargo tree -i ring` across all targets: empty under `tls-aws-lc`, still present
     under the default `tls-ring` (no change to default builds).
   - `cargo check`/`clippy` clean for `common` (both backends) and `sdk-core` (default
     and aws-lc feature sets).

3. Any docs updates needed?

   CHANGELOG.md updated.