### PR TITLE
feat(sdk): add UntypedActivity

### DIFF
--- a/crates/common-wasm/src/activity_definition.rs
+++ b/crates/common-wasm/src/activity_definition.rs
@@ -2,7 +2,7 @@
 //! activities, or directly by users targeting activities in other languages.
 
 use crate::{
-    data_converters::{TemporalDeserializable, TemporalSerializable},
+    data_converters::{RawValue, TemporalDeserializable, TemporalSerializable},
     error::{ApplicationFailure, FailurePayloads},
 };
 
@@ -17,9 +17,29 @@ pub trait ActivityDefinition {
     type Output: TemporalDeserializable + TemporalSerializable + 'static;
 
     /// The name that will be used for the activity type.
-    fn name() -> &'static str
-    where
-        Self: Sized;
+    fn name(&self) -> &str;
+}
+
+/// Marker type for starting activities by activity type name. Uses [`RawValue`] for both input and
+/// output.
+pub struct UntypedActivity {
+    name: String,
+}
+
+impl UntypedActivity {
+    /// Create a new `UntypedActivity` with the given activity type name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+impl ActivityDefinition for UntypedActivity {
+    type Input = RawValue;
+    type Output = RawValue;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 /// Returned as errors from activity functions.

--- a/crates/common-wasm/src/lib.rs
+++ b/crates/common-wasm/src/lib.rs
@@ -19,7 +19,7 @@ pub mod protos {
 pub mod worker;
 mod workflow_definition;
 
-pub use activity_definition::{ActivityDefinition, ActivityError};
+pub use activity_definition::{ActivityDefinition, ActivityError, UntypedActivity};
 pub use priority::Priority;
 pub use worker::WorkerDeploymentVersion;
 pub use workflow_definition::{

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -19,7 +19,7 @@ pub mod telemetry;
 pub mod worker;
 pub use temporalio_common_wasm::{
     ActivityDefinition, ActivityError, HasWorkflowDefinition, Priority, QueryDefinition,
-    SignalDefinition, UntypedWorkflow, UpdateDefinition, WorkerDeploymentVersion,
+    SignalDefinition, UntypedActivity, UntypedWorkflow, UpdateDefinition, WorkerDeploymentVersion,
     WorkflowDefinition, data_converters, error,
 };
 

--- a/crates/macros/src/activities_definitions.rs
+++ b/crates/macros/src/activities_definitions.rs
@@ -503,8 +503,8 @@ impl ActivitiesDefinition {
         // Common methods for all marker structs
         let common_methods = quote! {
             /// Returns the activity name (delegates to ActivityDefinition::name())
-            pub fn name(&self) -> &'static str {
-                <Self as ::temporalio_common::ActivityDefinition>::name()
+            pub fn name(&self) -> &str {
+                <Self as ::temporalio_common::ActivityDefinition>::name(self)
             }
         };
 
@@ -549,7 +549,9 @@ impl ActivitiesDefinition {
             .unwrap_or(quote! { () });
 
         let activity_name = if let Some(ref definition_path) = activity.attributes.definition_path {
-            quote! { <#definition_path as ::temporalio_common::ActivityDefinition>::name() }
+            quote! {
+                <#definition_path as ::temporalio_common::ActivityDefinition>::name(&#definition_path)
+            }
         } else if let Some(ref name_expr) = activity.attributes.name_override {
             quote! { #name_expr }
         } else {
@@ -591,10 +593,7 @@ impl ActivitiesDefinition {
                 type Input = #input_type;
                 type Output = #output_type;
 
-                fn name() -> &'static str
-                where
-                    Self: Sized,
-                {
+                fn name(&self) -> &str {
                     #activity_name
                 }
             }
@@ -667,6 +666,10 @@ impl ActivitiesDefinition {
 
             impl ::temporalio_sdk::activities::ExecutableActivity for #module_ident::#struct_ident {
                 type Implementer = #impl_type;
+
+                fn definition() -> Self {
+                    #module_ident::#struct_ident
+                }
 
                 fn execute(
                     #receiver_pattern: Option<::std::sync::Arc<Self::Implementer>>,

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -22,6 +22,8 @@ use temporalio_client::{
 };
 
 use temporalio_common::{
+    UntypedActivity,
+    data_converters::RawValue,
     error::{ApplicationFailure, IncomingError},
     protos::{
         coresdk::{
@@ -98,6 +100,26 @@ impl OneLocalActivityWorkflow {
             .start_local_activity(StdActivities::echo, input, LocalActivityOptions::default())
             .await?;
         Ok(r)
+    }
+}
+
+#[workflow]
+#[derive(Default)]
+struct UntypedActivityWorkflow;
+
+#[workflow_methods]
+impl UntypedActivityWorkflow {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<String> {
+        let raw_input = RawValue::from_value(&input, ctx.payload_converter());
+        let raw_output = ctx
+            .start_activity(
+                UntypedActivity::new("StdActivities::echo"),
+                raw_input,
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+            )
+            .await?;
+        Ok(raw_output.to_value(ctx.payload_converter()))
     }
 }
 
@@ -249,6 +271,32 @@ async fn one_activity_only() {
     let handle = worker
         .submit_workflow(
             OneActivityWorkflow::run,
+            input.clone(),
+            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    let r = handle.get_result(Default::default()).await.unwrap();
+    assert_eq!(r, input);
+}
+
+#[tokio::test]
+async fn untyped_activity_only() {
+    let wf_name = UntypedActivityWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<UntypedActivityWorkflow>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+
+    let input = "hello from raw input!".to_string();
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            UntypedActivityWorkflow::run,
             input.clone(),
             WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
         )

--- a/crates/sdk/examples/saga/workflows.rs
+++ b/crates/sdk/examples/saga/workflows.rs
@@ -92,9 +92,10 @@ impl Saga {
         let cmp_input: Compensation::Input = out.clone().into();
         let ctx = self.ctx.clone();
         let opts = self.opts.clone();
+        let compensation_name = compensate.name().to_owned();
         self.compensations.push(Box::pin(async move {
             if let Err(e) = ctx.start_activity(compensate, cmp_input, opts).await {
-                eprintln!("Compensation {} failed: {e}", Compensation::name());
+                eprintln!("Compensation {compensation_name} failed: {e}");
             }
         }));
         Ok(out)

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -369,8 +369,9 @@ pub trait ActivityImplementer {
 }
 
 #[doc(hidden)]
-pub trait ExecutableActivity: ActivityDefinition {
+pub trait ExecutableActivity: ActivityDefinition + Sized {
     type Implementer: ActivityImplementer + Send + Sync + 'static;
+    fn definition() -> Self;
     fn execute(
         receiver: Option<Arc<Self::Implementer>>,
         ctx: ActivityContext,
@@ -384,7 +385,7 @@ pub trait HasOnlyStaticMethods {}
 /// Contains activity registrations in a form ready for execution by workers.
 #[derive(Default, Clone)]
 pub struct ActivityDefinitions {
-    activities: HashMap<&'static str, ActivityInvocation>,
+    activities: HashMap<String, ActivityInvocation>,
 }
 
 impl ActivityDefinitions {
@@ -402,7 +403,7 @@ impl ActivityDefinitions {
         AD::Output: Send + Sync,
     {
         self.activities.insert(
-            AD::name(),
+            AD::definition().name().to_string(),
             Arc::new(move |payloads, dc, c, activity_inbound_interceptors| {
                 let instance = instance.clone();
                 async move {
@@ -441,8 +442,8 @@ impl ActivityDefinitions {
         self.activities.get(act_type).cloned()
     }
 
-    pub(crate) fn names(&self) -> Vec<&'static str> {
-        let mut names: Vec<_> = self.activities.keys().copied().collect();
+    pub(crate) fn names(&self) -> Vec<String> {
+        let mut names: Vec<_> = self.activities.keys().cloned().collect();
         names.sort_unstable();
         names
     }
@@ -464,7 +465,7 @@ where
                 Err(_) => {
                     return ready(Err(ApplicationFailure::new(anyhow::anyhow!(
                     "Activity inbound interceptor returned arguments with wrong concrete type for activity {}",
-                    AD::name()
+                    AD::definition().name()
                 ))
                 .into()))
                 .boxed();

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -493,14 +493,14 @@ enum ActivityNotRegisteredError {
     )]
     HasAvailable {
         activity_type: String,
-        available_activities: Vec<&'static str>,
+        available_activities: Vec<String>,
     },
     #[error("Activity {activity_type} is not registered on this worker, no available activities.")]
     NoAvailable { activity_type: String },
 }
 
 impl ActivityNotRegisteredError {
-    fn new(activity_type: String, available_activities: Vec<&'static str>) -> Self {
+    fn new(activity_type: String, available_activities: Vec<String>) -> Self {
         if available_activities.is_empty() {
             Self::NoAvailable { activity_type }
         } else {

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -556,7 +556,7 @@ impl BaseWorkflowContext {
     /// Request to run an activity
     pub fn start_activity<AD: ActivityDefinition>(
         &self,
-        _activity: AD,
+        activity: AD,
         input: impl Into<AD::Input>,
         mut opts: ActivityOptions,
     ) -> impl CancellableFuture<Result<AD::Output, ActivityExecutionError>>
@@ -586,7 +586,7 @@ impl BaseWorkflowContext {
         }
         self.inner.runtime.host.push_command(opts.into_command(
             seq,
-            AD::name().to_string(),
+            activity.name().to_string(),
             payloads,
         ));
         ActivityFut::running(cmd, self.inner.data_converter.clone())
@@ -595,7 +595,7 @@ impl BaseWorkflowContext {
     /// Request to run a local activity
     pub fn start_local_activity<AD: ActivityDefinition>(
         &self,
-        _activity: AD,
+        activity: AD,
         input: impl Into<AD::Input>,
         opts: LocalActivityOptions,
     ) -> impl CancellableFuture<Result<AD::Output, ActivityExecutionError>>
@@ -615,7 +615,7 @@ impl BaseWorkflowContext {
             }
         };
         ActivityFut::running(
-            LATimerBackoffFut::new(AD::name().to_string(), payloads, opts, self.clone()),
+            LATimerBackoffFut::new(activity.name().to_string(), payloads, opts, self.clone()),
             self.inner.data_converter.clone(),
         )
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add an `UntypedActivity` to allow calling an activity from a Rust workflow without a definition.

As a part of this:
 - `ActivityDefinition::name` no longer returns a `&'static str`
 - `ExecutableActivity::definition` added to allow mapping back from an activity implementer to the definition struct now that we can no longer get an activity type from just the type
 - Various places that list activity types move from `&'static str` to `String`

## Why?
Parity with `UntypedWorkflow`. Also useful for SAA.

## Checklist
<!--- add/delete as needed --->

1. Closes #1348 

2. How was this tested:
Added small integration test

3. Any docs updates needed?
N/A
