### PR TITLE
ci: Replace deprecated arduino/setup-protoc with direct protoc download

### DIFF
--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -25,9 +25,19 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
       - run: cargo integ-test -c "--release" -t heavy_tests -- --test-threads 1

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -25,11 +25,21 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
       - run: rustup component add rustfmt clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -68,11 +78,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
       # Workaround for https://github.com/actions/runner-images/issues/12432
       # from https://github.com/rust-lang/rust/issues/141626#issuecomment-2919419236
       # Visual Studio bug tracker https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960
@@ -118,11 +138,21 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
       - run: rustup component add rustfmt clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -174,11 +204,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
       # Workaround for https://github.com/actions/runner-images/issues/12432
       # from https://github.com/rust-lang/rust/issues/141626#issuecomment-2919419236
       # Visual Studio bug tracker https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960
@@ -205,11 +245,21 @@ jobs:
         # Install after checkout so rustup uses this repo's rust-toolchain.toml override.
         run: rustup target add wasm32-unknown-unknown wasm32-wasip1
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -232,11 +282,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -258,11 +318,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
       - name: Start container for otel-collector and prometheus
         uses: hoverkraft-tech/compose-action@4894d2492015c1774ee5a13a95b1072093087ec3 # v2.5.0
         with:
@@ -281,10 +351,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-bin: false
@@ -309,11 +390,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
-          version: "23.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PROTOC_VERSION=27.3
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-x86_64.zip" ;;
+            Linux-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-linux-aarch_64.zip" ;;
+            macOS-X64)   PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-x86_64.zip" ;;
+            macOS-ARM64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-osx-aarch_64.zip" ;;
+            Windows-X64) PROTOC_ARCHIVE="protoc-${PROTOC_VERSION}-win64.zip" ;;
+            *) echo "Unsupported platform: $RUNNER_OS-$RUNNER_ARCH" && exit 1 ;;
+          esac
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ARCHIVE}"
+          unzip -o "$PROTOC_ARCHIVE" -d "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          protoc --version
 
       - name: Build crate as static library
         run: cargo rustc --package temporalio-sdk-core-c-bridge --features xz2-static -- --crate-type=staticlib


### PR DESCRIPTION
Fixes #1376

## Summary

Replace all 10 instances of `arduino/setup-protoc@v3` (SHA `c65c819...`, targeting Node.js 20) with a cross-platform shell step that downloads protoc directly from protobuf GitHub releases.

## Changes

- **`per-pr.yml`**: Replaced 9 instances across all CI jobs (build-and-lint, test, msrv, integ-tests, wasm-workflow-tests, cloud-tests, docker-integ-tests, examples, c-bridge-static-link-test)
- **`heavy.yml`**: Replaced 1 instance

## What this does

1. **Eliminates Node.js runtime dependency** — no more deprecation warnings or future breakage
2. **Upgrades protoc** from 23.x to 27.3
3. **Cross-platform** — handles all 5 runner platforms:
   - Linux x86_64 (`ubuntu-latest`)
   - Linux ARM64 (`ubuntu-24.04-arm64-2-core`)
   - macOS x86_64 (`macos-26-intel`)
   - macOS ARM64 (`macos-14`)
   - Windows x86_64 (`windows-latest`)
4. **Removes the TODO** about `arduino/setup-protoc#99` (no longer relevant)

## Why

`arduino/setup-protoc@v3` targets Node.js 20, which is [deprecated on GitHub Actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). After **September 16, 2026**, these actions will fail entirely. The `arduino/setup-protoc` repo has not released a Node.js 24 update.