### PR TITLE
feat(sdk): move signal payload decoding to happen before dispatch

### DIFF
--- a/crates/macros/src/workflow_definitions.rs
+++ b/crates/macros/src/workflow_definitions.rs
@@ -1078,8 +1078,7 @@ impl WorkflowMethodsDefinition {
             })
             .collect();
 
-        // Generate dispatch_signal only if there are signals
-        let dispatch_signal_impl = if self.signals.is_empty() {
+        let decode_signal_impl = if self.signals.is_empty() {
             quote! {}
         } else {
             quote! {
@@ -1093,7 +1092,21 @@ impl WorkflowMethodsDefinition {
                         _ => Ok(::std::option::Option::None),
                     }
                 }
+            }
+        };
 
+        let dispatch_signal_impl = if self.signals.is_empty() {
+            quote! {
+                fn dispatch_signal(
+                    _ctx: ::temporalio_workflow::WorkflowContext<Self>,
+                    name: &str,
+                    _input: ::std::boxed::Box<dyn ::std::any::Any>,
+                ) -> ::temporalio_workflow::__private::futures_util::future::LocalBoxFuture<'static, Result<(), ::temporalio_workflow::workflows::WorkflowError>> {
+                    unreachable!("typed signal dispatch called for unknown signal handler '{name}'")
+                }
+            }
+        } else {
+            quote! {
                 fn dispatch_signal(
                     ctx: ::temporalio_workflow::WorkflowContext<Self>,
                     name: &str,
@@ -1101,7 +1114,7 @@ impl WorkflowMethodsDefinition {
                 ) -> ::temporalio_workflow::__private::futures_util::future::LocalBoxFuture<'static, Result<(), ::temporalio_workflow::workflows::WorkflowError>> {
                     match name {
                         #(#dispatch_signal_arms)*
-                        _ => panic!("typed signal dispatch called for unknown signal handler '{name}'"),
+                        _ => unreachable!("typed signal dispatch called for unknown signal handler '{name}'"),
                     }
                 }
             }
@@ -1197,8 +1210,7 @@ impl WorkflowMethodsDefinition {
             })
             .collect();
 
-        // Generate dispatch_update and validate_update only if there are updates
-        let dispatch_update_impl = if self.updates.is_empty() {
+        let decode_update_impl = if self.updates.is_empty() {
             quote! {}
         } else {
             quote! {
@@ -1212,7 +1224,31 @@ impl WorkflowMethodsDefinition {
                         _ => Ok(::std::option::Option::None),
                     }
                 }
+            }
+        };
 
+        let dispatch_update_impl = if self.updates.is_empty() {
+            quote! {
+                fn dispatch_update(
+                    _ctx: ::temporalio_workflow::WorkflowContext<Self>,
+                    name: &str,
+                    _input: ::std::boxed::Box<dyn ::std::any::Any>,
+                    _converter: &::temporalio_workflow::common::data_converters::PayloadConverter,
+                ) -> ::temporalio_workflow::__private::futures_util::future::LocalBoxFuture<'static, Result<::temporalio_workflow::common::protos::temporal::api::common::v1::Payload, ::temporalio_workflow::workflows::WorkflowError>> {
+                    unreachable!("typed update dispatch called for unknown update handler '{name}'")
+                }
+
+                fn validate_update(
+                    &self,
+                    _ctx: ::temporalio_workflow::WorkflowContextView,
+                    name: &str,
+                    _input: ::std::boxed::Box<dyn ::std::any::Any>,
+                ) -> Result<(), ::temporalio_workflow::workflows::WorkflowError> {
+                    unreachable!("typed update validation called for unknown update handler '{name}'")
+                }
+            }
+        } else {
+            quote! {
                 fn dispatch_update(
                     ctx: ::temporalio_workflow::WorkflowContext<Self>,
                     name: &str,
@@ -1221,7 +1257,7 @@ impl WorkflowMethodsDefinition {
                 ) -> ::temporalio_workflow::__private::futures_util::future::LocalBoxFuture<'static, Result<::temporalio_workflow::common::protos::temporal::api::common::v1::Payload, ::temporalio_workflow::workflows::WorkflowError>> {
                     match name {
                         #(#dispatch_update_arms)*
-                        _ => panic!("typed update dispatch called for unknown update handler '{name}'"),
+                        _ => unreachable!("typed update dispatch called for unknown update handler '{name}'"),
                     }
                 }
 
@@ -1233,7 +1269,7 @@ impl WorkflowMethodsDefinition {
                 ) -> Result<(), ::temporalio_workflow::workflows::WorkflowError> {
                     match name {
                         #(#validate_update_arms)*
-                        _ => panic!("typed update validation called for unknown update handler '{name}'"),
+                        _ => unreachable!("typed update validation called for unknown update handler '{name}'"),
                     }
                 }
             }
@@ -1293,8 +1329,7 @@ impl WorkflowMethodsDefinition {
             })
             .collect();
 
-        // Generate dispatch_query only if there are queries
-        let dispatch_query_impl = if self.queries.is_empty() {
+        let decode_query_impl = if self.queries.is_empty() {
             quote! {}
         } else {
             quote! {
@@ -1308,7 +1343,23 @@ impl WorkflowMethodsDefinition {
                         _ => Ok(::std::option::Option::None),
                     }
                 }
+            }
+        };
 
