### PR TITLE
fix: use worker hearbeat interval for heartbeat system info poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,5 @@ to docs, or any other relevant information.
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic
   metric reader reports an export error.
+* Worker heartbeat now samples host CPU/memory at the heartbeat interval (only when enabled) rather
+  than every 100ms.

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -631,7 +631,6 @@ impl Worker {
             sys_info = tuner_builder.get_sys_info();
             Arc::new(tuner_builder.build())
         });
-        let sys_info = sys_info.unwrap_or_else(|| Arc::new(RealSysInfo::new()));
 
         metrics.worker_registered();
         let shutdown_token = CancellationToken::new();
@@ -861,6 +860,8 @@ impl Worker {
 
         let sdk_name_and_ver = client.sdk_name_and_version();
         let worker_heartbeat = worker_heartbeat_interval.map(|hb_interval| {
+            let heartbeat_sys_info =
+                sys_info.unwrap_or_else(|| Arc::new(RealSysInfo::new(hb_interval)));
             let hb_metrics = HeartbeatMetrics {
                 in_mem_metrics: metrics.in_memory_meter(),
                 wft_slots: wft_slots.clone(),
@@ -872,7 +873,7 @@ impl Worker {
                 act_last_suc_poll_time,
                 nexus_last_suc_poll_time,
                 status: worker_status.clone(),
-                sys_info,
+                sys_info: heartbeat_sys_info,
             };
             WorkerHeartbeatManager::new(
                 config.clone(),

--- a/crates/sdk-core/src/worker/tuner/resource_based.rs
+++ b/crates/sdk-core/src/worker/tuner/resource_based.rs
@@ -45,14 +45,19 @@ impl ResourceBasedTuner<RealSysInfo> {
             .target_mem_usage(target_mem_usage)
             .target_cpu_usage(target_cpu_usage)
             .build();
-        let controller = ResourceController::new_with_sysinfo(opts, Arc::new(RealSysInfo::new()));
+        let controller = ResourceController::new_with_sysinfo(
+            opts,
+            Arc::new(RealSysInfo::new(RealSysInfo::MIN_REFRESH_INTERVAL)),
+        );
         Self::new_from_controller(controller)
     }
 
     /// Create an instance using the fully configurable set of PID controller options
     pub fn new_from_options(options: ResourceBasedSlotsOptions) -> Self {
-        let controller =
-            ResourceController::new_with_sysinfo(options, Arc::new(RealSysInfo::new()));
+        let controller = ResourceController::new_with_sysinfo(
+            options,
+            Arc::new(RealSysInfo::new(RealSysInfo::MIN_REFRESH_INTERVAL)),
+        );
         Self::new_from_controller(controller)
     }
 }
@@ -535,7 +540,19 @@ pub struct RealSysInfo {
 }
 
 impl RealSysInfo {
-    pub(crate) fn new() -> Self {
+    /// Lower bound for the refresh interval.
+    pub(crate) const MIN_REFRESH_INTERVAL: Duration = Duration::from_millis(100);
+    /// Upper bound for the refresh interval.
+    pub(crate) const MAX_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+    fn clamp_refresh_interval(interval: Duration) -> Duration {
+        interval.clamp(Self::MIN_REFRESH_INTERVAL, Self::MAX_REFRESH_INTERVAL)
+    }
+
+    /// Spawns a background thread refreshing host metrics every `refresh_interval` (clamped to
+    /// `[MIN_REFRESH_INTERVAL, MAX_REFRESH_INTERVAL]`).
+    pub(crate) fn new(refresh_interval: Duration) -> Self {
+        let refresh_interval = Self::clamp_refresh_interval(refresh_interval);
         let mut sys = sysinfo::System::new();
         sys.refresh_memory();
         let total_mem = sys.total_memory();
@@ -553,10 +570,9 @@ impl RealSysInfo {
         let handle = thread::Builder::new()
             .name("temporal-real-sysinfo".to_string())
             .spawn(move || {
-                const REFRESH_INTERVAL: Duration = Duration::from_millis(100);
                 loop {
                     thread_clone.refresh();
-                    let r = rx.recv_timeout(REFRESH_INTERVAL);
+                    let r = rx.recv_timeout(refresh_interval);
                     if matches!(r, Err(mpsc::RecvTimeoutError::Disconnected)) || r.is_ok() {
                         return;
                     }
@@ -768,6 +784,31 @@ mod tests {
             .target_mem_usage(0.8)
             .target_cpu_usage(1.0)
             .build()
+    }
+
+    #[test]
+    fn refresh_interval_clamped() {
+        // In-range passes through; out-of-range clamps at both ends.
+        assert_eq!(
+            RealSysInfo::clamp_refresh_interval(Duration::from_secs(30)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            RealSysInfo::clamp_refresh_interval(Duration::from_millis(1)),
+            RealSysInfo::MIN_REFRESH_INTERVAL
+        );
+        assert_eq!(
+            RealSysInfo::clamp_refresh_interval(Duration::from_secs(3600)),
+            RealSysInfo::MAX_REFRESH_INTERVAL
+        );
+    }
+
+    #[test]
+    fn realsysinfo_reports_sane_values() {
+        let sys_info = RealSysInfo::new(RealSysInfo::MIN_REFRESH_INTERVAL);
+        assert!(sys_info.total_mem() > 0);
+        let cpu = sys_info.used_cpu_percent();
+        assert!((0.0..=1.0).contains(&cpu), "cpu {cpu} out of range");
     }
 
     #[test]
@@ -1021,7 +1062,7 @@ mod tests {
             return;
         }
 
-        let sys_info = RealSysInfo::new();
+        let sys_info = RealSysInfo::new(RealSysInfo::MIN_REFRESH_INTERVAL);
         let cgroup_info = CGroupCpuInfo::new(CgroupV2CpuFileSystem);
         let CGroupCpuLimits { quota, period } = cgroup_info
             .read_cpus_limit()
@@ -1079,7 +1120,7 @@ mod tests {
             return;
         }
 
-        let sys_info = RealSysInfo::new();
+        let sys_info = RealSysInfo::new(RealSysInfo::MIN_REFRESH_INTERVAL);
 
         assert_eq!(
             sys_info.total_mem(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix worker heartbeat to sample host CPU/memory information at the heartbeat interval (if enabled).

## Why?

Host CPU/memory information doesn't need to be collected any faster than the heartbeat interval.

## Checklist
<!--- add/delete as needed --->

1. Closes #1392 

2. How was this tested: Will test end-to-end with .NET

3. Any docs updates needed? No
