### PR TITLE
fix(client): correctly handle grpc-js style unimplemented method message

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -278,7 +278,8 @@ impl Connection {
                                 || msg.contains("unknown service")
                                 || msg.contains("method not found")
                                 || (msg.contains("getsysteminfo")
-                                    && msg.contains("is unimplemented"))
+                                    && (msg.contains("is unimplemented")
+                                        || msg.contains("not implement")))
                         } =>
                     {
                         None
@@ -1567,6 +1568,9 @@ mod tests {
         "unknown method GetSystemInfo for service temporal.api.workflowservice.v1.WorkflowService"
     )]
     #[case("Method temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo is unimplemented")]
+    #[case(
+        "The server does not implement the method /temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo"
+    )]
     #[tokio::test]
     async fn get_system_info_missing_method_falls_back_to_empty_capabilities(
         #[case] message: &'static str,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add "not implemented" as a valid variation of "is unimplemented"

## Why?
Typescript uses grpc-js to create mock servers to assert that all methods defined on services are available on `NativeConnection`. Latest core bump fails these tests now since the `GetSystemInfo` request that always has returned `UNIMPLEMENTED` before is now treated as a failure.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
New test case

3. Any docs updates needed?
N/A