+        let dispatch_query_impl = if self.queries.is_empty() {
+            quote! {
+                fn dispatch_query(
+                    &self,
+                    _ctx: ::temporalio_workflow::WorkflowContextView,
+                    name: &str,
+                    _input: ::std::boxed::Box<dyn ::std::any::Any>,
+                    _converter: &::temporalio_workflow::common::data_converters::PayloadConverter,
+                ) -> Result<::temporalio_workflow::common::protos::temporal::api::common::v1::Payload, ::temporalio_workflow::workflows::WorkflowError> {
+                    unreachable!("typed query dispatch called for unknown query handler '{name}'")
+                }
+            }
+        } else {
+            quote! {
                 fn dispatch_query(
                     &self,
                     ctx: ::temporalio_workflow::WorkflowContextView,
@@ -1318,7 +1369,7 @@ impl WorkflowMethodsDefinition {
                 ) -> Result<::temporalio_workflow::common::protos::temporal::api::common::v1::Payload, ::temporalio_workflow::workflows::WorkflowError> {
                     match name {
                         #(#dispatch_query_arms)*
-                        _ => panic!("typed query dispatch called for unknown query handler '{name}'"),
+                        _ => unreachable!("typed query dispatch called for unknown query handler '{name}'"),
                     }
                 }
             }
@@ -1361,8 +1412,11 @@ impl WorkflowMethodsDefinition {
                 }
 
                 #dispatch_signal_impl
+                #decode_signal_impl
                 #dispatch_update_impl
+                #decode_update_impl
                 #dispatch_query_impl
+                #decode_query_impl
             }
         }
     }

--- a/crates/macros/src/workflow_definitions.rs
+++ b/crates/macros/src/workflow_definitions.rs
@@ -68,6 +68,29 @@ fn generate_method_call(prefixed_method: &syn::Ident, has_input: bool) -> TokenS
     }
 }
 
+fn generate_decode_arm(
+    handler_name: &TokenStream2,
+    input_type: &TokenStream2,
+    payloads: TokenStream2,
+) -> TokenStream2 {
+    quote! {
+        #handler_name => {
+            let ctx = ::temporalio_workflow::common::data_converters::SerializationContext {
+                data: &::temporalio_workflow::common::data_converters::SerializationContextData::Workflow,
+                converter,
+            };
+            let input: #input_type = <::temporalio_workflow::common::data_converters::PayloadConverter as ::temporalio_workflow::common::data_converters::GenericPayloadConverter>::from_payloads(
+                converter,
+                &ctx,
+                #payloads,
+            )?;
+            Ok(::std::option::Option::Some(
+                ::std::boxed::Box::new(input) as ::std::boxed::Box<dyn ::std::any::Any>
+            ))
+        },
+    }
+}
+
 /// Parsed representation of a `#[workflow_methods]` impl block
 pub(crate) struct WorkflowMethodsDefinition {
     impl_block: ItemImpl,
@@ -1014,6 +1037,22 @@ impl WorkflowMethodsDefinition {
                 quote! { (#handler_name).to_string() }
             })
             .collect();
+        let decode_signal_arms: Vec<TokenStream2> = self
+            .signals
+            .iter()
+            .map(|s| {
+                let info = HandlerCodegenInfo::new(
+                    &s.method,
+                    &s.attributes,
+                    s.input_type.as_ref(),
+                    module_ident,
+                );
+                let input_type = &info.input_type_tokens;
+                let handler_name = &info.handler_name;
+
+                generate_decode_arm(handler_name, input_type, quote! { payloads.payloads })
+            })
+            .collect();
         let dispatch_signal_arms: Vec<TokenStream2> = self
             .signals
             .iter()
@@ -1029,11 +1068,11 @@ impl WorkflowMethodsDefinition {
 
                 if s.is_async {
                     quote! {
-                        #handler_name => Some(<Self as ::temporalio_workflow::workflows::ExecutableAsyncSignal<#module_ident::#struct_ident>>::dispatch(ctx.clone(), payloads, converter)),
+                        #handler_name => <Self as ::temporalio_workflow::workflows::ExecutableAsyncSignal<#module_ident::#struct_ident>>::dispatch(ctx.clone(), input),
                     }
                 } else {
                     quote! {
-                        #handler_name => Some(<Self as ::temporalio_workflow::workflows::ExecutableSyncSignal<#module_ident::#struct_ident>>::dispatch(ctx, payloads, converter)),
+                        #handler_name => <Self as ::temporalio_workflow::workflows::ExecutableSyncSignal<#module_ident::#struct_ident>>::dispatch(ctx, input),
                     }
                 }
             })
@@ -1044,21 +1083,47 @@ impl WorkflowMethodsDefinition {
             quote! {}
         } else {
             quote! {
-                fn dispatch_signal(
-                    ctx: ::temporalio_workflow::WorkflowContext<Self>,
+                fn decode_signal_input(
                     name: &str,
                     payloads: ::temporalio_workflow::common::protos::temporal::api::common::v1::Payloads,
                     converter: &::temporalio_workflow::common::data_converters::PayloadConverter,
-                ) -> Option<::temporalio_workflow::__private::futures_util::future::LocalBoxFuture<'static, Result<(), ::temporalio_workflow::workflows::WorkflowError>>> {
+                ) -> Result<::std::option::Option<::std::boxed::Box<dyn ::std::any::Any>>, ::temporalio_workflow::workflows::WorkflowError> {
+                    match name {
+                        #(#decode_signal_arms)*
+                        _ => Ok(::std::option::Option::None),
+                    }
+                }
+
+                fn dispatch_signal(
+                    ctx: ::temporalio_workflow::WorkflowContext<Self>,
+                    name: &str,
+                    input: ::std::boxed::Box<dyn ::std::any::Any>,
+                ) -> ::temporalio_workflow::__private::futures_util::future::LocalBoxFuture<'static, Result<(), ::temporalio_workflow::workflows::WorkflowError>> {
                     match name {
                         #(#dispatch_signal_arms)*
-                        _ => None,
+                        _ => panic!("typed signal dispatch called for unknown signal handler '{name}'"),
                     }
                 }
             }
         };
 
         // Generate update dispatch match arms
