### PR TITLE
chore: extract composite action for CI setup, selective mise installs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,34 @@
+name: 'Setup Rust + mise'
+description: 'Common setup: checkout, Rust toolchain, mise tools, PROTOC env, Rust cache'
+
+inputs:
+  mise-install-args:
+    description: 'Tools to install (e.g. "protoc" or "protoc aqua:temporalio/cli"). Empty installs all.'
+    required: false
+    default: ''
+  rust-cache-key:
+    description: 'Extra key segment for Swatinem/rust-cache'
+    required: false
+    default: ''
+  save-cache:
+    description: 'Expression controlling when to save the Rust cache'
+    required: false
+    default: ${{ github.ref == 'refs/heads/main' }}
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    - name: Run mise install
+      uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      with:
+        version: 2026.7.1
+        install_args: ${{ inputs.mise-install-args }}
+    - name: Set PROTOC
+      shell: bash
+      run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        cache-bin: false
+        save-if: ${{ inputs.save-cache }}
+        key: ${{ inputs.rust-cache-key }}

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -21,13 +21,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
       - run: cargo integ-test -c "--release" -t heavy_tests -- --test-threads 1

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -21,19 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          mise-install-args: protoc
       - run: cargo fmt --all --check
       - run: cargo doc --workspace --all-features --no-deps
         env:
@@ -65,15 +55,9 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
       # Workaround for https://github.com/actions/runner-images/issues/12432
       # from https://github.com/rust-lang/rust/issues/141626#issuecomment-2919419236
       # Visual Studio bug tracker https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960
@@ -83,10 +67,6 @@ jobs:
         with:
           script: |
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test -- --include-ignored --nocapture
       - name: Find test executable for cgroup tests
         id: find-cgroup-test
@@ -115,20 +95,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc cargo:cargo-msrv
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          key: msrv
+          mise-install-args: protoc cargo:cargo-msrv
+          rust-cache-key: msrv
       - run: cargo msrv verify
         working-directory: ./crates/sdk-core
 
@@ -171,15 +141,9 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
       # Workaround for https://github.com/actions/runner-images/issues/12432
       # from https://github.com/rust-lang/rust/issues/141626#issuecomment-2919419236
       # Visual Studio bug tracker https://developercommunity.visualstudio.com/t/Regression-from-1943:-linkexe-crashes/10912960
@@ -189,10 +153,6 @@ jobs:
         with:
           script: |
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo integ-test
 
   wasm-workflow-tests:
@@ -201,23 +161,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup
+        with:
+          mise-install-args: protoc cargo:cargo-component
+          rust-cache-key: wasm-workflow-tests
       - name: Install WASM Rust targets
-        # Install after checkout so rustup uses this repo's rust-toolchain.toml override.
+        # Install after rust-toolchain so targets are added to the correct toolchain.
         run: rustup target add wasm32-unknown-unknown wasm32-wasip1
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-        with:
-          version: 2026.7.1
-          install_args: protoc cargo:cargo-component
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          key: wasm-workflow-tests
       - run: cargo integ-test -t wasm_workflow_tests -- --test-threads 1
 
   cloud-tests:
@@ -232,20 +182,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          mise-install-args: protoc
       - run: cargo test --features=test-utilities --test cloud_tests
 
   docker-integ-tests:
@@ -260,23 +199,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
       - name: Start container for otel-collector and prometheus
         uses: hoverkraft-tech/compose-action@4894d2492015c1774ee5a13a95b1072093087ec3 # v2.5.0
         with:
           compose-file: ./etc/docker/docker-compose-ci.yaml
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo integ-test docker_
 
   examples:
@@ -285,19 +214,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc aqua:temporalio/cli
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          mise-install-args: protoc aqua:temporalio/cli
       - name: Build examples
         run: cargo build --examples -p temporalio-sdk --features examples
       - name: Start Temporal dev server
@@ -314,15 +233,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Run mise install
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: ./.github/actions/setup
         with:
-          version: 2026.7.1
-          install_args: protoc
-      - name: Set PROTOC
-        shell: bash
-        run: printf 'PROTOC=%s\n' "$(mise which protoc)" >> "$GITHUB_ENV"
+          mise-install-args: protoc
 
       - name: Build crate as static library
         run: cargo rustc --package temporalio-sdk-core-c-bridge --features xz2-static -- --crate-type=staticlib


### PR DESCRIPTION
## Summary

Extract the repeated 4-step CI setup pattern into a reusable composite action and add selective mise tool installation per job.

**PR 2 of 3** — depends on #1386. See #1383 for the full effort.

## Changes

### `.github/actions/setup/action.yml` (new)

Composite action encapsulating:
1. `dtolnay/rust-toolchain` (stable via `rust-toolchain.toml`)
2. `jdx/mise-action` (with configurable `install_args`)
3. `Set PROTOC` env var
4. `Swatinem/rust-cache` (with `cache-bin: false`)

Inputs: `mise-install-args`, `rust-cache-key`, `save-cache`

### `per-pr.yml` — refactor all 9 jobs

Each job now uses:
```yaml
- uses: ./.github/actions/setup
  with:
    mise-install-args: protoc  # only what this job needs
```

Selective installs by job:
| Job | Tools |
|---|---|
| 7 jobs (build-and-lint, test, integ-tests, cloud-tests, docker-integ, c-bridge, examples*) | `protoc` only |
| msrv | `protoc cargo:cargo-msrv` |
| wasm-workflow-tests | `protoc cargo:cargo-component` |
| examples | `protoc temporal` |

### `heavy.yml` — same refactor

Reduces per-pr.yml from ~325 lines to ~248 lines (-24%).

Depends on #1386
Ref #1383