### PR TITLE
:boom: Payload limit enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ to docs, or any other relevant information.
   `ScheduleDescription::search_attributes`, and `ScheduleSummary::search_attributes` now return
   typed `SearchAttributes` instead of raw proto search attributes. Missing search attributes are
   returned as an empty collection instead of `None`.
+* Payload/memo size-limit enforcement (experimental), on by default. Workers now proactively
+  validate outbound payload/memo sizes against namespace limits before sending to the server.
+  If payload/memo-bearing fields exceed the warn threshold, the worker logs a warning; if over the
+  error limit, the task completion is failed retryably instead of sent to the server. Both cases log
+  `[TMPRL1103]` (at `WARN` and `ERROR` respectively).
+  Previously these were sent and the server terminated the workflow / failed the activity
+  non-retryably; failing retryably instead lets a corrected workflow or activity be redeployed and
+  recover. A deterministically-oversized completion now retries per its retry policy rather than
+  failing fast. Tune warn thresholds via `PayloadLimitsOptions`. Opt out of worker error enforcement
+  with `WorkerOptions::disable_payload_error_limit`.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/crates/client/src/grpc.rs
+++ b/crates/client/src/grpc.rs
@@ -13,8 +13,10 @@ use crate::{
 };
 use dyn_clone::DynClone;
 use futures_util::{FutureExt, TryFutureExt, future::BoxFuture};
