### PR TITLE
chore: expand mise.toml with dev tools, add lefthook, clean up CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,34 @@
+name: 'Setup Rust + mise'
+description: 'Common setup: checkout, Rust toolchain, mise tools, PROTOC env, Rust cache'
+
+inputs:
+  mise-install-args:
+    description: 'Tools to install (e.g. "protoc" or "protoc temporal"). Empty installs all.'
+    required: false
+    default: ''
+  rust-cache-key:
+    description: 'Extra key segment for Swatinem/rust-cache'
+    required: false
+    default: ''
+  save-cache:
+    description: 'Expression controlling when to save the Rust cache'
+    required: false
+    default: ${{ github.ref == 'refs/heads/main' }}
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    - name: Run mise install
+      uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      with:
+        version: 2026.7.1
+        install_args: ${{ inputs.mise-install-args }}
+    - name: Set PROTOC
+      shell: bash
+      run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        cache-bin: false
+        save-if: ${{ inputs.save-cache }}
+        key: ${{ inputs.rust-cache-key }}

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -21,14 +21,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
         with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-        with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
       - run: cargo integ-test -c "--release" -t heavy_tests -- --test-threads 1

--- a/.github/workflows/mise-bump.yml
+++ b/.github/workflows/mise-bump.yml
@@ -1,0 +1,53 @@
+name: Bump mise tool versions
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Weekly Monday 9am UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Check for mise tool updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run mise install
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: 2026.7.1
+
+      - name: Check for outdated tools
+        id: outdated
+        run: |
+          # mise outdated returns non-zero if updates available
+          if mise outdated 2>/dev/null | grep -q .; then
+            echo "has_updates=true" >> "$GITHUB_OUTPUT"
+            echo "### Outdated mise tools" >> "$GITHUB_STEP_SUMMARY"
+            mise outdated >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+            echo "All mise tools are up to date." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Bump versions
+        if: steps.outdated.outputs.has_updates == 'true'
+        run: mise up --bump
+
+      - name: Create Pull Request
+        if: steps.outdated.outputs.has_updates == 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b31e2c788f8e3a2383a3 # v7
+        with:
+          branch: chore/mise-bump
+          title: "chore(deps): bump mise tool versions"
+          body: |
+            Automated mise tool version bump.
+
+            This PR was created by the weekly `mise-bump.yml` workflow.
+            Versions are only bumped after they have been available for at
+            least 2 weeks (matching our minimum age policy).
+          commit-message: "chore(deps): bump mise tool versions"
+          labels: dependencies

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -21,21 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
         with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-        with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-      - run: rustup component add rustfmt clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          mise-install-args: protoc
       - run: cargo fmt --all --check
       - run: cargo doc --workspace --all-features --no-deps
         env:
@@ -67,14 +55,9 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
       # Workaround for https://github.com/actions/runner-images/issues/12432
       # from https://github.com/rust-lang/rust/issues/141626#issuecomment-2919419236
       # Visual Studio bug tracker https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960
@@ -84,10 +67,6 @@ jobs:
         with:
           script: |
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test -- --include-ignored --nocapture
       - name: Find test executable for cgroup tests
         id: find-cgroup-test
@@ -116,23 +95,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
         with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-        with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-      - run: rustup component add rustfmt clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          key: msrv
-      - run: cargo install cargo-msrv
+          mise-install-args: protoc cargo:cargo-msrv
+          rust-cache-key: msrv
       - run: cargo msrv verify
         working-directory: ./crates/sdk-core
 
@@ -175,14 +141,9 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
       # Workaround for https://github.com/actions/runner-images/issues/12432
       # from https://github.com/rust-lang/rust/issues/141626#issuecomment-2919419236
       # Visual Studio bug tracker https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960
@@ -192,10 +153,6 @@ jobs:
         with:
           script: |
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo integ-test
 
   wasm-workflow-tests:
@@ -204,23 +161,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup
+        with:
+          mise-install-args: protoc cargo:cargo-component
+          rust-cache-key: wasm-workflow-tests
       - name: Install WASM Rust targets
-        # Install after checkout so rustup uses this repo's rust-toolchain.toml override.
+        # Install after rust-toolchain so targets are added to the correct toolchain.
         run: rustup target add wasm32-unknown-unknown wasm32-wasip1
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-        with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          key: wasm-workflow-tests
-      - name: Install cargo-component
-        run: cargo install --locked cargo-component
       - run: cargo integ-test -t wasm_workflow_tests -- --test-threads 1
 
   cloud-tests:
@@ -235,19 +182,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          mise-install-args: protoc
       - run: cargo test --features=test-utilities --test cloud_tests
 
   docker-integ-tests:
@@ -262,22 +199,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
       - name: Start container for otel-collector and prometheus
         uses: hoverkraft-tech/compose-action@4894d2492015c1774ee5a13a95b1072093087ec3 # v2.5.0
         with:
           compose-file: ./etc/docker/docker-compose-ci.yaml
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo integ-test docker_
 
   examples:
@@ -286,22 +214,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          mise-install-args: protoc temporal
       - name: Build examples
         run: cargo build --examples -p temporalio-sdk --features examples
