### PR TITLE
chore: bump unit test timeouts across the board

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -46,8 +46,7 @@ jobs:
 
   test:
     name: Unit Tests
-    # Give extra time to ensure pushes to main have time to populate the cache
-    timeout-minutes: ${{ matrix.timeoutMinutes || (github.ref == 'refs/heads/main' && 20 || 15) }}
+    timeout-minutes: ${{ matrix.timeoutMinutes || 25 }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bump minimum timeout for unit tests to 25 minutes. Replacing custom logic that special cased main branches.

## Why?
Our `trybuild` tests are now taking 4+ minutes to run in CI and causing timeouts on the unit tests. Will look and see if there is a way to address, but even on my machine fans spin up and it takes over 2 minutes.

If there was a cache miss we would certainly timeout.
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