+use parking_lot::RwLock;
 use std::{any::Any, marker::PhantomData, sync::Arc};
 use temporalio_common::{
+    payload_limits::{PayloadLimits, validate_known_payload_limits},
     protos::{
         grpc::health::v1::{health_client::HealthClient, *},
         temporal::api::{
@@ -144,6 +146,13 @@ impl RawGrpcCaller for Connection {
         F: FnMut(Request<Req>) -> BoxFuture<'static, Result<Response<Resp>, Status>>,
         F: Send + Sync + Unpin + 'static,
     {
+        // Validate payload sizes after any request mutation but before encoding/metrics.
+        validate_request_payload_limits(
+            &req,
+            self.inner.payloads_size_warn,
+            self.inner.memo_size_warn,
+        )?;
+
         let info = self
             .inner
             .retry_options
@@ -180,6 +189,47 @@ fn req_cloner<T: Clone>(cloneme: &Request<T>) -> Request<T> {
     }
     *new_req.extensions_mut() = cloneme.extensions().clone();
     new_req
+}
+
+/// Per-call payload/memo size error limits, attached to a request's extensions by a caller that
+/// wants error-level enforcement on this call.
+#[derive(Debug, Clone, Copy)]
+pub struct PayloadErrorLimits {
+    /// Blob (payload) size error threshold, in bytes.
+    pub blob: usize,
+    /// Memo size error threshold, in bytes.
+    pub memo: usize,
+}
+
+/// `*_warn` are the connection's configured warn thresholds; per-call error limits ride a
+/// [`PayloadErrorLimits`] extension. On an error-level violation, returns a [`Status`] carrying
+/// the [`PayloadLimitViolation`] as its source (extract via [crate::payload_limit_violation_from]).
+fn validate_request_payload_limits<Req: Any>(
+    req: &Request<Req>,
+    blob_warn: Option<usize>,
+    memo_warn: Option<usize>,
+) -> Result<(), Status> {
+    let mut limits = PayloadLimits {
+        blob_warn,
+        memo_warn,
+        blob_error: None,
+        memo_error: None,
+    };
+    if let Some(error_limits) = req.extensions().get::<PayloadErrorLimits>() {
+        // A zero threshold means "no limit for this class" (how the server reports an unset limit).
+        if error_limits.blob > 0 {
+            limits.blob_error = Some(error_limits.blob);
+        }
+        if error_limits.memo > 0 {
+            limits.memo_error = Some(error_limits.memo);
+        }
+    }
+    if let Some(violation) = validate_known_payload_limits(req.get_ref(), &limits) {
+        let mut status = Status::invalid_argument(violation.to_string());
+        status.set_source(Arc::new(violation));
+        return Err(status);
+    }
+    Ok(())
 }
 
 #[async_trait::async_trait]
@@ -366,6 +416,79 @@ where
         self.inner_mut_refreshed()
             .call(call_name, callfn, req)
             .await
+    }
+}
+
+/// Wraps a client and injects a worker's configured [`PayloadErrorLimits`] (when set) as a request
+/// extension on every gRPC call, so the gRPC layer enforces error limits uniformly across all
+/// outbound requests — current and future — without each call site having to opt in.
+///
+/// The limits are shared and may be updated after construction (e.g. once a worker learns the
+/// namespace limits) via [`set_error_limits`](Self::set_error_limits); clones observe the update.
+#[derive(Clone)]
+pub struct PayloadLimitsClient<C> {
+    inner: C,
+    error_limits: Arc<RwLock<Option<PayloadErrorLimits>>>,
+}
+
+impl<C> PayloadLimitsClient<C> {
+    /// Wrap `inner`; no limits are enforced until [`set_error_limits`](Self::set_error_limits).
+    pub fn new(inner: C) -> Self {
+        Self {
+            inner,
+            error_limits: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Set (or clear) the error limits injected on every call. Shared across clones.
+    pub fn set_error_limits(&self, limits: Option<PayloadErrorLimits>) {
+        *self.error_limits.write() = limits;
+    }
+}
+
+impl<C: RawClientProducer> RawClientProducer for PayloadLimitsClient<C> {
+    fn get_workers_info(&self) -> Option<Arc<ClientWorkerSet>> {
+        self.inner.get_workers_info()
+    }
+    fn workflow_client(&mut self) -> Box<dyn WorkflowService> {
+        self.inner.workflow_client()
+    }
+    fn operator_client(&mut self) -> Box<dyn OperatorService> {
+        self.inner.operator_client()
+    }
+    fn cloud_client(&mut self) -> Box<dyn CloudService> {
+        self.inner.cloud_client()
+    }
+    fn test_client(&mut self) -> Box<dyn TestService> {
+        self.inner.test_client()
+    }
+    fn health_client(&mut self) -> Box<dyn HealthService> {
+        self.inner.health_client()
+    }
+}
+
+#[async_trait::async_trait]
+impl<C> RawGrpcCaller for PayloadLimitsClient<C>
+where
+    C: RawGrpcCaller + Clone + Sync + 'static,
+{
+    async fn call<F, Req, Resp>(
+        &mut self,
+        call_name: &'static str,
+        callfn: F,
+        mut req: Request<Req>,
+    ) -> Result<Response<Resp>, Status>
+    where
+        Req: Clone + Unpin + Send + Sync + 'static,
+        Resp: Send + 'static,
+        F: FnMut(Request<Req>) -> BoxFuture<'static, Result<Response<Resp>, Status>>,
+        F: Send + Sync + Unpin + 'static,
+    {
+        let limits = *self.error_limits.read();
+        if let Some(limits) = limits {
+            req.extensions_mut().insert(limits);
+        }
+        self.inner.call(call_name, callfn, req).await
     }
 }
 
@@ -1879,6 +2002,53 @@ mod tests {
     use tonic::IntoRequest;
     use url::Url;
     use uuid::Uuid;
+
+    #[test]
+    fn payload_limits_warn_only_vs_error() {
+        use temporalio_common::protos::temporal::api::{
+            common::v1::{Payload, Payloads},
+            workflowservice::v1::StartWorkflowExecutionRequest,
+        };
+        let big = Payloads {
+            payloads: vec![Payload {
+                data: vec![0u8; 1000],
+                ..Default::default()
+            }],
+        };
+        let new_req = || {
+            StartWorkflowExecutionRequest {
+                input: Some(big.clone()),
+                ..Default::default()
+            }
+            .into_request()
+        };
+
+        // warn thresholds = 1 byte. No per-call error limits: over-warn is allowed (warn-only).
+        assert!(validate_request_payload_limits(&new_req(), Some(1), Some(1)).is_ok());
+
+        // With per-call error limits below the payload size: rejected, carrying the typed violation.
+        let mut req = new_req();
+        req.extensions_mut()
+            .insert(PayloadErrorLimits { blob: 10, memo: 10 });
+        let err = validate_request_payload_limits(&req, Some(1), Some(1)).unwrap_err();
+        let violation =
+            crate::payload_limit_violation_from(&err).expect("violation carried on status");
+        assert_eq!(violation.path, "input");
+        assert_eq!(
+            violation.class,
+            temporalio_common::payload_limits::LimitClass::Blob
+        );
+        assert!(violation.size > violation.limit);
+
+        // A zero error threshold means "no limit" for that class, so it does not reject.
+        let mut req = new_req();
+        req.extensions_mut()
+            .insert(PayloadErrorLimits { blob: 0, memo: 0 });
+        assert!(validate_request_payload_limits(&req, Some(1), Some(1)).is_ok());
+
+        // `None` warn thresholds disable warnings (and there are no error limits): always ok.
+        assert!(validate_request_payload_limits(&new_req(), None, None).is_ok());
+    }
 
     // Just to help make sure some stuff compiles. Not run.
     #[allow(dead_code)]

--- a/crates/client/src/grpc.rs
+++ b/crates/client/src/grpc.rs
@@ -149,8 +149,8 @@ impl RawGrpcCaller for Connection {
         // Validate payload sizes after any request mutation but before encoding/metrics.
         validate_request_payload_limits(
             &req,
-            self.inner.payloads_size_warn,
-            self.inner.memo_size_warn,
+            self.inner.payloads_warn_size,
+            self.inner.memo_warn_size,
         )?;
 
         let info = self

--- a/crates/client/src/grpc.rs
+++ b/crates/client/src/grpc.rs
@@ -415,6 +415,7 @@ where
 ///
 /// The limits are shared and may be updated after construction (e.g. once a worker learns the
 /// namespace limits) via [`set_error_limits`](Self::set_error_limits); clones observe the update.
+#[doc(hidden)]
 #[derive(Clone)]
 pub struct PayloadLimitsClient<C> {
     inner: C,

--- a/crates/client/src/grpc.rs
+++ b/crates/client/src/grpc.rs
@@ -196,23 +196,18 @@ fn req_cloner<T: Clone>(cloneme: &Request<T>) -> Request<T> {
 /// the [`PayloadLimitViolation`] as its source (extract via [crate::payload_limit_violation_from]).
 fn validate_request_payload_limits<Req: Any>(
     req: &Request<Req>,
-    blob_warn: Option<usize>,
-    memo_warn: Option<usize>,
+    blob_warn: usize,
+    memo_warn: usize,
 ) -> Result<(), Status> {
     let mut limits = PayloadLimits {
         blob_warn,
         memo_warn,
-        blob_error: None,
-        memo_error: None,
+        blob_error: 0,
+        memo_error: 0,
     };
     if let Some(error_limits) = req.extensions().get::<PayloadErrorLimits>() {
-        // A zero threshold means "no limit for this class" (how the server reports an unset limit).
-        if error_limits.blob > 0 {
-            limits.blob_error = Some(error_limits.blob);
-        }
-        if error_limits.memo > 0 {
-            limits.memo_error = Some(error_limits.memo);
-        }
+        limits.blob_error = error_limits.blob;
+        limits.memo_error = error_limits.memo;
     }
     if let Some(violation) = validate_known_payload_limits(req.get_ref(), &limits) {
         let mut status = Status::invalid_argument(violation.to_string());
@@ -2024,13 +2019,13 @@ mod tests {
         };
 
         // warn thresholds = 1 byte. No per-call error limits: over-warn is allowed (warn-only).
-        assert!(validate_request_payload_limits(&new_req(), Some(1), Some(1)).is_ok());
+        assert!(validate_request_payload_limits(&new_req(), 1, 1).is_ok());
 
         // With per-call error limits below the payload size: rejected, carrying the typed violation.
         let mut req = new_req();
         req.extensions_mut()
             .insert(PayloadErrorLimits { blob: 10, memo: 10 });
-        let err = validate_request_payload_limits(&req, Some(1), Some(1)).unwrap_err();
+        let err = validate_request_payload_limits(&req, 1, 1).unwrap_err();
         let violation =
             crate::payload_limit_violation_from(&err).expect("violation carried on status");
         assert_eq!(violation.path, "input");
@@ -2044,10 +2039,10 @@ mod tests {
         let mut req = new_req();
         req.extensions_mut()
             .insert(PayloadErrorLimits { blob: 0, memo: 0 });
-        assert!(validate_request_payload_limits(&req, Some(1), Some(1)).is_ok());
+        assert!(validate_request_payload_limits(&req, 1, 1).is_ok());
 
-        // `None` warn thresholds disable warnings (and there are no error limits): always ok.
-        assert!(validate_request_payload_limits(&new_req(), None, None).is_ok());
+        // Zero warn thresholds disable warnings (and there are no error limits): always ok.
+        assert!(validate_request_payload_limits(&new_req(), 0, 0).is_ok());
     }
 
     // Just to help make sure some stuff compiles. Not run.

--- a/crates/client/src/grpc.rs
+++ b/crates/client/src/grpc.rs
@@ -5,7 +5,7 @@
 //! or making raw gRPC calls not covered by the higher-level API.
 
 use crate::{
-    Client, Connection, LONG_POLL_TIMEOUT, RequestExt, SharedReplaceableClient,
+    Client, Connection, LONG_POLL_TIMEOUT, PayloadErrorLimits, RequestExt, SharedReplaceableClient,
     TEMPORAL_NAMESPACE_HEADER_KEY, TemporalServiceClient,
     metrics::namespace_kv,
     retry::make_future_retry,
@@ -189,16 +189,6 @@ fn req_cloner<T: Clone>(cloneme: &Request<T>) -> Request<T> {
     }
     *new_req.extensions_mut() = cloneme.extensions().clone();
     new_req
-}
-
-/// Per-call payload/memo size error limits, attached to a request's extensions by a caller that
-/// wants error-level enforcement on this call.
-#[derive(Debug, Clone, Copy)]
-pub struct PayloadErrorLimits {
-    /// Blob (payload) size error threshold, in bytes.
-    pub blob: usize,
-    /// Memo size error threshold, in bytes.
-    pub memo: usize,
 }
 
 /// `*_warn` are the connection's configured warn thresholds; per-call error limits ride a

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -167,27 +167,24 @@ struct ConnectionInner {
     capabilities: Option<get_system_info_response::Capabilities>,
     workers: Arc<ClientWorkerSet>,
     _dns_task: Option<Arc<dns::DnsReresolutionHandle>>,
-    /// Configured payload/memo size warning thresholds (bytes); `None` disables that warning.
-    payloads_warn_size: Option<usize>,
-    memo_warn_size: Option<usize>,
+    /// Configured payload/memo size warning thresholds (bytes); `0` disables that warning.
+    payloads_warn_size: usize,
+    memo_warn_size: usize,
 }
 
 /// Resolve a user-configured warning threshold (bytes) into the internal representation. `0`
 /// disables the warning (`None`); so does a value that doesn't fit in `usize` on this platform (a
 /// threshold larger than any addressable payload could never fire anyway), with a warning logged.
 /// `option` names the configured field, for diagnostics.
-fn resolve_warn_threshold(option: &'static str, bytes: u64) -> Option<usize> {
-    if bytes == 0 {
-        return None;
-    }
-    usize::try_from(bytes).ok().or_else(|| {
+fn resolve_warn_threshold(option: &'static str, bytes: u64) -> usize {
+    usize::try_from(bytes).unwrap_or_else(|_| {
         warn!(
             option,
             configured_bytes = bytes,
             "Configured payload size warning threshold exceeds the maximum addressable size on this \
              platform; disabling this warning"
         );
-        None
+        0
     })
 }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -29,6 +29,7 @@ pub mod worker;
 mod workflow_handle;
 
 pub use crate::{
+    grpc::{PayloadErrorLimits, PayloadLimitsClient},
     proxy::HttpConnectProxyOptions,
     retry::{CallType, RETRYABLE_ERROR_CODES},
 };
@@ -128,6 +129,14 @@ static TEMPORAL_NAMESPACE_HEADER_KEY: &str = "temporal-namespace";
 /// Key used to communicate when a GRPC message is too large
 pub static MESSAGE_TOO_LARGE_KEY: &str = "message-too-large";
 #[doc(hidden)]
+/// The violation, if `status` is the client proactively rejecting an outbound request for exceeding a
+/// payload/memo error size limit.
+pub fn payload_limit_violation_from(
+    status: &tonic::Status,
+) -> Option<&temporalio_common::payload_limits::PayloadLimitViolation> {
+    std::error::Error::source(status).and_then(|src| src.downcast_ref())
+}
+#[doc(hidden)]
 /// Key used to indicate a error was returned by the retryer because of the short-circuit predicate
 pub static ERROR_RETURNED_DUE_TO_SHORT_CIRCUIT: &str = "short-circuit";
 
@@ -157,6 +166,28 @@ struct ConnectionInner {
     capabilities: Option<get_system_info_response::Capabilities>,
     workers: Arc<ClientWorkerSet>,
     _dns_task: Option<Arc<dns::DnsReresolutionHandle>>,
+    /// Configured payload/memo size warning thresholds (bytes); `None` disables that warning.
+    payloads_size_warn: Option<usize>,
+    memo_size_warn: Option<usize>,
+}
+
+/// Resolve a user-configured warning threshold (bytes) into the internal representation. `0`
+/// disables the warning (`None`); so does a value that doesn't fit in `usize` on this platform (a
+/// threshold larger than any addressable payload could never fire anyway), with a warning logged.
+/// `option` names the configured field, for diagnostics.
+fn resolve_warn_threshold(option: &'static str, bytes: u64) -> Option<usize> {
+    if bytes == 0 {
+        return None;
+    }
+    usize::try_from(bytes).ok().or_else(|| {
+        warn!(
+            option,
+            configured_bytes = bytes,
+            "Configured payload size warning threshold exceeds the maximum addressable size on this \
+             platform; disabling this warning"
+        );
+        None
+    })
 }
 
 impl Connection {
@@ -273,6 +304,14 @@ impl Connection {
                 capabilities,
                 workers: Arc::new(ClientWorkerSet::new()),
                 _dns_task: dns_task,
+                payloads_size_warn: resolve_warn_threshold(
+                    "payloads_size_warn",
+                    options.payload_limits.payloads_size_warn,
+                ),
+                memo_size_warn: resolve_warn_threshold(
+                    "memo_size_warn",
+                    options.payload_limits.memo_size_warn,
+                ),
             }),
         })
     }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -130,7 +130,7 @@ static TEMPORAL_NAMESPACE_HEADER_KEY: &str = "temporal-namespace";
 /// Key used to communicate when a GRPC message is too large
 pub static MESSAGE_TOO_LARGE_KEY: &str = "message-too-large";
 #[doc(hidden)]
-/// The violation, if `status` is the client proactively rejecting an outbound request for exceeding a
+/// Returns the violation, if `status` is the client proactively rejecting an outbound request for exceeding a
 /// payload/memo error size limit.
 pub fn payload_limit_violation_from(
     status: &tonic::Status,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -168,8 +168,8 @@ struct ConnectionInner {
     workers: Arc<ClientWorkerSet>,
     _dns_task: Option<Arc<dns::DnsReresolutionHandle>>,
     /// Configured payload/memo size warning thresholds (bytes); `None` disables that warning.
-    payloads_size_warn: Option<usize>,
-    memo_size_warn: Option<usize>,
+    payloads_warn_size: Option<usize>,
+    memo_warn_size: Option<usize>,
 }
 
 /// Resolve a user-configured warning threshold (bytes) into the internal representation. `0`
@@ -332,13 +332,13 @@ impl Connection {
                 capabilities,
                 workers: Arc::new(ClientWorkerSet::new()),
                 _dns_task: dns_task,
-                payloads_size_warn: resolve_warn_threshold(
-                    "payloads_size_warn",
-                    options.payload_limits.payloads_size_warn,
+                payloads_warn_size: resolve_warn_threshold(
+                    "payloads_warn_size",
+                    options.payload_limits.payloads_warn_size,
                 ),
-                memo_size_warn: resolve_warn_threshold(
-                    "memo_size_warn",
-                    options.payload_limits.memo_size_warn,
+                memo_warn_size: resolve_warn_threshold(
+                    "memo_warn_size",
+                    options.payload_limits.memo_warn_size,
                 ),
             }),
         })

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -29,7 +29,6 @@ pub mod worker;
 mod workflow_handle;
 
 pub use crate::{
-    grpc::PayloadLimitsClient,
     proxy::HttpConnectProxyOptions,
     request_extensions::PayloadErrorLimits,
     retry::{CallType, RETRYABLE_ERROR_CODES},

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -29,8 +29,9 @@ pub mod worker;
 mod workflow_handle;
 
 pub use crate::{
-    grpc::{PayloadErrorLimits, PayloadLimitsClient},
+    grpc::PayloadLimitsClient,
     proxy::HttpConnectProxyOptions,
+    request_extensions::PayloadErrorLimits,
     retry::{CallType, RETRYABLE_ERROR_CODES},
 };
 pub use async_activity_handle::{

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -87,6 +87,7 @@ pub struct ConnectionOptions {
     pub grpc_compression: GrpcCompression,
     /// Payload size limit options for this connection. Defaults to the standard warning thresholds;
     /// disable an individual warning by setting its threshold to `0`.
+    /// NOTE: Experimental
     #[builder(default)]
     pub payload_limits: PayloadLimitsOptions,
 
@@ -250,6 +251,7 @@ impl Default for DnsLoadBalancingOptions {
 }
 
 /// Payload size limit options for a connection.
+/// NOTE: Experimental
 #[derive(Clone, Debug)]
 pub struct PayloadLimitsOptions {
     /// Warning threshold (bytes) for the size of an outbound payload-bearing field; over-threshold

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -254,17 +254,17 @@ impl Default for DnsLoadBalancingOptions {
 pub struct PayloadLimitsOptions {
     /// Warning threshold (bytes) for the size of an outbound payload-bearing field; over-threshold
     /// fields are logged but still sent to server. Defaults to 512 KiB. Set to `0` to disable.
-    pub payloads_size_warn: u64,
+    pub payloads_warn_size: u64,
     /// Warning threshold (bytes) for outbound memo sizes; over-threshold memos are logged but still
     /// sent to server. Defaults to 2 KiB. Set to `0` to disable.
-    pub memo_size_warn: u64,
+    pub memo_warn_size: u64,
 }
 
 impl Default for PayloadLimitsOptions {
     fn default() -> Self {
         Self {
-            payloads_size_warn: 512 * 1024,
-            memo_size_warn: 2 * 1024,
+            payloads_warn_size: 512 * 1024,
+            memo_warn_size: 2 * 1024,
         }
     }
 }

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -85,6 +85,10 @@ pub struct ConnectionOptions {
     /// If service_override is specified, is forced to `None`.
     #[builder(default)]
     pub grpc_compression: GrpcCompression,
+    /// Payload size limit options for this connection. Defaults to the standard warning thresholds;
+    /// disable an individual warning by setting its threshold to `0`.
+    #[builder(default)]
+    pub payload_limits: PayloadLimitsOptions,
 
     // Internal / Core-based SDK only options below =============================================
     /// If set true, get_system_info will not be called upon connection.
@@ -241,6 +245,26 @@ impl Default for DnsLoadBalancingOptions {
     fn default() -> Self {
         Self {
             resolution_interval: Duration::from_secs(30),
+        }
+    }
+}
+
+/// Payload size limit options for a connection.
+#[derive(Clone, Debug)]
+pub struct PayloadLimitsOptions {
+    /// Warning threshold (bytes) for the size of an outbound payload-bearing field; over-threshold
+    /// fields are logged but still sent to server. Defaults to 512 KiB. Set to `0` to disable.
+    pub payloads_size_warn: u64,
+    /// Warning threshold (bytes) for outbound memo sizes; over-threshold memos are logged but still
+    /// sent to server. Defaults to 2 KiB. Set to `0` to disable.
+    pub memo_size_warn: u64,
+}
+
+impl Default for PayloadLimitsOptions {
+    fn default() -> Self {
+        Self {
+            payloads_size_warn: 512 * 1024,
+            memo_size_warn: 2 * 1024,
         }
     }
 }

--- a/crates/client/src/request_extensions.rs
+++ b/crates/client/src/request_extensions.rs
@@ -26,6 +26,7 @@ pub struct RetryConfigForCall(pub RetryOptions);
 
 /// Per-call payload/memo size error limits, attached to a request's extensions by a caller that
 /// wants error-level enforcement on this call.
+#[doc(hidden)]
 #[derive(Debug, Clone, Copy)]
 pub struct PayloadErrorLimits {
     /// Blob (payload) size error threshold, in bytes.

--- a/crates/client/src/request_extensions.rs
+++ b/crates/client/src/request_extensions.rs
@@ -24,6 +24,16 @@ pub struct NoRetryOnMatching {
 #[derive(Clone, Debug)]
 pub struct RetryConfigForCall(pub RetryOptions);
 
+/// Per-call payload/memo size error limits, attached to a request's extensions by a caller that
+/// wants error-level enforcement on this call.
+#[derive(Debug, Clone, Copy)]
+pub struct PayloadErrorLimits {
+    /// Blob (payload) size error threshold, in bytes.
+    pub blob: usize,
+    /// Memo size error threshold, in bytes.
+    pub memo: usize,
+}
+
 /// Extension trait for tonic requests to set default timeouts
 pub trait RequestExt {
     /// Set a timeout for a request if one is not already specified in the metadata

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -966,7 +966,7 @@ fn generate_payload_limits_validator(
     output.push_str("// Generated from descriptors.bin - DO NOT EDIT\n");
     output.push_str("// Payload-limits validators. Edit the *_FIELDS tables in build.rs to classify fields.\n\n");
 
-    let mut generate_names: Vec<String> = to_generate.into_iter().collect();
+    let mut generate_names: Vec<String> = to_generate.iter().cloned().collect();
     generate_names.sort();
     for name in &generate_names {
         output.push_str(&generate_limits_impl(
@@ -977,6 +977,27 @@ fn generate_payload_limits_validator(
             &mut unclassified,
         ));
     }
+
+    // Dispatch the gRPC client layer calls for every outbound request: downcast to the payload-bearing
+    // request roots and validate or return `None` for anything else.
+    let mut root_names: Vec<&String> = roots.iter().filter(|r| to_generate.contains(*r)).collect();
+    root_names.sort();
+    root_names.dedup();
+    output.push_str(
+        "\n/// Validate `req` if it is a known payload-bearing request type; otherwise return `None`.\n\
+         pub fn validate_known_payload_limits(\n    \
+             req: &dyn ::std::any::Any,\n    \
+             limits: &PayloadLimits,\n\
+         ) -> Option<PayloadLimitViolation> {\n",
+    );
+    for name in &root_names {
+        let rust_path = proto_to_rust_path(name);
+        output.push_str(&format!(
+            "    if let Some(inner) = req.downcast_ref::<{rust_path}>() {{\n        \
+                 return validate_payload_limits(inner, limits);\n    }}\n"
+        ));
+    }
+    output.push_str("    None\n}\n");
 
     // Fail the build on any unclassified leaf field (forces an explicit decision on proto changes).
     if !unclassified.is_empty() {

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -988,6 +988,7 @@ fn generate_payload_limits_validator(
     root_names.dedup();
     output.push_str(
         "\n/// Validate `req` if it is a known payload-bearing request type; otherwise return `None`.\n\
+         #[doc(hidden)]\n\
          pub fn validate_known_payload_limits(\n    \
              req: &dyn ::std::any::Any,\n    \
              limits: &PayloadLimits,\n\

--- a/crates/common/src/payload_limits.rs
+++ b/crates/common/src/payload_limits.rs
@@ -142,6 +142,7 @@ where
 /// Warn/error thresholds (bytes) for both limit classes. A `0` threshold disables that check for
 /// that class: `0` warn = no warnings, `0` error = no error enforcement (warnings only).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[doc(hidden)]
 pub struct PayloadLimits {
     /// Blob warning threshold (bytes); `0` disables blob warnings.
     pub blob_warn: usize,

--- a/crates/common/src/payload_limits.rs
+++ b/crates/common/src/payload_limits.rs
@@ -139,23 +139,23 @@ where
         .sum()
 }
 
-/// Warn/error thresholds for both limit classes. A `None` threshold disables that check for that
-/// class: `None` warn = no warnings, `None` error = no error enforcement (warnings only).
+/// Warn/error thresholds (bytes) for both limit classes. A `0` threshold disables that check for
+/// that class: `0` warn = no warnings, `0` error = no error enforcement (warnings only).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PayloadLimits {
-    /// Blob warning threshold (bytes), or `None` to disable blob warnings.
-    pub blob_warn: Option<usize>,
-    /// Blob error threshold (bytes), or `None` to disable blob error enforcement.
-    pub blob_error: Option<usize>,
-    /// Memo warning threshold (bytes), or `None` to disable memo warnings.
-    pub memo_warn: Option<usize>,
-    /// Memo error threshold (bytes), or `None` to disable memo error enforcement.
-    pub memo_error: Option<usize>,
+    /// Blob warning threshold (bytes); `0` disables blob warnings.
+    pub blob_warn: usize,
+    /// Blob error threshold (bytes); `0` disables blob error enforcement.
+    pub blob_error: usize,
+    /// Memo warning threshold (bytes); `0` disables memo warnings.
+    pub memo_warn: usize,
+    /// Memo error threshold (bytes); `0` disables memo error enforcement.
+    pub memo_error: usize,
 }
 
 impl PayloadLimits {
-    /// Returns the `(warn, error)` thresholds for a given class.
-    fn thresholds(&self, class: LimitClass) -> (Option<usize>, Option<usize>) {
+    /// Returns the `(warn, error)` thresholds for a given class; `0` means disabled.
+    fn thresholds(&self, class: LimitClass) -> (usize, usize) {
         match class {
             LimitClass::Blob => (self.blob_warn, self.blob_error),
             LimitClass::Memo => (self.memo_warn, self.memo_error),
@@ -241,10 +241,7 @@ impl PayloadLimitSink for CollectingSink {
         enforce_error: bool,
     ) {
         let (warn, error) = self.limits.thresholds(class);
-        if enforce_error
-            && let Some(error) = error
-            && size > error
-        {
+        if enforce_error && error > 0 && size > error {
             self.errors.push(PayloadLimitViolation {
                 path: self.path.leaf(field_name),
                 class,
@@ -252,9 +249,7 @@ impl PayloadLimitSink for CollectingSink {
                 size,
                 limit: error,
             });
-        } else if let Some(warn) = warn
-            && size > warn
-        {
+        } else if warn > 0 && size > warn {
             self.warnings.push(PayloadLimitViolation {
                 path: self.path.leaf(field_name),
                 class,
@@ -380,10 +375,10 @@ mod tests {
 
     fn worker_limits(blob_error: usize, memo_error: usize) -> PayloadLimits {
         PayloadLimits {
-            blob_warn: Some(10),
-            blob_error: Some(blob_error),
-            memo_warn: Some(10),
-            memo_error: Some(memo_error),
+            blob_warn: 10,
+            blob_error,
+            memo_warn: 10,
+            memo_error,
         }
     }
 
@@ -409,10 +404,10 @@ mod tests {
             ..Default::default()
         };
         let limits = PayloadLimits {
-            blob_warn: Some(10),
-            blob_error: Some(1_000_000),
-            memo_warn: Some(10),
-            memo_error: Some(20),
+            blob_warn: 10,
+            blob_error: 1_000_000,
+            memo_warn: 10,
+            memo_error: 20,
         };
         let violation = validate_payload_limits(&req, &limits).expect("memo should error");
         assert_eq!(violation.class, LimitClass::Memo);
@@ -443,29 +438,24 @@ mod tests {
     }
 
     #[test]
-    fn none_warn_threshold_disables_warnings() {
+    fn zero_warn_threshold_disables_warnings() {
         let req = StartWorkflowExecutionRequest {
             input: Some(payloads(1000)),
             ..Default::default()
         };
-        // A `Some` warn threshold below the field size produces a (non-error) warning.
+        // A nonzero warn threshold below the field size produces a (non-error) warning.
         let mut sink = CollectingSink::new(PayloadLimits {
-            blob_warn: Some(100),
-            blob_error: None,
-            memo_warn: None,
-            memo_error: None,
+            blob_warn: 100,
+            blob_error: 0,
+            memo_warn: 0,
+            memo_error: 0,
         });
         req.validate_payload_limits(&mut sink);
         assert_eq!(sink.warnings.len(), 1);
         assert!(sink.errors.is_empty());
 
-        // A `None` warn threshold disables the warning entirely.
-        let mut sink = CollectingSink::new(PayloadLimits {
-            blob_warn: None,
-            blob_error: None,
-            memo_warn: None,
-            memo_error: None,
-        });
+        // A `0` warn threshold disables the warning entirely.
+        let mut sink = CollectingSink::new(PayloadLimits::default());
         req.validate_payload_limits(&mut sink);
         assert!(sink.warnings.is_empty());
     }
@@ -564,10 +554,10 @@ mod tests {
         // Warn threshold set, no error threshold: an over-threshold field warns (never errors),
         // even with enforce_error = true.
         let mut sink = CollectingSink::new(PayloadLimits {
-            blob_warn: Some(100),
-            blob_error: None,
-            memo_warn: None,
-            memo_error: None,
+            blob_warn: 100,
+            blob_error: 0,
+            memo_warn: 0,
+            memo_error: 0,
         });
         sink.check("big", LimitClass::Blob, 101, true);
         assert!(sink.errors.is_empty());

--- a/crates/common/src/payload_limits.rs
+++ b/crates/common/src/payload_limits.rs
@@ -14,11 +14,6 @@
 use crate::protos::temporal::api::common::v1::{Memo, Payload, Payloads};
 use prost::Message;
 
-/// Default warning threshold for blob (payload) sizes: 512 KiB.
-pub const DEFAULT_BLOB_SIZE_WARN: usize = 512 * 1024;
-/// Default warning threshold for memo sizes: 2 KiB.
-pub const DEFAULT_MEMO_SIZE_WARN: usize = 2 * 1024;
-
 /// Which server-enforced size limit a payload field is subject to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LimitClass {
@@ -144,44 +139,37 @@ where
         .sum()
 }
 
-/// Warn/error thresholds for both limit classes. An error threshold of `None` disables error
-/// enforcement for that class (warnings only).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Warn/error thresholds for both limit classes. A `None` threshold disables that check for that
+/// class: `None` warn = no warnings, `None` error = no error enforcement (warnings only).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PayloadLimits {
-    /// Blob warning threshold (bytes).
-    pub blob_warn: usize,
-    /// Blob error threshold (bytes), or `None` to warn only.
+    /// Blob warning threshold (bytes), or `None` to disable blob warnings.
+    pub blob_warn: Option<usize>,
+    /// Blob error threshold (bytes), or `None` to disable blob error enforcement.
     pub blob_error: Option<usize>,
-    /// Memo warning threshold (bytes).
-    pub memo_warn: usize,
-    /// Memo error threshold (bytes), or `None` to warn only.
+    /// Memo warning threshold (bytes), or `None` to disable memo warnings.
+    pub memo_warn: Option<usize>,
+    /// Memo error threshold (bytes), or `None` to disable memo error enforcement.
     pub memo_error: Option<usize>,
 }
 
-impl Default for PayloadLimits {
-    fn default() -> Self {
-        Self {
-            blob_warn: DEFAULT_BLOB_SIZE_WARN,
-            blob_error: None,
-            memo_warn: DEFAULT_MEMO_SIZE_WARN,
-            memo_error: None,
-        }
-    }
-}
-
 impl PayloadLimits {
-    /// The default warning thresholds with no error enforcement.
-    pub fn warn_only() -> Self {
-        Self::default()
-    }
-
     /// Returns the `(warn, error)` thresholds for a given class.
-    fn thresholds(&self, class: LimitClass) -> (usize, Option<usize>) {
+    fn thresholds(&self, class: LimitClass) -> (Option<usize>, Option<usize>) {
         match class {
             LimitClass::Blob => (self.blob_warn, self.blob_error),
             LimitClass::Memo => (self.memo_warn, self.memo_error),
         }
     }
+}
+
+/// Whether a violation exceeded the warning threshold or the error threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitSeverity {
+    /// Exceeded the warning threshold.
+    Warning,
+    /// Exceeded the error threshold.
+    Error,
 }
 
 /// A payload field whose size exceeded one of its configured thresholds (warning or error).
@@ -192,6 +180,8 @@ pub struct PayloadLimitViolation {
     pub path: String,
     /// Which limit class the threshold belongs to.
     pub class: LimitClass,
+    /// Which threshold was exceeded.
+    pub severity: LimitSeverity,
     /// The field's measured size in bytes.
     pub size: usize,
     /// The threshold that was exceeded (warning threshold for warnings, error threshold for errors).
@@ -200,10 +190,17 @@ pub struct PayloadLimitViolation {
 
 impl std::fmt::Display for PayloadLimitViolation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let limit_class = match self.class {
+            LimitClass::Blob => "payloads",
+            LimitClass::Memo => "memo",
+        };
+        let limit_kind = match self.severity {
+            LimitSeverity::Warning => "warning",
+            LimitSeverity::Error => "error",
+        };
         write!(
             f,
-            "payload field `{}` size {} bytes exceeds the {:?} limit of {} bytes",
-            self.path, self.size, self.class, self.limit
+            "[TMPRL1103] Attempted to upload {limit_class} with size that exceeded the {limit_kind} limit."
         )
     }
 }
@@ -251,13 +248,17 @@ impl PayloadLimitSink for CollectingSink {
             self.errors.push(PayloadLimitViolation {
                 path: self.path.leaf(field_name),
                 class,
+                severity: LimitSeverity::Error,
                 size,
                 limit: error,
             });
-        } else if size > warn {
+        } else if let Some(warn) = warn
+            && size > warn
+        {
             self.warnings.push(PayloadLimitViolation {
                 path: self.path.leaf(field_name),
                 class,
+                severity: LimitSeverity::Warning,
                 size,
                 limit: warn,
             });
@@ -286,25 +287,13 @@ pub fn validate_payload_limits<M: PayloadLimitsValidatable + ?Sized>(
 
     if !sink.errors.is_empty() {
         for error in &sink.errors {
-            error!(
-                payload_path = error.path.as_str(),
-                payload_size = error.size,
-                error_limit = error.limit,
-                ?error.class,
-                "Payload size exceeds the error limit"
-            );
+            error!(size = error.size, limit = error.limit, "{error}",);
         }
         return sink.errors.into_iter().next();
     }
 
     for warning in &sink.warnings {
-        warn!(
-            payload_path = warning.path.as_str(),
-            payload_size = warning.size,
-            warn_limit = warning.limit,
-            ?warning.class,
-            "Payload size exceeds the warning limit"
-        );
+        warn!(size = warning.size, limit = warning.limit, "{warning}",);
     }
     None
 }
@@ -391,9 +380,9 @@ mod tests {
 
     fn worker_limits(blob_error: usize, memo_error: usize) -> PayloadLimits {
         PayloadLimits {
-            blob_warn: 10,
+            blob_warn: Some(10),
             blob_error: Some(blob_error),
-            memo_warn: 10,
+            memo_warn: Some(10),
             memo_error: Some(memo_error),
         }
     }
@@ -420,9 +409,9 @@ mod tests {
             ..Default::default()
         };
         let limits = PayloadLimits {
-            blob_warn: 10,
+            blob_warn: Some(10),
             blob_error: Some(1_000_000),
-            memo_warn: 10,
+            memo_warn: Some(10),
             memo_error: Some(20),
         };
         let violation = validate_payload_limits(&req, &limits).expect("memo should error");
@@ -451,6 +440,34 @@ mod tests {
             ..Default::default()
         };
         assert!(validate_payload_limits(&req, &worker_limits(100_000, 100_000)).is_none());
+    }
+
+    #[test]
+    fn none_warn_threshold_disables_warnings() {
+        let req = StartWorkflowExecutionRequest {
+            input: Some(payloads(1000)),
+            ..Default::default()
+        };
+        // A `Some` warn threshold below the field size produces a (non-error) warning.
+        let mut sink = CollectingSink::new(PayloadLimits {
+            blob_warn: Some(100),
+            blob_error: None,
+            memo_warn: None,
+            memo_error: None,
+        });
+        req.validate_payload_limits(&mut sink);
+        assert_eq!(sink.warnings.len(), 1);
+        assert!(sink.errors.is_empty());
+
+        // A `None` warn threshold disables the warning entirely.
+        let mut sink = CollectingSink::new(PayloadLimits {
+            blob_warn: None,
+            blob_error: None,
+            memo_warn: None,
+            memo_error: None,
+        });
+        req.validate_payload_limits(&mut sink);
+        assert!(sink.warnings.is_empty());
     }
 
     #[test]
@@ -544,8 +561,15 @@ mod tests {
 
     #[test]
     fn collecting_sink_no_error_limit_only_warns() {
-        let mut sink = CollectingSink::new(PayloadLimits::warn_only());
-        sink.check("big", LimitClass::Blob, DEFAULT_BLOB_SIZE_WARN + 1, true);
+        // Warn threshold set, no error threshold: an over-threshold field warns (never errors),
+        // even with enforce_error = true.
+        let mut sink = CollectingSink::new(PayloadLimits {
+            blob_warn: Some(100),
+            blob_error: None,
+            memo_warn: None,
+            memo_error: None,
+        });
+        sink.check("big", LimitClass::Blob, 101, true);
         assert!(sink.errors.is_empty());
         assert_eq!(sink.warnings.len(), 1);
         assert_eq!(sink.warnings[0].path, "big");

--- a/crates/common/src/payload_limits.rs
+++ b/crates/common/src/payload_limits.rs
@@ -16,6 +16,7 @@ use prost::Message;
 
 /// Which server-enforced size limit a payload field is subject to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
 pub enum LimitClass {
     /// Subject to the blob (payload) size limit.
     Blob,
@@ -25,7 +26,7 @@ pub enum LimitClass {
 
 /// How a nested field is addressed within its parent.
 #[derive(Debug, Clone, Copy)]
-pub enum FieldIndexer<'a> {
+pub(crate) enum FieldIndexer<'a> {
     /// A singular field.
     None,
     /// The `n`-th element of a repeated field.
@@ -67,7 +68,7 @@ impl PayloadPath {
 ///
 /// The generated traversal calls `enter`/`exit` around each nested message so the sink can track a
 /// field's location for `check`.
-pub trait PayloadLimitSink {
+pub(crate) trait PayloadLimitSink {
     /// Called for each validated payload field. `field_name` is the leaf field's proto name; `size`
     /// is the field's size in bytes for the given [`LimitClass`]. When `enforce_error` is `false`,
     /// the field may warn but must not produce an error-level violation.
@@ -88,35 +89,37 @@ pub trait PayloadLimitSink {
 
 /// Implemented via codegen for every outbound request message that transitively contains validated
 /// payload fields.
-pub trait PayloadLimitsValidatable {
+pub(crate) trait PayloadLimitsValidatable {
     /// Reports each validated payload field's size and class to `sink`.
     fn validate_payload_limits(&self, sink: &mut dyn PayloadLimitSink);
 }
 
 /// Serialized size of a [`Payloads`] message, as the server measures it.
-pub fn payloads_size(payloads: &Payloads) -> usize {
+pub(crate) fn payloads_size(payloads: &Payloads) -> usize {
     payloads.encoded_len()
 }
 
 /// Serialized size of a single [`Payload`], as the server measures it.
-pub fn payload_size(payload: &Payload) -> usize {
+pub(crate) fn payload_size(payload: &Payload) -> usize {
     payload.encoded_len()
 }
 
 /// Serialized size of a [`Memo`] message, as the server measures it.
-pub fn memo_size(memo: &Memo) -> usize {
+pub(crate) fn memo_size(memo: &Memo) -> usize {
     memo.encoded_len()
 }
 
 /// Serialized size of an arbitrary proto message, as the server measures it. Used for messages the
 /// server checks as a whole rather than per-payload-field (e.g. `Failure`).
-pub fn message_size<M: Message>(message: &M) -> usize {
+pub(crate) fn message_size<M: Message>(message: &M) -> usize {
     message.encoded_len()
 }
 
 /// Aggregate size of a marker-style `map<string, Payloads>`, mirroring the server's
 /// `sum(len(key) + payloads.Size())` accounting (e.g. `RecordMarkerCommandAttributes.details`).
-pub fn map_payloads_sum<'a, K>(entries: impl IntoIterator<Item = (&'a K, &'a Payloads)>) -> usize
+pub(crate) fn map_payloads_sum<'a, K>(
+    entries: impl IntoIterator<Item = (&'a K, &'a Payloads)>,
+) -> usize
 where
     K: AsRef<str> + 'a,
 {
@@ -129,7 +132,9 @@ where
 /// Aggregate size of a search-attribute-style `map<string, Payload>`, mirroring the server's
 /// `sum(len(key) + len(payload.data))` accounting — note the server counts the **raw data** length
 /// here, not the serialized payload size (e.g. `UpsertWorkflowSearchAttributes.indexed_fields`).
-pub fn map_payload_data_sum<'a, K>(entries: impl IntoIterator<Item = (&'a K, &'a Payload)>) -> usize
+pub(crate) fn map_payload_data_sum<'a, K>(
+    entries: impl IntoIterator<Item = (&'a K, &'a Payload)>,
+) -> usize
 where
     K: AsRef<str> + 'a,
 {
@@ -166,6 +171,7 @@ impl PayloadLimits {
 
 /// Whether a violation exceeded the warning threshold or the error threshold.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
 pub enum LimitSeverity {
     /// Exceeded the warning threshold.
     Warning,
@@ -175,6 +181,7 @@ pub enum LimitSeverity {
 
 /// A payload field whose size exceeded one of its configured thresholds (warning or error).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[doc(hidden)]
 pub struct PayloadLimitViolation {
     /// Path of proto field names from the root message
     /// (e.g. `commands[2].schedule_activity_task_command_attributes.input`).
@@ -214,18 +221,18 @@ impl std::error::Error for PayloadLimitViolation {}
 /// field over its error threshold (when `enforce_error` and an error threshold are set) is an error;
 /// otherwise a field over its warning threshold is a warning.
 #[derive(Debug, Clone, Default)]
-pub struct CollectingSink {
+struct CollectingSink {
     limits: PayloadLimits,
     path: PayloadPath,
     /// Fields that exceeded their warning threshold (but not an enforced error threshold).
-    pub warnings: Vec<PayloadLimitViolation>,
+    warnings: Vec<PayloadLimitViolation>,
     /// Fields that exceeded their enforced error threshold.
-    pub errors: Vec<PayloadLimitViolation>,
+    errors: Vec<PayloadLimitViolation>,
 }
 
 impl CollectingSink {
     /// A new collector that classifies fields against `limits`.
-    pub fn new(limits: PayloadLimits) -> Self {
+    fn new(limits: PayloadLimits) -> Self {
         Self {
             limits,
             ..Default::default()
@@ -274,7 +281,7 @@ impl PayloadLimitSink for CollectingSink {
 /// If any field exceeded its error threshold, logs the error(s) and returns the first one without
 /// logging warnings; otherwise logs each warning and returns `None`. With no error thresholds set,
 /// there are never errors, so this only warns and always returns `None`.
-pub fn validate_payload_limits<M: PayloadLimitsValidatable + ?Sized>(
+pub(crate) fn validate_payload_limits<M: PayloadLimitsValidatable + ?Sized>(
     msg: &M,
     limits: &PayloadLimits,
 ) -> Option<PayloadLimitViolation> {

--- a/crates/common/src/telemetry/log_export.rs
+++ b/crates/common/src/telemetry/log_export.rs
@@ -270,6 +270,133 @@ mod tests {
         assert_logs(instance.fetch_buffered_logs());
     }
 
+    /// A payload-limit log uses the `[TMPRL1103]` code and inherits execution context (workflow id,
+    /// type, namespace, …) from the enclosing span via span-field flattening — the path by which that
+    /// context reaches lang SDKs through log forwarding.
+    #[tokio::test]
+    async fn payload_limit_log_carries_span_context() {
+        use crate::payload_limits::{PayloadLimits, validate_payload_limits};
+        use crate::protos::temporal::api::{
+            common::v1::{Payload, Payloads},
+            workflowservice::v1::StartWorkflowExecutionRequest,
+        };
+
+        let opts = TelemetryOptions::builder()
+            .logging(Logger::Forward {
+                filter: construct_filter_string(Level::INFO, Level::WARN),
+            })
+            .build();
+        let instance = telemetry_init(opts).unwrap();
+        let _g = tracing::subscriber::set_default(instance.trace_subscriber().unwrap().clone());
+
+        let req = StartWorkflowExecutionRequest {
+            input: Some(Payloads {
+                payloads: vec![Payload {
+                    data: vec![0u8; 1000],
+                    ..Default::default()
+                }],
+            }),
+            ..Default::default()
+        };
+        // Warn-only limits: logs a warning, returns None.
+        let limits = PayloadLimits {
+            blob_warn: Some(1),
+            memo_warn: Some(1),
+            blob_error: None,
+            memo_error: None,
+        };
+        {
+            let span = span!(
+                Level::INFO,
+                "wf_completion",
+                namespace = "myns",
+                workflow_id = "wf1",
+                workflow_type = "MyWorkflow"
+            );
+            let _guard = span.enter();
+            assert!(validate_payload_limits(&req, &limits).is_none());
+        }
+
+        let logs = instance.fetch_buffered_logs();
+        let warn = logs
+            .iter()
+            .find(|l| l.message.starts_with("[TMPRL1103]"))
+            .expect("payload-limit warning was forwarded");
+        assert_eq!(warn.level, Level::WARN);
+        assert!(warn.message.contains("payloads"));
+        // Span context flattened into the forwarded record:
+        assert_eq!(warn.fields.get("namespace"), Some(&"myns".into()));
+        assert_eq!(warn.fields.get("workflow_id"), Some(&"wf1".into()));
+        assert_eq!(warn.fields.get("workflow_type"), Some(&"MyWorkflow".into()));
+        // Event fields present
+        assert!(warn.fields.contains_key("size"));
+        // Ensure high cardinality fields are not included
+        assert!(!warn.fields.contains_key("payload_path"));
+    }
+
+    /// Error-level counterpart: an over-error-limit field emits an `ERROR` `[TMPRL1103]` log carrying
+    /// the same span context.
+    #[tokio::test]
+    async fn payload_limit_error_log_carries_span_context() {
+        use crate::payload_limits::{PayloadLimits, validate_payload_limits};
+        use crate::protos::temporal::api::{
+            common::v1::{Payload, Payloads},
+            workflowservice::v1::StartWorkflowExecutionRequest,
+        };
+
+        let opts = TelemetryOptions::builder()
+            .logging(Logger::Forward {
+                filter: construct_filter_string(Level::INFO, Level::WARN),
+            })
+            .build();
+        let instance = telemetry_init(opts).unwrap();
+        let _g = tracing::subscriber::set_default(instance.trace_subscriber().unwrap().clone());
+
+        let req = StartWorkflowExecutionRequest {
+            input: Some(Payloads {
+                payloads: vec![Payload {
+                    data: vec![0u8; 1000],
+                    ..Default::default()
+                }],
+            }),
+            ..Default::default()
+        };
+        // Error limits set: the oversized input produces an error-level violation.
+        let limits = PayloadLimits {
+            blob_warn: Some(1),
+            memo_warn: Some(1),
+            blob_error: Some(1),
+            memo_error: Some(1),
+        };
+        {
+            let span = span!(
+                Level::INFO,
+                "wf_completion",
+                namespace = "myns",
+                workflow_id = "wf1",
+                workflow_type = "MyWorkflow"
+            );
+            let _guard = span.enter();
+            assert!(validate_payload_limits(&req, &limits).is_some());
+        }
+
+        let logs = instance.fetch_buffered_logs();
+        let error = logs
+            .iter()
+            .find(|l| l.message.starts_with("[TMPRL1103]"))
+            .expect("payload-limit error was forwarded");
+        assert_eq!(error.level, Level::ERROR);
+        assert!(error.message.contains("payloads"));
+        assert_eq!(error.fields.get("namespace"), Some(&"myns".into()));
+        assert_eq!(error.fields.get("workflow_id"), Some(&"wf1".into()));
+        assert_eq!(
+            error.fields.get("workflow_type"),
+            Some(&"MyWorkflow".into())
+        );
+        assert!(error.fields.contains_key("size"));
+        assert!(!error.fields.contains_key("payload_path"));
+    }
+
     struct CaptureConsumer(Mutex<Vec<CoreLog>>);
 
     impl CoreLogConsumer for CaptureConsumer {

--- a/crates/common/src/telemetry/log_export.rs
+++ b/crates/common/src/telemetry/log_export.rs
@@ -300,10 +300,10 @@ mod tests {
         };
         // Warn-only limits: logs a warning, returns None.
         let limits = PayloadLimits {
-            blob_warn: Some(1),
-            memo_warn: Some(1),
-            blob_error: None,
-            memo_error: None,
+            blob_warn: 1,
+            memo_warn: 1,
+            blob_error: 0,
+            memo_error: 0,
         };
         {
             let span = span!(
@@ -363,10 +363,10 @@ mod tests {
         };
         // Error limits set: the oversized input produces an error-level violation.
         let limits = PayloadLimits {
-            blob_warn: Some(1),
-            memo_warn: Some(1),
-            blob_error: Some(1),
-            memo_error: Some(1),
+            blob_warn: 1,
+            memo_warn: 1,
+            blob_error: 1,
+            memo_error: 1,
         };
         {
             let span = span!(

--- a/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
+++ b/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
@@ -201,12 +201,12 @@ typedef struct TemporalCoreConnectionOptions {
    * Warning threshold (bytes) for the size of an outbound payload-bearing field.
    * Over-threshold fields are logged but still sent to server. 0 disables the warning.
    */
-  uint64_t payloads_size_warn;
+  uint64_t payloads_warn_size;
   /**
    * Warning threshold (bytes) for outbound memo size. Over-threshold memos are logged but still
    * sent to server. 0 disables the warning.
    */
-  uint64_t memo_size_warn;
+  uint64_t memo_warn_size;
 } TemporalCoreConnectionOptions;
 
 typedef struct TemporalCoreByteArray {

--- a/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
+++ b/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
@@ -197,6 +197,16 @@ typedef struct TemporalCoreConnectionOptions {
    * compressed request bodies.
    */
   enum TemporalCoreClientGrpcCompression grpc_compression;
+  /**
+   * Warning threshold (bytes) for the size of an outbound payload-bearing field.
+   * Over-threshold fields are logged but still sent to server. 0 disables the warning.
+   */
+  uint64_t payloads_size_warn;
+  /**
+   * Warning threshold (bytes) for outbound memo size. Over-threshold memos are logged but still
+   * sent to server. 0 disables the warning.
+   */
+  uint64_t memo_size_warn;
 } TemporalCoreConnectionOptions;
 
 typedef struct TemporalCoreByteArray {
@@ -821,6 +831,7 @@ typedef struct TemporalCoreWorkerOptions {
   struct TemporalCoreByteArrayRefArray nondeterminism_as_workflow_fail_for_types;
   struct TemporalCoreByteArrayRefArray plugins;
   struct TemporalCoreByteArrayRefArray storage_drivers;
+  bool disable_payload_error_limit;
 } TemporalCoreWorkerOptions;
 
 /**

--- a/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
+++ b/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
@@ -200,11 +200,13 @@ typedef struct TemporalCoreConnectionOptions {
   /**
    * Warning threshold (bytes) for the size of an outbound payload-bearing field.
    * Over-threshold fields are logged but still sent to server. 0 disables the warning.
+   * NOTE: Experimental
    */
   uint64_t payloads_warn_size;
   /**
    * Warning threshold (bytes) for outbound memo size. Over-threshold memos are logged but still
    * sent to server. 0 disables the warning.
+   * NOTE: Experimental
    */
   uint64_t memo_warn_size;
 } TemporalCoreConnectionOptions;
@@ -831,6 +833,11 @@ typedef struct TemporalCoreWorkerOptions {
   struct TemporalCoreByteArrayRefArray nondeterminism_as_workflow_fail_for_types;
   struct TemporalCoreByteArrayRefArray plugins;
   struct TemporalCoreByteArrayRefArray storage_drivers;
+  /**
+   * If set, the worker won't proactively fail completions whose payloads exceed the namespace
+   * error limits; oversized payloads are sent and the server enforces the limit.
+   * NOTE: Experimental
+   */
   bool disable_payload_error_limit;
 } TemporalCoreWorkerOptions;
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -54,6 +54,12 @@ pub struct ConnectionOptions {
     /// default. Ignored when grpc_override_callback is set, since that transport cannot decode
     /// compressed request bodies.
     pub grpc_compression: ClientGrpcCompression,
+    /// Warning threshold (bytes) for the size of an outbound payload-bearing field.
+    /// Over-threshold fields are logged but still sent to server. 0 disables the warning.
+    pub payloads_size_warn: u64,
+    /// Warning threshold (bytes) for outbound memo size. Over-threshold memos are logged but still
+    /// sent to server. 0 disables the warning.
+    pub memo_size_warn: u64,
 }
 
 #[derive(Clone, Copy)]
@@ -1454,6 +1460,10 @@ impl TryFrom<&ConnectionOptions> for temporalio_client::ConnectionOptions {
                     ClientGrpcCompression::Gzip => temporalio_client::GrpcCompression::Gzip,
                     ClientGrpcCompression::None => temporalio_client::GrpcCompression::None,
                 })
+                .payload_limits(temporalio_client::PayloadLimitsOptions {
+                    payloads_size_warn: opts.payloads_size_warn,
+                    memo_size_warn: opts.memo_size_warn,
+                })
                 .build(),
         )
     }
@@ -1566,6 +1576,8 @@ mod tests {
             grpc_override_callback_user_data: std::ptr::null_mut(),
             dns_load_balancing_options: std::ptr::null(),
             grpc_compression: ClientGrpcCompression::Gzip,
+            payloads_size_warn: 0,
+            memo_size_warn: 0,
         }
     }
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -56,10 +56,10 @@ pub struct ConnectionOptions {
     pub grpc_compression: ClientGrpcCompression,
     /// Warning threshold (bytes) for the size of an outbound payload-bearing field.
     /// Over-threshold fields are logged but still sent to server. 0 disables the warning.
-    pub payloads_size_warn: u64,
+    pub payloads_warn_size: u64,
     /// Warning threshold (bytes) for outbound memo size. Over-threshold memos are logged but still
     /// sent to server. 0 disables the warning.
-    pub memo_size_warn: u64,
+    pub memo_warn_size: u64,
 }
 
 #[derive(Clone, Copy)]
@@ -1462,8 +1462,8 @@ impl TryFrom<&ConnectionOptions> for temporalio_client::ConnectionOptions {
                     ClientGrpcCompression::None => temporalio_client::GrpcCompression::None,
                 })
                 .payload_limits(temporalio_client::PayloadLimitsOptions {
-                    payloads_size_warn: opts.payloads_size_warn,
-                    memo_size_warn: opts.memo_size_warn,
+                    payloads_warn_size: opts.payloads_warn_size,
+                    memo_warn_size: opts.memo_warn_size,
                 })
                 .build(),
         )
@@ -1577,8 +1577,8 @@ mod tests {
             grpc_override_callback_user_data: std::ptr::null_mut(),
             dns_load_balancing_options: std::ptr::null(),
             grpc_compression: ClientGrpcCompression::Gzip,
-            payloads_size_warn: 0,
-            memo_size_warn: 0,
+            payloads_warn_size: 0,
+            memo_warn_size: 0,
         }
     }
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -56,9 +56,11 @@ pub struct ConnectionOptions {
     pub grpc_compression: ClientGrpcCompression,
     /// Warning threshold (bytes) for the size of an outbound payload-bearing field.
     /// Over-threshold fields are logged but still sent to server. 0 disables the warning.
+    /// NOTE: Experimental
     pub payloads_warn_size: u64,
     /// Warning threshold (bytes) for outbound memo size. Over-threshold memos are logged but still
     /// sent to server. 0 disables the warning.
+    /// NOTE: Experimental
     pub memo_warn_size: u64,
 }
 

--- a/crates/sdk-core-c-bridge/src/tests/context.rs
+++ b/crates/sdk-core-c-bridge/src/tests/context.rs
@@ -367,6 +367,8 @@ impl Context {
                 }
                 _ => crate::client::ClientGrpcCompression::Gzip,
             },
+            payloads_size_warn: 0,
+            memo_size_warn: 0,
         });
 
         let client_options_ptr = &*client_options as *const _;

--- a/crates/sdk-core-c-bridge/src/tests/context.rs
+++ b/crates/sdk-core-c-bridge/src/tests/context.rs
@@ -367,8 +367,8 @@ impl Context {
                 }
                 _ => crate::client::ClientGrpcCompression::Gzip,
             },
-            payloads_size_warn: 0,
-            memo_size_warn: 0,
+            payloads_warn_size: 0,
+            memo_warn_size: 0,
         });
 
         let client_options_ptr = &*client_options as *const _;

--- a/crates/sdk-core-c-bridge/src/worker.rs
+++ b/crates/sdk-core-c-bridge/src/worker.rs
@@ -52,6 +52,7 @@ pub struct WorkerOptions {
     pub nondeterminism_as_workflow_fail_for_types: ByteArrayRefArray,
     pub plugins: ByteArrayRefArray,
     pub storage_drivers: ByteArrayRefArray,
+    pub disable_payload_error_limit: bool,
 }
 
 #[repr(C)]
@@ -1287,6 +1288,7 @@ impl TryFrom<&WorkerOptions> for temporalio_sdk_core::WorkerConfig {
                     })
                     .collect::<HashSet<_>>(),
             )
+            .disable_payload_error_limit(opt.disable_payload_error_limit)
             .build()
             .map_err(|err| anyhow::anyhow!(err))
     }
@@ -1440,6 +1442,7 @@ mod tests {
             nondeterminism_as_workflow_fail_for_types: crate::ByteArrayRefArray::empty(),
             plugins: crate::ByteArrayRefArray::empty(),
             storage_drivers: crate::ByteArrayRefArray::empty(),
+            disable_payload_error_limit: false,
         }
     }
 

--- a/crates/sdk-core-c-bridge/src/worker.rs
+++ b/crates/sdk-core-c-bridge/src/worker.rs
@@ -52,6 +52,9 @@ pub struct WorkerOptions {
     pub nondeterminism_as_workflow_fail_for_types: ByteArrayRefArray,
     pub plugins: ByteArrayRefArray,
     pub storage_drivers: ByteArrayRefArray,
+    /// If set, the worker won't proactively fail completions whose payloads exceed the namespace
+    /// error limits; oversized payloads are sent and the server enforces the limit.
+    /// NOTE: Experimental
     pub disable_payload_error_limit: bool,
 }
 

--- a/crates/sdk-core/src/core_tests/activity_tasks.rs
+++ b/crates/sdk-core/src/core_tests/activity_tasks.rs
@@ -26,6 +26,7 @@ use std::{
     time::{Duration, Instant},
 };
 use temporalio_common::{
+    payload_limits::{LimitClass, LimitSeverity, PayloadLimitViolation},
     protos::{
         coresdk::{
             ActivityTaskCompletion,
@@ -46,6 +47,7 @@ use temporalio_common::{
         temporal::api::{
             command::v1::{ScheduleActivityTaskCommandAttributes, command::Attributes},
             enums::v1::EventType,
+            failure::v1::failure::FailureInfo,
             workflowservice::v1::{
                 PollActivityTaskQueueResponse, RecordActivityTaskHeartbeatResponse,
                 RespondActivityTaskCanceledResponse, RespondActivityTaskCompletedResponse,
@@ -705,6 +707,129 @@ async fn complete_act_with_fail_flushes_heartbeat() {
     // Verify the last seen call to record a heartbeat had the last detail payload
     let last_seen_payload = &last_seen_payload.take().unwrap().payloads[0];
     assert_eq!(last_seen_payload.data, &[last_hb]);
+}
+
+/// Builds a tonic `Status` carrying a `PayloadLimitViolation` source, exactly as the gRPC client
+/// layer produces when an outbound payload exceeds the error limit.
+fn payload_too_large_status() -> tonic::Status {
+    let violation = PayloadLimitViolation {
+        path: "details".to_string(),
+        class: LimitClass::Blob,
+        severity: LimitSeverity::Error,
+        size: 1024,
+        limit: 10,
+    };
+    let mut status = tonic::Status::invalid_argument("Payload size limit exceeded");
+    status.set_source(Arc::new(violation));
+    status
+}
+
+fn assert_payloads_too_large_retryable(
+    failure: &Option<temporalio_common::protos::temporal::api::failure::v1::Failure>,
+) {
+    let failure = failure.as_ref().expect("failure present");
+    assert_matches!(
+        &failure.failure_info,
+        Some(FailureInfo::ApplicationFailureInfo(afi))
+            if afi.r#type == crate::worker::PAYLOADS_TOO_LARGE_FAILURE_TYPE && !afi.non_retryable
+    );
+}
+
+/// An oversized cancel `details` payload must be reported as a (retryable) activity task failure
+/// rather than a cancellation — mirroring the success path and the server's own behavior.
+#[tokio::test]
+async fn oversized_cancel_details_fails_activity() {
+    let mut mock_client = mock_worker_client();
+    mock_client
+        .expect_cancel_activity_task()
+        .times(1)
+        .returning(|_, _| Err(payload_too_large_status()));
+    mock_client
+        .expect_fail_activity_task()
+        .times(1)
+        .returning(|_, failure| {
+            assert_payloads_too_large_retryable(&failure);
+            Ok(RespondActivityTaskFailedResponse::default())
+        });
+
+    let core = mock_worker(MocksHolder::from_client_with_activities(
+        mock_client,
+        [PollActivityTaskQueueResponse {
+            task_token: vec![1],
+            activity_id: "act1".to_string(),
+            ..Default::default()
+        }
+        .into()],
+    ));
+
+    let act = core.poll_activity_task().await.unwrap();
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: act.task_token,
+        result: Some(ActivityExecutionResult::cancel_from_details(Some(
+            vec![1_u8; 1024].into(),
+        ))),
+    })
+    .await
+    .unwrap();
+    core.drain_activity_poller_and_shutdown().await;
+}
+
+/// An oversized heartbeat `details` payload must fail the activity task (retryably) and stop the
+/// running activity with a `Cancelled` cancel — replicating the server, which fails the activity
+/// task and returns `cancel_requested = true`.
+#[tokio::test]
+async fn oversized_heartbeat_fails_activity() {
+    let mut mock_client = mock_worker_client();
+    mock_client
+        .expect_record_activity_heartbeat()
+        .times(1)
+        .returning(|_, _| Err(payload_too_large_status()));
+    mock_client
+        .expect_fail_activity_task()
+        .times(1)
+        .returning(|_, failure| {
+            assert_payloads_too_large_retryable(&failure);
+            Ok(RespondActivityTaskFailedResponse::default())
+        });
+    // The activity winds down after the stop-cancel and reports its cancellation, which races to a
+    // NotFound (already failed); allow that call.
+    mock_client
+        .expect_cancel_activity_task()
+        .returning(|_, _| Ok(RespondActivityTaskCanceledResponse::default()));
+
+    let core = mock_worker(MocksHolder::from_client_with_activities(
+        mock_client,
+        [PollActivityTaskQueueResponse {
+            task_token: vec![1],
+            activity_id: "act1".to_string(),
+            heartbeat_timeout: Some(prost_dur!(from_millis(1))),
+            ..Default::default()
+        }
+        .into()],
+    ));
+
+    let act = core.poll_activity_task().await.unwrap();
+    core.record_activity_heartbeat(ActivityHeartbeat {
+        task_token: act.task_token.clone(),
+        details: vec![vec![1_u8; 1024].into()],
+    });
+    // Wait for the heartbeat to be processed and the stop-cancel to be issued.
+    sleep(Duration::from_millis(10)).await;
+    let cancel = core.poll_activity_task().await.unwrap();
+    assert_matches!(
+        &cancel,
+        ActivityTask {
+            variant: Some(activity_task::Variant::Cancel(Cancel { reason, .. })),
+            ..
+        } if *reason == ActivityCancelReason::Cancelled as i32
+    );
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: cancel.task_token,
+        result: Some(ActivityExecutionResult::cancel_from_details(None)),
+    })
+    .await
+    .unwrap();
+    core.drain_activity_poller_and_shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/sdk-core/src/telemetry/metrics.rs
+++ b/crates/sdk-core/src/telemetry/metrics.rs
@@ -759,6 +759,7 @@ pub(crate) enum FailureReason {
     NexusOperation(String),
     NexusHandlerError(String),
     GrpcMessageTooLarge,
+    PayloadsTooLarge,
 }
 impl Display for FailureReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -769,6 +770,7 @@ impl Display for FailureReason {
             FailureReason::NexusOperation(op) => format!("operation_{op}"),
             FailureReason::NexusHandlerError(op) => format!("handler_error_{op}"),
             FailureReason::GrpcMessageTooLarge => "GrpcMessageTooLarge".to_owned(),
+            FailureReason::PayloadsTooLarge => "PayloadsTooLarge".to_owned(),
         };
         write!(f, "{str}")
     }

--- a/crates/sdk-core/src/worker/activities.rs
+++ b/crates/sdk-core/src/worker/activities.rs
@@ -36,16 +36,21 @@ use std::{
     },
     time::{Duration, Instant, SystemTime},
 };
-use temporalio_client::worker::CancelActivityCallback;
-use temporalio_common::protos::{
-    coresdk::{
-        ActivityHeartbeat, ActivitySlotInfo,
-        activity_result::{self as ar, activity_execution_result as aer},
-        activity_task::{ActivityCancelReason, ActivityCancellationDetails, ActivityTask},
-    },
-    temporal::api::{
-        failure::v1::{ApplicationFailureInfo, CanceledFailureInfo, Failure, failure::FailureInfo},
-        workflowservice::v1::PollActivityTaskQueueResponse,
+use temporalio_client::{payload_limit_violation_from, worker::CancelActivityCallback};
+use temporalio_common::{
+    payload_limits::PayloadLimitViolation,
+    protos::{
+        coresdk::{
+            ActivityHeartbeat, ActivitySlotInfo,
+            activity_result::{self as ar, activity_execution_result as aer},
+            activity_task::{ActivityCancelReason, ActivityCancellationDetails, ActivityTask},
+        },
+        temporal::api::{
+            failure::v1::{
+                ApplicationFailureInfo, CanceledFailureInfo, Failure, failure::FailureInfo,
+            },
+            workflowservice::v1::PollActivityTaskQueueResponse,
+        },
     },
 };
 use tokio::{
@@ -92,6 +97,8 @@ struct InFlightActInfo {
     workflow_id: String,
     /// Only kept for logging reasons
     workflow_run_id: String,
+    /// Only kept for logging reasons
+    attempt: i32,
     start_time: Instant,
     scheduled_time: Option<SystemTime>,
 }
@@ -127,6 +134,7 @@ impl RemoteInFlightActInfo {
                 workflow_type: poll_resp.workflow_type.clone().unwrap_or_default().name,
                 workflow_id: wec.workflow_id,
                 workflow_run_id: wec.run_id,
+                attempt: poll_resp.attempt,
                 start_time: Instant::now(),
                 scheduled_time: poll_resp.scheduled_time.and_then(|i| i.try_into().ok()),
             },
@@ -330,12 +338,16 @@ impl WorkerActivityTasks {
             outstanding_activity_tasks.remove(&task_token)
         };
         if let Some(act_info) = act_info {
+            let span = Span::current();
+            span.record("workflow_id", act_info.base.workflow_id.as_str());
+            span.record("run_id", act_info.base.workflow_run_id.as_str());
+            span.record("workflow_type", act_info.base.workflow_type.as_str());
+            span.record("activity_type", act_info.base.activity_type.as_str());
+            span.record("attempt", act_info.base.attempt as i64);
             let act_metrics = self.metrics.with_new_attrs([
                 activity_type(act_info.base.activity_type),
                 workflow_type(act_info.base.workflow_type),
             ]);
-            Span::current().record("workflow_id", act_info.base.workflow_id);
-            Span::current().record("run_id", act_info.base.workflow_run_id);
             act_metrics.act_execution_latency(act_info.base.start_time.elapsed());
             let known_not_found = act_info.known_not_found;
 
@@ -357,17 +369,36 @@ impl WorkerActivityTasks {
                 let maybe_net_err = match status {
                     aer::Status::WillCompleteAsync(_) => None,
                     aer::Status::Completed(ar::Success { result }) => {
-                        if let Some(sched_time) = act_info
-                            .base
-                            .scheduled_time
-                            .and_then(|st| st.elapsed().ok())
-                        {
-                            act_metrics.act_execution_succeeded(sched_time);
-                        }
-                        client
+                        // If the gRPC layer rejects an oversized result, report the activity task as failed.
+                        match client
                             .complete_activity_task(task_token.clone(), result.map(Into::into))
                             .await
-                            .err()
+                        {
+                            Ok(_) => {
+                                if let Some(sched_time) = act_info
+                                    .base
+                                    .scheduled_time
+                                    .and_then(|st| st.elapsed().ok())
+                                {
+                                    act_metrics.act_execution_succeeded(sched_time);
+                                }
+                                None
+                            }
+                            Err(e) => {
+                                if let Some(violation) = payload_limit_violation_from(&e) {
+                                    act_metrics.act_execution_failed();
+                                    client
+                                        .fail_activity_task(
+                                            task_token.clone(),
+                                            Some(make_payloads_too_large_failure(violation)),
+                                        )
+                                        .await
+                                        .err()
+                                } else {
+                                    Some(e)
+                                }
+                            }
+                        }
                     }
                     aer::Status::Failed(ar::Failure { failure }) => {
                         if should_record_failure_metric(&failure) {
@@ -409,10 +440,26 @@ impl WorkerActivityTasks {
                                     "Expected activity cancelled status with CanceledFailureInfo");
                                 None
                             };
-                            client
+                            match client
                                 .cancel_activity_task(task_token.clone(), details)
                                 .await
-                                .err()
+                            {
+                                Ok(_) => None,
+                                Err(e) => {
+                                    if let Some(violation) = payload_limit_violation_from(&e) {
+                                        act_metrics.act_execution_failed();
+                                        client
+                                            .fail_activity_task(
+                                                task_token.clone(),
+                                                Some(make_payloads_too_large_failure(violation)),
+                                            )
+                                            .await
+                                            .err()
+                                    } else {
+                                        Some(e)
+                                    }
+                                }
+                            }
                         }
                     }
                 };
@@ -749,6 +796,23 @@ fn worker_shutdown_failure() -> Failure {
                 ..Default::default()
             },
         )),
+    }
+}
+
+/// The failure is deliberately retryable: catching the violation client-side exists precisely to
+/// turn what the server would hard-fail into a recoverable activity task failure, so fixing and
+/// redeploying the activity lets the next attempt succeed.
+pub(super) fn make_payloads_too_large_failure(violation: &PayloadLimitViolation) -> Failure {
+    Failure {
+        message: violation.to_string(),
+        failure_info: Some(FailureInfo::ApplicationFailureInfo(
+            ApplicationFailureInfo {
+                r#type: crate::worker::PAYLOADS_TOO_LARGE_FAILURE_TYPE.to_string(),
+                non_retryable: false,
+                ..Default::default()
+            },
+        )),
+        ..Default::default()
     }
 }
 

--- a/crates/sdk-core/src/worker/activities.rs
+++ b/crates/sdk-core/src/worker/activities.rs
@@ -97,8 +97,6 @@ struct InFlightActInfo {
     workflow_id: String,
     /// Only kept for logging reasons
     workflow_run_id: String,
-    /// Only kept for logging reasons
-    attempt: i32,
     start_time: Instant,
     scheduled_time: Option<SystemTime>,
 }
@@ -134,7 +132,6 @@ impl RemoteInFlightActInfo {
                 workflow_type: poll_resp.workflow_type.clone().unwrap_or_default().name,
                 workflow_id: wec.workflow_id,
                 workflow_run_id: wec.run_id,
-                attempt: poll_resp.attempt,
                 start_time: Instant::now(),
                 scheduled_time: poll_resp.scheduled_time.and_then(|i| i.try_into().ok()),
             },
@@ -338,16 +335,12 @@ impl WorkerActivityTasks {
             outstanding_activity_tasks.remove(&task_token)
         };
         if let Some(act_info) = act_info {
-            let span = Span::current();
-            span.record("workflow_id", act_info.base.workflow_id.as_str());
-            span.record("run_id", act_info.base.workflow_run_id.as_str());
-            span.record("workflow_type", act_info.base.workflow_type.as_str());
-            span.record("activity_type", act_info.base.activity_type.as_str());
-            span.record("attempt", act_info.base.attempt as i64);
             let act_metrics = self.metrics.with_new_attrs([
                 activity_type(act_info.base.activity_type),
                 workflow_type(act_info.base.workflow_type),
             ]);
+            Span::current().record("workflow_id", act_info.base.workflow_id);
+            Span::current().record("run_id", act_info.base.workflow_run_id);
             act_metrics.act_execution_latency(act_info.base.start_time.elapsed());
             let known_not_found = act_info.known_not_found;
 

--- a/crates/sdk-core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/crates/sdk-core/src/worker/activities/activity_heartbeat_manager.rs
@@ -192,35 +192,35 @@ impl ActivityHeartbeatManager {
                                             ))
                                             .expect("Receive half of heartbeat cancels not blocked");
                                     }
-                                    // Caught client-side, so we fail the activity task ourselves (the
-                                    // server otherwise would have) and stop the activity with the
-                                    // same `Cancelled`/`cancel_requested` signal the server uses.
-                                    Err(e) if payload_limit_violation_from(&e).is_some() => {
-                                        let violation = payload_limit_violation_from(&e)
-                                            .expect("violation present per guard");
-                                        if let Err(fe) = sg
-                                            .fail_activity_task(
-                                                tt.clone(),
-                                                Some(make_payloads_too_large_failure(violation)),
-                                            )
-                                            .await
-                                        {
-                                            warn!(task_token = %tt, error = ?fe,
-                                                "Failed to fail activity after oversized heartbeat");
-                                        }
-                                        cancels_tx
-                                            .send(PendingActivityCancel::new(
-                                                tt.clone(),
-                                                ActivityCancelReason::Cancelled,
-                                                ActivityCancellationDetails {
-                                                    is_cancelled: true,
-                                                    ..Default::default()
-                                                },
-                                            ))
-                                            .expect("Receive half of heartbeat cancels not blocked");
-                                    }
                                     Err(e) => {
-                                        warn!("Error when recording heartbeat: {:?}", e);
+                                        if let Some(violation) = payload_limit_violation_from(&e) {
+                                            // Caught client-side, so we fail the activity task
+                                            // ourselves (the server otherwise would have) and stop
+                                            // the activity with the same `Cancelled`/`cancel_requested`
+                                            // signal the server uses.
+                                            if let Err(fe) = sg
+                                                .fail_activity_task(
+                                                    tt.clone(),
+                                                    Some(make_payloads_too_large_failure(violation)),
+                                                )
+                                                .await
+                                            {
+                                                warn!(task_token = %tt, error = ?fe,
+                                                    "Failed to fail activity after oversized heartbeat");
+                                            }
+                                            cancels_tx
+                                                .send(PendingActivityCancel::new(
+                                                    tt.clone(),
+                                                    ActivityCancelReason::Cancelled,
+                                                    ActivityCancellationDetails {
+                                                        is_cancelled: true,
+                                                        ..Default::default()
+                                                    },
+                                                ))
+                                                .expect("Receive half of heartbeat cancels not blocked");
+                                        } else {
+                                            warn!("Error when recording heartbeat: {:?}", e);
+                                        }
                                     }
                                 };
                                 let _ = heartbeat_tx.send(HeartbeatAction::CompleteReport(tt));

--- a/crates/sdk-core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/crates/sdk-core/src/worker/activities/activity_heartbeat_manager.rs
@@ -1,7 +1,10 @@
 use crate::{
     TaskToken,
     abstractions::take_cell::TakeCell,
-    worker::{activities::PendingActivityCancel, client::WorkerClient},
+    worker::{
+        activities::{PendingActivityCancel, make_payloads_too_large_failure},
+        client::WorkerClient,
+    },
 };
 use futures_util::StreamExt;
 use std::{
@@ -9,6 +12,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use temporalio_client::payload_limit_violation_from;
 use temporalio_common::protos::{
     coresdk::{
         ActivityHeartbeat, IntoPayloadsExt,
@@ -185,6 +189,33 @@ impl ActivityHeartbeatManager {
                                                 tt.clone(),
                                                 ActivityCancelReason::NotFound,
                                                 ActivityTask::primary_reason_to_cancellation_details(ActivityCancelReason::NotFound)
+                                            ))
+                                            .expect("Receive half of heartbeat cancels not blocked");
+                                    }
+                                    // Caught client-side, so we fail the activity task ourselves (the
+                                    // server otherwise would have) and stop the activity with the
+                                    // same `Cancelled`/`cancel_requested` signal the server uses.
+                                    Err(e) if payload_limit_violation_from(&e).is_some() => {
+                                        let violation = payload_limit_violation_from(&e)
+                                            .expect("violation present per guard");
+                                        if let Err(fe) = sg
+                                            .fail_activity_task(
+                                                tt.clone(),
+                                                Some(make_payloads_too_large_failure(violation)),
+                                            )
+                                            .await
+                                        {
+                                            warn!(task_token = %tt, error = ?fe,
+                                                "Failed to fail activity after oversized heartbeat");
+                                        }
+                                        cancels_tx
+                                            .send(PendingActivityCancel::new(
+                                                tt.clone(),
+                                                ActivityCancelReason::Cancelled,
+                                                ActivityCancellationDetails {
+                                                    is_cancelled: true,
+                                                    ..Default::default()
+                                                },
                                             ))
                                             .expect("Receive half of heartbeat cancels not blocked");
                                     }

--- a/crates/sdk-core/src/worker/client.rs
+++ b/crates/sdk-core/src/worker/client.rs
@@ -13,7 +13,8 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_client::{
-    Connection, Namespace, NamespacedClient, RetryOptions, SharedReplaceableClient,
+    Connection, Namespace, NamespacedClient, PayloadErrorLimits, PayloadLimitsClient, RetryOptions,
+    SharedReplaceableClient,
     grpc::WorkflowService,
     request_extensions::{IsWorkerTaskLongPoll, NoRetryOnMatching, RetryConfigForCall},
     worker::ClientWorkerSet,
@@ -57,7 +58,13 @@ pub enum LegacyQueryResult {
 
 /// Contains everything a worker needs to interact with the server
 pub(crate) struct WorkerClientBag {
+    /// Shared connection handle, used for management operations (capabilities, identity, client
+    /// replacement, etc.).
     connection: SharedReplaceableClient<Connection>,
+    /// Issues outbound gRPC calls, automatically attaching this worker's payload/memo error limits
+    /// (set via `set_payload_error_limits`) so the gRPC layer can enforce them. Wraps a clone of
+    /// `connection`, so a client replacement on `connection` is reflected here too.
+    client: PayloadLimitsClient<SharedReplaceableClient<Connection>>,
     namespace: String,
     worker_versioning_strategy: WorkerVersioningStrategy,
     worker_instance_key: Uuid,
@@ -72,6 +79,7 @@ impl WorkerClientBag {
         worker_instance_key: Uuid,
     ) -> Self {
         Self {
+            client: PayloadLimitsClient::new(connection.clone()),
             connection,
             namespace,
             worker_versioning_strategy,
@@ -267,6 +275,8 @@ pub trait WorkerClient: Sync + Send {
     /// Sets the client-reliant fields for WorkerHeartbeat. This also updates client-level tracking
     /// of heartbeat fields, like last heartbeat timestamp.
     fn set_heartbeat_client_fields(&self, heartbeat: &mut WorkerHeartbeat);
+    /// Set the worker's payload/memo error limits
+    fn set_payload_error_limits(&self, _limits: Option<PayloadErrorLimits>) {}
 }
 
 /// Configuration options shared by workflow, activity, and Nexus polling calls
@@ -341,7 +351,7 @@ impl WorkerClient for WorkerClientBag {
         }
 
         Ok(self
-            .connection
+            .client
             .clone()
             .poll_workflow_task_queue(request)
             .await?
@@ -381,7 +391,7 @@ impl WorkerClient for WorkerClientBag {
         }
 
         Ok(self
-            .connection
+            .client
             .clone()
             .poll_activity_task_queue(request)
             .await?
@@ -425,7 +435,7 @@ impl WorkerClient for WorkerClientBag {
         }
 
         Ok(self
-            .connection
+            .client
             .clone()
             .poll_nexus_task_queue(request)
             .await?
@@ -479,7 +489,7 @@ impl WorkerClient for WorkerClientBag {
             resource_id: Default::default(),
         };
         Ok(self
-            .connection
+            .client
             .clone()
             .respond_workflow_task_completed(request.into_request())
             .await?
@@ -492,7 +502,7 @@ impl WorkerClient for WorkerClientBag {
         result: Option<Payloads>,
     ) -> Result<RespondActivityTaskCompletedResponse> {
         Ok(self
-            .connection
+            .client
             .clone()
             .respond_activity_task_completed(
                 #[allow(deprecated)] // want to list all fields explicitly
@@ -519,7 +529,7 @@ impl WorkerClient for WorkerClientBag {
         response: nexus::v1::Response,
     ) -> Result<RespondNexusTaskCompletedResponse> {
         Ok(self
-            .connection
+            .client
             .clone()
             .respond_nexus_task_completed(
                 RespondNexusTaskCompletedRequest {
@@ -541,7 +551,7 @@ impl WorkerClient for WorkerClientBag {
         details: Option<Payloads>,
     ) -> Result<RecordActivityTaskHeartbeatResponse> {
         Ok(self
-            .connection
+            .client
             .clone()
             .record_activity_task_heartbeat(
                 RecordActivityTaskHeartbeatRequest {
@@ -563,7 +573,7 @@ impl WorkerClient for WorkerClientBag {
         details: Option<Payloads>,
     ) -> Result<RespondActivityTaskCanceledResponse> {
         Ok(self
-            .connection
+            .client
             .clone()
             .respond_activity_task_canceled(
                 #[allow(deprecated)] // want to list all fields explicitly
@@ -590,7 +600,7 @@ impl WorkerClient for WorkerClientBag {
         failure: Option<Failure>,
     ) -> Result<RespondActivityTaskFailedResponse> {
         Ok(self
-            .connection
+            .client
             .clone()
             .respond_activity_task_failed(
                 #[allow(deprecated)] // want to list all fields explicitly
@@ -635,7 +645,7 @@ impl WorkerClient for WorkerClientBag {
             resource_id: Default::default(),
         };
         Ok(self
-            .connection
+            .client
             .clone()
             .respond_workflow_task_failed(request.into_request())
             .await?
@@ -653,7 +663,7 @@ impl WorkerClient for WorkerClientBag {
         };
 
         Ok(self
-            .connection
+            .client
             .clone()
             .respond_nexus_task_failed(
                 #[allow(deprecated)]
@@ -678,7 +688,7 @@ impl WorkerClient for WorkerClientBag {
         page_token: Vec<u8>,
     ) -> Result<GetWorkflowExecutionHistoryResponse> {
         Ok(self
-            .connection
+            .client
             .clone()
             .get_workflow_execution_history(
                 GetWorkflowExecutionHistoryRequest {
@@ -714,7 +724,7 @@ impl WorkerClient for WorkerClientBag {
         let (_, completed_type, query_result, error_message) = query_result.into_components();
 
         Ok(self
-            .connection
+            .client
             .clone()
             .respond_query_task_completed(
                 RespondQueryTaskCompletedRequest {
@@ -735,7 +745,7 @@ impl WorkerClient for WorkerClientBag {
 
     async fn describe_namespace(&self) -> Result<DescribeNamespaceResponse> {
         Ok(self
-            .connection
+            .client
             .clone()
             .describe_namespace(
                 Namespace::Name(self.namespace.clone())
@@ -773,7 +783,7 @@ impl WorkerClient for WorkerClientBag {
             .insert(RetryConfigForCall(RetryOptions::no_retries()));
 
         Ok(
-            WorkflowService::shutdown_worker(&mut self.connection.clone(), request)
+            WorkflowService::shutdown_worker(&mut self.client.clone(), request)
                 .await?
                 .into_inner(),
         )
@@ -791,7 +801,7 @@ impl WorkerClient for WorkerClientBag {
             resource_id: Default::default(),
         };
         Ok(self
-            .connection
+            .client
             .clone()
             .record_worker_heartbeat(request.into_request())
             .await?
@@ -880,6 +890,10 @@ impl WorkerClient for WorkerClientBag {
             &mut heartbeat.local_activity_slots_info,
             &mut client_heartbeat_data.local_activity_slots_info,
         );
+    }
+
+    fn set_payload_error_limits(&self, limits: Option<PayloadErrorLimits>) {
+        self.client.set_error_limits(limits);
     }
 }
 

--- a/crates/sdk-core/src/worker/client.rs
+++ b/crates/sdk-core/src/worker/client.rs
@@ -13,9 +13,9 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_client::{
-    Connection, Namespace, NamespacedClient, PayloadErrorLimits, PayloadLimitsClient, RetryOptions,
+    Connection, Namespace, NamespacedClient, PayloadErrorLimits, RetryOptions,
     SharedReplaceableClient,
-    grpc::WorkflowService,
+    grpc::{PayloadLimitsClient, WorkflowService},
     request_extensions::{IsWorkerTaskLongPoll, NoRetryOnMatching, RetryConfigForCall},
     worker::ClientWorkerSet,
 };

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -6,7 +6,11 @@ mod slot_provider;
 pub(crate) mod tuner;
 mod workflow;
 
-use temporalio_client::Connection;
+/// The failure `type` set on the task failures workers synthesize when an outbound payload exceeds
+/// the error limit, shared so every conversion site reports the same identifier.
+pub(crate) const PAYLOADS_TOO_LARGE_FAILURE_TYPE: &str = "PayloadsTooLarge";
+
+use temporalio_client::{Connection, PayloadErrorLimits};
 use temporalio_common::{
     protos::{
         coresdk::{
@@ -273,6 +277,12 @@ pub struct WorkerConfig {
     /// List of storage drivers used by lang.
     #[builder(default)]
     pub storage_drivers: HashSet<StorageDriverInfo>,
+
+    /// If set, the worker won't enforce server payload/memo error limits on outbound completions —
+    /// oversized payloads are still warned about, and the server still rejects them. When unset, an
+    /// oversized completion is proactively failed as a WFT/activity rather than sent.
+    #[builder(default = false)]
+    pub disable_payload_error_limit: bool,
 }
 
 impl WorkerConfig {
@@ -531,6 +541,17 @@ impl Worker {
                         memo_size_limit_error: api_limits.memo_size_limit_error,
                     })
                 });
+                // Install the namespace error limits on the client (enforced on completions) unless
+                // opted out; warn-level enforcement is always on, configured on the connection.
+                if !self.config.disable_payload_error_limit
+                    && let Some(limits) = limits.as_ref()
+                {
+                    self.client
+                        .set_payload_error_limits(Some(PayloadErrorLimits {
+                            blob: limits.blob_size_limit_error.max(0) as usize,
+                            memo: limits.memo_size_limit_error.max(0) as usize,
+                        }));
+                }
                 if let Some(caps) = ns_info.and_then(|ns| ns.capabilities) {
                     if caps.worker_poll_complete_on_shutdown {
                         self.capabilities
@@ -1212,8 +1233,9 @@ impl Worker {
     /// Tell the worker that an activity has finished executing. May (and should) be freely called
     /// concurrently.
     #[instrument(skip(self, completion),
-                 fields(task_token, status,
-                        task_queue=%self.config.task_queue, workflow_id, run_id))]
+                 fields(task_token, status, namespace=%self.config.namespace,
+                        task_queue=%self.config.task_queue, worker_id=%self.client.identity(),
+                        workflow_id, run_id, workflow_type, activity_type, attempt))]
     pub async fn complete_activity_task(
         &self,
         completion: ActivityTaskCompletion,
@@ -1286,8 +1308,9 @@ impl Worker {
     /// necessary for completion to... complete - thus SDK implementers should make sure they do
     /// not serialize completions.
     #[instrument(skip(self, completion),
-        fields(completion=%&completion, run_id=%completion.run_id, workflow_id,
-               task_queue=%self.config.task_queue))]
+        fields(completion=%&completion, namespace=%self.config.namespace,
+               task_queue=%self.config.task_queue, worker_id=%self.client.identity(),
+               run_id, workflow_id, workflow_type, attempt))]
     pub async fn complete_workflow_activation(
         &self,
         completion: WorkflowActivationCompletion,

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -281,6 +281,7 @@ pub struct WorkerConfig {
     /// If set, the worker won't enforce server payload/memo error limits on outbound completions —
     /// oversized payloads are still warned about, and the server still rejects them. When unset, an
     /// oversized completion is proactively failed as a WFT/activity rather than sent.
+    /// NOTE: Experimental
     #[builder(default = false)]
     pub disable_payload_error_limit: bool,
 }

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -1235,9 +1235,8 @@ impl Worker {
     /// Tell the worker that an activity has finished executing. May (and should) be freely called
     /// concurrently.
     #[instrument(skip(self, completion),
-                 fields(task_token, status, namespace=%self.config.namespace,
-                        task_queue=%self.config.task_queue, worker_id=%self.client.identity(),
-                        workflow_id, run_id, workflow_type, activity_type, attempt))]
+                 fields(task_token, status,
+                        task_queue=%self.config.task_queue, workflow_id, run_id))]
     pub async fn complete_activity_task(
         &self,
         completion: ActivityTaskCompletion,
@@ -1310,9 +1309,8 @@ impl Worker {
     /// necessary for completion to... complete - thus SDK implementers should make sure they do
     /// not serialize completions.
     #[instrument(skip(self, completion),
-        fields(completion=%&completion, namespace=%self.config.namespace,
-               task_queue=%self.config.task_queue, worker_id=%self.client.identity(),
-               run_id, workflow_id, workflow_type, attempt))]
+        fields(completion=%&completion, run_id=%completion.run_id, workflow_id,
+               task_queue=%self.config.task_queue))]
     pub async fn complete_workflow_activation(
         &self,
         completion: WorkflowActivationCompletion,

--- a/crates/sdk-core/src/worker/nexus.rs
+++ b/crates/sdk-core/src/worker/nexus.rs
@@ -18,6 +18,8 @@ use std::{
     },
     time::{Duration, Instant, SystemTime},
 };
+use temporalio_client::payload_limit_violation_from;
+use temporalio_common::payload_limits::PayloadLimitViolation;
 use temporalio_common::protos::{
     TaskToken,
     coresdk::{
@@ -28,6 +30,7 @@ use temporalio_common::protos::{
         },
     },
     temporal::api::{
+        enums::v1::NexusHandlerErrorRetryBehavior,
         failure::v1::failure::FailureInfo,
         nexus::{
             self,
@@ -219,7 +222,23 @@ impl NexusManager {
                             });
                         }
                     }
-                    (true, client.complete_nexus_task(tt, c).await.err())
+                    let net_err = match client.complete_nexus_task(tt.clone(), c).await {
+                        Ok(_) => None,
+                        Err(e) => {
+                            if let Some(violation) = payload_limit_violation_from(&e) {
+                                client
+                                    .fail_nexus_task(
+                                        tt,
+                                        payloads_too_large_nexus_failure(violation),
+                                    )
+                                    .await
+                                    .err()
+                            } else {
+                                Some(e)
+                            }
+                        }
+                    };
+                    (true, net_err)
                 }
 
                 nexus_task_completion::Status::AckCancel(_) => {
@@ -534,6 +553,17 @@ enum TaskStreamInput {
     SourceComplete,
 }
 
+fn payloads_too_large_nexus_failure(violation: &PayloadLimitViolation) -> NexusTaskFailure {
+    NexusTaskFailure::Legacy(nexus::v1::HandlerError {
+        error_type: crate::worker::PAYLOADS_TOO_LARGE_FAILURE_TYPE.to_string(),
+        failure: Some(nexus::v1::Failure {
+            message: violation.to_string(),
+            ..Default::default()
+        }),
+        retry_behavior: NexusHandlerErrorRetryBehavior::Retryable as i32,
+    })
+}
+
 fn parse_request_timeout(timeout: &str) -> Result<Duration, anyhow::Error> {
     let timeout = timeout.trim();
     let (value, unit) = timeout.split_at(
@@ -562,6 +592,7 @@ fn parse_request_timeout(timeout: &str) -> Result<Duration, anyhow::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use temporalio_common::payload_limits::{LimitClass, LimitSeverity};
 
     #[tokio::test]
     async fn test_parse_request_timeout() {
@@ -580,6 +611,29 @@ mod tests {
         assert_eq!(
             parse_request_timeout("9.155416ms").unwrap(),
             Duration::from_secs_f64(9.155416 / 1000.0)
+        );
+    }
+
+    #[test]
+    fn payloads_too_large_nexus_failure_is_retryable() {
+        let violation = PayloadLimitViolation {
+            path: "payload".to_string(),
+            class: LimitClass::Blob,
+            severity: LimitSeverity::Error,
+            size: 1024,
+            limit: 10,
+        };
+        let NexusTaskFailure::Legacy(handler_err) = payloads_too_large_nexus_failure(&violation)
+        else {
+            panic!("expected a legacy handler error");
+        };
+        assert_eq!(
+            handler_err.error_type,
+            crate::worker::PAYLOADS_TOO_LARGE_FAILURE_TYPE
+        );
+        assert_eq!(
+            handler_err.retry_behavior,
+            NexusHandlerErrorRetryBehavior::Retryable as i32
         );
     }
 }

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -436,6 +436,7 @@ impl ManagedRun {
             self.reply_to_complete(
                 ActivationCompleteOutcome::ReportWFTSuccess(ServerCommandsWithWorkflowInfo {
                     task_token,
+                    workflow_type: self.wfm.machines.workflow_type.clone(),
                     action: ActivationAction::RespondLegacyQuery {
                         result: Box::new(qr),
                     },
@@ -1097,6 +1098,7 @@ impl ManagedRun {
         data: CompletionDataForWFT,
         due_to_heartbeat_timeout: bool,
     ) -> FulfillableActivationComplete {
+        let workflow_type = self.wfm.machines.workflow_type.clone();
         let mut machines_wft_response = self.wfm.prepare_for_wft_response();
         if data.activation_was_eviction
             && (machines_wft_response.commands().peek().is_some()
@@ -1147,6 +1149,7 @@ impl ManagedRun {
             let attempt = self.wft.as_ref().map(|t| t.info.attempt).unwrap_or(1);
             ActivationCompleteOutcome::ReportWFTSuccess(ServerCommandsWithWorkflowInfo {
                 task_token: data.task_token,
+                workflow_type,
                 action: ActivationAction::WftComplete {
                     force_new_wft,
                     commands,

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -436,7 +436,6 @@ impl ManagedRun {
             self.reply_to_complete(
                 ActivationCompleteOutcome::ReportWFTSuccess(ServerCommandsWithWorkflowInfo {
                     task_token,
-                    workflow_type: self.wfm.machines.workflow_type.clone(),
                     action: ActivationAction::RespondLegacyQuery {
                         result: Box::new(qr),
                     },
@@ -1098,7 +1097,6 @@ impl ManagedRun {
         data: CompletionDataForWFT,
         due_to_heartbeat_timeout: bool,
     ) -> FulfillableActivationComplete {
-        let workflow_type = self.wfm.machines.workflow_type.clone();
         let mut machines_wft_response = self.wfm.prepare_for_wft_response();
         if data.activation_was_eviction
             && (machines_wft_response.commands().peek().is_some()
@@ -1149,7 +1147,6 @@ impl ManagedRun {
             let attempt = self.wft.as_ref().map(|t| t.info.attempt).unwrap_or(1);
             ActivationCompleteOutcome::ReportWFTSuccess(ServerCommandsWithWorkflowInfo {
                 task_token: data.task_token,
-                workflow_type,
                 action: ActivationAction::WftComplete {
                     force_new_wft,
                     commands,

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -58,8 +58,9 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use temporalio_client::MESSAGE_TOO_LARGE_KEY;
+use temporalio_client::{MESSAGE_TOO_LARGE_KEY, payload_limit_violation_from};
 use temporalio_common::{
+    payload_limits::PayloadLimitViolation,
     protos::{
         TaskToken,
         coresdk::{
@@ -339,6 +340,7 @@ impl Workflows {
         match report {
             ServerCommandsWithWorkflowInfo {
                 task_token,
+                workflow_type,
                 action:
                     ActivationAction::WftComplete {
                         mut commands,
@@ -351,6 +353,9 @@ impl Workflows {
                     },
                 metrics: run_metrics,
             } => {
+                let span = tracing::Span::current();
+                span.record("workflow_type", workflow_type.as_str());
+                span.record("attempt", attempt as i64);
                 let reserved_act_permits =
                     self.reserve_activity_slots_for_outgoing_commands(commands.as_mut_slice());
                 debug!(commands=%commands.display(), query_responses=%query_responses.display(),
@@ -424,6 +429,26 @@ impl Workflows {
                             run_metrics
                                 .with_new_attrs([metrics::failure_reason(
                                     FailureReason::GrpcMessageTooLarge,
+                                )])
+                                .wf_task_failed();
+                            return Err(e);
+                        }
+                        // Client layer rejected the completion for exceeding the worker's payload
+                        // error limit; proactively fail the WFT instead.
+                        Err(e) if payload_limit_violation_from(&e).is_some() => {
+                            let violation = payload_limit_violation_from(&e)
+                                .expect("violation present per guard");
+                            let failure = make_payloads_too_large_failure(violation);
+                            let new_outcome = FailedActivationWFTReport::Report(
+                                task_token,
+                                WorkflowTaskFailedCause::PayloadsTooLarge,
+                                failure,
+                            );
+                            self.handle_activation_failed(run_id, completion_time, new_outcome)
+                                .await;
+                            run_metrics
+                                .with_new_attrs([metrics::failure_reason(
+                                    FailureReason::PayloadsTooLarge,
                                 )])
                                 .wf_task_failed();
                             return Err(e);
@@ -1016,6 +1041,8 @@ enum FailedActivationWFTReport {
 
 struct ServerCommandsWithWorkflowInfo {
     task_token: TaskToken,
+    /// Kept for tracing context on the completion (the run's span lacks workflow type/attempt).
+    workflow_type: String,
     action: ActivationAction,
     metrics: MetricsContext,
 }
@@ -1725,11 +1752,54 @@ fn make_grpc_message_too_large_failure() -> Failure {
     }
 }
 
+fn make_payloads_too_large_failure(violation: &PayloadLimitViolation) -> Failure {
+    Failure {
+        failure: Some(
+            temporalio_common::protos::temporal::api::failure::v1::Failure {
+                message: violation.to_string(),
+                failure_info: Some(FailureInfo::ApplicationFailureInfo(
+                    ApplicationFailureInfo {
+                        r#type: crate::worker::PAYLOADS_TOO_LARGE_FAILURE_TYPE.to_string(),
+                        non_retryable: false,
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            },
+        ),
+        force_cause: WorkflowTaskFailedCause::PayloadsTooLarge as i32,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use itertools::Itertools;
+    use temporalio_common::payload_limits::{LimitClass, LimitSeverity};
     use temporalio_common::protos::coresdk::workflow_activation::SignalWorkflow;
+
+    #[test]
+    fn payloads_too_large_wft_failure_is_retryable() {
+        let violation = PayloadLimitViolation {
+            path: "input".to_string(),
+            class: LimitClass::Blob,
+            severity: LimitSeverity::Error,
+            size: 1024,
+            limit: 10,
+        };
+        let failure = make_payloads_too_large_failure(&violation);
+        assert_eq!(
+            failure.force_cause,
+            WorkflowTaskFailedCause::PayloadsTooLarge as i32
+        );
+        let Some(FailureInfo::ApplicationFailureInfo(afi)) =
+            &failure.failure.as_ref().unwrap().failure_info
+        else {
+            panic!("expected application failure info");
+        };
+        assert_eq!(afi.r#type, crate::worker::PAYLOADS_TOO_LARGE_FAILURE_TYPE);
+        assert!(!afi.non_retryable);
+    }
 
     #[test]
     fn jobs_sort() {

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -414,7 +414,9 @@ impl Workflows {
                             );
                         }
                         Err(e) => {
-                            let cause_reason_failure = if e.metadata().contains_key(MESSAGE_TOO_LARGE_KEY)
+                            let cause_reason_failure = if e
+                                .metadata()
+                                .contains_key(MESSAGE_TOO_LARGE_KEY)
                                 && attempt < 2
                             {
                                 // gRPC message too large from server; skip on nonfirst attempts to

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -413,48 +413,38 @@ impl Workflows {
                                 response.activity_tasks,
                             );
                         }
-                        // Reply with a task failure if we got grpc too large from server, but
-                        // not if this is a nonfirst attempt to avoid spamming.
-                        Err(e)
-                            if e.metadata().contains_key(MESSAGE_TOO_LARGE_KEY) && attempt < 2 =>
-                        {
-                            let failure = make_grpc_message_too_large_failure();
-                            let new_outcome = FailedActivationWFTReport::Report(
-                                task_token,
-                                WorkflowTaskFailedCause::GrpcMessageTooLarge,
-                                failure,
-                            );
-                            self.handle_activation_failed(run_id, completion_time, new_outcome)
-                                .await;
-                            run_metrics
-                                .with_new_attrs([metrics::failure_reason(
+                        Err(e) => {
+                            let cause_reason_failure = if e.metadata().contains_key(MESSAGE_TOO_LARGE_KEY)
+                                && attempt < 2
+                            {
+                                // gRPC message too large from server; skip on nonfirst attempts to
+                                // avoid spamming.
+                                Some((
+                                    WorkflowTaskFailedCause::GrpcMessageTooLarge,
                                     FailureReason::GrpcMessageTooLarge,
-                                )])
-                                .wf_task_failed();
+                                    make_grpc_message_too_large_failure(),
+                                ))
+                            } else {
+                                // Client layer rejected the completion for exceeding the worker's
+                                // payload error limit.
+                                payload_limit_violation_from(&e).map(|violation| {
+                                    (
+                                        WorkflowTaskFailedCause::PayloadsTooLarge,
+                                        FailureReason::PayloadsTooLarge,
+                                        make_payloads_too_large_failure(violation),
+                                    )
+                                })
+                            };
+                            if let Some((cause, reason, failure)) = cause_reason_failure {
+                                let new_outcome =
+                                    FailedActivationWFTReport::Report(task_token, cause, failure);
+                                self.handle_activation_failed(run_id, completion_time, new_outcome)
+                                    .await;
+                                run_metrics
+                                    .with_new_attrs([metrics::failure_reason(reason)])
+                                    .wf_task_failed();
+                            }
                             return Err(e);
-                        }
-                        // Client layer rejected the completion for exceeding the worker's payload
-                        // error limit; proactively fail the WFT instead.
-                        Err(e) if payload_limit_violation_from(&e).is_some() => {
-                            let violation = payload_limit_violation_from(&e)
-                                .expect("violation present per guard");
-                            let failure = make_payloads_too_large_failure(violation);
-                            let new_outcome = FailedActivationWFTReport::Report(
-                                task_token,
-                                WorkflowTaskFailedCause::PayloadsTooLarge,
-                                failure,
-                            );
-                            self.handle_activation_failed(run_id, completion_time, new_outcome)
-                                .await;
-                            run_metrics
-                                .with_new_attrs([metrics::failure_reason(
-                                    FailureReason::PayloadsTooLarge,
-                                )])
-                                .wf_task_failed();
-                            return Err(e);
-                        }
-                        e => {
-                            e?;
                         }
                     };
 

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -340,7 +340,6 @@ impl Workflows {
         match report {
             ServerCommandsWithWorkflowInfo {
                 task_token,
-                workflow_type,
                 action:
                     ActivationAction::WftComplete {
                         mut commands,
@@ -353,9 +352,6 @@ impl Workflows {
                     },
                 metrics: run_metrics,
             } => {
-                let span = tracing::Span::current();
-                span.record("workflow_type", workflow_type.as_str());
-                span.record("attempt", attempt as i64);
                 let reserved_act_permits =
                     self.reserve_activity_slots_for_outgoing_commands(commands.as_mut_slice());
                 debug!(commands=%commands.display(), query_responses=%query_responses.display(),
@@ -1033,8 +1029,6 @@ enum FailedActivationWFTReport {
 
 struct ServerCommandsWithWorkflowInfo {
     task_token: TaskToken,
-    /// Kept for tracing context on the completion (the run's span lacks workflow type/attempt).
-    workflow_type: String,
     action: ActivationAction,
     metrics: MetricsContext,
 }

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -544,8 +544,8 @@ async fn warn_band_payload_is_logged_and_completes() {
     let mut conn_opts = get_integ_server_options();
     conn_opts.metrics_meter = runtime.telemetry().get_temporal_metric_meter();
     conn_opts.payload_limits = PayloadLimitsOptions {
-        payloads_size_warn: 1,
-        memo_size_warn: 1,
+        payloads_warn_size: 1,
+        memo_warn_size: 1,
     };
     let connection = Connection::connect(conn_opts).await.unwrap();
     let client = Client::new(connection, ClientOptions::new(integ_namespace()).build()).unwrap();

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -1,12 +1,13 @@
 use crate::{
     common::{
         CoreWfStarter, activity_functions::StdActivities, fake_grpc_server::fake_server,
-        get_integ_runtime_options, get_integ_server_options, get_integ_telem_options, mock_sdk_cfg,
+        get_integ_runtime_options, get_integ_server_options, get_integ_telem_options,
+        integ_namespace, mock_sdk_cfg,
     },
     shared_tests::{self, is_oversize_grpc_event},
 };
 use assert_matches::assert_matches;
-use futures_util::FutureExt;
+use futures_util::{FutureExt, StreamExt};
 use std::{
     cell::Cell,
     sync::{
@@ -18,7 +19,10 @@ use std::{
     },
     time::Duration,
 };
-use temporalio_client::{Connection, WorkflowStartOptions};
+use temporalio_client::{
+    Client, ClientOptions, Connection, PayloadLimitsOptions, WorkflowStartOptions,
+    errors::WorkflowGetResultError,
+};
 use temporalio_common::{
     data_converters::{DataConverter, RawValue},
     protos::{
@@ -31,14 +35,14 @@ use temporalio_common::{
         },
         temporal::api::{
             command::v1::command::Attributes,
-            common::v1::WorkerVersionStamp,
+            common::v1::{Payload, RetryPolicy, WorkerVersionStamp},
             enums::v1::{
                 EventType,
                 WorkflowTaskFailedCause::{self},
             },
             failure::v1::Failure as InnerFailure,
             history::v1::{
-                ActivityTaskScheduledEventAttributes,
+                ActivityTaskScheduledEventAttributes, HistoryEvent,
                 history_event::{
                     self,
                     Attributes::{self as EventAttributes},
@@ -50,11 +54,13 @@ use temporalio_common::{
             },
         },
     },
+    telemetry::{CoreLogStreamConsumer, Logger, TelemetryOptions, construct_filter_string},
     worker::WorkerTaskTypes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, LocalActivityOptions, WorkerOptions, WorkflowContext, WorkflowResult,
+    WorkflowTermination,
     activities::{ActivityContext, ActivityError},
     interceptors::WorkerInterceptor,
 };
@@ -63,6 +69,7 @@ use temporalio_sdk_core::{
     ResourceBasedTuner, ResourceSlotOptions, SlotInfo, SlotInfoTrait, SlotMarkUsedContext,
     SlotReleaseContext, SlotReservationContext, SlotSupplier, SlotSupplierPermit, TunerBuilder,
     WorkerConfig, WorkerValidationError, WorkerVersioningStrategy, WorkflowSlotKind, init_worker,
+    prost_dur,
     replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
     test_help::{
         FakeWfResponses, MockPollCfg, ResponseType, build_mock_pollers, drain_pollers_and_shutdown,
@@ -71,6 +78,7 @@ use temporalio_sdk_core::{
 };
 use tokio::sync::{Barrier, Notify, Semaphore};
 use tokio_util::sync::CancellationToken;
+use tracing::Level;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -226,6 +234,7 @@ async fn oversize_grpc_message() {
     let runtime = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, runtime);
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter.sdk_config.disable_payload_error_limit = true;
     let mut core = starter.worker().await;
 
     let has_run = Arc::new(AtomicBool::new(false));
@@ -296,6 +305,397 @@ async fn oversize_grpc_message() {
 #[tokio::test]
 async fn grpc_message_too_large_test() {
     shared_tests::grpc_message_too_large().await
+}
+
+// Serializes to between the default blob error limit (2 MiB) and the gRPC transport limit (4 MiB).
+const OVERSIZE_PAYLOAD_BYTES: usize = 3 * 1024 * 1024;
+
+/// True for a `WorkflowTaskFailed` history event caused by the payload error limit.
+fn is_wft_payloads_too_large(e: &HistoryEvent) -> bool {
+    e.event_type == EventType::WorkflowTaskFailed as i32
+        && matches!(
+            e.attributes.as_ref(),
+            Some(EventAttributes::WorkflowTaskFailedEventAttributes(attr))
+                if attr.cause == WorkflowTaskFailedCause::PayloadsTooLarge as i32
+        )
+}
+
+/// Oversized completion payload fails the WFT with `PayloadsTooLarge`, then recovers on the second
+/// attempt.
+#[tokio::test]
+async fn oversize_wft_payload_fails_retryably_then_completes() {
+    let wf_name = "oversize_wft_payload_retryable";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    let mut core = starter.worker().await;
+
+    let has_run = Arc::new(AtomicBool::new(false));
+    let has_run_clone = has_run.clone();
+
+    #[workflow]
+    struct OversizeWftWf {
+        has_run: Arc<AtomicBool>,
+    }
+    #[workflow_methods(factory_only)]
+    impl OversizeWftWf {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<String> {
+            if ctx.state(|wf| wf.has_run.load(Relaxed)) {
+                Ok(String::new())
+            } else {
+                ctx.state(|wf| wf.has_run.store(true, Relaxed));
+                Ok("a".repeat(OVERSIZE_PAYLOAD_BYTES))
+            }
+        }
+    }
+
+    core.register_workflow_with_factory(move || OversizeWftWf {
+        has_run: has_run_clone.clone(),
+    })
+    .unwrap();
+    let handle = core
+        .submit_workflow(OversizeWftWf::run, (), starter.workflow_options.clone())
+        .await
+        .unwrap();
+    core.run_until_done().await.unwrap();
+    // `run_until_done` reports Ok for any terminal outcome, so confirm success via the handle.
+    handle.get_result(Default::default()).await.unwrap();
+
+    // The intermediate failure isn't visible from the result, so assert it via history.
+    let events = starter.get_history().await.events;
+    assert!(
+        events.iter().any(is_wft_payloads_too_large),
+        "expected a WorkflowTaskFailed(PayloadsTooLarge) event: {events:?}"
+    );
+}
+
+/// Oversized activity result is rejected client-side as a retryable failure; the activity retries
+/// and the workflow completes. (A retried-then-succeeded activity leaves no `ActivityTaskFailed`
+/// event, so the retry is checked via the attempt count.)
+#[tokio::test]
+async fn oversize_activity_result_fails_retryably_then_completes() {
+    let wf_name = "oversize_activity_result_retryable";
+    let mut starter = CoreWfStarter::new(wf_name);
+
+    let max_attempt = Arc::new(AtomicU8::new(0));
+
+    struct OversizeResultActs {
+        max_attempt: Arc<AtomicU8>,
+    }
+    #[activities]
+    impl OversizeResultActs {
+        #[activity]
+        async fn maybe_oversize(
+            self: Arc<Self>,
+            ctx: ActivityContext,
+            _: (),
+        ) -> Result<String, ActivityError> {
+            let attempt = ctx.info().attempt;
+            self.max_attempt.fetch_max(attempt as u8, Relaxed);
+            if attempt == 1 {
+                Ok("a".repeat(OVERSIZE_PAYLOAD_BYTES))
+            } else {
+                Ok(String::new())
+            }
+        }
+    }
+    starter.sdk_config.register_activities(OversizeResultActs {
+        max_attempt: max_attempt.clone(),
+    });
+    let mut core = starter.worker().await;
+
+    #[workflow]
+    struct OversizeActResultWf;
+    #[workflow_methods(factory_only)]
+    impl OversizeActResultWf {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            ctx.start_activity(
+                OversizeResultActs::maybe_oversize,
+                (),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(10))
+                    .retry_policy(RetryPolicy {
+                        initial_interval: Some(prost_dur!(from_millis(1))),
+                        maximum_attempts: 3,
+                        ..Default::default()
+                    })
+                    .build(),
+            )
+            .await
+            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            Ok(())
+        }
+    }
+
+    core.register_workflow_with_factory(|| OversizeActResultWf)
+        .unwrap();
+    let handle = core
+        .submit_workflow(
+            OversizeActResultWf::run,
+            (),
+            starter.workflow_options.clone(),
+        )
+        .await
+        .unwrap();
+    core.run_until_done().await.unwrap();
+    // `run_until_done` reports Ok for any terminal outcome, so confirm success via the handle.
+    handle.get_result(Default::default()).await.unwrap();
+
+    assert!(
+        max_attempt.load(Relaxed) >= 2,
+        "activity should have retried after the oversized first attempt was rejected"
+    );
+}
+
+/// Oversized heartbeat details fail the attempt (retryably) client-side; the activity retries and
+/// the workflow completes.
+#[tokio::test]
+async fn oversize_activity_heartbeat_fails_retryably_then_completes() {
+    let wf_name = "oversize_activity_heartbeat_retryable";
+    let mut starter = CoreWfStarter::new(wf_name);
+
+    let max_attempt = Arc::new(AtomicU8::new(0));
+
+    struct OversizeHbActs {
+        max_attempt: Arc<AtomicU8>,
+    }
+    #[activities]
+    impl OversizeHbActs {
+        #[activity]
+        async fn maybe_oversize_heartbeat(
+            self: Arc<Self>,
+            ctx: ActivityContext,
+            _: (),
+        ) -> Result<(), ActivityError> {
+            let attempt = ctx.info().attempt;
+            self.max_attempt.fetch_max(attempt as u8, Relaxed);
+            if attempt == 1 {
+                ctx.record_heartbeat(vec![Payload {
+                    data: vec![0u8; OVERSIZE_PAYLOAD_BYTES],
+                    ..Default::default()
+                }]);
+                // The oversized heartbeat is rejected client-side, which fails this attempt and
+                // cancels us; wait for that cancel rather than returning a normal completion.
+                ctx.cancelled().await;
+                Ok(())
+            } else {
+                Ok(())
+            }
+        }
+    }
+    starter.sdk_config.register_activities(OversizeHbActs {
+        max_attempt: max_attempt.clone(),
+    });
+    let mut core = starter.worker().await;
+
+    #[workflow]
+    struct OversizeHbWf;
+    #[workflow_methods(factory_only)]
+    impl OversizeHbWf {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            ctx.start_activity(
+                OversizeHbActs::maybe_oversize_heartbeat,
+                (),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(60))
+                    .heartbeat_timeout(Duration::from_secs(10))
+                    .retry_policy(RetryPolicy {
+                        initial_interval: Some(prost_dur!(from_millis(1))),
+                        maximum_attempts: 3,
+                        ..Default::default()
+                    })
+                    .build(),
+            )
+            .await
+            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            Ok(())
+        }
+    }
+
+    core.register_workflow_with_factory(|| OversizeHbWf)
+        .unwrap();
+    let handle = core
+        .submit_workflow(OversizeHbWf::run, (), starter.workflow_options.clone())
+        .await
+        .unwrap();
+    core.run_until_done().await.unwrap();
+    // `run_until_done` reports Ok for any terminal outcome, so confirm success via the handle.
+    handle.get_result(Default::default()).await.unwrap();
+
+    assert!(
+        max_attempt.load(Relaxed) >= 2,
+        "activity should have retried after the oversized heartbeat failed the first attempt"
+    );
+}
+
+/// A payload over the warn threshold but under the error limit is sent to the server, the workflow
+/// completes and the worker emits the `[TMPRL1103]` warning carrying the expected structured context.
+#[tokio::test]
+async fn warn_band_payload_is_logged_and_completes() {
+    let (log_consumer, mut log_rx) = CoreLogStreamConsumer::new(512);
+    let telem = TelemetryOptions::builder()
+        .logging(Logger::Push {
+            filter: construct_filter_string(Level::INFO, Level::WARN),
+            consumer: Arc::new(log_consumer),
+        })
+        .build();
+    let runtime = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telem)).unwrap();
+
+    let mut conn_opts = get_integ_server_options();
+    conn_opts.metrics_meter = runtime.telemetry().get_temporal_metric_meter();
+    conn_opts.payload_limits = PayloadLimitsOptions {
+        payloads_size_warn: 1,
+        memo_size_warn: 1,
+    };
+    let connection = Connection::connect(conn_opts).await.unwrap();
+    let client = Client::new(connection, ClientOptions::new(integ_namespace()).build()).unwrap();
+
+    let wf_name = "warn_band_payload";
+    let mut starter = CoreWfStarter::new_with_overrides(wf_name, Some(runtime), Some(client));
+    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    let mut core = starter.worker().await;
+
+    #[workflow]
+    struct WarnBandWf;
+    #[workflow_methods(factory_only)]
+    impl WarnBandWf {
+        #[run]
+        async fn run(_ctx: &mut WorkflowContext<Self>) -> WorkflowResult<Vec<u8>> {
+            // Over the 1-byte warn threshold, far under any error limit.
+            Ok(vec![0u8; 256])
+        }
+    }
+    core.register_workflow_with_factory(|| WarnBandWf).unwrap();
+    let handle = core
+        .submit_workflow(WarnBandWf::run, (), starter.workflow_options.clone())
+        .await
+        .unwrap();
+    core.run_until_done().await.unwrap();
+    // `run_until_done` reports Ok for any terminal outcome, so confirm success via the handle.
+    handle.get_result(Default::default()).await.unwrap();
+
+    let scan = tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(log) = log_rx.next().await {
+            if log.message.starts_with("[TMPRL1103]") {
+                return Some(log);
+            }
+        }
+        None
+    })
+    .await;
+    let log = match scan {
+        Ok(Some(log)) => log,
+        Ok(None) => panic!("log stream ended without a [TMPRL1103] warning"),
+        Err(_) => panic!("timed out waiting for a [TMPRL1103] warning"),
+    };
+    assert_eq!(log.level, Level::WARN, "the payload should warn, not error");
+
+    // Validate expected structured logging information.
+    let fields = &log.fields;
+    let as_u64 = |k: &str| fields.get(k).and_then(|v| v.as_u64());
+    let as_str = |k: &str| fields.get(k).and_then(|v| v.as_str());
+    assert_eq!(
+        as_u64("limit"),
+        Some(1),
+        "warn limit is the client option: {fields:?}"
+    );
+    assert!(
+        as_u64("size").is_some_and(|s| s > 1),
+        "size should be recorded and exceed the warn limit: {fields:?}"
+    );
+    assert_eq!(as_str("workflow_type"), Some("WarnBandWf"), "{fields:?}");
+    assert_eq!(as_u64("attempt"), Some(1), "{fields:?}");
+    assert_eq!(
+        as_str("workflow_id"),
+        Some(starter.get_wf_id()),
+        "{fields:?}"
+    );
+    assert!(
+        as_str("run_id").is_some_and(|r| !r.is_empty()),
+        "run_id should be recorded: {fields:?}"
+    );
+}
+
+/// With the worker error limit disabled, an oversized activity result (under the gRPC transport
+/// limit) reaches the server, which hard-fails it non-retryably — so the activity isn't retried and
+/// the workflow fails. Independent of how the gRPC hard limit is handled.
+#[tokio::test]
+async fn disabled_error_limit_lets_server_hard_fail() {
+    let wf_name = "disabled_error_limit_activity";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.disable_payload_error_limit = true;
+
+    let max_attempt = Arc::new(AtomicU8::new(0));
+
+    struct DisabledOversizeActs {
+        max_attempt: Arc<AtomicU8>,
+    }
+    #[activities]
+    impl DisabledOversizeActs {
+        #[activity]
+        async fn always_oversize(
+            self: Arc<Self>,
+            ctx: ActivityContext,
+            _: (),
+        ) -> Result<String, ActivityError> {
+            self.max_attempt
+                .fetch_max(ctx.info().attempt as u8, Relaxed);
+            Ok("a".repeat(OVERSIZE_PAYLOAD_BYTES))
+        }
+    }
+    starter
+        .sdk_config
+        .register_activities(DisabledOversizeActs {
+            max_attempt: max_attempt.clone(),
+        });
+    let mut core = starter.worker().await;
+
+    #[workflow]
+    struct DisabledOversizeWf;
+    #[workflow_methods(factory_only)]
+    impl DisabledOversizeWf {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            ctx.start_activity(
+                DisabledOversizeActs::always_oversize,
+                (),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(10))
+                    .retry_policy(RetryPolicy {
+                        initial_interval: Some(prost_dur!(from_millis(1))),
+                        maximum_attempts: 3,
+                        ..Default::default()
+                    })
+                    .build(),
+            )
+            .await
+            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            Ok(())
+        }
+    }
+    core.register_workflow_with_factory(|| DisabledOversizeWf)
+        .unwrap();
+    let handle = core
+        .submit_workflow(
+            DisabledOversizeWf::run,
+            (),
+            starter.workflow_options.clone(),
+        )
+        .await
+        .unwrap();
+
+    core.run_until_done().await.unwrap();
+    // `run_until_done` reports Ok even for a failed workflow (it ignores workflow-outcome errors),
+    // so assert the failure via the handle.
+    assert_matches!(
+        handle.get_result(Default::default()).await,
+        Err(WorkflowGetResultError::Failed(_)),
+        "the server hard-fails the oversized activity result, failing the workflow"
+    );
+    assert_eq!(
+        max_attempt.load(Relaxed),
+        1,
+        "the server's size failure is non-retryable, so the activity task isn't retried"
+    );
 }
 
 #[tokio::test]

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -35,7 +35,7 @@ use temporalio_common::{
         },
         temporal::api::{
             command::v1::command::Attributes,
-            common::v1::{Payload, RetryPolicy, WorkerVersionStamp},
+            common::v1::{RetryPolicy, WorkerVersionStamp},
             enums::v1::{
                 EventType,
                 WorkflowTaskFailedCause::{self},
@@ -470,10 +470,7 @@ async fn oversize_activity_heartbeat_fails_retryably_then_completes() {
             let attempt = ctx.info().attempt;
             self.max_attempt.fetch_max(attempt as u8, Relaxed);
             if attempt == 1 {
-                ctx.record_heartbeat(vec![Payload {
-                    data: vec![0u8; OVERSIZE_PAYLOAD_BYTES],
-                    ..Default::default()
-                }]);
+                ctx.record_heartbeat("a".repeat(OVERSIZE_PAYLOAD_BYTES)).await?;
                 // The oversized heartbeat is rejected client-side, which fails this attempt and
                 // cancels us; wait for that cancel rather than returning a normal completion.
                 ctx.cancelled().await;

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -470,7 +470,8 @@ async fn oversize_activity_heartbeat_fails_retryably_then_completes() {
             let attempt = ctx.info().attempt;
             self.max_attempt.fetch_max(attempt as u8, Relaxed);
             if attempt == 1 {
-                ctx.record_heartbeat("a".repeat(OVERSIZE_PAYLOAD_BYTES)).await?;
+                ctx.record_heartbeat("a".repeat(OVERSIZE_PAYLOAD_BYTES))
+                    .await?;
                 // The oversized heartbeat is rejected client-side, which fails this attempt and
                 // cancels us; wait for that cancel rather than returning a normal completion.
                 ctx.cancelled().await;

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -54,7 +54,7 @@ use temporalio_common::{
             },
         },
     },
-    telemetry::{CoreLogStreamConsumer, Logger, TelemetryOptions},
+    telemetry::{CoreLogStreamConsumer, Logger, TelemetryOptions, construct_filter_string},
     worker::WorkerTaskTypes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -54,7 +54,7 @@ use temporalio_common::{
             },
         },
     },
-    telemetry::{CoreLogStreamConsumer, Logger, TelemetryOptions, construct_filter_string},
+    telemetry::{CoreLogStreamConsumer, Logger, TelemetryOptions},
     worker::WorkerTaskTypes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
@@ -577,43 +577,17 @@ async fn warn_band_payload_is_logged_and_completes() {
     let scan = tokio::time::timeout(Duration::from_secs(5), async {
         while let Some(log) = log_rx.next().await {
             if log.message.starts_with("[TMPRL1103]") {
-                return Some(log);
+                return Some(log.level);
             }
         }
         None
     })
     .await;
-    let log = match scan {
-        Ok(Some(log)) => log,
+    match scan {
+        Ok(Some(level)) => assert_eq!(level, Level::WARN, "the payload should warn, not error"),
         Ok(None) => panic!("log stream ended without a [TMPRL1103] warning"),
         Err(_) => panic!("timed out waiting for a [TMPRL1103] warning"),
-    };
-    assert_eq!(log.level, Level::WARN, "the payload should warn, not error");
-
-    // Validate expected structured logging information.
-    let fields = &log.fields;
-    let as_u64 = |k: &str| fields.get(k).and_then(|v| v.as_u64());
-    let as_str = |k: &str| fields.get(k).and_then(|v| v.as_str());
-    assert_eq!(
-        as_u64("limit"),
-        Some(1),
-        "warn limit is the client option: {fields:?}"
-    );
-    assert!(
-        as_u64("size").is_some_and(|s| s > 1),
-        "size should be recorded and exceed the warn limit: {fields:?}"
-    );
-    assert_eq!(as_str("workflow_type"), Some("WarnBandWf"), "{fields:?}");
-    assert_eq!(as_u64("attempt"), Some(1), "{fields:?}");
-    assert_eq!(
-        as_str("workflow_id"),
-        Some(starter.get_wf_id()),
-        "{fields:?}"
-    );
-    assert!(
-        as_str("run_id").is_some_and(|r| !r.is_empty()),
-        "run_id should be recorded: {fields:?}"
-    );
+    }
 }
 
 /// With the worker error limit disabled, an oversized activity result (under the gRPC transport

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -243,6 +243,7 @@ pub(crate) async fn grpc_message_too_large() {
         .await
         .unwrap();
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter.sdk_config.disable_payload_error_limit = true;
     starter
         .sdk_config
         .register_workflow_with_factory(move || OversizeGrpcMessageWf {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -262,6 +262,7 @@ pub struct WorkerOptions {
     /// If set true, the worker will not proactively fail workflow/activity tasks whose payloads
     /// exceed the namespace error limits; oversized payloads are sent to server, which enforces the
     /// limit. Defaults to false.
+    /// NOTE: Experimental
     #[builder(default = false)]
     pub disable_payload_error_limit: bool,
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -259,6 +259,11 @@ pub struct WorkerOptions {
     /// channels, etc.) will have their tasks failed with a descriptive error.
     #[builder(default = true)]
     pub detect_nondeterministic_futures: bool,
+    /// If set true, the worker will not proactively fail workflow/activity tasks whose payloads
+    /// exceed the namespace error limits; oversized payloads are sent to server, which enforces the
+    /// limit. Defaults to false.
+    #[builder(default = false)]
+    pub disable_payload_error_limit: bool,
 }
 
 impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
@@ -428,6 +433,7 @@ impl WorkerOptions {
             ))
             .workflow_failure_errors(self.workflow_failure_errors.clone())
             .workflow_types_to_failure_errors(self.workflow_types_to_failure_errors.clone())
+            .disable_payload_error_limit(self.disable_payload_error_limit)
             .build()
     }
 }
@@ -1372,5 +1378,23 @@ mod tests {
             .to_core_options("ns".into(), connection_identity.into())
             .unwrap();
         assert_eq!(config.client_identity_override, expected);
+    }
+
+    #[rstest::rstest]
+    #[case::default_enforces_error_limit(None, false)]
+    #[case::opt_out_disables_error_limit(Some(true), true)]
+    #[case::explicit_enable_error_limit(Some(false), false)]
+    #[test]
+    fn disable_payload_error_limit_propagates(
+        #[case] override_value: Option<bool>,
+        #[case] expected: bool,
+    ) {
+        let config = WorkerOptions::new("task_q")
+            .task_types(WorkerTaskTypes::activity_only())
+            .maybe_disable_payload_error_limit(override_value)
+            .build()
+            .to_core_options("ns".into(), String::new())
+            .unwrap();
+        assert_eq!(config.disable_payload_error_limit, expected);
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
 protoc = "23.4"
-"aqua:temporalio/cli" = "1.7.2"
+"aqua:temporalio/cli" = "1.8.0"
 "cargo:cargo-component" = "0.21.1"
 "cargo:cargo-msrv" = "0.19.3"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Builds on the existing payload-field classification codegen to add end-to-end payload/memo
size-limit enforcement in the client and worker.

- Validate every outbound request via generated dispatcher; error-level violation fails with an invalid argument status carrying the `PayloadLimitViolation` as its source.
- Warning thresholds configured on `ConnectionOptions` as `payload_limits PayloadLimitsOptions` field. Default is to warn payloads at 512 KiB and memos at 2 KiB, same defaults as server.
- Error limits are read by workers when describing the namespace and set on the `PayloadLimitsClient` decorator that wraps the existing connection decorator. Each request has the error limits (if set) attached as a request extension.
- On error limit violation, worker converts requests to their corresponding failures and the operations are retryable:
  - WFT completion → `RespondWorkflowTaskFailed`
  - Activity completion / cancel → `RespondActivityTaskFailed`
  - Activity heartbeat → `RespondActivityTaskFailed` and report activity as cancelled
  - Nexus completion → `RespondNexusTaskFailed`
- Logs and task-failure messages render the same TMPRL1103 string.
- Richer completion-span context (namespace/workflow_id/type/attempt/worker_id) threaded through for log forwarding.
- New `FailureReason::PayloadsTooLarge` metric reason.

## :boom: Breaking Change

Payload size-limit enforcement is now on by default; existing code changes behavior without opting in: an oversized payload is now failed proactively by the worker (as a retryable task failure) before it's sent, rather than being sent and hard-failed by the server as before.

If you use a proxy between the worker and server that alters the size of payloads (e.g.
compression, encryption, external storage), it is advised that you disable size enforcement by
setting `disable_payload_error_limit` to `true` on the worker.

## Why?

Prevent server from hard-failing workflows, activities, and operations due to payloads/memo size limit violations. Allows customers to potentially update their workflows, activities, and operations to reduce the oversized payloads/memos.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: New unit tests and integration tests
1. Any docs updates needed? Yes
