### PR TITLE
Fix workflow executor cooperative budget livelock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ to docs, or any other relevant information.
   returned as an empty collection instead of `None`.
 
 ### Fixed
+* Workflow tasks no longer livelock when a burst of ready async operations exhausts Tokio's
+  cooperative scheduling budget.
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic
   metric reader reports an export error.
 * Worker heartbeat now samples host CPU/memory at the heartbeat interval (only when enabled) rather

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -950,6 +950,9 @@ impl WorkflowHalf {
                     return Ok(None);
                 }
             };
+            // The executor consumes self-wakes synchronously, so cooperative budget exhaustion
+            // would otherwise re-poll the workflow forever without returning to Tokio.
+            let wff = tokio::task::coop::unconstrained(wff);
             // TODO [rust-sdk-branch]: Deadlock detection
             let jh = executor.spawn(async move {
                 tokio::select! {

--- a/crates/sdk/src/workflow_executor.rs
+++ b/crates/sdk/src/workflow_executor.rs
@@ -331,7 +331,6 @@ mod tests {
             .await;
     }
 
-
     #[test]
     fn sdk_wake_guard_nesting() {
         assert!(!is_sdk_wake());

--- a/crates/sdk/src/workflow_executor.rs
+++ b/crates/sdk/src/workflow_executor.rs
@@ -331,6 +331,39 @@ mod tests {
             .await;
     }
 
+    #[tokio::test]
+    async fn executor_drains_unconstrained_future_past_cooperative_budget() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let executor = WorkflowExecutor::new();
+                let receivers = (0..256)
+                    .map(|_| {
+                        let (tx, rx) = oneshot::channel();
+                        tx.send(()).unwrap();
+                        rx
+                    })
+                    .collect::<Vec<_>>();
+                let workflow = async move {
+                    for receiver in receivers {
+                        receiver.await.unwrap();
+                    }
+                };
+                let workflow = tokio::task::coop::unconstrained(workflow);
+                let handle = executor.spawn(async move {
+                    tokio::select! {
+                        _ = workflow => {}
+                        _ = std::future::pending::<()>() => {}
+                    }
+                });
+
+                executor.shutdown().await;
+
+                handle.await.unwrap();
+            })
+            .await;
+    }
+
     #[test]
     fn sdk_wake_guard_nesting() {
         assert!(!is_sdk_wake());

--- a/crates/sdk/src/workflow_executor.rs
+++ b/crates/sdk/src/workflow_executor.rs
@@ -331,38 +331,6 @@ mod tests {
             .await;
     }
 
-    #[tokio::test]
-    async fn executor_drains_unconstrained_future_past_cooperative_budget() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let executor = WorkflowExecutor::new();
-                let receivers = (0..256)
-                    .map(|_| {
-                        let (tx, rx) = oneshot::channel();
-                        tx.send(()).unwrap();
-                        rx
-                    })
-                    .collect::<Vec<_>>();
-                let workflow = async move {
-                    for receiver in receivers {
-                        receiver.await.unwrap();
-                    }
-                };
-                let workflow = tokio::task::coop::unconstrained(workflow);
-                let handle = executor.spawn(async move {
-                    tokio::select! {
-                        _ = workflow => {}
-                        _ = std::future::pending::<()>() => {}
-                    }
-                });
-
-                executor.shutdown().await;
-
-                handle.await.unwrap();
-            })
-            .await;
-    }
 
     #[test]
     fn sdk_wake_guard_nesting() {


### PR DESCRIPTION
## What was changed

- Restored the Tokio cooperative-budget exemption around the workflow future at the narrow scope used before #1185.
- Added a regression test that resolves 256 pre-completed oneshots inside an unconstrained workflow while keeping the outer select and custom executor constrained.
- Added a changelog entry.

## Why?

PR #1185 replaced spawn_local with the custom WorkflowExecutor and inadvertently dropped the existing unconstrained wrapper around workflow futures.

WorkflowExecutor drains self-woken tasks synchronously. If a workflow resolves enough already-ready Tokio operations to exhaust the cooperative budget, the workflow returns Pending and self-wakes. The executor then immediately polls it again without returning to Tokio, so the budget is never replenished and the worker livelocks.

Restoring the previous narrow exemption lets the workflow drain ready resolutions without the cooperative cutoff while retaining the custom executor, its wake tracking, and nondeterministic-future detection.

## Checklist

1. How was this tested:

- cargo test -p temporalio-sdk
- timeout 180 cargo integ-test nondeterministic_future_detection_fails_wft
- cargo lint
- cargo test-lint
- cargo +nightly fmt
- git diff --check

2. Any docs updates needed?

No documentation changes. Added an Unreleased changelog entry.