+        let decode_update_arms: Vec<TokenStream2> = self
+            .updates
+            .iter()
+            .map(|u| {
+                let info = HandlerCodegenInfo::new(
+                    &u.method,
+                    &u.attributes,
+                    u.input_type.as_ref(),
+                    module_ident,
+                );
+                let input_type = &info.input_type_tokens;
+                let handler_name = &info.handler_name;
+
+                generate_decode_arm(handler_name, input_type, quote! { payloads.payloads })
+            })
+            .collect();
         let dispatch_update_arms: Vec<TokenStream2> = self
             .updates
             .iter()
@@ -1074,11 +1139,11 @@ impl WorkflowMethodsDefinition {
 
                 if u.is_async {
                     quote! {
-                        #handler_name => Some(<Self as ::temporalio_workflow::workflows::ExecutableAsyncUpdate<#module_ident::#struct_ident>>::dispatch(ctx.clone(), payloads, converter)),
+                        #handler_name => <Self as ::temporalio_workflow::workflows::ExecutableAsyncUpdate<#module_ident::#struct_ident>>::dispatch(ctx.clone(), input, converter),
                     }
                 } else {
                     quote! {
-                        #handler_name => Some(<Self as ::temporalio_workflow::workflows::ExecutableSyncUpdate<#module_ident::#struct_ident>>::dispatch(ctx, payloads, converter)),
+                        #handler_name => <Self as ::temporalio_workflow::workflows::ExecutableSyncUpdate<#module_ident::#struct_ident>>::dispatch(ctx, input, converter),
                     }
                 }
             })
