### PR TITLE
chore: limit wasm test concurrency

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -216,7 +216,7 @@ jobs:
           key: wasm-workflow-tests
       - name: Install cargo-component
         run: cargo install --locked cargo-component
-      - run: cargo integ-test -t wasm_workflow_tests
+      - run: cargo integ-test -t wasm_workflow_tests -- --test-threads 1
 
   cloud-tests:
     if: github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-rust'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Limit test threads for WASM test to 1.

## Why?
Each WASM test attempts to read/write the same sample component. This has been causing flakes on CI.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI doesn't flake

3. Any docs updates needed?
N/A
