### PR TITLE
feat(schedules): provide typed accessor to schedule action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,8 @@ to docs, or any other relevant information.
   `anyhow::Error`.
 
 ## [Unreleased]
+
+### Added
+* Schedule descriptions now expose their configured action via `ScheduleDescription::action()`,
+  including start-workflow accessors for workflow type, task queue, workflow ID, raw argument
+  payloads, and typed argument decoding through the client's data converter.

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -526,12 +526,17 @@ impl ScheduleDescription {
     }
 
     /// The action configured on this schedule.
-    pub fn action(&self) -> Option<ScheduleDescriptionAction> {
-        self.raw
+    pub fn action(&self) -> ScheduleDescriptionAction {
+        let action = self
+            .raw
             .schedule
             .as_ref()
-            .and_then(|s| s.action.as_ref())
-            .and_then(|a| ScheduleDescriptionAction::from_proto(a, self.data_converter.clone()))
+            .expect("schedule description should contain schedule")
+            .action
+            .as_ref()
+            .expect("schedule description should contain action");
+        ScheduleDescriptionAction::from_proto(action, self.data_converter.clone())
+            .expect("schedule action should contain an action variant")
     }
 
     /// Whether the schedule is paused.
@@ -1843,8 +1848,7 @@ mod tests {
             data_converter,
         );
 
-        let ScheduleDescriptionAction::StartWorkflow(action) =
-            desc.action().expect("action should be present");
+        let ScheduleDescriptionAction::StartWorkflow(action) = desc.action();
 
         assert_eq!(action.workflow_type(), "MyWorkflow");
         assert_eq!(action.task_queue(), "task-queue");
@@ -1856,8 +1860,7 @@ mod tests {
     #[tokio::test]
     async fn schedule_description_start_workflow_args_returns_none_without_input() {
         let desc = ScheduleDescription::from(describe_response_with_start_workflow(None));
-        let ScheduleDescriptionAction::StartWorkflow(action) =
-            desc.action().expect("action should be present");
+        let ScheduleDescriptionAction::StartWorkflow(action) = desc.action();
 
         let decoded: Option<String> = action.args().await.unwrap();
         assert_eq!(decoded, None);
@@ -1875,11 +1878,27 @@ mod tests {
             ScheduleDescription::from(describe_response_with_start_workflow(Some(Payloads {
                 payloads,
             })));
-        let ScheduleDescriptionAction::StartWorkflow(action) =
-            desc.action().expect("action should be present");
+        let ScheduleDescriptionAction::StartWorkflow(action) = desc.action();
 
         let err = action.args::<i32>().await.unwrap_err();
         assert!(matches!(err, PayloadConversionError::EncodingError(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "schedule description should contain schedule")]
+    fn schedule_description_action_panics_when_schedule_is_missing() {
+        let desc = ScheduleDescription::from(DescribeScheduleResponse::default());
+        let _ = desc.action();
+    }
+
+    #[test]
+    #[should_panic(expected = "schedule description should contain action")]
+    fn schedule_description_action_panics_when_action_is_missing() {
+        let desc = ScheduleDescription::from(DescribeScheduleResponse {
+            schedule: Some(Schedule::default()),
+            ..Default::default()
+        });
+        let _ = desc.action();
     }
 
     #[test]

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -10,7 +10,8 @@ use std::{
 use temporalio_common::{
     HasWorkflowDefinition,
     data_converters::{
-        DataConverter, PayloadConversionError, SerializationContextData, TemporalSerializable,
+        DataConverter, PayloadConversionError, SerializationContextData, TemporalDeserializable,
+        TemporalSerializable,
     },
     protos::{
         coresdk::IntoPayloadsExt,
@@ -394,6 +395,97 @@ pub struct ScheduleRunningAction {
     pub run_id: String,
 }
 
+/// The action configured on a described schedule.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum ScheduleDescriptionAction {
+    /// Start a workflow execution.
+    StartWorkflow(ScheduleDescriptionStartWorkflowAction),
+}
+
+impl ScheduleDescriptionAction {
+    fn from_proto(
+        action: &schedule_proto::ScheduleAction,
+        data_converter: DataConverter,
+    ) -> Option<Self> {
+        match action.action.as_ref()? {
+            schedule_proto::schedule_action::Action::StartWorkflow(info) => {
+                Some(Self::StartWorkflow(
+                    ScheduleDescriptionStartWorkflowAction::from_proto(info, data_converter),
+                ))
+            }
+        }
+    }
+}
+
+/// Start-workflow action details returned by a schedule description.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ScheduleDescriptionStartWorkflowAction {
+    workflow_type: String,
+    task_queue: String,
+    workflow_id: String,
+    input: Option<common_proto::Payloads>,
+    data_converter: DataConverter,
+}
+
+impl ScheduleDescriptionStartWorkflowAction {
+    fn from_proto(
+        info: &workflow_proto::NewWorkflowExecutionInfo,
+        data_converter: DataConverter,
+    ) -> Self {
+        Self {
+            workflow_type: info
+                .workflow_type
+                .as_ref()
+                .map(|t| t.name.clone())
+                .unwrap_or_default(),
+            task_queue: info
+                .task_queue
+                .as_ref()
+                .map(|t| t.name.clone())
+                .unwrap_or_default(),
+            workflow_id: info.workflow_id.clone(),
+            input: info.input.clone(),
+            data_converter,
+        }
+    }
+
+    /// The workflow type name.
+    pub fn workflow_type(&self) -> &str {
+        &self.workflow_type
+    }
+
+    /// The task queue to run the workflow on.
+    pub fn task_queue(&self) -> &str {
+        &self.task_queue
+    }
+
+    /// The workflow ID configured on the schedule action.
+    pub fn workflow_id(&self) -> &str {
+        &self.workflow_id
+    }
+
+    /// Returns the workflow arguments deserialized as the requested type, if present.
+    pub async fn args<T: TemporalDeserializable + 'static>(
+        &self,
+    ) -> Result<Option<T>, PayloadConversionError> {
+        match &self.input {
+            Some(input) => self
+                .data_converter
+                .from_payloads(&SerializationContextData::Workflow, input.payloads.clone())
+                .await
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the raw workflow argument payloads, if present.
+    pub fn raw_args(&self) -> Option<&[common_proto::Payload]> {
+        self.input.as_ref().map(|input| input.payloads.as_slice())
+    }
+}
+
 impl From<&schedule_proto::ScheduleActionResult> for ScheduleRecentAction {
     fn from(a: &schedule_proto::ScheduleActionResult) -> Self {
         let workflow_result = a
@@ -417,12 +509,29 @@ impl From<&schedule_proto::ScheduleActionResult> for ScheduleRecentAction {
 #[derive(Debug, Clone)]
 pub struct ScheduleDescription {
     raw: DescribeScheduleResponse,
+    data_converter: DataConverter,
 }
 
 impl ScheduleDescription {
+    pub(crate) fn new(raw: DescribeScheduleResponse, data_converter: DataConverter) -> Self {
+        Self {
+            raw,
+            data_converter,
+        }
+    }
+
     /// Token used for optimistic concurrency on updates.
     pub fn conflict_token(&self) -> &[u8] {
         &self.raw.conflict_token
+    }
+
+    /// The action configured on this schedule.
+    pub fn action(&self) -> Option<ScheduleDescriptionAction> {
+        self.raw
+            .schedule
+            .as_ref()
+            .and_then(|s| s.action.as_ref())
+            .and_then(|a| ScheduleDescriptionAction::from_proto(a, self.data_converter.clone()))
     }
 
     /// Whether the schedule is paused.
@@ -551,7 +660,7 @@ impl ScheduleDescription {
 
 impl From<DescribeScheduleResponse> for ScheduleDescription {
     fn from(raw: DescribeScheduleResponse) -> Self {
-        Self { raw }
+        Self::new(raw, DataConverter::default())
     }
 }
 
@@ -839,7 +948,10 @@ where
         .await?
         .into_inner();
 
-        Ok(ScheduleDescription::from(resp))
+        Ok(ScheduleDescription::new(
+            resp,
+            self.client.data_converter().clone(),
+        ))
     }
 
     /// Update the schedule definition.
@@ -1151,17 +1263,24 @@ mod tests {
         },
         time::SystemTime,
     };
-    use temporalio_common::protos::temporal::api::{
-        common::v1::{
-            Memo, SearchAttributes, WorkflowExecution as ProtoWorkflowExecution, WorkflowType,
-        },
-        schedule::v1::{
-            Schedule, ScheduleActionResult, ScheduleInfo, ScheduleListEntry, ScheduleListInfo,
-            ScheduleSpec, ScheduleState,
-        },
-        workflowservice::v1::{
-            DeleteScheduleResponse, DescribeScheduleResponse, PatchScheduleResponse,
-            UpdateScheduleResponse,
+    use temporalio_common::{
+        UntypedWorkflow,
+        data_converters::{DataConverter, MultiArgs2, RawValue},
+        protos::temporal::api::{
+            common::v1::{
+                Memo, Payload, Payloads, SearchAttributes,
+                WorkflowExecution as ProtoWorkflowExecution, WorkflowType,
+            },
+            schedule::v1::{
+                Schedule, ScheduleActionResult, ScheduleInfo, ScheduleListEntry, ScheduleListInfo,
+                ScheduleSpec, ScheduleState,
+            },
+            taskqueue::v1::TaskQueue,
+            workflow::v1::NewWorkflowExecutionInfo,
+            workflowservice::v1::{
+                DeleteScheduleResponse, DescribeScheduleResponse, PatchScheduleResponse,
+                UpdateScheduleResponse,
+            },
         },
     };
     use tonic::{Request, Response};
@@ -1275,6 +1394,31 @@ mod tests {
             "test-namespace".to_string(),
             "test-schedule-id".to_string(),
         )
+    }
+
+    fn describe_response_with_start_workflow(input: Option<Payloads>) -> DescribeScheduleResponse {
+        DescribeScheduleResponse {
+            schedule: Some(Schedule {
+                action: Some(schedule_proto::ScheduleAction {
+                    action: Some(schedule_proto::schedule_action::Action::StartWorkflow(
+                        NewWorkflowExecutionInfo {
+                            workflow_id: "wf-id".to_string(),
+                            workflow_type: Some(WorkflowType {
+                                name: "MyWorkflow".to_string(),
+                            }),
+                            task_queue: Some(TaskQueue {
+                                name: "task-queue".to_string(),
+                                ..Default::default()
+                            }),
+                            input,
+                            ..Default::default()
+                        },
+                    )),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -1686,6 +1830,58 @@ mod tests {
         assert!(recovered.schedule.is_some());
     }
 
+    #[tokio::test]
+    async fn schedule_description_action_decodes_start_workflow_args() {
+        let data_converter = DataConverter::default();
+        let expected = MultiArgs2("hello".to_string(), 42i32);
+        let payloads = data_converter
+            .to_payloads(&SerializationContextData::Workflow, &expected)
+            .await
+            .unwrap();
+        let desc = ScheduleDescription::new(
+            describe_response_with_start_workflow(Some(Payloads { payloads })),
+            data_converter,
+        );
+
+        let ScheduleDescriptionAction::StartWorkflow(action) =
+            desc.action().expect("action should be present");
+
+        assert_eq!(action.workflow_type(), "MyWorkflow");
+        assert_eq!(action.task_queue(), "task-queue");
+        assert_eq!(action.workflow_id(), "wf-id");
+        let decoded: MultiArgs2<String, i32> = action.args().await.unwrap().unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    #[tokio::test]
+    async fn schedule_description_start_workflow_args_returns_none_without_input() {
+        let desc = ScheduleDescription::from(describe_response_with_start_workflow(None));
+        let ScheduleDescriptionAction::StartWorkflow(action) =
+            desc.action().expect("action should be present");
+
+        let decoded: Option<String> = action.args().await.unwrap();
+        assert_eq!(decoded, None);
+    }
+
+    #[tokio::test]
+    async fn schedule_description_start_workflow_args_propagates_decode_errors() {
+        let data_converter = DataConverter::default();
+        let expected: String = "not-an-int".to_string();
+        let payloads = data_converter
+            .to_payloads(&SerializationContextData::Workflow, &expected)
+            .await
+            .unwrap();
+        let desc =
+            ScheduleDescription::from(describe_response_with_start_workflow(Some(Payloads {
+                payloads,
+            })));
+        let ScheduleDescriptionAction::StartWorkflow(action) =
+            desc.action().expect("action should be present");
+
+        let err = action.args::<i32>().await.unwrap_err();
+        assert!(matches!(err, PayloadConversionError::EncodingError(_)));
+    }
+
     #[test]
     fn schedule_summary_raw_round_trip() {
         let entry = ScheduleListEntry {
@@ -1769,12 +1965,6 @@ mod tests {
 
     #[tokio::test]
     async fn schedule_action_start_workflow_with_input_into_proto() {
-        use temporalio_common::{
-            UntypedWorkflow,
-            data_converters::{DataConverter, RawValue},
-            protos::temporal::api::common::v1::Payload,
-        };
-
         let payload = Payload {
             metadata: [("encoding".to_string(), b"json/plain".to_vec())]
                 .into_iter()

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -36,6 +36,14 @@ pub enum ScheduleError {
     /// Failed to encode workflow input payloads.
     #[error("Payload conversion error: {0}")]
     PayloadConversion(#[from] PayloadConversionError),
+    /// The server returned a schedule description that is missing required fields.
+    #[error("Malformed schedule description for schedule ID '{schedule_id}': {reason}")]
+    MalformedDescription {
+        /// ID of the schedule whose description was malformed.
+        schedule_id: String,
+        /// Details about the malformed response.
+        reason: String,
+    },
 }
 
 trait SerializableScheduleInput: Send + Sync {
@@ -513,10 +521,36 @@ pub struct ScheduleDescription {
 }
 
 impl ScheduleDescription {
-    pub(crate) fn new(raw: DescribeScheduleResponse, data_converter: DataConverter) -> Self {
-        Self {
+    pub(crate) fn new(
+        raw: DescribeScheduleResponse,
+        data_converter: DataConverter,
+        schedule_id: &str,
+    ) -> Result<Self, ScheduleError> {
+        let action = raw
+            .schedule
+            .as_ref()
+            .ok_or_else(|| Self::malformed_description_error(schedule_id, "missing schedule"))?
+            .action
+            .as_ref()
+            .ok_or_else(|| {
+                Self::malformed_description_error(schedule_id, "missing schedule action")
+            })?;
+        if action.action.is_none() {
+            return Err(Self::malformed_description_error(
+                schedule_id,
+                "missing schedule action variant",
+            ));
+        }
+        Ok(Self {
             raw,
             data_converter,
+        })
+    }
+
+    fn malformed_description_error(schedule_id: &str, reason: impl Into<String>) -> ScheduleError {
+        ScheduleError::MalformedDescription {
+            schedule_id: schedule_id.to_string(),
+            reason: reason.into(),
         }
     }
 
@@ -660,12 +694,6 @@ impl ScheduleDescription {
             schedule: self.raw.schedule.unwrap_or_default(),
             pending_action: None,
         }
-    }
-}
-
-impl From<DescribeScheduleResponse> for ScheduleDescription {
-    fn from(raw: DescribeScheduleResponse) -> Self {
-        Self::new(raw, DataConverter::default())
     }
 }
 
@@ -953,10 +981,11 @@ where
         .await?
         .into_inner();
 
-        Ok(ScheduleDescription::new(
+        ScheduleDescription::new(
             resp,
             self.client.data_converter().clone(),
-        ))
+            &self.schedule_id,
+        )
     }
 
     /// Update the schedule definition.
@@ -1298,11 +1327,21 @@ mod tests {
         patch: AtomicUsize,
     }
 
-    #[derive(Clone, Default)]
+    #[derive(Clone)]
     struct MockScheduleClient {
         captured: Arc<CapturedRequests>,
         describe_response: DescribeScheduleResponse,
         should_error: bool,
+    }
+
+    impl Default for MockScheduleClient {
+        fn default() -> Self {
+            Self {
+                captured: Arc::new(CapturedRequests::default()),
+                describe_response: describe_response_with_start_workflow(None),
+                should_error: false,
+            }
+        }
     }
 
     impl NamespacedClient for MockScheduleClient {
@@ -1426,6 +1465,31 @@ mod tests {
         }
     }
 
+    fn schedule_description_from_response(raw: DescribeScheduleResponse) -> ScheduleDescription {
+        ScheduleDescription::new(raw, DataConverter::default(), "test-schedule-id").unwrap()
+    }
+
+    fn describe_response_without_schedule() -> DescribeScheduleResponse {
+        DescribeScheduleResponse::default()
+    }
+
+    fn describe_response_without_action() -> DescribeScheduleResponse {
+        DescribeScheduleResponse {
+            schedule: Some(Schedule::default()),
+            ..Default::default()
+        }
+    }
+
+    fn describe_response_without_action_variant() -> DescribeScheduleResponse {
+        DescribeScheduleResponse {
+            schedule: Some(Schedule {
+                action: Some(schedule_proto::ScheduleAction::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn schedule_handle_exposes_namespace_and_id() {
         let handle = make_schedule_handle(MockScheduleClient::default());
@@ -1436,19 +1500,18 @@ mod tests {
     #[tokio::test]
     async fn schedule_describe_returns_response_fields() {
         let conflict_token = b"token-123".to_vec();
+        let mut describe_response = describe_response_with_start_workflow(None);
+        describe_response.info = Some(ScheduleInfo::default());
+        describe_response.memo = Some(Memo {
+            fields: Default::default(),
+        });
+        describe_response.search_attributes = Some(SearchAttributes {
+            indexed_fields: Default::default(),
+        });
+        describe_response.conflict_token = conflict_token.clone();
 
         let client = MockScheduleClient {
-            describe_response: DescribeScheduleResponse {
-                schedule: Some(Schedule::default()),
-                info: Some(ScheduleInfo::default()),
-                memo: Some(Memo {
-                    fields: Default::default(),
-                }),
-                search_attributes: Some(SearchAttributes {
-                    indexed_fields: Default::default(),
-                }),
-                conflict_token: conflict_token.clone(),
-            },
+            describe_response,
             ..Default::default()
         };
 
@@ -1633,52 +1696,50 @@ mod tests {
 
     #[tokio::test]
     async fn schedule_describe_accessors_with_populated_fields() {
-        let client = MockScheduleClient {
-            describe_response: DescribeScheduleResponse {
-                schedule: Some(Schedule {
-                    spec: Some(ScheduleSpec {
-                        timezone_name: "US/Eastern".to_string(),
-                        ..Default::default()
-                    }),
-                    state: Some(ScheduleState {
-                        paused: true,
-                        notes: "maintenance window".to_string(),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
+        let mut describe_response = describe_response_with_start_workflow(None);
+        let schedule = describe_response.schedule.as_mut().unwrap();
+        schedule.spec = Some(ScheduleSpec {
+            timezone_name: "US/Eastern".to_string(),
+            ..Default::default()
+        });
+        schedule.state = Some(ScheduleState {
+            paused: true,
+            notes: "maintenance window".to_string(),
+            ..Default::default()
+        });
+        describe_response.info = Some(ScheduleInfo {
+            action_count: 42,
+            missed_catchup_window: 3,
+            overlap_skipped: 5,
+            recent_actions: vec![ScheduleActionResult {
+                start_workflow_result: Some(ProtoWorkflowExecution {
+                    workflow_id: "ra-wf".to_string(),
+                    run_id: "ra-run".to_string(),
                 }),
-                info: Some(ScheduleInfo {
-                    action_count: 42,
-                    missed_catchup_window: 3,
-                    overlap_skipped: 5,
-                    recent_actions: vec![ScheduleActionResult {
-                        start_workflow_result: Some(ProtoWorkflowExecution {
-                            workflow_id: "ra-wf".to_string(),
-                            run_id: "ra-run".to_string(),
-                        }),
-                        ..Default::default()
-                    }],
-                    running_workflows: vec![ProtoWorkflowExecution {
-                        workflow_id: "wf-1".to_string(),
-                        run_id: "run-1".to_string(),
-                    }],
-                    create_time: Some(prost_types::Timestamp {
-                        seconds: 1_700_000_000,
-                        nanos: 0,
-                    }),
-                    update_time: Some(prost_types::Timestamp {
-                        seconds: 1_700_001_000,
-                        nanos: 0,
-                    }),
-                    future_action_times: vec![prost_types::Timestamp {
-                        seconds: 1_700_002_000,
-                        nanos: 0,
-                    }],
-                    ..Default::default()
-                }),
-                conflict_token: b"tok".to_vec(),
                 ..Default::default()
-            },
+            }],
+            running_workflows: vec![ProtoWorkflowExecution {
+                workflow_id: "wf-1".to_string(),
+                run_id: "run-1".to_string(),
+            }],
+            create_time: Some(prost_types::Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            }),
+            update_time: Some(prost_types::Timestamp {
+                seconds: 1_700_001_000,
+                nanos: 0,
+            }),
+            future_action_times: vec![prost_types::Timestamp {
+                seconds: 1_700_002_000,
+                nanos: 0,
+            }],
+            ..Default::default()
+        });
+        describe_response.conflict_token = b"tok".to_vec();
+
+        let client = MockScheduleClient {
+            describe_response,
             ..Default::default()
         };
 
@@ -1727,17 +1788,14 @@ mod tests {
 
     #[tokio::test]
     async fn schedule_note_returns_none_for_empty_string() {
+        let mut describe_response = describe_response_with_start_workflow(None);
+        describe_response.schedule.as_mut().unwrap().state = Some(ScheduleState {
+            notes: String::new(),
+            ..Default::default()
+        });
+
         let client = MockScheduleClient {
-            describe_response: DescribeScheduleResponse {
-                schedule: Some(Schedule {
-                    state: Some(ScheduleState {
-                        notes: String::new(),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
+            describe_response,
             ..Default::default()
         };
 
@@ -1823,12 +1881,10 @@ mod tests {
 
     #[test]
     fn schedule_description_raw_round_trip() {
-        let resp = DescribeScheduleResponse {
-            conflict_token: b"ct".to_vec(),
-            schedule: Some(Schedule::default()),
-            ..Default::default()
-        };
-        let desc = ScheduleDescription::from(resp.clone());
+        let mut resp = describe_response_with_start_workflow(None);
+        resp.conflict_token = b"ct".to_vec();
+
+        let desc = schedule_description_from_response(resp.clone());
         assert_eq!(desc.raw().conflict_token, b"ct");
         let recovered = desc.into_raw();
         assert_eq!(recovered.conflict_token, resp.conflict_token);
@@ -1846,7 +1902,9 @@ mod tests {
         let desc = ScheduleDescription::new(
             describe_response_with_start_workflow(Some(Payloads { payloads })),
             data_converter,
-        );
+            "test-schedule-id",
+        )
+        .unwrap();
 
         let ScheduleDescriptionAction::StartWorkflow(action) = desc.action();
 
@@ -1859,7 +1917,7 @@ mod tests {
 
     #[tokio::test]
     async fn schedule_description_start_workflow_args_returns_none_without_input() {
-        let desc = ScheduleDescription::from(describe_response_with_start_workflow(None));
+        let desc = schedule_description_from_response(describe_response_with_start_workflow(None));
         let ScheduleDescriptionAction::StartWorkflow(action) = desc.action();
 
         let decoded: Option<String> = action.args().await.unwrap();
@@ -1874,31 +1932,38 @@ mod tests {
             .to_payloads(&SerializationContextData::Workflow, &expected)
             .await
             .unwrap();
-        let desc =
-            ScheduleDescription::from(describe_response_with_start_workflow(Some(Payloads {
-                payloads,
-            })));
+        let desc = schedule_description_from_response(describe_response_with_start_workflow(Some(
+            Payloads { payloads },
+        )));
         let ScheduleDescriptionAction::StartWorkflow(action) = desc.action();
 
         let err = action.args::<i32>().await.unwrap_err();
         assert!(matches!(err, PayloadConversionError::EncodingError(_)));
     }
 
-    #[test]
-    #[should_panic(expected = "schedule description should contain schedule")]
-    fn schedule_description_action_panics_when_schedule_is_missing() {
-        let desc = ScheduleDescription::from(DescribeScheduleResponse::default());
-        let _ = desc.action();
-    }
-
-    #[test]
-    #[should_panic(expected = "schedule description should contain action")]
-    fn schedule_description_action_panics_when_action_is_missing() {
-        let desc = ScheduleDescription::from(DescribeScheduleResponse {
-            schedule: Some(Schedule::default()),
+    #[rstest::rstest]
+    #[case::schedule(describe_response_without_schedule(), "missing schedule")]
+    #[case::action(describe_response_without_action(), "missing schedule action")]
+    #[case::action_variant(
+        describe_response_without_action_variant(),
+        "missing schedule action variant"
+    )]
+    #[tokio::test]
+    async fn schedule_describe_errors_when_required_field_is_missing(
+        #[case] describe_response: DescribeScheduleResponse,
+        #[case] reason: &str,
+    ) {
+        let client = MockScheduleClient {
+            describe_response,
             ..Default::default()
-        });
-        let _ = desc.action();
+        };
+        let handle = make_schedule_handle(client);
+
+        let err = handle.describe().await.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!("Malformed schedule description for schedule ID 'test-schedule-id': {reason}")
+        );
     }
 
     #[test]
@@ -1915,17 +1980,12 @@ mod tests {
 
     #[test]
     fn schedule_into_update_preserves_schedule() {
-        let resp = DescribeScheduleResponse {
-            schedule: Some(Schedule {
-                state: Some(ScheduleState {
-                    notes: "my notes".to_string(),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }),
+        let mut resp = describe_response_with_start_workflow(None);
+        resp.schedule.as_mut().unwrap().state = Some(ScheduleState {
+            notes: "my notes".to_string(),
             ..Default::default()
-        };
-        let desc = ScheduleDescription::from(resp);
+        });
+        let desc = schedule_description_from_response(resp);
         let update = desc.into_update();
 
         assert_eq!(update.raw().state.as_ref().unwrap().notes, "my notes");
@@ -1933,11 +1993,7 @@ mod tests {
 
     #[test]
     fn schedule_update_setters_are_chainable() {
-        let resp = DescribeScheduleResponse {
-            schedule: Some(Schedule::default()),
-            ..Default::default()
-        };
-        let desc = ScheduleDescription::from(resp);
+        let desc = schedule_description_from_response(describe_response_with_start_workflow(None));
         let mut update = desc.into_update();
         update.set_note("chained").set_paused(true);
         assert_eq!(update.raw().state.as_ref().unwrap().notes, "chained");

--- a/crates/sdk-core/tests/integ_tests/schedule_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/schedule_tests.rs
@@ -5,9 +5,10 @@ use temporalio_client::{
     UntypedWorkflow,
     schedules::{
         CreateScheduleOptions, ListSchedulesOptions, ScheduleAction, ScheduleBackfill,
-        ScheduleCalendarSpec, ScheduleOverlapPolicy, ScheduleSpec,
+        ScheduleCalendarSpec, ScheduleDescriptionAction, ScheduleOverlapPolicy, ScheduleSpec,
     },
 };
+use temporalio_common::{data_converters::RawValue, protos::temporal::api::common::v1::Payload};
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult};
 
@@ -25,31 +26,6 @@ impl ScheduleInputWorkflow {
     async fn run(_ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<String> {
         Ok(input)
     }
-}
-
-/// Pull the `NewWorkflowExecutionInfo` out of a described schedule's start-workflow action.
-fn start_workflow_info(
-    desc: &temporalio_client::schedules::ScheduleDescription,
-) -> &temporalio_common::protos::temporal::api::workflow::v1::NewWorkflowExecutionInfo {
-    let raw_action = desc
-        .raw()
-        .schedule
-        .as_ref()
-        .expect("schedule present")
-        .action
-        .as_ref()
-        .expect("action present")
-        .action
-        .as_ref()
-        .expect("action oneof present");
-    #[allow(irrefutable_let_patterns)]
-    let temporalio_common::protos::temporal::api::schedule::v1::schedule_action::Action::StartWorkflow(
-        info,
-    ) = raw_action
-    else {
-        panic!("expected StartWorkflow action")
-    };
-    info
 }
 
 #[tokio::test]
@@ -484,12 +460,9 @@ async fn describe_accessors_match_created_values() {
 
 #[tokio::test]
 async fn create_schedule_with_workflow_input() {
-    use temporalio_common::{
-        data_converters::RawValue, protos::temporal::api::common::v1::Payload,
-    };
-
     let client = test_client().await;
     let schedule_id = format!("sched-with-input-{}", rand_6_chars());
+    let workflow_id = format!("wf-{}", rand_6_chars());
 
     let expected_payload = Payload {
         metadata: [("encoding".to_string(), b"json/plain".to_vec())]
@@ -507,7 +480,7 @@ async fn create_schedule_with_workflow_input() {
                     UntypedWorkflow::new("MyWorkflow"),
                     RawValue::new(vec![expected_payload.clone()]),
                     "my-task-queue",
-                    format!("wf-{}", rand_6_chars()),
+                    workflow_id.clone(),
                 ))
                 .spec(ScheduleSpec::from_interval(Duration::from_secs(3600)))
                 .paused(true)
@@ -519,9 +492,25 @@ async fn create_schedule_with_workflow_input() {
     let desc = handle.describe().await.unwrap();
     assert!(desc.paused());
 
-    let wf_info = start_workflow_info(&desc);
-    let stored_payloads = wf_info.input.as_ref().expect("input should be present");
-    assert_eq!(stored_payloads.payloads, vec![expected_payload]);
+    let ScheduleDescriptionAction::StartWorkflow(action) =
+        desc.action().expect("action should be present")
+    else {
+        panic!("expected start workflow action")
+    };
+    assert_eq!(action.workflow_type(), "MyWorkflow");
+    assert_eq!(action.task_queue(), "my-task-queue");
+    assert_eq!(action.workflow_id(), workflow_id);
+    assert_eq!(
+        action.raw_args().expect("input should be present"),
+        std::slice::from_ref(&expected_payload)
+    );
+
+    let stored: RawValue = action
+        .args()
+        .await
+        .unwrap()
+        .expect("input should be present");
+    assert_eq!(stored.payloads, vec![expected_payload]);
 
     handle.delete().await.unwrap();
 }
@@ -530,6 +519,7 @@ async fn create_schedule_with_workflow_input() {
 async fn schedule_action_start_workflow_encodes_typed_input() {
     let client = test_client().await;
     let schedule_id = format!("sched-typed-input-{}", rand_6_chars());
+    let workflow_id = format!("wf-{}", rand_6_chars());
 
     let handle = client
         .create_schedule(
@@ -539,7 +529,7 @@ async fn schedule_action_start_workflow_encodes_typed_input() {
                     ScheduleInputWorkflow::run,
                     "hello".to_string(),
                     "my-task-queue",
-                    format!("wf-{}", rand_6_chars()),
+                    workflow_id.clone(),
                 ))
                 .spec(ScheduleSpec::from_interval(Duration::from_secs(3600)))
                 .paused(true)
@@ -549,15 +539,21 @@ async fn schedule_action_start_workflow_encodes_typed_input() {
         .unwrap();
 
     let desc = handle.describe().await.unwrap();
-    let wf_info = start_workflow_info(&desc);
-    assert_eq!(
-        wf_info.workflow_type.as_ref().unwrap().name,
-        "ScheduleInputWorkflow"
-    );
-    let stored = wf_info.input.as_ref().expect("input should be present");
-    assert_eq!(stored.payloads.len(), 1);
-    // Default data converter encodes the String as json/plain.
-    assert_eq!(stored.payloads[0].data, b"\"hello\"");
+    let ScheduleDescriptionAction::StartWorkflow(action) =
+        desc.action().expect("action should be present")
+    else {
+        panic!("expected start workflow action")
+    };
+    assert_eq!(action.workflow_type(), "ScheduleInputWorkflow");
+    assert_eq!(action.task_queue(), "my-task-queue");
+    assert_eq!(action.workflow_id(), workflow_id);
+
+    let stored: String = action
+        .args()
+        .await
+        .unwrap()
+        .expect("input should be present");
+    assert_eq!(stored, "hello");
 
     handle.delete().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/schedule_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/schedule_tests.rs
@@ -492,9 +492,7 @@ async fn create_schedule_with_workflow_input() {
     let desc = handle.describe().await.unwrap();
     assert!(desc.paused());
 
-    let ScheduleDescriptionAction::StartWorkflow(action) =
-        desc.action().expect("action should be present")
-    else {
+    let ScheduleDescriptionAction::StartWorkflow(action) = desc.action() else {
         panic!("expected start workflow action")
     };
     assert_eq!(action.workflow_type(), "MyWorkflow");
@@ -539,9 +537,7 @@ async fn schedule_action_start_workflow_encodes_typed_input() {
         .unwrap();
 
     let desc = handle.describe().await.unwrap();
-    let ScheduleDescriptionAction::StartWorkflow(action) =
-        desc.action().expect("action should be present")
-    else {
+    let ScheduleDescriptionAction::StartWorkflow(action) = desc.action() else {
         panic!("expected start workflow action")
     };
     assert_eq!(action.workflow_type(), "ScheduleInputWorkflow");


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add `ScheduleDescription::action` to access `ScheduleDescriptionAction` with `ScheduleDescriptionStartWorkflowAction`. `ScheduleDescriptionStartWorkflowAction::args` provides typed access to the workflow input.

## Why?
SDK parity, ergonomics.

## Checklist
<!--- add/delete as needed --->

1. Closes  N/A

2. How was this tested:
Added unit tests for unhappy path. Updated integration test to verify round trip.

3. Any docs updates needed?
N/A