@@ -1109,6 +1174,7 @@ impl WorkflowMethodsDefinition {
         let validate_update_arms: Vec<TokenStream2> = self
             .updates
             .iter()
+            .filter(|u| u.validator.is_some())
             .map(|u| {
                 let info = HandlerCodegenInfo::new(
                     &u.method,
@@ -1119,14 +1185,14 @@ impl WorkflowMethodsDefinition {
                 let struct_ident = &info.struct_ident;
                 let handler_name = &info.handler_name;
 
-                let validate_trait = if u.is_async {
+                let update_trait = if u.is_async {
                     quote! { ::temporalio_workflow::workflows::ExecutableAsyncUpdate<#module_ident::#struct_ident> }
                 } else {
                     quote! { ::temporalio_workflow::workflows::ExecutableSyncUpdate<#module_ident::#struct_ident> }
                 };
 
                 quote! {
-                    #handler_name => Some(<Self as #validate_trait>::dispatch_validate(self, &ctx, payloads, converter)),
+                    #handler_name => <Self as #update_trait>::dispatch_validate(self, &ctx, input),
                 }
             })
             .collect();
@@ -1136,15 +1202,26 @@ impl WorkflowMethodsDefinition {
             quote! {}
         } else {
             quote! {
-                fn dispatch_update(
-                    ctx: ::temporalio_workflow::WorkflowContext<Self>,
+                fn decode_update_input(
                     name: &str,
                     payloads: ::temporalio_workflow::common::protos::temporal::api::common::v1::Payloads,
                     converter: &::temporalio_workflow::common::data_converters::PayloadConverter,
-                ) -> Option<::temporalio_workflow::__private::futures_util::future::LocalBoxFuture<'static, Result<::temporalio_workflow::common::protos::temporal::api::common::v1::Payload, ::temporalio_workflow::workflows::WorkflowError>>> {
+                ) -> Result<::std::option::Option<::std::boxed::Box<dyn ::std::any::Any>>, ::temporalio_workflow::workflows::WorkflowError> {
+                    match name {
+                        #(#decode_update_arms)*
+                        _ => Ok(::std::option::Option::None),
+                    }
+                }
+
+                fn dispatch_update(
+                    ctx: ::temporalio_workflow::WorkflowContext<Self>,
+                    name: &str,
+                    input: ::std::boxed::Box<dyn ::std::any::Any>,
+                    converter: &::temporalio_workflow::common::data_converters::PayloadConverter,
+                ) -> ::temporalio_workflow::__private::futures_util::future::LocalBoxFuture<'static, Result<::temporalio_workflow::common::protos::temporal::api::common::v1::Payload, ::temporalio_workflow::workflows::WorkflowError>> {
                     match name {
                         #(#dispatch_update_arms)*
-                        _ => None,
+                        _ => panic!("typed update dispatch called for unknown update handler '{name}'"),
                     }
                 }
 
@@ -1152,13 +1229,11 @@ impl WorkflowMethodsDefinition {
                     &self,
                     ctx: ::temporalio_workflow::WorkflowContextView,
                     name: &str,
-                    payloads: &::temporalio_workflow::common::protos::temporal::api::common::v1::Payloads,
-                    converter: &::temporalio_workflow::common::data_converters::PayloadConverter,
-                ) -> Option<Result<(), ::temporalio_workflow::workflows::WorkflowError>> {
-
+                    input: ::std::boxed::Box<dyn ::std::any::Any>,
+                ) -> Result<(), ::temporalio_workflow::workflows::WorkflowError> {
                     match name {
                         #(#validate_update_arms)*
-                        _ => None,
+                        _ => panic!("typed update validation called for unknown update handler '{name}'"),
                     }
                 }
             }
@@ -1179,6 +1254,26 @@ impl WorkflowMethodsDefinition {
                 quote! { (#handler_name).to_string() }
             })
             .collect();
+        let decode_query_arms: Vec<TokenStream2> = self
+            .queries
+            .iter()
+            .map(|q| {
+                let info = HandlerCodegenInfo::new(
+                    &q.method,
+                    &q.attributes,
+                    q.input_type.as_ref(),
+                    module_ident,
+                );
+                let input_type = &info.input_type_tokens;
+                let handler_name = &info.handler_name;
+
+                generate_decode_arm(
+                    handler_name,
+                    input_type,
+                    quote! { payloads.payloads.clone() },
+                )
+            })
+            .collect();
         let dispatch_query_arms: Vec<TokenStream2> = self
             .queries
             .iter()
@@ -1193,7 +1288,7 @@ impl WorkflowMethodsDefinition {
                 let handler_name = &info.handler_name;
 
                 quote! {
-                    #handler_name => Some(<Self as ::temporalio_workflow::workflows::ExecutableQuery<#module_ident::#struct_ident>>::dispatch(self, &ctx, payloads, converter)),
+                    #handler_name => <Self as ::temporalio_workflow::workflows::ExecutableQuery<#module_ident::#struct_ident>>::dispatch(self, &ctx, input, converter),
                 }
             })
             .collect();
@@ -1203,16 +1298,27 @@ impl WorkflowMethodsDefinition {
             quote! {}
         } else {
             quote! {
+                fn decode_query_input(
+                    name: &str,
+                    payloads: &::temporalio_workflow::common::protos::temporal::api::common::v1::Payloads,
+                    converter: &::temporalio_workflow::common::data_converters::PayloadConverter,
+                ) -> Result<::std::option::Option<::std::boxed::Box<dyn ::std::any::Any>>, ::temporalio_workflow::workflows::WorkflowError> {
+                    match name {
+                        #(#decode_query_arms)*
+                        _ => Ok(::std::option::Option::None),
+                    }
+                }
+
                 fn dispatch_query(
                     &self,
                     ctx: ::temporalio_workflow::WorkflowContextView,
                     name: &str,
-                    payloads: &::temporalio_workflow::common::protos::temporal::api::common::v1::Payloads,
+                    input: ::std::boxed::Box<dyn ::std::any::Any>,
                     converter: &::temporalio_workflow::common::data_converters::PayloadConverter,
-                ) -> Option<Result<::temporalio_workflow::common::protos::temporal::api::common::v1::Payload, ::temporalio_workflow::workflows::WorkflowError>> {
+                ) -> Result<::temporalio_workflow::common::protos::temporal::api::common::v1::Payload, ::temporalio_workflow::workflows::WorkflowError> {
                     match name {
                         #(#dispatch_query_arms)*
-                        _ => None,
+                        _ => panic!("typed query dispatch called for unknown query handler '{name}'"),
                     }
                 }
             }

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -861,6 +861,81 @@ async fn update_fail_sdk() {
 }
 
 #[tokio::test]
+async fn unknown_update_rejected_sdk() {
+    let wf_name = "unknown_update_rejected_sdk";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    let mut worker = starter.worker().await;
+    let client = starter.get_client().await;
+
+    #[workflow]
+    #[derive(Default)]
+    struct UnknownUpdateRejectedSdkWf {
+        done: bool,
+    }
+
+    #[workflow_methods]
+    impl UnknownUpdateRejectedSdkWf {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            ctx.wait_condition(|s| s.done).await;
+            Ok(())
+        }
+
+        #[update]
+        async fn known_update(_ctx: &mut WorkflowContext<Self>, _: ()) {}
+
+        #[signal]
+        fn done_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _: ()) {
+            self.done = true;
+        }
+    }
+
+    worker
+        .register_workflow::<UnknownUpdateRejectedSdkWf>()
+        .unwrap();
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            UnknownUpdateRejectedSdkWf::run,
+            (),
+            WorkflowStartOptions::new(task_queue, starter.get_wf_id().to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    let update = async {
+        let res = handle
+            .execute_update(
+                UntypedUpdate::new("missing_update"),
+                RawValue::from_value(&(), client.data_converter().payload_converter()),
+                WorkflowExecuteUpdateOptions::default(),
+            )
+            .await;
+        match res.unwrap_err() {
+            temporalio_client::errors::WorkflowUpdateError::Failed(failure) => {
+                assert_eq!(
+                    failure.message,
+                    "No update handler registered for update name missing_update"
+                )
+            }
+            _ => panic!("expected failure"),
+        }
+        handle
+            .signal(
+                UnknownUpdateRejectedSdkWf::done_signal,
+                (),
+                WorkflowSignalOptions::default(),
+            )
+            .await
+            .unwrap();
+    };
+    let run = async {
+        worker.run_until_done().await.unwrap();
+    };
+    join!(update, run);
+}
+
+#[tokio::test]
 async fn update_timer_sequence() {
     let wf_name = "update_timer_sequence";
     let mut starter = CoreWfStarter::new(wf_name);

--- a/crates/workflow/src/runtime/entry.rs
+++ b/crates/workflow/src/runtime/entry.rs
@@ -90,12 +90,10 @@ pub trait WorkflowImplementation: Sized + 'static {
 
     /// Dispatch a signal using an already decoded input value.
     fn dispatch_signal(
-        _ctx: WorkflowContext<Self>,
+        ctx: WorkflowContext<Self>,
         name: &str,
-        _input: Box<dyn Any>,
-    ) -> LocalBoxFuture<'static, Result<(), WorkflowError>> {
-        panic!("typed signal dispatch called for unknown signal handler '{name}'")
-    }
+        input: Box<dyn Any>,
+    ) -> LocalBoxFuture<'static, Result<(), WorkflowError>>;
 
     /// Decode a query's payloads into that query handler's concrete input type.
     fn decode_query_input(
@@ -109,13 +107,11 @@ pub trait WorkflowImplementation: Sized + 'static {
     /// Dispatch a query using an already decoded input value.
     fn dispatch_query(
         &self,
-        _ctx: WorkflowContextView,
+        ctx: WorkflowContextView,
         name: &str,
-        _input: Box<dyn Any>,
-        _converter: &PayloadConverter,
-    ) -> Result<Payload, WorkflowError> {
-        panic!("typed query dispatch called for unknown query handler '{name}'")
-    }
+        input: Box<dyn Any>,
+        converter: &PayloadConverter,
+    ) -> Result<Payload, WorkflowError>;
 
     /// Decode an update's payloads into that update handler's concrete input type.
     fn decode_update_input(
@@ -128,23 +124,19 @@ pub trait WorkflowImplementation: Sized + 'static {
 
     /// Dispatch an update using an already decoded input value.
     fn dispatch_update(
-        _ctx: WorkflowContext<Self>,
+        ctx: WorkflowContext<Self>,
         name: &str,
-        _input: Box<dyn Any>,
-        _converter: &PayloadConverter,
-    ) -> LocalBoxFuture<'static, Result<Payload, WorkflowError>> {
-        panic!("typed update dispatch called for unknown update handler '{name}'")
-    }
+        input: Box<dyn Any>,
+        converter: &PayloadConverter,
+    ) -> LocalBoxFuture<'static, Result<Payload, WorkflowError>>;
 
     /// Validate an update using an already decoded input value.
     fn validate_update(
         &self,
-        _ctx: WorkflowContextView,
+        ctx: WorkflowContextView,
         name: &str,
-        _input: Box<dyn Any>,
-    ) -> Result<(), WorkflowError> {
-        panic!("typed update validation called for unknown update handler '{name}'")
-    }
+        input: Box<dyn Any>,
+    ) -> Result<(), WorkflowError>;
 }
 
 /// Trait for executing synchronous signal handlers on a workflow.

--- a/crates/workflow/src/runtime/entry.rs
+++ b/crates/workflow/src/runtime/entry.rs
@@ -5,11 +5,12 @@ use crate::{
     runtime::{model::WorkflowTermination, types::WorkflowDefinitionDescriptor},
 };
 use futures_util::future::{FutureExt, LocalBoxFuture};
+use std::any::Any;
 use temporalio_common_wasm::{
     QueryDefinition, SignalDefinition, UpdateDefinition, WorkflowDefinition,
     data_converters::{
         GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
-        SerializationContextData, TemporalDeserializable, TemporalSerializable,
+        SerializationContextData, TemporalSerializable,
     },
     protos::temporal::api::{
         common::v1::{Payload, Payloads},
@@ -36,6 +37,12 @@ impl From<WorkflowError> for Failure {
             ..Default::default()
         }
     }
+}
+
+fn downcast_handler_input<T: Any>(input: Box<dyn Any>, handler_kind: &'static str) -> T {
+    *input.downcast::<T>().unwrap_or_else(|_| {
+        panic!("typed {handler_kind} dispatch received input with wrong concrete type")
+    })
 }
 
 /// Trait implemented by workflow structs to enable execution by the worker.
@@ -72,46 +79,71 @@ pub trait WorkflowImplementation: Sized + 'static {
         input: Option<<Self::Run as WorkflowDefinition>::Input>,
     ) -> LocalBoxFuture<'static, Result<Payload, WorkflowTermination>>;
 
-    /// Dispatch an update request by name. Returns `None` if no handler for that name.
-    fn dispatch_update(
-        _ctx: WorkflowContext<Self>,
+    /// Decode a signal's payloads into that signal handler's concrete input type.
+    fn decode_signal_input(
         _name: &str,
         _payloads: Payloads,
         _converter: &PayloadConverter,
-    ) -> Option<LocalBoxFuture<'static, Result<Payload, WorkflowError>>> {
-        None
+    ) -> Result<Option<Box<dyn Any>>, WorkflowError> {
+        Ok(None)
     }
 
-    /// Validate an update request by name.
-    fn validate_update(
-        &self,
-        _ctx: WorkflowContextView,
+    /// Dispatch a signal using an already decoded input value.
+    fn dispatch_signal(
+        _ctx: WorkflowContext<Self>,
+        name: &str,
+        _input: Box<dyn Any>,
+    ) -> LocalBoxFuture<'static, Result<(), WorkflowError>> {
+        panic!("typed signal dispatch called for unknown signal handler '{name}'")
+    }
+
+    /// Decode a query's payloads into that query handler's concrete input type.
+    fn decode_query_input(
         _name: &str,
         _payloads: &Payloads,
         _converter: &PayloadConverter,
-    ) -> Option<Result<(), WorkflowError>> {
-        None
+    ) -> Result<Option<Box<dyn Any>>, WorkflowError> {
+        Ok(None)
     }
 
-    /// Dispatch a signal by name.
-    fn dispatch_signal(
-        _ctx: WorkflowContext<Self>,
-        _name: &str,
-        _payloads: Payloads,
-        _converter: &PayloadConverter,
-    ) -> Option<LocalBoxFuture<'static, Result<(), WorkflowError>>> {
-        None
-    }
-
-    /// Dispatch a query by name.
+    /// Dispatch a query using an already decoded input value.
     fn dispatch_query(
         &self,
         _ctx: WorkflowContextView,
-        _name: &str,
-        _payloads: &Payloads,
+        name: &str,
+        _input: Box<dyn Any>,
         _converter: &PayloadConverter,
-    ) -> Option<Result<Payload, WorkflowError>> {
-        None
+    ) -> Result<Payload, WorkflowError> {
+        panic!("typed query dispatch called for unknown query handler '{name}'")
+    }
+
+    /// Decode an update's payloads into that update handler's concrete input type.
+    fn decode_update_input(
+        _name: &str,
+        _payloads: Payloads,
+        _converter: &PayloadConverter,
+    ) -> Result<Option<Box<dyn Any>>, WorkflowError> {
+        Ok(None)
+    }
+
+    /// Dispatch an update using an already decoded input value.
+    fn dispatch_update(
+        _ctx: WorkflowContext<Self>,
+        name: &str,
+        _input: Box<dyn Any>,
+        _converter: &PayloadConverter,
+    ) -> LocalBoxFuture<'static, Result<Payload, WorkflowError>> {
+        panic!("typed update dispatch called for unknown update handler '{name}'")
+    }
+
+    /// Validate an update using an already decoded input value.
+    fn validate_update(
+        &self,
+        _ctx: WorkflowContextView,
+        name: &str,
+        _input: Box<dyn Any>,
+    ) -> Result<(), WorkflowError> {
+        panic!("typed update validation called for unknown update handler '{name}'")
     }
 }
 
