### PR TITLE
feat(sdk): switch to rich search attributes from all getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,9 @@ to docs, or any other relevant information.
   `anyhow::Error`.
 
 ## [Unreleased]
+
+### Breaking Changes
+* `WorkflowExecution::search_attributes`, `WorkflowExecutionDescription::search_attributes`,
+  `ScheduleDescription::search_attributes`, and `ScheduleSummary::search_attributes` now return
+  typed `SearchAttributes` instead of raw proto search attributes. Missing search attributes are
+  returned as an empty collection instead of `None`.

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1408,31 +1408,6 @@ mod tests {
     }
 
     #[test]
-    fn workflow_execution_search_attributes_are_typed() {
-        use temporalio_common::protos::temporal::api::common::v1::SearchAttributes as ProtoSearchAttributes;
-
-        let payload = Payload::default();
-        let execution = WorkflowExecution::from(workflow::WorkflowExecutionInfo {
-            search_attributes: Some(ProtoSearchAttributes {
-                indexed_fields: HashMap::from([(
-                    "CustomKeywordField".to_string(),
-                    payload.clone(),
-                )]),
-            }),
-            ..Default::default()
-        });
-
-        let search_attributes = execution.search_attributes();
-        assert_eq!(
-            search_attributes.raw_payload("CustomKeywordField"),
-            Some(&payload)
-        );
-
-        let execution = WorkflowExecution::from(workflow::WorkflowExecutionInfo::default());
-        assert!(execution.search_attributes().is_empty());
-    }
-
-    #[test]
     fn applies_headers() {
         // Initial header set
         let headers = Arc::new(RwLock::new(ClientHeaders {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -88,7 +88,7 @@ use temporalio_common::{
         proto_ts_to_system_time,
         temporal::api::{
             cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
-            common::v1::{Memo, Payload, SearchAttributes, WorkflowType},
+            common::v1::{Memo, Payload, WorkflowType},
             enums::v1::{TaskQueueKind, WorkflowExecutionStatus},
             errordetails::v1::WorkflowExecutionAlreadyStartedFailure,
             operatorservice::v1::operator_service_client::OperatorServiceClient,
@@ -103,6 +103,7 @@ use temporalio_common::{
         },
         utilities::decode_status_detail,
     },
+    search_attributes::SearchAttributes,
 };
 use tonic::{
     Code, IntoRequest,
@@ -1000,8 +1001,12 @@ impl WorkflowExecution {
     }
 
     /// Search attributes on the workflow.
-    pub fn search_attributes(&self) -> Option<&SearchAttributes> {
-        self.raw.search_attributes.as_ref()
+    pub fn search_attributes(&self) -> SearchAttributes {
+        self.raw
+            .search_attributes
+            .as_ref()
+            .map(SearchAttributes::from_proto)
+            .unwrap_or_default()
     }
 
     /// Access the raw proto for additional fields not exposed via accessors.
@@ -1400,6 +1405,31 @@ mod tests {
             .service_override(service_override)
             .dns_load_balancing(None)
             .build()
+    }
+
+    #[test]
+    fn workflow_execution_search_attributes_are_typed() {
+        use temporalio_common::protos::temporal::api::common::v1::SearchAttributes as ProtoSearchAttributes;
+
+        let payload = Payload::default();
+        let execution = WorkflowExecution::from(workflow::WorkflowExecutionInfo {
+            search_attributes: Some(ProtoSearchAttributes {
+                indexed_fields: HashMap::from([(
+                    "CustomKeywordField".to_string(),
+                    payload.clone(),
+                )]),
+            }),
+            ..Default::default()
+        });
+
+        let search_attributes = execution.search_attributes();
+        assert_eq!(
+            search_attributes.raw_payload("CustomKeywordField"),
+            Some(&payload)
+        );
+
+        let execution = WorkflowExecution::from(workflow::WorkflowExecutionInfo::default());
+        assert!(execution.search_attributes().is_empty());
     }
 
     #[test]

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -21,6 +21,7 @@ use temporalio_common::{
             workflowservice::v1::*,
         },
     },
+    search_attributes::SearchAttributes,
 };
 use tonic::IntoRequest;
 use uuid::Uuid;
@@ -519,8 +520,12 @@ impl ScheduleDescription {
     }
 
     /// Search attributes on the schedule.
-    pub fn search_attributes(&self) -> Option<&common_proto::SearchAttributes> {
-        self.raw.search_attributes.as_ref()
+    pub fn search_attributes(&self) -> SearchAttributes {
+        self.raw
+            .search_attributes
+            .as_ref()
+            .map(SearchAttributes::from_proto)
+            .unwrap_or_default()
     }
 
     /// Access the raw proto for additional fields not exposed via accessors.
@@ -768,8 +773,12 @@ impl ScheduleSummary {
     }
 
     /// Search attributes on the schedule.
-    pub fn search_attributes(&self) -> Option<&common_proto::SearchAttributes> {
-        self.raw.search_attributes.as_ref()
+    pub fn search_attributes(&self) -> SearchAttributes {
+        self.raw
+            .search_attributes
+            .as_ref()
+            .map(SearchAttributes::from_proto)
+            .unwrap_or_default()
     }
 
     /// Access the raw proto for additional fields not exposed via accessors.
@@ -1311,6 +1320,7 @@ mod tests {
         assert!(desc.raw().info.is_some());
         assert!(desc.raw().memo.is_some());
         assert!(desc.raw().search_attributes.is_some());
+        assert!(desc.search_attributes().is_empty());
         assert_eq!(desc.conflict_token(), conflict_token);
     }
 
@@ -1647,6 +1657,7 @@ mod tests {
         assert_eq!(summary.schedule_id(), "sched-1");
         assert!(summary.raw().memo.is_some());
         assert!(summary.raw().search_attributes.is_some());
+        assert!(summary.search_attributes().is_empty());
         assert_eq!(summary.workflow_type(), Some("MyWorkflow"));
         assert_eq!(summary.note(), Some("some note"));
         assert!(summary.paused());
@@ -1665,6 +1676,7 @@ mod tests {
         assert_eq!(summary.schedule_id(), "sched-2");
         assert!(summary.raw().memo.is_none());
         assert!(summary.raw().search_attributes.is_none());
+        assert!(summary.search_attributes().is_empty());
         assert_eq!(summary.workflow_type(), None);
         assert_eq!(summary.note(), None);
         assert!(!summary.paused());

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -41,6 +41,7 @@ use temporalio_common::{
             },
         },
     },
+    search_attributes::SearchAttributes,
 };
 use tonic::IntoRequest;
 use uuid::Uuid;
@@ -225,10 +226,12 @@ impl WorkflowExecutionDescription {
     }
 
     /// Search attributes on the workflow.
-    pub fn search_attributes(
-        &self,
-    ) -> Option<&temporalio_common::protos::temporal::api::common::v1::SearchAttributes> {
-        self.workflow_info().search_attributes.as_ref()
+    pub fn search_attributes(&self) -> SearchAttributes {
+        self.workflow_info()
+            .search_attributes
+            .as_ref()
+            .map(SearchAttributes::from_proto)
+            .unwrap_or_default()
     }
 
     /// Static summary configured on the workflow, if present.
@@ -1101,9 +1104,10 @@ mod tests {
         assert_eq!(description.parent_id(), Some("parent-id"));
         assert_eq!(description.parent_run_id(), Some("parent-run-id"));
         assert_eq!(description.memo().unwrap().fields["memo-key"], memo_payload);
+        let search_attributes = description.search_attributes();
         assert_eq!(
-            description.search_attributes().unwrap().indexed_fields["CustomKeywordField"],
-            search_attr_payload
+            search_attributes.raw_payload("CustomKeywordField"),
+            Some(&search_attr_payload)
         );
         assert_eq!(description.static_summary(), Some("workflow summary"));
         assert_eq!(description.static_details(), Some("workflow details"));


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
#1346 added the new rich `SearchAttributes` type, but we didn't switch over to using it over the raw proto everywhere.

This PR switches over to the new type the various other places search attributes appear. Small note, I went with returning `SearchAttributes::default()` in the case of an empty proto. This seems to line up with other SDKs aside from Ruby which preserves missing search attributes as `nil`.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
👀 

3. Any docs updates needed?
N/A
