### PR TITLE
fix(macros): remove redundant `.into_iter()` call

### DIFF
--- a/crates/macros/src/fsm_impl.rs
+++ b/crates/macros/src/fsm_impl.rs
@@ -496,7 +496,7 @@ fn merge_transition_dests(transitions: Vec<Transition>) -> Vec<Transition> {
         };
         match map.entry(without_dests) {
             Entry::Occupied(mut e) => {
-                e.get_mut().to.extend(t.to.into_iter());
+                e.get_mut().to.extend(t.to);
             }
             Entry::Vacant(v) => {
                 v.insert(t);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Remove the `clippy::useless_conversion` warning (from my latest Rust 1.96.0 clippy version).