@@ -120,20 +152,15 @@ pub trait ExecutableSyncSignal<S: SignalDefinition>: WorkflowImplementation {
     /// Handle an incoming signal with the given input.
     fn handle(&mut self, ctx: &mut SyncWorkflowContext<Self>, input: S::Input);
 
-    /// Dispatch the signal with payload deserialization.
+    /// Dispatch the signal with an already decoded input.
     fn dispatch(
         ctx: WorkflowContext<Self>,
-        payloads: Payloads,
-        converter: &PayloadConverter,
+        input: Box<dyn Any>,
     ) -> LocalBoxFuture<'static, Result<(), WorkflowError>> {
-        match deserialize_input::<S::Input>(payloads.payloads, converter) {
-            Ok(input) => {
-                let mut sync_ctx = ctx.sync_context();
-                ctx.state_mut(|wf| Self::handle(wf, &mut sync_ctx, input));
-                std::future::ready(Ok(())).boxed_local()
-            }
-            Err(e) => std::future::ready(Err(e)).boxed_local(),
-        }
+        let input = downcast_handler_input::<S::Input>(input, "signal");
+        let mut sync_ctx = ctx.sync_context();
+        ctx.state_mut(|wf| Self::handle(wf, &mut sync_ctx, input));
+        std::future::ready(Ok(())).boxed_local()
     }
 }
 