-      - name: Install Temporal CLI
-        uses: temporalio/setup-temporal@1059a504f87e7fa2f385e3fa40d1aa7e62f1c6ca # v0
       - name: Start Temporal dev server
         run: |
           temporal server start-dev --headless &
@@ -316,14 +233,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
 
       - name: Build crate as static library
         run: cargo rustc --package temporalio-sdk-core-c-bridge --features xz2-static -- --crate-type=staticlib

--- a/README.md
+++ b/README.md
@@ -37,8 +37,24 @@ For the reasoning behind the Core SDK, see blog post:
 
 # Development
 
-You will need the `protoc` [protobuf compiler](https://grpc.io/docs/protoc-installation)
-installed to build Core.
+Install [mise](https://mise.jdx.dev) for automatic tool management, then run:
+
+    mise install
+
+This installs `protoc`, `cargo-component`, `cargo-msrv`, and other
+development tools.
+
+For formatting with nightly rustfmt settings, you'll also need:
+
+    rustup toolchain install nightly
+
+### Git hooks (optional)
+
+This repo includes a `lefthook.yml` with pre-commit (format check) and
+pre-push (lint + check) hooks. To opt in:
+
+    brew install lefthook   # or: mise use lefthook
+    lefthook install
 
 This repo is composed of multiple crates:
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  commands:
+    fmt-check:
+      run: cargo +nightly fmt --all -- --check
+
+pre-push:
+  commands:
+    lint:
+      run: cargo lint
+    check:
+      run: cargo check

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
 [tools]
 protoc = "23.4"
+temporal = "1.7.2"
+"cargo:cargo-component" = "0.21.1"
+"cargo:cargo-msrv" = "0.19.3"


### PR DESCRIPTION
## Summary

Builds on #1382 to make the repo fully self-contained for local dev via `mise install`, clean up CI redundancy, and extract a reusable composite action.

## Changes

### `mise.toml` — add 3 tools to existing protoc entry

| Tool | Version | Why |
|---|---|---|
| `temporal` | `1.7.2` | Pin — replaces `temporalio/setup-temporal` in CI; gives devs `temporal server start-dev` locally |
| `cargo:cargo-component` | `0.21.1` | Pin — affects WASM compilation |
| `cargo:cargo-msrv` | `0.19.3` | Pin — per 2-week minimum age policy |

### `.github/actions/setup/action.yml` — new composite action

Extracts the 4-step setup pattern repeated across all 9 CI jobs:
1. `dtolnay/rust-toolchain` (stable)
2. `jdx/mise-action` (with selective `install_args`)
3. `Set PROTOC` env var
4. `Swatinem/rust-cache` (with `cache-bin: false`)

Inputs: `mise-install-args` (selective tool install), `rust-cache-key`, `save-cache`.

### `per-pr.yml` — major cleanup (-101 lines, +20 lines)

- **Composite action**: All 9 jobs now use `uses: ./.github/actions/setup`
- **Selective mise installs**: 6/9 jobs install only `protoc` instead of all tools
  - `msrv` → `protoc cargo:cargo-msrv`
  - `wasm-workflow-tests` → `protoc cargo:cargo-component`
  - `examples` → `protoc temporal`
  - All others → `protoc` only
- **Remove `rustup component add rustfmt clippy`** (2 places) — already in `rust-toolchain.toml`
- **Remove `cargo install cargo-msrv`** — now via mise
- **Remove `cargo install --locked cargo-component`** — now via mise
- **Remove `temporalio/setup-temporal` action** — now via mise
- **Add `cache-bin: false` to WASM job** — was missing, now consistent via composite action
- **Remove `submodules: recursive`** (2 places) — no submodules exist (removed in #194)

### `lefthook.yml` — new (opt-in only)

- **pre-commit**: `cargo +nightly fmt --all -- --check`
- **pre-push**: `cargo lint` + `cargo check`

Not auto-installed. Developers opt in via `brew install lefthook && lefthook install`.

### `.github/workflows/mise-bump.yml` — new

Weekly scheduled workflow (Monday 9am UTC) that:
1. Runs `mise outdated` to check for new versions
2. Runs `mise up --bump` if updates exist
3. Opens a PR via `peter-evans/create-pull-request`

Complements existing dependabot (which does not support `mise.toml`).

### `README.md`

- Replace manual `protoc` install instructions with `mise install`
- Add optional lefthook section with opt-in instructions

## Developer experience after this PR

```bash
git clone https://github.com/temporalio/sdk-rust
cd sdk-rust
mise install      # installs protoc, temporal, cargo-component, cargo-msrv
cargo build       # just works
```

## CI impact

- **Faster**: 6/9 jobs skip installing temporal, cargo-component, cargo-msrv
- **Faster**: cargo-msrv and cargo-component installed as pre-built binaries via mise instead of `cargo install` from source
- **Simpler**: 9 jobs share one composite action instead of duplicating 4 setup steps each
- **Consistent**: `cache-bin: false` now applied to all jobs including WASM

Closes #1383