@@ -142,16 +169,13 @@ pub trait ExecutableAsyncSignal<S: SignalDefinition>: WorkflowImplementation {
     /// Handle an incoming signal with the given input.
     fn handle(ctx: WorkflowContext<Self>, input: S::Input) -> LocalBoxFuture<'static, ()>;
 
-    /// Dispatch the signal with payload deserialization.
+    /// Dispatch the signal with an already decoded input.
     fn dispatch(
         ctx: WorkflowContext<Self>,
-        payloads: Payloads,
-        converter: &PayloadConverter,
+        input: Box<dyn Any>,
     ) -> LocalBoxFuture<'static, Result<(), WorkflowError>> {
-        match deserialize_input::<S::Input>(payloads.payloads, converter) {
-            Ok(input) => Self::handle(ctx, input).map(|()| Ok(())).boxed_local(),
-            Err(e) => std::future::ready(Err(e)).boxed_local(),
-        }
+        let input = downcast_handler_input::<S::Input>(input, "signal");
+        Self::handle(ctx, input).map(|()| Ok(())).boxed_local()
     }
 }
 
@@ -164,14 +188,14 @@ pub trait ExecutableQuery<Q: QueryDefinition>: WorkflowImplementation {
         input: Q::Input,
     ) -> Result<Q::Output, Box<dyn std::error::Error + Send + Sync>>;
 
-    /// Dispatch the query with payload deserialization and output serialization.
+    /// Dispatch the query with an already decoded input.
     fn dispatch(
         &self,
         ctx: &WorkflowContextView,
-        payloads: &Payloads,
+        input: Box<dyn Any>,
         converter: &PayloadConverter,
     ) -> Result<Payload, WorkflowError> {
-        let input = deserialize_input::<Q::Input>(payloads.payloads.clone(), converter)?;
+        let input = downcast_handler_input::<Q::Input>(input, "query");
         let output = self.handle(ctx, input).map_err(WorkflowError::Execution)?;
         serialize_output(&output, converter)
     }
@@ -195,21 +219,17 @@ pub trait ExecutableSyncUpdate<U: UpdateDefinition>: WorkflowImplementation {
         Ok(())
     }
 
-    /// Dispatch the update with payload deserialization and output serialization.
+    /// Dispatch the update with an already decoded input.
     fn dispatch(
         ctx: WorkflowContext<Self>,
-        payloads: Payloads,
+        input: Box<dyn Any>,
         converter: &PayloadConverter,
     ) -> LocalBoxFuture<'static, Result<Payload, WorkflowError>> {
-        let input = match deserialize_input::<U::Input>(payloads.payloads, converter) {
-            Ok(v) => v,
-            Err(e) => return std::future::ready(Err(e)).boxed_local(),
-        };
-        let converter = converter.clone();
+        let input = downcast_handler_input::<U::Input>(input, "update");
         let mut sync_ctx = ctx.sync_context();
         let result = ctx.state_mut(|wf| Self::handle(wf, &mut sync_ctx, input));
         match result {
-            Ok(output) => match serialize_output(&output, &converter) {
+            Ok(output) => match serialize_output(&output, converter) {
                 Ok(payload) => std::future::ready(Ok(payload)).boxed_local(),
                 Err(e) => std::future::ready(Err(e)).boxed_local(),
             },
@@ -217,14 +237,13 @@ pub trait ExecutableSyncUpdate<U: UpdateDefinition>: WorkflowImplementation {
         }
     }
 
-    /// Dispatch validation with payload deserialization.
+    /// Dispatch validation with an already decoded input.
     fn dispatch_validate(
         &self,
         ctx: &WorkflowContextView,
-        payloads: &Payloads,
-        converter: &PayloadConverter,
+        input: Box<dyn Any>,
     ) -> Result<(), WorkflowError> {
-        let input = deserialize_input::<U::Input>(payloads.payloads.clone(), converter)?;
+        let input = downcast_handler_input::<U::Input>(input, "update validation");
         self.validate(ctx, &input).map_err(WorkflowError::Execution)
     }
 }
@@ -246,16 +265,13 @@ pub trait ExecutableAsyncUpdate<U: UpdateDefinition>: WorkflowImplementation {
         Ok(())
     }
 
-    /// Dispatch the update with payload deserialization and output serialization.
+    /// Dispatch the update with an already decoded input.
     fn dispatch(
         ctx: WorkflowContext<Self>,
-        payloads: Payloads,
+        input: Box<dyn Any>,
         converter: &PayloadConverter,
     ) -> LocalBoxFuture<'static, Result<Payload, WorkflowError>> {
-        let input = match deserialize_input::<U::Input>(payloads.payloads, converter) {
-            Ok(v) => v,
-            Err(e) => return std::future::ready(Err(e)).boxed_local(),
-        };
+        let input = downcast_handler_input::<U::Input>(input, "update");
         let converter = converter.clone();
         async move {
             let output = Self::handle(ctx, input)
@@ -266,28 +282,15 @@ pub trait ExecutableAsyncUpdate<U: UpdateDefinition>: WorkflowImplementation {
         .boxed_local()
     }
 
-    /// Dispatch validation with payload deserialization.
+    /// Dispatch validation with an already decoded input.
     fn dispatch_validate(
         &self,
         ctx: &WorkflowContextView,
-        payloads: &Payloads,
-        converter: &PayloadConverter,
+        input: Box<dyn Any>,
     ) -> Result<(), WorkflowError> {
-        let input = deserialize_input::<U::Input>(payloads.payloads.clone(), converter)?;
+        let input = downcast_handler_input::<U::Input>(input, "update validation");
         self.validate(ctx, &input).map_err(WorkflowError::Execution)
     }
-}
-
-/// Deserialize handler input from payloads.
-pub(crate) fn deserialize_input<I: TemporalDeserializable + 'static>(
-    payloads: Vec<Payload>,
-    converter: &PayloadConverter,
-) -> Result<I, WorkflowError> {
-    let ctx = SerializationContext {
-        data: &SerializationContextData::Workflow,
-        converter,
-    };
-    converter.from_payloads(&ctx, payloads).map_err(Into::into)
 }
 
 /// Serialize handler output to a payload.

--- a/crates/workflow/src/runtime/instance.rs
+++ b/crates/workflow/src/runtime/instance.rs
@@ -21,6 +21,7 @@ use futures_util::{
 use std::{
     cell::RefCell,
     collections::HashMap,
+    future::ready,
     rc::Rc,
     task::{Context, Poll, Waker},
 };
@@ -191,68 +192,101 @@ where
             payloads: signal.input,
         };
         let converter = self.ctx.payload_converter();
-        let ctx = self.ctx.with_headers(signal.headers);
-        if let Some(future) = W::dispatch_signal(ctx, &name, payloads, converter) {
-            let routine_id = self.next_routine_id();
-            self.routines
-                .insert(routine_id, GuestRoutine::Signal { future });
-            ActivationJobResult::StartedRoutine(StartedRoutine {
-                routine_id,
-                kind: RoutineKind::Signal(name),
-            })
-        } else {
-            ActivationJobResult::None
-        }
+        let future = match W::decode_signal_input(&name, payloads, converter) {
+            Ok(Some(input)) => {
+                let ctx = self.ctx.with_headers(signal.headers);
+                W::dispatch_signal(ctx, &name, input)
+            }
+            Err(err) => ready(Err(err)).boxed_local(),
+            Ok(None) => return ActivationJobResult::None,
+        };
+        let routine_id = self.next_routine_id();
+        self.routines
+            .insert(routine_id, GuestRoutine::Signal { future });
+        ActivationJobResult::StartedRoutine(StartedRoutine {
+            routine_id,
+            kind: RoutineKind::Signal(name),
+        })
     }
 
     fn start_update_routine(&mut self, update: DoUpdate) -> ActivationJobResult {
-        let protocol_instance_id = update.protocol_instance_id.clone();
-        let name = update.name.clone();
-        if update.run_validator {
+        let DoUpdate {
+            id,
+            protocol_instance_id,
+            name,
+            input,
+            headers,
+            run_validator,
+            ..
+        } = update;
+        let has_validator = match W::definition()
+            .updates
+            .into_iter()
+            .find(|update| update.name.as_str() == name)
+            .map(|update| update.has_validator)
+        {
+            Some(has_validator) => has_validator,
+            None => return self.rejection_for_missing_update_handler(name),
+        };
+
+        if run_validator && has_validator {
             let payloads = Payloads {
-                payloads: update.input.clone(),
+                payloads: input.clone(),
             };
             let converter = self.ctx.payload_converter();
+            let decoded_input = match W::decode_update_input(&name, payloads, converter) {
+                Ok(Some(input)) => input,
+                Err(err) => {
+                    return ActivationJobResult::UpdateRejected(Box::new(
+                        self.workflow_error_to_failure(err),
+                    ));
+                }
+                Ok(None) => {
+                    return self.rejection_for_missing_update_handler(name);
+                }
+            };
             let view = self.ctx.view();
             let validation = self
                 .ctx
-                .state(|wf| wf.validate_update(view, &update.name, &payloads, converter));
+                .state(|wf| wf.validate_update(view, &name, decoded_input));
             match validation {
-                Some(Ok(())) => {}
-                Some(Err(e)) => {
+                Ok(()) => {}
+                Err(e) => {
                     return ActivationJobResult::UpdateRejected(Box::new(
                         self.workflow_error_to_failure(e),
                     ));
                 }
-                None => return self.rejection_for_missing_update_handler(name),
             }
         }
 
-        let payloads = Payloads {
-            payloads: update.input,
-        };
+        let payloads = Payloads { payloads: input };
         let converter = self.ctx.payload_converter();
-        let ctx = self.ctx.with_headers(update.headers);
-        if let Some(future) = W::dispatch_update(ctx, &name, payloads, converter) {
-            let routine_id = self.next_routine_id();
-            self.routines.insert(
-                routine_id,
-                GuestRoutine::Update {
-                    protocol_instance_id: protocol_instance_id.clone(),
-                    future,
-                },
-            );
-            ActivationJobResult::StartedRoutine(StartedRoutine {
-                routine_id,
-                kind: RoutineKind::Update(UpdateRoutineKind {
-                    name,
-                    update_id: update.id,
-                    protocol_instance_id,
-                }),
-            })
-        } else {
-            self.rejection_for_missing_update_handler(name)
-        }
+        let future = match W::decode_update_input(&name, payloads, converter) {
+            Ok(Some(input)) => {
+                let ctx = self.ctx.with_headers(headers);
+                W::dispatch_update(ctx, &name, input, converter)
+            }
+            Err(err) => ready(Err(err)).boxed_local(),
+            Ok(None) => {
+                return self.rejection_for_missing_update_handler(name);
+            }
+        };
+        let routine_id = self.next_routine_id();
+        self.routines.insert(
+            routine_id,
+            GuestRoutine::Update {
+                protocol_instance_id: protocol_instance_id.clone(),
+                future,
+            },
+        );
+        ActivationJobResult::StartedRoutine(StartedRoutine {
+            routine_id,
+            kind: RoutineKind::Update(UpdateRoutineKind {
+                name,
+                update_id: id,
+                protocol_instance_id,
+            }),
+        })
     }
 
     fn query(&self, query: QueryWorkflow) -> QueryResponse {
@@ -265,18 +299,27 @@ where
         };
         let converter = self.ctx.payload_converter();
         let view = self.ctx.view();
+        let decoded_input = match W::decode_query_input(&query.query_type, &payloads, converter) {
+            Ok(Some(input)) => input,
+            Err(err) => {
+                return QueryResponse {
+                    result: Err(self.workflow_error_to_failure(err)),
+                };
+            }
+            Ok(None) => {
+                return QueryResponse {
+                    result: Err(self.message_to_failure(format!(
+                        "No query handler for '{}'",
+                        query.query_type
+                    ))),
+                };
+            }
+        };
         QueryResponse {
-            result: match self
+            result: self
                 .ctx
-                .state(|wf| wf.dispatch_query(view, &query.query_type, &payloads, converter))
-            {
-                Some(Ok(payload)) => Ok(payload),
-                None => {
-                    Err(self
-                        .message_to_failure(format!("No query handler for '{}'", query.query_type)))
-                }
-                Some(Err(e)) => Err(self.workflow_error_to_failure(e)),
-            },
+                .state(|wf| wf.dispatch_query(view, &query.query_type, decoded_input, converter))
+                .map_err(|err| self.workflow_error_to_failure(err)),
         }
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Moves Payload conversion to happen before dispatch to various workflow handlers. This means that dispatch now takes `Box<dyn Any>` instead of `Payloads`.

This does split dispatch method into distinct `decode` and `dispatch` steps. Instead of adding a new failure variant if the `dyn Any` produced by `decode` doesn't match what `dispatch` expects we panic. This should only happen in handwritten `WorkflowDefinition`s and is considered a programmer error.

This is a breaking change for users who don't make use of the workflow proc macros.

## Why?
This is some prework for #1139 where handler interceptors should be able to see the handler input types for args instead of raw payloads.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Exisiting tests, new test to verify missing update handler failure.

3. Any docs updates needed?
N/A
