### PR TITLE
feat(sdk): remove remaining raw protos in APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ to docs, or any other relevant information.
 * Async activity completion, failure, cancellation, and heartbeat methods now convert typed Rust
   values with the client's data converter. Activity heartbeat details are exposed through the
   typed `ActivityHeartbeatDetails` wrapper.
+* Workflow and schedule list/description memo accessors now return the typed `Memo` wrapper
+  instead of raw protobuf memos.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ to docs, or any other relevant information.
   `ScheduleDescription::search_attributes`, and `ScheduleSummary::search_attributes` now return
   typed `SearchAttributes` instead of raw proto search attributes. Missing search attributes are
   returned as an empty collection instead of `None`.
+* Activity and child-workflow failure metadata now exposes activity and workflow type names as
+  strings, and workflow executions as the Rust-native `WorkflowExecution` type. `ActivityInfo`
+  uses the same Rust-native workflow execution type.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ to docs, or any other relevant information.
 * Activity and child-workflow failure metadata now exposes activity and workflow type names as
   strings, and workflow executions as the Rust-native `WorkflowExecution` type. `ActivityInfo`
   uses the same Rust-native workflow execution type.
+* Workflow status accessors and query rejection errors now use the Rust-native
+  `WorkflowExecutionStatus` enum instead of generated protobuf types.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ to docs, or any other relevant information.
   `WorkflowExecutionStatus` enum instead of generated protobuf types.
 * Activity, child-workflow, and timeout errors now expose Rust-native `RetryState` and
   `TimeoutType` enums instead of generated protobuf enums.
+* Workflow and worker options now use Rust-native cancellation, parent-close, workflow-ID reuse,
+  versioning, and Nexus cancellation policy enums instead of generated protobuf enums.
+* Child workflow cancellation now defaults to `WaitCancellationCompleted` instead of `Abandon`,
+  aligning Rust with the Core-based SDKs and Java. Set `ChildWorkflowCancellationType::Abandon`
+  explicitly to retain the previous behavior.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ to docs, or any other relevant information.
 * Workflow memo reads use the typed `Memo` collection. Upserts accept maps of optional
   `MemoValue`s, where `None` removes a key, and continue-as-new memo replacements use
   `MemoValues`.
+* Removed the raw-protobuf `Namespace::into_describe_namespace_request` and
+  `WorkerTaskTypes::to_task_queue_types` helpers. These conversions are now internal plumbing.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ to docs, or any other relevant information.
   `RetryPolicy` type instead of the generated protobuf message.
 * Workflow result failures now expose decoded `IncomingError` values, and cancellation and
   termination details use typed `WorkflowResultDetails` instead of raw payloads.
+* Async activity completion, failure, cancellation, and heartbeat methods now convert typed Rust
+  values with the client's data converter. Activity heartbeat details are exposed through the
+  typed `ActivityHeartbeatDetails` wrapper.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ to docs, or any other relevant information.
   `MemoValues`.
 * Removed the raw-protobuf `Namespace::into_describe_namespace_request` and
   `WorkerTaskTypes::to_task_queue_types` helpers. These conversions are now internal plumbing.
+* `WorkflowContext::workflow_initial_info` and its synchronous counterpart are replaced by
+  `info()`, which returns the Rust-native `WorkflowContextView` and includes typed workflow
+  priority. The internal `BaseWorkflowContext::new` raw-protobuf boundary is now explicitly named
+  `from_raw`.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ to docs, or any other relevant information.
 * Child workflow cancellation now defaults to `WaitCancellationCompleted` instead of `Abandon`,
   aligning Rust with the Core-based SDKs and Java. Set `ChildWorkflowCancellationType::Abandon`
   explicitly to retain the previous behavior.
+* Workflow and activity retry configuration and runtime information now use the Rust-native
+  `RetryPolicy` type instead of the generated protobuf message.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ to docs, or any other relevant information.
   uses the same Rust-native workflow execution type.
 * Workflow status accessors and query rejection errors now use the Rust-native
   `WorkflowExecutionStatus` enum instead of generated protobuf types.
+* Activity, child-workflow, and timeout errors now expose Rust-native `RetryState` and
+  `TimeoutType` enums instead of generated protobuf enums.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ to docs, or any other relevant information.
   explicitly to retain the previous behavior.
 * Workflow and activity retry configuration and runtime information now use the Rust-native
   `RetryPolicy` type instead of the generated protobuf message.
+* Workflow result failures now expose decoded `IncomingError` values, and cancellation and
+  termination details use typed `WorkflowResultDetails` instead of raw payloads.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ to docs, or any other relevant information.
   typed `ActivityHeartbeatDetails` wrapper.
 * Workflow and schedule list/description memo accessors now return the typed `Memo` wrapper
   instead of raw protobuf memos.
+* Workflow memo reads use the typed `Memo` collection. Upserts accept maps of optional
+  `MemoValue`s, where `None` removes a key, and continue-as-new memo replacements use
+  `MemoValues`.
 
 ### Fixed
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/crates/client/src/async_activity_handle.rs
+++ b/crates/client/src/async_activity_handle.rs
@@ -1,17 +1,21 @@
 //! Handle for completing activities asynchronously via a client.
 
 use crate::{NamespacedClient, errors::AsyncActivityError, grpc::WorkflowService};
-use temporalio_common::protos::{
-    TaskToken,
-    temporal::api::{
-        common::v1::Payloads,
-        failure::v1::Failure,
-        workflowservice::v1::{
-            RecordActivityTaskHeartbeatByIdRequest, RecordActivityTaskHeartbeatByIdResponse,
-            RecordActivityTaskHeartbeatRequest, RecordActivityTaskHeartbeatResponse,
-            RespondActivityTaskCanceledByIdRequest, RespondActivityTaskCanceledRequest,
-            RespondActivityTaskCompletedByIdRequest, RespondActivityTaskCompletedRequest,
-            RespondActivityTaskFailedByIdRequest, RespondActivityTaskFailedRequest,
+use temporalio_common::{
+    data_converters::{SerializationContextData, TemporalSerializable},
+    error::{ApplicationFailure, OutgoingActivityError, OutgoingError},
+    payload_visitor::encode_payloads,
+    protos::{
+        TaskToken,
+        temporal::api::{
+            common::v1::Payloads,
+            workflowservice::v1::{
+                RecordActivityTaskHeartbeatByIdRequest, RecordActivityTaskHeartbeatByIdResponse,
+                RecordActivityTaskHeartbeatRequest, RecordActivityTaskHeartbeatResponse,
+                RespondActivityTaskCanceledByIdRequest, RespondActivityTaskCanceledRequest,
+                RespondActivityTaskCompletedByIdRequest, RespondActivityTaskCompletedRequest,
+                RespondActivityTaskFailedByIdRequest, RespondActivityTaskFailedRequest,
+            },
         },
     },
 };
@@ -79,7 +83,21 @@ impl<CT> AsyncActivityHandle<CT> {
 
 impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
     /// Complete the activity with a successful result.
-    pub async fn complete(&self, result: Option<Payloads>) -> Result<(), AsyncActivityError> {
+    pub async fn complete<T>(&self, result: Option<T>) -> Result<(), AsyncActivityError>
+    where
+        T: TemporalSerializable + 'static,
+    {
+        let result = match result {
+            Some(result) => Some(Payloads {
+                payloads: vec![
+                    self.client
+                        .data_converter()
+                        .to_payload(&SerializationContextData::Activity, &result)
+                        .await?,
+                ],
+            }),
+            None => None,
+        };
         match &self.identifier {
             ActivityIdentifier::TaskToken(token) => {
                 WorkflowService::respond_activity_task_completed(
@@ -122,11 +140,29 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
     }
 
     /// Fail the activity with a failure.
-    pub async fn fail(
+    pub async fn fail<E, T>(
         &self,
-        failure: Failure,
-        last_heartbeat_details: Option<Payloads>,
-    ) -> Result<(), AsyncActivityError> {
+        failure: E,
+        last_heartbeat_details: Option<T>,
+    ) -> Result<(), AsyncActivityError>
+    where
+        E: Into<ApplicationFailure>,
+        T: TemporalSerializable + 'static,
+    {
+        let data_converter = self.client.data_converter();
+        let mut failure = data_converter.to_failure(
+            &SerializationContextData::Activity,
+            OutgoingError::Activity(OutgoingActivityError::Application(Box::new(failure.into()))),
+        );
+        encode_payloads(
+            &mut failure,
+            data_converter.codec(),
+            &SerializationContextData::Activity,
+        )
+        .await;
+        let last_heartbeat_details = self
+            .encode_optional_payloads(last_heartbeat_details)
+            .await?;
         match &self.identifier {
             ActivityIdentifier::TaskToken(token) => {
                 WorkflowService::respond_activity_task_failed(
@@ -171,10 +207,11 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
     }
 
     /// Reports the activity as canceled.
-    pub async fn report_cancelation(
-        &self,
-        details: Option<Payloads>,
-    ) -> Result<(), AsyncActivityError> {
+    pub async fn report_cancelation<T>(&self, details: Option<T>) -> Result<(), AsyncActivityError>
+    where
+        T: TemporalSerializable + 'static,
+    {
+        let details = self.encode_optional_payloads(details).await?;
         match &self.identifier {
             ActivityIdentifier::TaskToken(token) => {
                 WorkflowService::respond_activity_task_canceled(
@@ -220,10 +257,14 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
     ///
     /// Heartbeats let the server know the activity is still running and can carry
     /// progress information. The response indicates if cancellation has been requested.
-    pub async fn heartbeat(
+    pub async fn heartbeat<T>(
         &self,
-        details: Option<Payloads>,
-    ) -> Result<ActivityHeartbeatResponse, AsyncActivityError> {
+        details: Option<T>,
+    ) -> Result<ActivityHeartbeatResponse, AsyncActivityError>
+    where
+        T: TemporalSerializable + 'static,
+    {
+        let details = self.encode_optional_payloads(details).await?;
         match &self.identifier {
             ActivityIdentifier::TaskToken(token) => {
                 let resp = WorkflowService::record_activity_task_heartbeat(
@@ -265,6 +306,25 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
                 .into_inner();
                 Ok(ActivityHeartbeatResponse::from(resp))
             }
+        }
+    }
+
+    async fn encode_optional_payloads<T>(
+        &self,
+        value: Option<T>,
+    ) -> Result<Option<Payloads>, AsyncActivityError>
+    where
+        T: TemporalSerializable + 'static,
+    {
+        match value {
+            Some(value) => Ok(Some(Payloads {
+                payloads: self
+                    .client
+                    .data_converter()
+                    .to_payloads(&SerializationContextData::Activity, &value)
+                    .await?,
+            })),
+            None => Ok(None),
         }
     }
 }

--- a/crates/client/src/async_activity_handle.rs
+++ b/crates/client/src/async_activity_handle.rs
@@ -160,9 +160,16 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
             &SerializationContextData::Activity,
         )
         .await;
-        let last_heartbeat_details = self
-            .encode_optional_payloads(last_heartbeat_details)
-            .await?;
+        let last_heartbeat_details = match last_heartbeat_details {
+            Some(details) => Some(Payloads {
+                payloads: self
+                    .client
+                    .data_converter()
+                    .to_payloads(&SerializationContextData::Activity, &details)
+                    .await?,
+            }),
+            None => None,
+        };
         match &self.identifier {
             ActivityIdentifier::TaskToken(token) => {
                 WorkflowService::respond_activity_task_failed(
@@ -211,7 +218,16 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
     where
         T: TemporalSerializable + 'static,
     {
-        let details = self.encode_optional_payloads(details).await?;
+        let details = match details {
+            Some(details) => Some(Payloads {
+                payloads: self
+                    .client
+                    .data_converter()
+                    .to_payloads(&SerializationContextData::Activity, &details)
+                    .await?,
+            }),
+            None => None,
+        };
         match &self.identifier {
             ActivityIdentifier::TaskToken(token) => {
                 WorkflowService::respond_activity_task_canceled(
@@ -264,7 +280,16 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
     where
         T: TemporalSerializable + 'static,
     {
-        let details = self.encode_optional_payloads(details).await?;
+        let details = match details {
+            Some(details) => Some(Payloads {
+                payloads: self
+                    .client
+                    .data_converter()
+                    .to_payloads(&SerializationContextData::Activity, &details)
+                    .await?,
+            }),
+            None => None,
+        };
         match &self.identifier {
             ActivityIdentifier::TaskToken(token) => {
                 let resp = WorkflowService::record_activity_task_heartbeat(
@@ -306,25 +331,6 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
                 .into_inner();
                 Ok(ActivityHeartbeatResponse::from(resp))
             }
-        }
-    }
-
-    async fn encode_optional_payloads<T>(
-        &self,
-        value: Option<T>,
-    ) -> Result<Option<Payloads>, AsyncActivityError>
-    where
-        T: TemporalSerializable + 'static,
-    {
-        match value {
-            Some(value) => Ok(Some(Payloads {
-                payloads: self
-                    .client
-                    .data_converter()
-                    .to_payloads(&SerializationContextData::Activity, &value)
-                    .await?,
-            })),
-            None => Ok(None),
         }
     }
 }

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -1,10 +1,10 @@
 //! Contains errors that can be returned by clients.
 
-use crate::WorkflowExecutionStatus;
+use crate::{WorkflowExecutionStatus, workflow_handle::WorkflowResultDetails};
 use http::uri::InvalidUri;
 use temporalio_common::{
-    data_converters::PayloadConversionError,
-    protos::temporal::api::{common::v1::Payload, failure::v1::Failure},
+    data_converters::PayloadConversionError, error::IncomingError,
+    protos::temporal::api::failure::v1::Failure,
 };
 use tonic::Code;
 
@@ -170,21 +170,21 @@ impl WorkflowUpdateError {
 #[non_exhaustive]
 pub enum WorkflowGetResultError {
     /// The workflow finished in failure.
-    #[error("Workflow failed: {0:?}")]
-    Failed(Box<Failure>),
+    #[error("Workflow failed: {0}")]
+    Failed(#[source] Box<IncomingError>),
 
     /// The workflow was cancelled.
     #[error("Workflow cancelled")]
     Cancelled {
         /// Details provided at cancellation time.
-        details: Vec<Payload>,
+        details: WorkflowResultDetails,
     },
 
     /// The workflow was terminated.
     #[error("Workflow terminated")]
     Terminated {
         /// Details provided at termination time.
-        details: Vec<Payload>,
+        details: WorkflowResultDetails,
     },
 
     /// The workflow timed out.

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -1,9 +1,10 @@
 //! Contains errors that can be returned by clients.
 
+use crate::WorkflowExecutionStatus;
 use http::uri::InvalidUri;
 use temporalio_common::{
     data_converters::PayloadConversionError,
-    protos::temporal::api::{common::v1::Payload, failure::v1::Failure, query::v1::QueryRejected},
+    protos::temporal::api::{common::v1::Payload, failure::v1::Failure},
 };
 use tonic::Code;
 
@@ -100,8 +101,11 @@ pub enum WorkflowQueryError {
     NotFound(#[source] tonic::Status),
 
     /// The query was rejected based on the rejection condition.
-    #[error("Query rejected: workflow status {:?}", .0.status)]
-    Rejected(QueryRejected),
+    #[error("Query rejected: workflow status {status:?}")]
+    Rejected {
+        /// The workflow status that caused the query rejection, if reported.
+        status: Option<WorkflowExecutionStatus>,
+    },
 
     /// Error serializing input or deserializing output.
     #[error("Payload conversion error: {0}")]

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -287,6 +287,9 @@ pub enum AsyncActivityError {
     /// The activity was not found (e.g., already completed, cancelled, or never existed).
     #[error("Activity not found")]
     NotFound(#[source] tonic::Status),
+    /// Error serializing an activity result, failure, or details.
+    #[error("Payload conversion error: {0}")]
+    PayloadConversion(#[from] PayloadConversionError),
     /// An uncategorized rpc error from the server.
     #[error("Server error: {0}")]
     Rpc(#[from] tonic::Status),

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -27,6 +27,7 @@ mod retry;
 pub mod schedules;
 pub mod worker;
 mod workflow_handle;
+mod workflow_status;
 
 pub use crate::{
     proxy::HttpConnectProxyOptions,
@@ -53,6 +54,7 @@ pub use workflow_handle::{
     WorkflowExecutionDescription, WorkflowExecutionInfo, WorkflowExecutionResult, WorkflowHandle,
     WorkflowHistory, WorkflowUpdateHandle,
 };
+pub use workflow_status::WorkflowExecutionStatus;
 
 use crate::{
     grpc::{
@@ -89,7 +91,7 @@ use temporalio_common::{
         temporal::api::{
             cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
             common::v1::{Memo, Payload, WorkflowType},
-            enums::v1::{TaskQueueKind, WorkflowExecutionStatus},
+            enums::v1::TaskQueueKind,
             errordetails::v1::WorkflowExecutionAlreadyStartedFailure,
             operatorservice::v1::operator_service_client::OperatorServiceClient,
             sdk::v1::UserMetadata,
@@ -943,7 +945,7 @@ impl WorkflowExecution {
 
     /// The current status of the workflow execution.
     pub fn status(&self) -> WorkflowExecutionStatus {
-        self.raw.status()
+        WorkflowExecutionStatus::from_raw(self.raw.status)
     }
 
     /// When the workflow was created.

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -25,6 +25,8 @@ pub mod request_extensions;
 mod retry;
 /// Schedule operations: create, describe, update, pause, trigger, backfill, list, and delete.
 pub mod schedules;
+#[cfg(test)]
+mod test_helpers;
 pub mod worker;
 mod workflow_handle;
 mod workflow_status;
@@ -1744,44 +1746,16 @@ mod tests {
 
     mod list_workflows_tests {
         use super::*;
+        use crate::test_helpers::XorCodec;
         use futures_util::{FutureExt, StreamExt};
         use std::sync::atomic::{AtomicUsize, Ordering};
         use temporalio_common::{
-            data_converters::{DefaultFailureConverter, PayloadCodec},
+            data_converters::DefaultFailureConverter,
             protos::temporal::api::common::v1::{
                 Memo as ProtoMemo, WorkflowExecution as ProtoWorkflowExecution,
             },
         };
         use tonic::{Request, Response};
-
-        struct XorCodec;
-
-        impl PayloadCodec for XorCodec {
-            fn encode(
-                &self,
-                _context: &SerializationContextData,
-                payloads: Vec<Payload>,
-            ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
-                async move {
-                    payloads
-                        .into_iter()
-                        .map(|mut payload| {
-                            payload.data.iter_mut().for_each(|byte| *byte ^= 0x42);
-                            payload
-                        })
-                        .collect()
-                }
-                .boxed()
-            }
-
-            fn decode(
-                &self,
-                context: &SerializationContextData,
-                payloads: Vec<Payload>,
-            ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
-                self.encode(context, payloads)
-            }
-        }
 
         #[derive(Clone)]
         struct MockListWorkflowsClient {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -53,7 +53,7 @@ pub use tonic;
 pub use workflow_handle::{
     UntypedQuery, UntypedSignal, UntypedUpdate, UntypedWorkflow, UntypedWorkflowHandle,
     WorkflowExecutionDescription, WorkflowExecutionInfo, WorkflowExecutionResult, WorkflowHandle,
-    WorkflowHistory, WorkflowUpdateHandle,
+    WorkflowHistory, WorkflowResultDetails, WorkflowUpdateHandle,
 };
 pub use workflow_status::WorkflowExecutionStatus;
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -41,7 +41,7 @@ pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM
 pub use options_structs::*;
 pub use replaceable::SharedReplaceableClient;
 pub use retry::RetryOptions;
-pub use temporalio_common::RetryPolicy;
+pub use temporalio_common::{Memo, RetryPolicy};
 /// Potentially dangerous TLS related functionality.
 pub mod danger {
     /// Re-export the `ServerCertVerifier` trait so that users can implement custom TLS
@@ -85,13 +85,14 @@ use temporalio_common::{
         DataConverter, GenericPayloadConverter, PayloadConverter, SerializationContext,
         SerializationContextData,
     },
+    payload_visitor::decode_payloads,
     protos::{
         coresdk::IntoPayloadsExt,
         grpc::health::v1::health_client::HealthClient,
         proto_ts_to_system_time,
         temporal::api::{
             cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
-            common::v1::{Memo, Payload, WorkflowType},
+            common::v1::{Payload, WorkflowType},
             enums::v1::TaskQueueKind,
             errordetails::v1::WorkflowExecutionAlreadyStartedFailure,
             operatorservice::v1::operator_service_client::OperatorServiceClient,
@@ -909,12 +910,18 @@ pub trait NamespacedClient {
 #[derive(Debug, Clone)]
 pub struct WorkflowExecution {
     raw: workflow::WorkflowExecutionInfo,
+    data_converter: DataConverter,
 }
 
 impl WorkflowExecution {
-    /// Create a new WorkflowExecution from the raw proto.
-    pub fn new(raw: workflow::WorkflowExecutionInfo) -> Self {
-        Self { raw }
+    fn new_with_data_converter(
+        raw: workflow::WorkflowExecutionInfo,
+        data_converter: DataConverter,
+    ) -> Self {
+        Self {
+            raw,
+            data_converter,
+        }
     }
 
     /// The workflow ID.
@@ -983,9 +990,13 @@ impl WorkflowExecution {
         self.raw.history_length
     }
 
-    /// Workflow memo.
-    pub fn memo(&self) -> Option<&Memo> {
-        self.raw.memo.as_ref()
+    /// Workflow memo decoded with the client's payload converter.
+    pub fn memo(&self) -> Memo {
+        Memo::from_raw(
+            self.raw.memo.clone(),
+            self.data_converter.payload_converter().clone(),
+            SerializationContextData::Workflow,
+        )
     }
 
     /// Parent workflow ID, if this is a child workflow.
@@ -1021,12 +1032,6 @@ impl WorkflowExecution {
     /// Consume the wrapper and return the raw proto.
     pub fn into_raw(self) -> workflow::WorkflowExecutionInfo {
         self.raw
-    }
-}
-
-impl From<workflow::WorkflowExecutionInfo> for WorkflowExecution {
-    fn from(raw: workflow::WorkflowExecutionInfo) -> Self {
-        Self::new(raw)
     }
 }
 
@@ -1333,14 +1338,30 @@ where
 
                     match response {
                         Ok(resp) => {
-                            let resp = resp.into_inner();
+                            let mut resp = resp.into_inner();
                             let new_exhausted = resp.next_page_token.is_empty();
                             let new_token = resp.next_page_token;
 
+                            let data_converter = client.data_converter().clone();
+                            for execution in &mut resp.executions {
+                                if let Some(memo) = execution.memo.as_mut() {
+                                    decode_payloads(
+                                        memo,
+                                        data_converter.codec(),
+                                        &SerializationContextData::Workflow,
+                                    )
+                                    .await;
+                                }
+                            }
                             buffer = resp
                                 .executions
                                 .into_iter()
-                                .map(WorkflowExecution::from)
+                                .map(|raw| {
+                                    WorkflowExecution::new_with_data_converter(
+                                        raw,
+                                        data_converter.clone(),
+                                    )
+                                })
                                 .collect();
 
                             if let Some(exec) = buffer.pop_front() {
@@ -1740,8 +1761,42 @@ mod tests {
         use super::*;
         use futures_util::{FutureExt, StreamExt};
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use temporalio_common::protos::temporal::api::common::v1::WorkflowExecution as ProtoWorkflowExecution;
+        use temporalio_common::{
+            data_converters::{DefaultFailureConverter, PayloadCodec},
+            protos::temporal::api::common::v1::{
+                Memo as ProtoMemo, WorkflowExecution as ProtoWorkflowExecution,
+            },
+        };
         use tonic::{Request, Response};
+
+        struct XorCodec;
+
+        impl PayloadCodec for XorCodec {
+            fn encode(
+                &self,
+                _context: &SerializationContextData,
+                payloads: Vec<Payload>,
+            ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
+                async move {
+                    payloads
+                        .into_iter()
+                        .map(|mut payload| {
+                            payload.data.iter_mut().for_each(|byte| *byte ^= 0x42);
+                            payload
+                        })
+                        .collect()
+                }
+                .boxed()
+            }
+
+            fn decode(
+                &self,
+                context: &SerializationContextData,
+                payloads: Vec<Payload>,
+            ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
+                self.encode(context, payloads)
+            }
+        }
 
         #[derive(Clone)]
         struct MockListWorkflowsClient {
@@ -1750,6 +1805,8 @@ mod tests {
             page_size: usize,
             // Total workflows available
             total_workflows: usize,
+            data_converter: DataConverter,
+            memo_payload: Option<Payload>,
         }
 
         impl NamespacedClient for MockListWorkflowsClient {
@@ -1758,6 +1815,9 @@ mod tests {
             }
             fn identity(&self) -> String {
                 "test-identity".to_string()
+            }
+            fn data_converter(&self) -> &DataConverter {
+                &self.data_converter
             }
         }
 
@@ -1796,6 +1856,9 @@ mod tests {
                             name: "TestWorkflow".to_string(),
                         }),
                         task_queue: "test-queue".to_string(),
+                        memo: self.memo_payload.clone().map(|payload| ProtoMemo {
+                            fields: HashMap::from([("memo-key".to_owned(), payload)]),
+                        }),
                         ..Default::default()
                     })
                     .collect();
@@ -1823,6 +1886,8 @@ mod tests {
                 call_count: call_count.clone(),
                 page_size: 3,
                 total_workflows: 10,
+                data_converter: DataConverter::default(),
+                memo_payload: None,
             };
 
             let stream = client.list_workflows("", WorkflowListOptions::default());
@@ -1845,6 +1910,8 @@ mod tests {
                 call_count: call_count.clone(),
                 page_size: 3,
                 total_workflows: 10,
+                data_converter: DataConverter::default(),
+                memo_payload: None,
             };
 
             let opts = WorkflowListOptions::builder().limit(5).build();
@@ -1867,6 +1934,8 @@ mod tests {
                 call_count: call_count.clone(),
                 page_size: 10,
                 total_workflows: 100,
+                data_converter: DataConverter::default(),
+                memo_payload: None,
             };
 
             let opts = WorkflowListOptions::builder().limit(3).build();
@@ -1885,6 +1954,8 @@ mod tests {
                 call_count: call_count.clone(),
                 page_size: 10,
                 total_workflows: 0,
+                data_converter: DataConverter::default(),
+                memo_payload: None,
             };
 
             let stream = client.list_workflows("", WorkflowListOptions::default());
@@ -1892,6 +1963,41 @@ mod tests {
 
             assert_eq!(results.len(), 0);
             assert_eq!(call_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn list_workflows_exposes_typed_memo() {
+            let data_converter = DataConverter::new(
+                PayloadConverter::default(),
+                DefaultFailureConverter,
+                XorCodec,
+            );
+            let memo_payload = data_converter
+                .to_payload(
+                    &SerializationContextData::Workflow,
+                    &"memo-value".to_owned(),
+                )
+                .await
+                .unwrap();
+            let client = MockListWorkflowsClient {
+                call_count: Arc::new(AtomicUsize::new(0)),
+                page_size: 1,
+                total_workflows: 1,
+                data_converter,
+                memo_payload: Some(memo_payload),
+            };
+
+            let workflow = client
+                .list_workflows("", WorkflowListOptions::default())
+                .next()
+                .await
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(
+                workflow.memo().get::<String>("memo-key").unwrap(),
+                Some("memo-value".to_owned())
+            );
         }
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -821,21 +821,6 @@ pub enum Namespace {
     Id(String),
 }
 
-impl Namespace {
-    /// Convert into grpc request
-    pub fn into_describe_namespace_request(self) -> DescribeNamespaceRequest {
-        let (namespace, id) = match self {
-            Namespace::Name(n) => (n, "".to_owned()),
-            Namespace::Id(n) => ("".to_owned(), n),
-        };
-        DescribeNamespaceRequest {
-            namespace,
-            id,
-            weak_consistency: false,
-        }
-    }
-}
-
 /// This trait provides higher-level friendlier interaction with the server.
 /// See the [WorkflowService] trait for a lower-level client.
 pub(crate) trait WorkflowClientTrait: NamespacedClient {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -41,6 +41,7 @@ pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM
 pub use options_structs::*;
 pub use replaceable::SharedReplaceableClient;
 pub use retry::RetryOptions;
+pub use temporalio_common::RetryPolicy;
 /// Potentially dangerous TLS related functionality.
 pub mod danger {
     /// Re-export the `ServerCertVerifier` trait so that users can implement custom TLS
@@ -1185,6 +1186,7 @@ where
                     workflow_task_timeout: options.task_timeout.and_then(|d| d.try_into().ok()),
                     search_attributes: options.search_attributes.map(|t| t.into_proto()),
                     cron_schedule: options.cron_schedule.unwrap_or_default(),
+                    retry_policy: options.retry_policy.map(Into::into),
                     header: options.header.or(start_signal.header),
                     user_metadata,
                     ..Default::default()
@@ -1222,7 +1224,7 @@ where
                         search_attributes: options.search_attributes.map(|t| t.into_proto()),
                         cron_schedule: options.cron_schedule.unwrap_or_default(),
                         request_eager_execution: options.enable_eager_workflow_start,
-                        retry_policy: options.retry_policy,
+                        retry_policy: options.retry_policy.map(Into::into),
                         links: options.links,
                         completion_callbacks: options.completion_callbacks,
                         priority: Some(options.priority.into()),

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -2,6 +2,7 @@ use crate::{HttpConnectProxyOptions, RetryOptions, VERSION, callback_based};
 use http::Uri;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use temporalio_common::{
+    RetryPolicy,
     data_converters::DataConverter,
     protos::temporal::api::{
         common::{
@@ -296,7 +297,8 @@ pub struct WorkflowStartOptions {
     pub enable_eager_workflow_start: bool,
 
     /// Optionally set a retry policy for the workflow
-    pub retry_policy: Option<common::v1::RetryPolicy>,
+    #[builder(into)]
+    pub retry_policy: Option<RetryPolicy>,
 
     /// If set, send a signal to the workflow atomically with start.
     /// The workflow will receive this signal before its first task.

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -1336,7 +1336,7 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{NamespacedClient, grpc::WorkflowService};
+    use crate::{NamespacedClient, grpc::WorkflowService, test_helpers::XorCodec};
     use futures_util::FutureExt;
     use std::{
         collections::HashMap,
@@ -1349,8 +1349,7 @@ mod tests {
     use temporalio_common::{
         UntypedWorkflow,
         data_converters::{
-            DataConverter, DefaultFailureConverter, MultiArgs2, PayloadCodec, PayloadConverter,
-            RawValue,
+            DataConverter, DefaultFailureConverter, MultiArgs2, PayloadConverter, RawValue,
         },
         protos::temporal::api::{
             common::v1::{
@@ -1370,35 +1369,6 @@ mod tests {
         },
     };
     use tonic::{Request, Response};
-
-    struct XorCodec;
-
-    impl PayloadCodec for XorCodec {
-        fn encode(
-            &self,
-            _context: &SerializationContextData,
-            payloads: Vec<Payload>,
-        ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
-            async move {
-                payloads
-                    .into_iter()
-                    .map(|mut payload| {
-                        payload.data.iter_mut().for_each(|byte| *byte ^= 0x42);
-                        payload
-                    })
-                    .collect()
-            }
-            .boxed()
-        }
-
-        fn decode(
-            &self,
-            context: &SerializationContextData,
-            payloads: Vec<Payload>,
-        ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
-            self.encode(context, payloads)
-        }
-    }
 
     fn data_converter_with_codec() -> DataConverter {
         DataConverter::new(

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -13,6 +13,7 @@ use temporalio_common::{
         DataConverter, PayloadConversionError, SerializationContextData, TemporalDeserializable,
         TemporalSerializable,
     },
+    payload_visitor::decode_payloads,
     protos::{
         coresdk::IntoPayloadsExt,
         proto_ts_to_system_time,
@@ -662,9 +663,13 @@ impl ScheduleDescription {
             .and_then(proto_ts_to_system_time)
     }
 
-    /// Memo attached to the schedule.
-    pub fn memo(&self) -> Option<&common_proto::Memo> {
-        self.raw.memo.as_ref()
+    /// Memo attached to the schedule, decoded with the client's payload converter.
+    pub fn memo(&self) -> crate::Memo {
+        crate::Memo::from_raw(
+            self.raw.memo.clone(),
+            self.data_converter.payload_converter().clone(),
+            SerializationContextData::Workflow,
+        )
     }
 
     /// Search attributes on the schedule.
@@ -857,6 +862,7 @@ impl ScheduleUpdate {
 #[derive(Debug, Clone)]
 pub struct ScheduleSummary {
     raw: schedule_proto::ScheduleListEntry,
+    data_converter: DataConverter,
 }
 
 impl ScheduleSummary {
@@ -909,9 +915,13 @@ impl ScheduleSummary {
             .unwrap_or_default()
     }
 
-    /// Memo attached to the schedule.
-    pub fn memo(&self) -> Option<&common_proto::Memo> {
-        self.raw.memo.as_ref()
+    /// Memo attached to the schedule, decoded with the client's payload converter.
+    pub fn memo(&self) -> crate::Memo {
+        crate::Memo::from_raw(
+            self.raw.memo.clone(),
+            self.data_converter.payload_converter().clone(),
+            SerializationContextData::Workflow,
+        )
     }
 
     /// Search attributes on the schedule.
@@ -940,7 +950,16 @@ impl ScheduleSummary {
 
 impl From<schedule_proto::ScheduleListEntry> for ScheduleSummary {
     fn from(raw: schedule_proto::ScheduleListEntry) -> Self {
-        Self { raw }
+        Self::new(raw, DataConverter::default())
+    }
+}
+
+impl ScheduleSummary {
+    fn new(raw: schedule_proto::ScheduleListEntry, data_converter: DataConverter) -> Self {
+        Self {
+            raw,
+            data_converter,
+        }
     }
 }
 
@@ -979,7 +998,7 @@ where
 
     /// Describe this schedule, returning its full definition, info, and conflict token.
     pub async fn describe(&self) -> Result<ScheduleDescription, ScheduleError> {
-        let resp = WorkflowService::describe_schedule(
+        let mut resp = WorkflowService::describe_schedule(
             &mut self.client.clone(),
             DescribeScheduleRequest {
                 namespace: self.namespace.clone(),
@@ -989,6 +1008,15 @@ where
         )
         .await?
         .into_inner();
+
+        if let Some(memo) = resp.memo.as_mut() {
+            decode_payloads(
+                memo,
+                self.client.data_converter().codec(),
+                &SerializationContextData::Workflow,
+            )
+            .await;
+        }
 
         ScheduleDescription::new(
             resp,
@@ -1270,14 +1298,25 @@ impl Client {
 
                     match response {
                         Ok(resp) => {
-                            let resp = resp.into_inner();
+                            let mut resp = resp.into_inner();
                             let new_exhausted = resp.next_page_token.is_empty();
                             let new_token = resp.next_page_token;
 
+                            let data_converter = client.data_converter().clone();
+                            for schedule in &mut resp.schedules {
+                                if let Some(memo) = schedule.memo.as_mut() {
+                                    decode_payloads(
+                                        memo,
+                                        data_converter.codec(),
+                                        &SerializationContextData::Workflow,
+                                    )
+                                    .await;
+                                }
+                            }
                             buffer = resp
                                 .schedules
                                 .into_iter()
-                                .map(ScheduleSummary::from)
+                                .map(|raw| ScheduleSummary::new(raw, data_converter.clone()))
                                 .collect();
 
                             buffer
@@ -1300,6 +1339,7 @@ mod tests {
     use crate::{NamespacedClient, grpc::WorkflowService};
     use futures_util::FutureExt;
     use std::{
+        collections::HashMap,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -1308,7 +1348,10 @@ mod tests {
     };
     use temporalio_common::{
         UntypedWorkflow,
-        data_converters::{DataConverter, MultiArgs2, RawValue},
+        data_converters::{
+            DataConverter, DefaultFailureConverter, MultiArgs2, PayloadCodec, PayloadConverter,
+            RawValue,
+        },
         protos::temporal::api::{
             common::v1::{
                 Memo, Payload, Payloads, SearchAttributes,
@@ -1328,6 +1371,43 @@ mod tests {
     };
     use tonic::{Request, Response};
 
+    struct XorCodec;
+
+    impl PayloadCodec for XorCodec {
+        fn encode(
+            &self,
+            _context: &SerializationContextData,
+            payloads: Vec<Payload>,
+        ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
+            async move {
+                payloads
+                    .into_iter()
+                    .map(|mut payload| {
+                        payload.data.iter_mut().for_each(|byte| *byte ^= 0x42);
+                        payload
+                    })
+                    .collect()
+            }
+            .boxed()
+        }
+
+        fn decode(
+            &self,
+            context: &SerializationContextData,
+            payloads: Vec<Payload>,
+        ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
+            self.encode(context, payloads)
+        }
+    }
+
+    fn data_converter_with_codec() -> DataConverter {
+        DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            XorCodec,
+        )
+    }
+
     #[derive(Default)]
     struct CapturedRequests {
         describe: AtomicUsize,
@@ -1340,6 +1420,7 @@ mod tests {
     struct MockScheduleClient {
         captured: Arc<CapturedRequests>,
         describe_response: DescribeScheduleResponse,
+        data_converter: DataConverter,
         should_error: bool,
     }
 
@@ -1348,6 +1429,7 @@ mod tests {
             Self {
                 captured: Arc::new(CapturedRequests::default()),
                 describe_response: describe_response_with_start_workflow(None),
+                data_converter: DataConverter::default(),
                 should_error: false,
             }
         }
@@ -1359,6 +1441,9 @@ mod tests {
         }
         fn identity(&self) -> String {
             "test-identity".to_string()
+        }
+        fn data_converter(&self) -> &DataConverter {
+            &self.data_converter
         }
     }
 
@@ -1534,6 +1619,61 @@ mod tests {
         assert!(desc.raw().search_attributes.is_some());
         assert!(desc.search_attributes().is_empty());
         assert_eq!(desc.conflict_token(), conflict_token);
+    }
+
+    #[tokio::test]
+    async fn schedule_description_exposes_typed_memo() {
+        let data_converter = data_converter_with_codec();
+        let memo_payload = data_converter
+            .to_payload(
+                &SerializationContextData::Workflow,
+                &"memo-value".to_owned(),
+            )
+            .await
+            .unwrap();
+        let mut describe_response = describe_response_with_start_workflow(None);
+        describe_response.memo = Some(Memo {
+            fields: HashMap::from([("memo-key".to_owned(), memo_payload)]),
+        });
+        let client = MockScheduleClient {
+            describe_response,
+            data_converter,
+            ..Default::default()
+        };
+
+        let description = make_schedule_handle(client).describe().await.unwrap();
+
+        assert_eq!(
+            description.memo().get::<String>("memo-key").unwrap(),
+            Some("memo-value".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn schedule_summary_exposes_typed_memo() {
+        let data_converter = DataConverter::default();
+        let memo_payload = data_converter
+            .to_payload(
+                &SerializationContextData::Workflow,
+                &"memo-value".to_owned(),
+            )
+            .await
+            .unwrap();
+        let summary = ScheduleSummary::new(
+            ScheduleListEntry {
+                schedule_id: "schedule-id".to_owned(),
+                memo: Some(Memo {
+                    fields: HashMap::from([("memo-key".to_owned(), memo_payload)]),
+                }),
+                ..Default::default()
+            },
+            data_converter,
+        );
+
+        assert_eq!(
+            summary.memo().get::<String>("memo-key").unwrap(),
+            Some("memo-value".to_owned())
+        );
     }
 
     #[tokio::test]

--- a/crates/client/src/test_helpers.rs
+++ b/crates/client/src/test_helpers.rs
@@ -1,0 +1,34 @@
+use futures_util::{FutureExt, future::BoxFuture};
+use temporalio_common::{
+    data_converters::{PayloadCodec, SerializationContextData},
+    protos::temporal::api::common::v1::Payload,
+};
+
+pub(crate) struct XorCodec;
+
+impl PayloadCodec for XorCodec {
+    fn encode(
+        &self,
+        _context: &SerializationContextData,
+        payloads: Vec<Payload>,
+    ) -> BoxFuture<'static, Vec<Payload>> {
+        async move {
+            payloads
+                .into_iter()
+                .map(|mut payload| {
+                    payload.data.iter_mut().for_each(|byte| *byte ^= 0x42);
+                    payload
+                })
+                .collect()
+        }
+        .boxed()
+    }
+
+    fn decode(
+        &self,
+        context: &SerializationContextData,
+        payloads: Vec<Payload>,
+    ) -> BoxFuture<'static, Vec<Payload>> {
+        self.encode(context, payloads)
+    }
+}

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -1,8 +1,8 @@
 use crate::{
     NamespacedClient, WorkflowCancelOptions, WorkflowDescribeOptions, WorkflowExecuteUpdateOptions,
-    WorkflowFetchHistoryOptions, WorkflowGetResultOptions, WorkflowQueryOptions,
-    WorkflowSignalOptions, WorkflowStartUpdateOptions, WorkflowTerminateOptions,
-    WorkflowUpdateWaitStage,
+    WorkflowExecutionStatus, WorkflowFetchHistoryOptions, WorkflowGetResultOptions,
+    WorkflowQueryOptions, WorkflowSignalOptions, WorkflowStartUpdateOptions,
+    WorkflowTerminateOptions, WorkflowUpdateWaitStage,
     errors::{
         WorkflowGetResultError, WorkflowInteractionError, WorkflowQueryError, WorkflowUpdateError,
     },
@@ -164,10 +164,8 @@ impl WorkflowExecutionDescription {
     }
 
     /// The current status of the workflow execution.
-    pub fn status(
-        &self,
-    ) -> temporalio_common::protos::temporal::api::enums::v1::WorkflowExecutionStatus {
-        self.workflow_info().status()
+    pub fn status(&self) -> WorkflowExecutionStatus {
+        WorkflowExecutionStatus::from_raw(self.workflow_info().status)
     }
 
     /// When the workflow was created.
@@ -660,7 +658,10 @@ where
             .into_inner();
 
         if let Some(rejected) = response.query_rejected {
-            return Err(WorkflowQueryError::Rejected(rejected));
+            return Err(WorkflowQueryError::Rejected {
+                status: (rejected.status != 0)
+                    .then(|| WorkflowExecutionStatus::from_raw(rejected.status)),
+            });
         }
 
         let result_payloads = response
@@ -1027,7 +1028,7 @@ mod tests {
     use std::collections::HashMap;
     use temporalio_common::protos::temporal::api::{
         common::v1::{Memo, SearchAttributes},
-        enums::v1::WorkflowExecutionStatus,
+        enums::v1::WorkflowExecutionStatus as ProtoWorkflowExecutionStatus,
         sdk::v1::UserMetadata,
         workflow::v1::WorkflowExecutionConfig,
     };
@@ -1063,7 +1064,7 @@ mod tests {
                             name: "wf-type".to_string(),
                         },
                     ),
-                    status: WorkflowExecutionStatus::Completed as i32,
+                    status: ProtoWorkflowExecutionStatus::Completed as i32,
                     task_queue: "task-queue".to_string(),
                     history_length: 42,
                     memo: Some(Memo {
@@ -1099,6 +1100,17 @@ mod tests {
         assert_eq!(description.run_id(), "run-id");
         assert_eq!(description.workflow_type(), "wf-type");
         assert_eq!(description.status(), WorkflowExecutionStatus::Completed);
+        let mut unknown_status_description = description.clone();
+        unknown_status_description
+            .raw_description
+            .workflow_execution_info
+            .as_mut()
+            .unwrap()
+            .status = 123_456;
+        assert_eq!(
+            unknown_status_description.status(),
+            WorkflowExecutionStatus::Unknown
+        );
         assert_eq!(description.task_queue(), "task-queue");
         assert_eq!(description.history_length(), 42);
         assert_eq!(description.parent_id(), Some("parent-id"));

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -1083,10 +1083,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::{FutureExt, future::BoxFuture};
+    use crate::test_helpers::XorCodec;
     use std::collections::HashMap;
     use temporalio_common::{
-        data_converters::{DefaultFailureConverter, PayloadCodec},
+        data_converters::DefaultFailureConverter,
         protos::temporal::api::{
             common::v1::{Memo, SearchAttributes},
             enums::v1::WorkflowExecutionStatus as ProtoWorkflowExecutionStatus,
@@ -1094,35 +1094,6 @@ mod tests {
             workflow::v1::WorkflowExecutionConfig,
         },
     };
-
-    struct XorCodec;
-
-    impl PayloadCodec for XorCodec {
-        fn encode(
-            &self,
-            _context: &SerializationContextData,
-            payloads: Vec<Payload>,
-        ) -> BoxFuture<'static, Vec<Payload>> {
-            async move {
-                payloads
-                    .into_iter()
-                    .map(|mut payload| {
-                        payload.data.iter_mut().for_each(|byte| *byte ^= 0x42);
-                        payload
-                    })
-                    .collect()
-            }
-            .boxed()
-        }
-
-        fn decode(
-            &self,
-            context: &SerializationContextData,
-            payloads: Vec<Payload>,
-        ) -> BoxFuture<'static, Vec<Payload>> {
-            self.encode(context, payloads)
-        }
-    }
 
     #[tokio::test]
     async fn workflow_result_details_support_typed_decoding() {

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -13,9 +13,10 @@ pub use temporalio_common::UntypedWorkflow;
 use temporalio_common::{
     HasWorkflowDefinition, QueryDefinition, SignalDefinition, UpdateDefinition, WorkflowDefinition,
     data_converters::{
-        DataConverter, GenericPayloadConverter, PayloadConversionError, PayloadConverter, RawValue,
-        SerializationContext, SerializationContextData,
+        DataConverter, DecodablePayloads, GenericPayloadConverter, PayloadConversionError,
+        PayloadConverter, RawValue, SerializationContext, SerializationContextData,
     },
+    error::IncomingError,
     payload_visitor::decode_payloads,
     protos::{
         coresdk::FromPayloadsExt,
@@ -23,7 +24,6 @@ use temporalio_common::{
         temporal::api::{
             common::v1::{Payload, Payloads, WorkflowExecution as ProtoWorkflowExecution},
             enums::v1::{HistoryEventFilterType, UpdateWorkflowExecutionLifecycleStage},
-            failure::v1::Failure,
             history::{
                 self,
                 v1::{HistoryEvent, history_event::Attributes},
@@ -76,6 +76,46 @@ fn decode_user_metadata(
     })
 }
 
+/// Details attached to a cancelled or terminated workflow result.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct WorkflowResultDetails {
+    payloads: DecodablePayloads,
+}
+
+impl WorkflowResultDetails {
+    async fn new(payloads: Vec<Payload>, data_converter: &DataConverter) -> Self {
+        let payloads = data_converter
+            .codec()
+            .decode(&SerializationContextData::Workflow, payloads)
+            .await;
+        Self {
+            payloads: DecodablePayloads::new(
+                payloads,
+                data_converter.payload_converter().clone(),
+                SerializationContextData::Workflow,
+            ),
+        }
+    }
+
+    /// Deserialize the details into a typed value using the client's payload converter.
+    pub fn deserialize<T: temporalio_common::data_converters::TemporalDeserializable + 'static>(
+        &self,
+    ) -> Result<T, PayloadConversionError> {
+        self.payloads.deserialize()
+    }
+
+    /// Returns the codec-decoded payloads.
+    pub fn raw(&self) -> &[Payload] {
+        self.payloads.raw()
+    }
+
+    /// Consume these details and return their codec-decoded payloads.
+    pub fn into_raw(self) -> RawValue {
+        self.payloads.into_raw()
+    }
+}
+
 /// Enumerates terminal states for a particular workflow execution
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -83,16 +123,16 @@ pub enum WorkflowExecutionResult<T> {
     /// The workflow finished successfully
     Succeeded(T),
     /// The workflow finished in failure
-    Failed(Failure),
+    Failed(IncomingError),
     /// The workflow was cancelled
     Cancelled {
         /// Details provided at cancellation time
-        details: Vec<Payload>,
+        details: WorkflowResultDetails,
     },
     /// The workflow was terminated
     Terminated {
         /// Details provided at termination time
-        details: Vec<Payload>,
+        details: WorkflowResultDetails,
     },
     /// The workflow timed out
     TimedOut,
@@ -532,13 +572,24 @@ where
                 }
                 Some(Attributes::WorkflowExecutionFailedEventAttributes(attrs)) => {
                     follow!(attrs);
-                    Ok(WorkflowExecutionResult::Failed(
-                        attrs.failure.unwrap_or_default(),
-                    ))
+                    let mut failure = attrs.failure.unwrap_or_default();
+                    decode_payloads(
+                        &mut failure,
+                        dc.codec(),
+                        &SerializationContextData::Workflow,
+                    )
+                    .await;
+                    let error = dc.failure_converter().to_error(
+                        failure,
+                        dc.payload_converter(),
+                        &SerializationContextData::Workflow,
+                    )?;
+                    Ok(WorkflowExecutionResult::Failed(error))
                 }
                 Some(Attributes::WorkflowExecutionCanceledEventAttributes(attrs)) => {
                     Ok(WorkflowExecutionResult::Cancelled {
-                        details: Vec::from_payloads(attrs.details),
+                        details: WorkflowResultDetails::new(Vec::from_payloads(attrs.details), dc)
+                            .await,
                     })
                 }
                 Some(Attributes::WorkflowExecutionTimedOutEventAttributes(attrs)) => {
@@ -547,7 +598,8 @@ where
                 }
                 Some(Attributes::WorkflowExecutionTerminatedEventAttributes(attrs)) => {
                     Ok(WorkflowExecutionResult::Terminated {
-                        details: Vec::from_payloads(attrs.details),
+                        details: WorkflowResultDetails::new(Vec::from_payloads(attrs.details), dc)
+                            .await,
                     })
                 }
                 Some(Attributes::WorkflowExecutionContinuedAsNewEventAttributes(attrs)) => {
@@ -1025,13 +1077,80 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::{FutureExt, future::BoxFuture};
     use std::collections::HashMap;
-    use temporalio_common::protos::temporal::api::{
-        common::v1::{Memo, SearchAttributes},
-        enums::v1::WorkflowExecutionStatus as ProtoWorkflowExecutionStatus,
-        sdk::v1::UserMetadata,
-        workflow::v1::WorkflowExecutionConfig,
+    use temporalio_common::{
+        data_converters::{DefaultFailureConverter, PayloadCodec},
+        protos::temporal::api::{
+            common::v1::{Memo, SearchAttributes},
+            enums::v1::WorkflowExecutionStatus as ProtoWorkflowExecutionStatus,
+            sdk::v1::UserMetadata,
+            workflow::v1::WorkflowExecutionConfig,
+        },
     };
+
+    struct XorCodec;
+
+    impl PayloadCodec for XorCodec {
+        fn encode(
+            &self,
+            _context: &SerializationContextData,
+            payloads: Vec<Payload>,
+        ) -> BoxFuture<'static, Vec<Payload>> {
+            async move {
+                payloads
+                    .into_iter()
+                    .map(|mut payload| {
+                        payload.data.iter_mut().for_each(|byte| *byte ^= 0x42);
+                        payload
+                    })
+                    .collect()
+            }
+            .boxed()
+        }
+
+        fn decode(
+            &self,
+            context: &SerializationContextData,
+            payloads: Vec<Payload>,
+        ) -> BoxFuture<'static, Vec<Payload>> {
+            self.encode(context, payloads)
+        }
+    }
+
+    #[tokio::test]
+    async fn workflow_result_details_support_typed_decoding() {
+        let converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            XorCodec,
+        );
+        let payloads = converter
+            .to_payloads(
+                &SerializationContextData::Workflow,
+                &"workflow-result-details".to_owned(),
+            )
+            .await
+            .unwrap();
+        let details = WorkflowResultDetails::new(payloads.clone(), &converter).await;
+
+        assert_ne!(details.raw(), payloads);
+        let decoded_payloads = details.raw().to_vec();
+        assert_eq!(
+            details.deserialize::<String>().unwrap(),
+            "workflow-result-details"
+        );
+        assert_eq!(details.into_raw().payloads, decoded_payloads);
+    }
+
+    #[tokio::test]
+    async fn workflow_result_detail_conversion_errors_are_reported() {
+        let details =
+            WorkflowResultDetails::new(vec![Payload::default()], &DataConverter::default()).await;
+
+        assert_eq!(details.raw(), &[Payload::default()]);
+        assert!(details.deserialize::<String>().is_err());
+    }
 
     #[tokio::test]
     async fn workflow_description_accessors_expose_decoded_fields() {

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -150,6 +150,7 @@ pub struct WorkflowExecutionDescription {
     history_length: usize,
     static_summary: Option<String>,
     static_details: Option<String>,
+    data_converter: DataConverter,
 }
 
 impl WorkflowExecutionDescription {
@@ -185,6 +186,7 @@ impl WorkflowExecutionDescription {
             history_length,
             static_summary: decoded_metadata.summary,
             static_details: decoded_metadata.details,
+            data_converter: data_converter.clone(),
         })
     }
 
@@ -242,9 +244,13 @@ impl WorkflowExecutionDescription {
         self.history_length
     }
 
-    /// Workflow memo after codec decoding.
-    pub fn memo(&self) -> Option<&temporalio_common::protos::temporal::api::common::v1::Memo> {
-        self.workflow_info().memo.as_ref()
+    /// Workflow memo decoded with the client's payload converter.
+    pub fn memo(&self) -> crate::Memo {
+        crate::Memo::from_raw(
+            self.workflow_info().memo.clone(),
+            self.data_converter.payload_converter().clone(),
+            SerializationContextData::Workflow,
+        )
     }
 
     /// Parent workflow ID, if this is a child workflow.
@@ -1153,6 +1159,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workflow_description_memo_uses_saved_converter() {
+        let converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            XorCodec,
+        );
+        let encoded = converter
+            .to_payload(
+                &SerializationContextData::Workflow,
+                &"memo-value".to_owned(),
+            )
+            .await
+            .unwrap();
+        let description = WorkflowExecutionDescription::new(
+            DescribeWorkflowExecutionResponse {
+                workflow_execution_info: Some(workflow::WorkflowExecutionInfo {
+                    memo: Some(Memo {
+                        fields: HashMap::from([("memo-key".to_owned(), encoded)]),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &converter,
+        )
+        .await
+        .unwrap();
+        let memo = description.memo();
+
+        assert_eq!(
+            memo.get::<String>("memo-key").unwrap(),
+            Some("memo-value".to_owned())
+        );
+    }
+
+    #[tokio::test]
     async fn workflow_description_accessors_expose_decoded_fields() {
         let converter = DataConverter::default();
         let memo_payload = converter
@@ -1234,7 +1276,12 @@ mod tests {
         assert_eq!(description.history_length(), 42);
         assert_eq!(description.parent_id(), Some("parent-id"));
         assert_eq!(description.parent_run_id(), Some("parent-run-id"));
-        assert_eq!(description.memo().unwrap().fields["memo-key"], memo_payload);
+        let memo = description.memo();
+        assert_eq!(memo.raw_value("memo-key"), Some(&memo_payload));
+        assert_eq!(
+            memo.get::<String>("memo-key").unwrap(),
+            Some("memo-value".to_owned())
+        );
         let search_attributes = description.search_attributes();
         assert_eq!(
             search_attributes.raw_payload("CustomKeywordField"),

--- a/crates/client/src/workflow_status.rs
+++ b/crates/client/src/workflow_status.rs
@@ -1,0 +1,50 @@
+use temporalio_common::protos::temporal::api::enums::v1::WorkflowExecutionStatus as ProtoWorkflowExecutionStatus;
+
+/// The lifecycle status of a workflow execution.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum WorkflowExecutionStatus {
+    /// No status was specified.
+    Unspecified,
+    /// The workflow is running.
+    Running,
+    /// The workflow completed successfully.
+    Completed,
+    /// The workflow failed.
+    Failed,
+    /// The workflow was canceled.
+    Canceled,
+    /// The workflow was terminated.
+    Terminated,
+    /// The workflow continued as new.
+    ContinuedAsNew,
+    /// The workflow timed out.
+    TimedOut,
+    /// The workflow is paused.
+    Paused,
+    /// A status introduced by a newer server or API version.
+    Unknown,
+}
+
+impl WorkflowExecutionStatus {
+    pub(crate) fn from_raw(value: i32) -> Self {
+        match ProtoWorkflowExecutionStatus::try_from(value) {
+            Ok(ProtoWorkflowExecutionStatus::Unspecified) => Self::Unspecified,
+            Ok(ProtoWorkflowExecutionStatus::Running) => Self::Running,
+            Ok(ProtoWorkflowExecutionStatus::Completed) => Self::Completed,
+            Ok(ProtoWorkflowExecutionStatus::Failed) => Self::Failed,
+            Ok(ProtoWorkflowExecutionStatus::Canceled) => Self::Canceled,
+            Ok(ProtoWorkflowExecutionStatus::Terminated) => Self::Terminated,
+            Ok(ProtoWorkflowExecutionStatus::ContinuedAsNew) => Self::ContinuedAsNew,
+            Ok(ProtoWorkflowExecutionStatus::TimedOut) => Self::TimedOut,
+            Ok(ProtoWorkflowExecutionStatus::Paused) => Self::Paused,
+            Err(_) => Self::Unknown,
+        }
+    }
+}
+
+impl From<ProtoWorkflowExecutionStatus> for WorkflowExecutionStatus {
+    fn from(value: ProtoWorkflowExecutionStatus) -> Self {
+        Self::from_raw(value as i32)
+    }
+}

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -1325,13 +1325,11 @@ mod tests {
         assert_eq!(
             decoded_failure
                 .workflow_execution()
-                .map(|wf| wf.workflow_id.as_str()),
+                .map(|wf| wf.workflow_id()),
             Some("child-id")
         );
         assert_eq!(
-            decoded_failure
-                .workflow_execution()
-                .map(|wf| wf.run_id.as_str()),
+            decoded_failure.workflow_execution().map(|wf| wf.run_id()),
             Some("run-id")
         );
         assert_eq!(decoded_failure.workflow_type(), Some("child-type"));

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -1155,7 +1155,7 @@ mod tests {
         assert_eq!(decoded_failure.identity(), "worker-1");
         assert_eq!(
             decoded_failure.retry_state(),
-            crate::protos::temporal::api::enums::v1::RetryState::Timeout
+            crate::error::RetryState::Timeout
         );
         assert!(matches!(
             decoded_failure.cause(),
@@ -1245,10 +1245,7 @@ mod tests {
         let IncomingError::Timeout(timeout) = decoded else {
             panic!("expected timeout error");
         };
-        assert_eq!(
-            timeout.timeout_type(),
-            crate::protos::temporal::api::enums::v1::TimeoutType::Heartbeat
-        );
+        assert_eq!(timeout.timeout_type(), crate::error::TimeoutType::Heartbeat);
         assert_eq!(
             timeout.raw_last_heartbeat_details(),
             Some(heartbeat_details.payloads.as_slice())
@@ -1342,7 +1339,7 @@ mod tests {
         assert_eq!(decoded_failure.started_event_id(), 22);
         assert_eq!(
             decoded_failure.retry_state(),
-            crate::protos::temporal::api::enums::v1::RetryState::Timeout
+            crate::error::RetryState::Timeout
         );
     }
 

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -1149,10 +1149,7 @@ mod tests {
         };
         assert_eq!(decoded_failure.failure(), &failure);
         assert_eq!(decoded_failure.activity_id(), "act-1");
-        assert_eq!(
-            decoded_failure.activity_type().map(|ty| ty.name.as_str()),
-            Some("test-activity")
-        );
+        assert_eq!(decoded_failure.activity_type(), Some("test-activity"));
         assert_eq!(decoded_failure.scheduled_event_id(), 5);
         assert_eq!(decoded_failure.started_event_id(), 6);
         assert_eq!(decoded_failure.identity(), "worker-1");
@@ -1340,10 +1337,7 @@ mod tests {
                 .map(|wf| wf.run_id.as_str()),
             Some("run-id")
         );
-        assert_eq!(
-            decoded_failure.workflow_type().map(|wf| wf.name.as_str()),
-            Some("child-type")
-        );
+        assert_eq!(decoded_failure.workflow_type(), Some("child-type"));
         assert_eq!(decoded_failure.initiated_event_id(), 11);
         assert_eq!(decoded_failure.started_event_id(), 22);
         assert_eq!(

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -11,12 +11,98 @@ use crate::{
         coresdk::child_workflow::StartChildWorkflowExecutionFailedCause,
         temporal::api::{
             common::v1::{Payload, Payloads},
-            enums::v1::{ApplicationErrorCategory as ProtoApplicationErrorCategory, TimeoutType},
+            enums::v1::{
+                ApplicationErrorCategory as ProtoApplicationErrorCategory,
+                RetryState as ProtoRetryState, TimeoutType as ProtoTimeoutType,
+            },
             failure::v1::Failure,
         },
     },
 };
 use std::time::Duration;
+
+/// Describes why a retry did or did not occur.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum RetryState {
+    /// No retry state was specified.
+    Unspecified,
+    /// Another retry is in progress.
+    InProgress,
+    /// The failure is not retryable.
+    NonRetryableFailure,
+    /// The retry timed out.
+    Timeout,
+    /// The retry policy's maximum attempts were reached.
+    MaximumAttemptsReached,
+    /// No retry policy was configured.
+    RetryPolicyNotSet,
+    /// An internal server error prevented retrying.
+    InternalServerError,
+    /// Cancellation was requested.
+    CancelRequested,
+    /// A state introduced by a newer server or API version.
+    Unknown,
+}
+
+impl RetryState {
+    fn from_raw(value: i32) -> Self {
+        match ProtoRetryState::try_from(value) {
+            Ok(ProtoRetryState::Unspecified) => Self::Unspecified,
+            Ok(ProtoRetryState::InProgress) => Self::InProgress,
+            Ok(ProtoRetryState::NonRetryableFailure) => Self::NonRetryableFailure,
+            Ok(ProtoRetryState::Timeout) => Self::Timeout,
+            Ok(ProtoRetryState::MaximumAttemptsReached) => Self::MaximumAttemptsReached,
+            Ok(ProtoRetryState::RetryPolicyNotSet) => Self::RetryPolicyNotSet,
+            Ok(ProtoRetryState::InternalServerError) => Self::InternalServerError,
+            Ok(ProtoRetryState::CancelRequested) => Self::CancelRequested,
+            Err(_) => Self::Unknown,
+        }
+    }
+}
+
+impl From<ProtoRetryState> for RetryState {
+    fn from(value: ProtoRetryState) -> Self {
+        Self::from_raw(value as i32)
+    }
+}
+
+/// Identifies which timeout expired.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum TimeoutType {
+    /// No timeout type was specified.
+    Unspecified,
+    /// The execution exceeded its start-to-close timeout.
+    StartToClose,
+    /// The task exceeded its schedule-to-start timeout.
+    ScheduleToStart,
+    /// The execution exceeded its schedule-to-close timeout.
+    ScheduleToClose,
+    /// An activity heartbeat was not received in time.
+    Heartbeat,
+    /// A timeout introduced by a newer server or API version.
+    Unknown,
+}
+
+impl TimeoutType {
+    fn from_raw(value: i32) -> Self {
+        match ProtoTimeoutType::try_from(value) {
+            Ok(ProtoTimeoutType::Unspecified) => Self::Unspecified,
+            Ok(ProtoTimeoutType::StartToClose) => Self::StartToClose,
+            Ok(ProtoTimeoutType::ScheduleToStart) => Self::ScheduleToStart,
+            Ok(ProtoTimeoutType::ScheduleToClose) => Self::ScheduleToClose,
+            Ok(ProtoTimeoutType::Heartbeat) => Self::Heartbeat,
+            Err(_) => Self::Unknown,
+        }
+    }
+}
+
+impl From<ProtoTimeoutType> for TimeoutType {
+    fn from(value: ProtoTimeoutType) -> Self {
+        Self::from_raw(value as i32)
+    }
+}
 
 // We cannot store `Box<dyn TemporalSerializable>` directly here because erased values still need
 // to be driven back through the active `PayloadConverter` to reach serde-based implementations.
@@ -620,7 +706,7 @@ impl TimeoutError {
         Self {
             failure,
             cause: cause.map(Box::new),
-            timeout_type: failure_info.timeout_type(),
+            timeout_type: TimeoutType::from_raw(failure_info.timeout_type),
             last_heartbeat_details: failure_info.last_heartbeat_details.map(|details| {
                 DecodablePayloads::new(details.payloads, payload_converter.clone(), *context)
             }),
@@ -710,7 +796,7 @@ pub struct ActivityFailureError {
     scheduled_event_id: i64,
     started_event_id: i64,
     identity: String,
-    retry_state: crate::protos::temporal::api::enums::v1::RetryState,
+    retry_state: RetryState,
 }
 
 impl ActivityFailureError {
@@ -720,7 +806,7 @@ impl ActivityFailureError {
         failure_info: crate::protos::temporal::api::failure::v1::ActivityFailureInfo,
         cause: Option<IncomingError>,
     ) -> Self {
-        let retry_state = failure_info.retry_state();
+        let retry_state = RetryState::from_raw(failure_info.retry_state);
         Self {
             failure,
             cause: cause.map(Box::new),
@@ -761,7 +847,7 @@ impl ActivityFailureError {
     }
 
     /// Returns the retry state reported by core.
-    pub fn retry_state(&self) -> crate::protos::temporal::api::enums::v1::RetryState {
+    pub fn retry_state(&self) -> RetryState {
         self.retry_state
     }
 
@@ -789,7 +875,7 @@ pub struct ChildWorkflowFailureError {
     workflow_type: Option<String>,
     initiated_event_id: i64,
     started_event_id: i64,
-    retry_state: crate::protos::temporal::api::enums::v1::RetryState,
+    retry_state: RetryState,
 }
 
 impl ChildWorkflowFailureError {
@@ -799,7 +885,7 @@ impl ChildWorkflowFailureError {
         failure_info: crate::protos::temporal::api::failure::v1::ChildWorkflowExecutionFailureInfo,
         cause: Option<IncomingError>,
     ) -> Self {
-        let retry_state = failure_info.retry_state();
+        let retry_state = RetryState::from_raw(failure_info.retry_state);
         Self {
             failure,
             cause: cause.map(Box::new),
@@ -840,7 +926,7 @@ impl ChildWorkflowFailureError {
     }
 
     /// Returns the retry state reported by core.
-    pub fn retry_state(&self) -> crate::protos::temporal::api::enums::v1::RetryState {
+    pub fn retry_state(&self) -> RetryState {
         self.retry_state
     }
 
@@ -1116,7 +1202,10 @@ mod tests {
             DefaultFailureConverter, FailureConverter, GenericPayloadConverter, PayloadConverter,
             SerializationContext, SerializationContextData,
         },
-        protos::temporal::api::{common::v1::Payload, failure::v1::failure::FailureInfo},
+        protos::temporal::api::{
+            common::v1::Payload,
+            failure::v1::{ActivityFailureInfo, TimeoutFailureInfo, failure::FailureInfo},
+        },
     };
 
     struct AlwaysFailsSerialize;
@@ -1125,6 +1214,52 @@ mod tests {
         fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
             Err(serde::ser::Error::custom("serialize boom"))
         }
+    }
+
+    #[test]
+    fn decoded_failures_hide_unknown_state_values() {
+        let failure = Failure {
+            cause: Some(Box::new(Failure {
+                failure_info: Some(FailureInfo::TimeoutFailureInfo(TimeoutFailureInfo {
+                    timeout_type: 654_321,
+                    ..Default::default()
+                })),
+                ..Default::default()
+            })),
+            failure_info: Some(FailureInfo::ActivityFailureInfo(ActivityFailureInfo {
+                retry_state: 123_456,
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let decoded = DefaultFailureConverter
+            .to_error(
+                failure,
+                &PayloadConverter::default(),
+                &SerializationContextData::Workflow,
+            )
+            .unwrap();
+        let IncomingError::Activity(activity) = decoded else {
+            panic!("expected activity failure");
+        };
+        assert_eq!(activity.retry_state(), RetryState::Unknown);
+        let Some(FailureInfo::ActivityFailureInfo(raw_activity)) =
+            activity.failure().failure_info.as_ref()
+        else {
+            panic!("expected raw activity failure info");
+        };
+        assert_eq!(raw_activity.retry_state, 123_456);
+        let Some(IncomingError::Timeout(timeout)) = activity.cause() else {
+            panic!("expected timeout cause");
+        };
+        assert_eq!(timeout.timeout_type(), TimeoutType::Unknown);
+        let Some(FailureInfo::TimeoutFailureInfo(raw_timeout)) =
+            timeout.failure().failure_info.as_ref()
+        else {
+            panic!("expected raw timeout failure info");
+        };
+        assert_eq!(raw_timeout.timeout_type, 654_321);
     }
 
     #[test]

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -1,6 +1,7 @@
 //! Shared error types used across Temporal SDK crates.
 
 use crate::{
+    WorkflowExecution,
     data_converters::{
         DecodablePayloads, GenericPayloadConverter, PayloadConversionError, PayloadConverter,
         RawValue, SerializationContext, SerializationContextData, TemporalDeserializable,
@@ -705,7 +706,7 @@ pub struct ActivityFailureError {
     failure: Failure,
     cause: Option<Box<IncomingError>>,
     activity_id: String,
-    activity_type: Option<crate::protos::temporal::api::common::v1::ActivityType>,
+    activity_type: Option<String>,
     scheduled_event_id: i64,
     started_event_id: i64,
     identity: String,
@@ -724,7 +725,9 @@ impl ActivityFailureError {
             failure,
             cause: cause.map(Box::new),
             activity_id: failure_info.activity_id,
-            activity_type: failure_info.activity_type,
+            activity_type: failure_info
+                .activity_type
+                .map(|activity_type| activity_type.name),
             scheduled_event_id: failure_info.scheduled_event_id,
             started_event_id: failure_info.started_event_id,
             identity: failure_info.identity,
@@ -738,8 +741,8 @@ impl ActivityFailureError {
     }
 
     /// Returns the activity type, if present.
-    pub fn activity_type(&self) -> Option<&crate::protos::temporal::api::common::v1::ActivityType> {
-        self.activity_type.as_ref()
+    pub fn activity_type(&self) -> Option<&str> {
+        self.activity_type.as_deref()
     }
 
     /// Returns the scheduled event id.
@@ -782,8 +785,8 @@ pub struct ChildWorkflowFailureError {
     failure: Failure,
     cause: Option<Box<IncomingError>>,
     namespace: String,
-    workflow_execution: Option<crate::protos::temporal::api::common::v1::WorkflowExecution>,
-    workflow_type: Option<crate::protos::temporal::api::common::v1::WorkflowType>,
+    workflow_execution: Option<WorkflowExecution>,
+    workflow_type: Option<String>,
     initiated_event_id: i64,
     started_event_id: i64,
     retry_state: crate::protos::temporal::api::enums::v1::RetryState,
@@ -801,8 +804,10 @@ impl ChildWorkflowFailureError {
             failure,
             cause: cause.map(Box::new),
             namespace: failure_info.namespace,
-            workflow_execution: failure_info.workflow_execution,
-            workflow_type: failure_info.workflow_type,
+            workflow_execution: failure_info.workflow_execution.map(Into::into),
+            workflow_type: failure_info
+                .workflow_type
+                .map(|workflow_type| workflow_type.name),
             initiated_event_id: failure_info.initiated_event_id,
             started_event_id: failure_info.started_event_id,
             retry_state,
@@ -815,15 +820,13 @@ impl ChildWorkflowFailureError {
     }
 
     /// Returns the child workflow execution, if present.
-    pub fn workflow_execution(
-        &self,
-    ) -> Option<&crate::protos::temporal::api::common::v1::WorkflowExecution> {
+    pub fn workflow_execution(&self) -> Option<&WorkflowExecution> {
         self.workflow_execution.as_ref()
     }
 
     /// Returns the child workflow type, if present.
-    pub fn workflow_type(&self) -> Option<&crate::protos::temporal::api::common::v1::WorkflowType> {
-        self.workflow_type.as_ref()
+    pub fn workflow_type(&self) -> Option<&str> {
+        self.workflow_type.as_deref()
     }
 
     /// Returns the initiated event id.

--- a/crates/common-wasm/src/lib.rs
+++ b/crates/common-wasm/src/lib.rs
@@ -11,6 +11,7 @@ mod activity_definition;
 pub mod data_converters;
 pub mod error;
 mod priority;
+mod retry_policy;
 mod workflow_execution;
 pub mod protos {
     //! Protobuf definitions re-exported from `temporalio-protos`.
@@ -23,6 +24,7 @@ mod workflow_definition;
 
 pub use activity_definition::{ActivityDefinition, ActivityError, UntypedActivity};
 pub use priority::Priority;
+pub use retry_policy::RetryPolicy;
 pub use search_attributes::{
     SearchAttributeError, SearchAttributeKey, SearchAttributeUpdate, SearchAttributeValue,
     SearchAttributes, Timestamp,

--- a/crates/common-wasm/src/lib.rs
+++ b/crates/common-wasm/src/lib.rs
@@ -10,6 +10,7 @@ extern crate tracing;
 mod activity_definition;
 pub mod data_converters;
 pub mod error;
+mod memo;
 mod priority;
 mod retry_policy;
 mod workflow_execution;
@@ -23,6 +24,7 @@ pub mod worker;
 mod workflow_definition;
 
 pub use activity_definition::{ActivityDefinition, ActivityError, UntypedActivity};
+pub use memo::Memo;
 pub use priority::Priority;
 pub use retry_policy::RetryPolicy;
 pub use search_attributes::{

--- a/crates/common-wasm/src/lib.rs
+++ b/crates/common-wasm/src/lib.rs
@@ -11,6 +11,7 @@ mod activity_definition;
 pub mod data_converters;
 pub mod error;
 mod priority;
+mod workflow_execution;
 pub mod protos {
     //! Protobuf definitions re-exported from `temporalio-protos`.
 
@@ -31,6 +32,7 @@ pub use workflow_definition::{
     HasWorkflowDefinition, QueryDefinition, SignalDefinition, UntypedWorkflow, UpdateDefinition,
     WorkflowDefinition,
 };
+pub use workflow_execution::WorkflowExecution;
 
 #[allow(unused_macros)]
 macro_rules! dbg_panic {

--- a/crates/common-wasm/src/memo.rs
+++ b/crates/common-wasm/src/memo.rs
@@ -1,0 +1,135 @@
+use crate::{
+    data_converters::{
+        GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
+        SerializationContextData, TemporalDeserializable,
+    },
+    protos::temporal::api::common::v1::{Memo as ProtoMemo, Payload},
+};
+
+/// A collection of memo payloads that can be deserialized into typed values.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Memo {
+    raw: ProtoMemo,
+    payload_converter: PayloadConverter,
+    context: SerializationContextData,
+}
+
+impl Memo {
+    /// Construct a memo with the payload converter and serialization context associated with its
+    /// source.
+    #[doc(hidden)]
+    pub fn from_raw(
+        raw: Option<ProtoMemo>,
+        payload_converter: PayloadConverter,
+        context: SerializationContextData,
+    ) -> Self {
+        Self {
+            raw: raw.unwrap_or_default(),
+            payload_converter,
+            context,
+        }
+    }
+
+    /// Decode a memo value as `T`, returning `None` when the key is absent.
+    pub fn get<T: TemporalDeserializable + 'static>(
+        &self,
+        key: &str,
+    ) -> Result<Option<T>, PayloadConversionError> {
+        let Some(payload) = self.raw.fields.get(key) else {
+            return Ok(None);
+        };
+        self.payload_converter
+            .from_payload(
+                &SerializationContext {
+                    data: &self.context,
+                    converter: &self.payload_converter,
+                },
+                payload.clone(),
+            )
+            .map(Some)
+    }
+
+    /// Returns whether the memo contains `key`.
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.raw.fields.contains_key(key)
+    }
+
+    /// Returns the number of memo entries.
+    pub fn len(&self) -> usize {
+        self.raw.fields.len()
+    }
+
+    /// Returns whether the memo has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.raw.fields.is_empty()
+    }
+
+    /// Iterates over memo keys.
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
+        self.raw.fields.keys().map(String::as_str)
+    }
+
+    /// Returns the underlying payload without applying payload conversion.
+    pub fn raw_value(&self, key: &str) -> Option<&Payload> {
+        self.raw.fields.get(key)
+    }
+
+    /// Access the underlying memo protobuf.
+    pub fn raw(&self) -> &ProtoMemo {
+        &self.raw
+    }
+
+    /// Consume this wrapper and return the underlying memo protobuf.
+    pub fn into_raw(self) -> ProtoMemo {
+        self.raw
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn memo_decodes_serialized_values() {
+        let payload_converter = PayloadConverter::default();
+        let context = SerializationContext {
+            data: &SerializationContextData::Workflow,
+            converter: &payload_converter,
+        };
+        let payload = payload_converter.to_payload(&context, &7_u32).unwrap();
+        let raw = ProtoMemo {
+            fields: HashMap::from([("count".to_owned(), payload.clone())]),
+        };
+        let memo = Memo::from_raw(
+            Some(raw.clone()),
+            payload_converter,
+            SerializationContextData::Workflow,
+        );
+
+        assert_eq!(memo.get::<u32>("count").unwrap(), Some(7));
+        assert_eq!(memo.get::<u32>("missing").unwrap(), None);
+        assert_eq!(memo.raw_value("count"), Some(&payload));
+        assert_eq!(memo.into_raw(), raw);
+    }
+
+    #[test]
+    fn memo_reports_deserialization_errors() {
+        let payload_converter = PayloadConverter::default();
+        let context = SerializationContext {
+            data: &SerializationContextData::Workflow,
+            converter: &payload_converter,
+        };
+        let payload = payload_converter.to_payload(&context, &7_u32).unwrap();
+        let memo = Memo::from_raw(
+            Some(ProtoMemo {
+                fields: HashMap::from([("count".to_owned(), payload)]),
+            }),
+            payload_converter,
+            SerializationContextData::Workflow,
+        );
+
+        assert!(memo.get::<String>("count").is_err());
+    }
+}

--- a/crates/common-wasm/src/retry_policy.rs
+++ b/crates/common-wasm/src/retry_policy.rs
@@ -4,70 +4,128 @@ use crate::protos::temporal::api::common::v1::RetryPolicy as ProtoRetryPolicy;
 
 const DEFAULT_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
 const DEFAULT_BACKOFF_COEFFICIENT: f64 = 2.0;
+const MAX_PROTO_DURATION: prost_types::Duration = prost_types::Duration {
+    seconds: 315_576_000_000,
+    nanos: 999_999_999,
+};
 
-/// Options for retrying workflows and activities.
-#[derive(Clone, Debug, bon::Builder)]
-#[non_exhaustive]
-#[builder(state_mod(vis = "pub"))]
-pub struct RetryPolicy {
-    /// Backoff interval for the first retry.
-    #[builder(default = DEFAULT_INITIAL_INTERVAL)]
-    pub initial_interval: Duration,
-    /// Coefficient used to calculate the next retry interval.
-    #[builder(default = DEFAULT_BACKOFF_COEFFICIENT)]
-    pub backoff_coefficient: f64,
-    /// Maximum backoff interval between retries.
-    pub maximum_interval: Option<Duration>,
-    /// Maximum number of attempts. Zero means unlimited attempts.
-    #[builder(default)]
-    pub maximum_attempts: i32,
-    /// Error type names that should not be retried.
-    #[builder(
-        with = |values: impl IntoIterator<Item = impl Into<String>>| values
-            .into_iter()
-            .map(Into::into)
-            .collect(),
-        default
-    )]
-    pub non_retryable_error_types: Vec<String>,
-    #[builder(skip = ProtoRetryPolicy {
-        initial_interval: initial_interval.try_into().ok(),
-        backoff_coefficient,
-        maximum_interval: maximum_interval.and_then(|duration| duration.try_into().ok()),
-        maximum_attempts,
-        non_retryable_error_types: non_retryable_error_types.clone(),
-    })]
-    raw: ProtoRetryPolicy,
+fn duration_to_proto(duration: Duration) -> prost_types::Duration {
+    duration.try_into().unwrap_or(MAX_PROTO_DURATION)
 }
 
-impl PartialEq for RetryPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.initial_interval == other.initial_interval
-            && self.backoff_coefficient == other.backoff_coefficient
-            && self.maximum_interval == other.maximum_interval
-            && self.maximum_attempts == other.maximum_attempts
-            && self.non_retryable_error_types == other.non_retryable_error_types
-    }
+/// Options for retrying workflows and activities.
+///
+/// Durations longer than 10,000 years are clamped to the maximum valid protobuf duration.
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct RetryPolicy {
+    raw: ProtoRetryPolicy,
 }
 
 impl Default for RetryPolicy {
     fn default() -> Self {
-        Self {
-            initial_interval: DEFAULT_INITIAL_INTERVAL,
-            backoff_coefficient: DEFAULT_BACKOFF_COEFFICIENT,
-            maximum_interval: None,
-            maximum_attempts: 0,
-            non_retryable_error_types: Vec::new(),
-            raw: ProtoRetryPolicy {
-                initial_interval: DEFAULT_INITIAL_INTERVAL.try_into().ok(),
-                backoff_coefficient: DEFAULT_BACKOFF_COEFFICIENT,
-                ..Default::default()
-            },
-        }
+        Self::builder().build()
     }
 }
 
+#[bon::bon]
 impl RetryPolicy {
+    /// Create a retry policy.
+    #[builder(state_mod(vis = "pub"))]
+    pub fn new(
+        #[builder(default = DEFAULT_INITIAL_INTERVAL)] initial_interval: Duration,
+        #[builder(default = DEFAULT_BACKOFF_COEFFICIENT)] backoff_coefficient: f64,
+        maximum_interval: Option<Duration>,
+        #[builder(default)] maximum_attempts: u32,
+        #[builder(
+            with = |values: impl IntoIterator<Item = impl Into<String>>| values
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            default
+        )]
+        non_retryable_error_types: Vec<String>,
+    ) -> Self {
+        let mut policy = Self {
+            raw: ProtoRetryPolicy::default(),
+        };
+        policy
+            .set_initial_interval(initial_interval)
+            .set_backoff_coefficient(backoff_coefficient)
+            .set_maximum_interval(maximum_interval)
+            .set_maximum_attempts(maximum_attempts)
+            .set_non_retryable_error_types(non_retryable_error_types);
+        policy
+    }
+
+    /// Backoff interval for the first retry.
+    pub fn initial_interval(&self) -> Duration {
+        self.raw
+            .initial_interval
+            .map(|duration| duration.try_into().ok().unwrap_or(Duration::ZERO))
+            .unwrap_or(DEFAULT_INITIAL_INTERVAL)
+    }
+
+    /// Set the backoff interval for the first retry.
+    pub fn set_initial_interval(&mut self, initial_interval: Duration) -> &mut Self {
+        self.raw.initial_interval = Some(duration_to_proto(initial_interval));
+        self
+    }
+
+    /// Coefficient used to calculate the next retry interval.
+    pub fn backoff_coefficient(&self) -> f64 {
+        if self.raw.backoff_coefficient == 0.0 {
+            DEFAULT_BACKOFF_COEFFICIENT
+        } else {
+            self.raw.backoff_coefficient
+        }
+    }
+
+    /// Set the coefficient used to calculate the next retry interval.
+    pub fn set_backoff_coefficient(&mut self, backoff_coefficient: f64) -> &mut Self {
+        self.raw.backoff_coefficient = backoff_coefficient;
+        self
+    }
+
+    /// Maximum backoff interval between retries.
+    pub fn maximum_interval(&self) -> Option<Duration> {
+        self.raw
+            .maximum_interval
+            .map(|duration| duration.try_into().ok().unwrap_or(Duration::ZERO))
+    }
+
+    /// Set the maximum backoff interval between retries.
+    pub fn set_maximum_interval(&mut self, maximum_interval: Option<Duration>) -> &mut Self {
+        self.raw.maximum_interval = maximum_interval.map(duration_to_proto);
+        self
+    }
+
+    /// Maximum number of attempts. Zero means unlimited attempts.
+    pub fn maximum_attempts(&self) -> u32 {
+        self.raw.maximum_attempts.try_into().unwrap_or_default()
+    }
+
+    /// Set the maximum number of attempts. Zero means unlimited attempts. Values greater than
+    /// [`i32::MAX`] are clamped to [`i32::MAX`].
+    pub fn set_maximum_attempts(&mut self, maximum_attempts: u32) -> &mut Self {
+        self.raw.maximum_attempts = maximum_attempts.try_into().unwrap_or(i32::MAX);
+        self
+    }
+
+    /// Error type names that should not be retried.
+    pub fn non_retryable_error_types(&self) -> &[String] {
+        &self.raw.non_retryable_error_types
+    }
+
+    /// Set the error type names that should not be retried.
+    pub fn set_non_retryable_error_types(
+        &mut self,
+        values: impl IntoIterator<Item = impl Into<String>>,
+    ) -> &mut Self {
+        self.raw.non_retryable_error_types = values.into_iter().map(Into::into).collect();
+        self
+    }
+
     /// Access the underlying retry policy protobuf.
     pub fn raw(&self) -> &ProtoRetryPolicy {
         &self.raw
@@ -81,58 +139,34 @@ impl RetryPolicy {
 
 impl From<ProtoRetryPolicy> for RetryPolicy {
     fn from(value: ProtoRetryPolicy) -> Self {
-        let raw = value.clone();
-        Self {
-            initial_interval: value
-                .initial_interval
-                .and_then(|duration| duration.try_into().ok())
-                .unwrap_or(DEFAULT_INITIAL_INTERVAL),
-            backoff_coefficient: if value.backoff_coefficient == 0.0 {
-                DEFAULT_BACKOFF_COEFFICIENT
-            } else {
-                value.backoff_coefficient
-            },
-            maximum_interval: value
-                .maximum_interval
-                .and_then(|duration| duration.try_into().ok()),
-            maximum_attempts: value.maximum_attempts,
-            non_retryable_error_types: value.non_retryable_error_types,
-            raw,
-        }
+        Self { raw: value }
     }
 }
 
 impl From<RetryPolicy> for ProtoRetryPolicy {
     fn from(value: RetryPolicy) -> Self {
-        Self {
-            initial_interval: value.initial_interval.try_into().ok(),
-            backoff_coefficient: value.backoff_coefficient,
-            maximum_interval: value
-                .maximum_interval
-                .and_then(|duration| duration.try_into().ok()),
-            maximum_attempts: value.maximum_attempts,
-            non_retryable_error_types: value.non_retryable_error_types,
-        }
+        value.raw
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn defaults_match_temporal_retry_defaults() {
-        assert_eq!(RetryPolicy::default(), RetryPolicy::builder().build());
-        assert_eq!(
-            RetryPolicy::default().initial_interval,
-            Duration::from_secs(1)
-        );
-        assert_eq!(RetryPolicy::default().backoff_coefficient, 2.0);
-        assert_eq!(RetryPolicy::default().maximum_attempts, 0);
+    #[rstest]
+    #[case::default(RetryPolicy::default())]
+    #[case::builder(RetryPolicy::builder().build())]
+    #[case::proto(RetryPolicy::from(ProtoRetryPolicy::default()))]
+    fn defaults_match_temporal_retry_defaults(#[case] policy: RetryPolicy) {
+        assert_eq!(policy.initial_interval(), Duration::from_secs(1));
+        assert_eq!(policy.backoff_coefficient(), 2.0);
+        assert_eq!(policy.maximum_attempts(), 0);
+        assert_eq!(policy.maximum_interval(), None);
     }
 
     #[test]
-    fn builder_uses_rust_duration_and_proto_round_trips() {
+    fn retry_policy_round_trips() {
         let policy = RetryPolicy::builder()
             .initial_interval(Duration::from_millis(250))
             .backoff_coefficient(1.5)
@@ -148,26 +182,52 @@ mod tests {
     }
 
     #[test]
-    fn absent_proto_defaults_are_normalized() {
+    fn setters_update_raw_proto() {
+        let mut policy = RetryPolicy::default();
+        policy
+            .set_initial_interval(Duration::from_millis(250))
+            .set_backoff_coefficient(1.5)
+            .set_maximum_interval(Some(Duration::from_secs(10)))
+            .set_maximum_attempts(5)
+            .set_non_retryable_error_types(["InvalidInput"]);
+
+        assert_eq!(policy.initial_interval(), Duration::from_millis(250));
+        assert_eq!(policy.backoff_coefficient(), 1.5);
+        assert_eq!(policy.maximum_interval(), Some(Duration::from_secs(10)));
+        assert_eq!(policy.maximum_attempts(), 5);
+        assert_eq!(policy.non_retryable_error_types(), ["InvalidInput"]);
         assert_eq!(
-            RetryPolicy::from(ProtoRetryPolicy::default()),
-            RetryPolicy::default()
+            policy.raw().initial_interval,
+            Duration::from_millis(250).try_into().ok()
         );
+        assert_eq!(policy.raw().backoff_coefficient, 1.5);
+        assert_eq!(
+            policy.raw().maximum_interval,
+            Duration::from_secs(10).try_into().ok()
+        );
+        assert_eq!(policy.raw().maximum_attempts, 5);
+        assert_eq!(policy.raw().non_retryable_error_types, ["InvalidInput"]);
     }
 
     #[test]
-    fn normalization_retains_source_proto() {
+    fn invalid_raw_values_are_normalized_by_getters() {
         let raw = ProtoRetryPolicy {
             initial_interval: Some(prost_types::Duration {
-                seconds: -1,
-                nanos: 0,
+                seconds: i64::MIN,
+                nanos: 999_999_999,
             }),
+            maximum_interval: Some(prost_types::Duration {
+                seconds: i64::MIN,
+                nanos: 999_999_999,
+            }),
+            maximum_attempts: -1,
             ..Default::default()
         };
         let policy = RetryPolicy::from(raw.clone());
 
-        assert_eq!(policy.initial_interval, DEFAULT_INITIAL_INTERVAL);
+        assert_eq!(policy.initial_interval(), Duration::ZERO);
+        assert_eq!(policy.maximum_interval(), Some(Duration::ZERO));
+        assert_eq!(policy.maximum_attempts(), 0);
         assert_eq!(policy.raw(), &raw);
-        assert_eq!(policy.into_raw(), raw);
     }
 }

--- a/crates/common-wasm/src/retry_policy.rs
+++ b/crates/common-wasm/src/retry_policy.rs
@@ -1,0 +1,173 @@
+use std::time::Duration;
+
+use crate::protos::temporal::api::common::v1::RetryPolicy as ProtoRetryPolicy;
+
+const DEFAULT_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_BACKOFF_COEFFICIENT: f64 = 2.0;
+
+/// Options for retrying workflows and activities.
+#[derive(Clone, Debug, bon::Builder)]
+#[non_exhaustive]
+#[builder(state_mod(vis = "pub"))]
+pub struct RetryPolicy {
+    /// Backoff interval for the first retry.
+    #[builder(default = DEFAULT_INITIAL_INTERVAL)]
+    pub initial_interval: Duration,
+    /// Coefficient used to calculate the next retry interval.
+    #[builder(default = DEFAULT_BACKOFF_COEFFICIENT)]
+    pub backoff_coefficient: f64,
+    /// Maximum backoff interval between retries.
+    pub maximum_interval: Option<Duration>,
+    /// Maximum number of attempts. Zero means unlimited attempts.
+    #[builder(default)]
+    pub maximum_attempts: i32,
+    /// Error type names that should not be retried.
+    #[builder(
+        with = |values: impl IntoIterator<Item = impl Into<String>>| values
+            .into_iter()
+            .map(Into::into)
+            .collect(),
+        default
+    )]
+    pub non_retryable_error_types: Vec<String>,
+    #[builder(skip = ProtoRetryPolicy {
+        initial_interval: initial_interval.try_into().ok(),
+        backoff_coefficient,
+        maximum_interval: maximum_interval.and_then(|duration| duration.try_into().ok()),
+        maximum_attempts,
+        non_retryable_error_types: non_retryable_error_types.clone(),
+    })]
+    raw: ProtoRetryPolicy,
+}
+
+impl PartialEq for RetryPolicy {
+    fn eq(&self, other: &Self) -> bool {
+        self.initial_interval == other.initial_interval
+            && self.backoff_coefficient == other.backoff_coefficient
+            && self.maximum_interval == other.maximum_interval
+            && self.maximum_attempts == other.maximum_attempts
+            && self.non_retryable_error_types == other.non_retryable_error_types
+    }
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            initial_interval: DEFAULT_INITIAL_INTERVAL,
+            backoff_coefficient: DEFAULT_BACKOFF_COEFFICIENT,
+            maximum_interval: None,
+            maximum_attempts: 0,
+            non_retryable_error_types: Vec::new(),
+            raw: ProtoRetryPolicy {
+                initial_interval: DEFAULT_INITIAL_INTERVAL.try_into().ok(),
+                backoff_coefficient: DEFAULT_BACKOFF_COEFFICIENT,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Access the underlying retry policy protobuf.
+    pub fn raw(&self) -> &ProtoRetryPolicy {
+        &self.raw
+    }
+
+    /// Consume this wrapper and return the underlying retry policy protobuf.
+    pub fn into_raw(self) -> ProtoRetryPolicy {
+        self.raw
+    }
+}
+
+impl From<ProtoRetryPolicy> for RetryPolicy {
+    fn from(value: ProtoRetryPolicy) -> Self {
+        let raw = value.clone();
+        Self {
+            initial_interval: value
+                .initial_interval
+                .and_then(|duration| duration.try_into().ok())
+                .unwrap_or(DEFAULT_INITIAL_INTERVAL),
+            backoff_coefficient: if value.backoff_coefficient == 0.0 {
+                DEFAULT_BACKOFF_COEFFICIENT
+            } else {
+                value.backoff_coefficient
+            },
+            maximum_interval: value
+                .maximum_interval
+                .and_then(|duration| duration.try_into().ok()),
+            maximum_attempts: value.maximum_attempts,
+            non_retryable_error_types: value.non_retryable_error_types,
+            raw,
+        }
+    }
+}
+
+impl From<RetryPolicy> for ProtoRetryPolicy {
+    fn from(value: RetryPolicy) -> Self {
+        Self {
+            initial_interval: value.initial_interval.try_into().ok(),
+            backoff_coefficient: value.backoff_coefficient,
+            maximum_interval: value
+                .maximum_interval
+                .and_then(|duration| duration.try_into().ok()),
+            maximum_attempts: value.maximum_attempts,
+            non_retryable_error_types: value.non_retryable_error_types,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_temporal_retry_defaults() {
+        assert_eq!(RetryPolicy::default(), RetryPolicy::builder().build());
+        assert_eq!(
+            RetryPolicy::default().initial_interval,
+            Duration::from_secs(1)
+        );
+        assert_eq!(RetryPolicy::default().backoff_coefficient, 2.0);
+        assert_eq!(RetryPolicy::default().maximum_attempts, 0);
+    }
+
+    #[test]
+    fn builder_uses_rust_duration_and_proto_round_trips() {
+        let policy = RetryPolicy::builder()
+            .initial_interval(Duration::from_millis(250))
+            .backoff_coefficient(1.5)
+            .maximum_interval(Duration::from_secs(10))
+            .maximum_attempts(5)
+            .non_retryable_error_types(["InvalidInput"])
+            .build();
+
+        assert_eq!(
+            RetryPolicy::from(ProtoRetryPolicy::from(policy.clone())),
+            policy
+        );
+    }
+
+    #[test]
+    fn absent_proto_defaults_are_normalized() {
+        assert_eq!(
+            RetryPolicy::from(ProtoRetryPolicy::default()),
+            RetryPolicy::default()
+        );
+    }
+
+    #[test]
+    fn normalization_retains_source_proto() {
+        let raw = ProtoRetryPolicy {
+            initial_interval: Some(prost_types::Duration {
+                seconds: -1,
+                nanos: 0,
+            }),
+            ..Default::default()
+        };
+        let policy = RetryPolicy::from(raw.clone());
+
+        assert_eq!(policy.initial_interval, DEFAULT_INITIAL_INTERVAL);
+        assert_eq!(policy.raw(), &raw);
+        assert_eq!(policy.into_raw(), raw);
+    }
+}

--- a/crates/common-wasm/src/workflow_execution.rs
+++ b/crates/common-wasm/src/workflow_execution.rs
@@ -1,56 +1,64 @@
 use crate::protos::temporal::api::common::v1::WorkflowExecution as ProtoWorkflowExecution;
 
 /// Identifies a workflow execution by workflow and run ID.
-#[derive(Clone, Debug, Default, bon::Builder)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
-#[builder(on(String, into), state_mod(vis = "pub"))]
 pub struct WorkflowExecution {
-    /// The workflow ID.
-    pub workflow_id: String,
-    /// The run ID, or an empty string when targeting the latest run.
-    pub run_id: String,
-    #[builder(skip = ProtoWorkflowExecution {
-        workflow_id: workflow_id.clone(),
-        run_id: run_id.clone(),
-    })]
     raw: ProtoWorkflowExecution,
 }
 
+#[bon::bon]
 impl WorkflowExecution {
+    /// Create a workflow execution identifier.
+    #[builder(on(String, into), state_mod(vis = "pub"))]
+    pub fn new(workflow_id: String, run_id: String) -> Self {
+        let mut execution = Self::default();
+        execution.set_workflow_id(workflow_id).set_run_id(run_id);
+        execution
+    }
+
+    /// The workflow ID.
+    pub fn workflow_id(&self) -> &str {
+        &self.raw.workflow_id
+    }
+
+    /// Set the workflow ID.
+    pub fn set_workflow_id(&mut self, workflow_id: impl Into<String>) -> &mut Self {
+        self.raw.workflow_id = workflow_id.into();
+        self
+    }
+
+    /// The run ID.
+    pub fn run_id(&self) -> &str {
+        &self.raw.run_id
+    }
+
+    /// Set the run ID.
+    pub fn set_run_id(&mut self, run_id: impl Into<String>) -> &mut Self {
+        self.raw.run_id = run_id.into();
+        self
+    }
+
     /// Access the underlying workflow execution protobuf.
     pub fn raw(&self) -> &ProtoWorkflowExecution {
         &self.raw
     }
 
     /// Consume this wrapper and return the underlying workflow execution protobuf.
-    pub fn into_raw(mut self) -> ProtoWorkflowExecution {
-        self.raw.workflow_id = self.workflow_id;
-        self.raw.run_id = self.run_id;
+    pub fn into_raw(self) -> ProtoWorkflowExecution {
         self.raw
     }
 }
 
-impl PartialEq for WorkflowExecution {
-    fn eq(&self, other: &Self) -> bool {
-        self.workflow_id == other.workflow_id && self.run_id == other.run_id
-    }
-}
-
-impl Eq for WorkflowExecution {}
-
 impl From<ProtoWorkflowExecution> for WorkflowExecution {
     fn from(value: ProtoWorkflowExecution) -> Self {
-        Self {
-            workflow_id: value.workflow_id.clone(),
-            run_id: value.run_id.clone(),
-            raw: value,
-        }
+        Self { raw: value }
     }
 }
 
 impl From<WorkflowExecution> for ProtoWorkflowExecution {
     fn from(value: WorkflowExecution) -> Self {
-        value.into_raw()
+        value.raw
     }
 }
 
@@ -65,6 +73,8 @@ mod tests {
             .run_id("run-id")
             .build();
 
+        assert_eq!(execution.workflow_id(), "workflow-id");
+        assert_eq!(execution.run_id(), "run-id");
         assert_eq!(execution.raw().workflow_id, "workflow-id");
         assert_eq!(execution.raw().run_id, "run-id");
 
@@ -75,14 +85,15 @@ mod tests {
     }
 
     #[test]
-    fn retains_source_proto() {
-        let raw = ProtoWorkflowExecution {
-            workflow_id: "workflow-id".to_owned(),
-            run_id: "run-id".to_owned(),
-        };
-        let execution = WorkflowExecution::from(raw.clone());
+    fn setters_update_raw_proto() {
+        let mut execution = WorkflowExecution::default();
+        execution
+            .set_workflow_id("workflow-id")
+            .set_run_id("run-id");
 
-        assert_eq!(execution.raw(), &raw);
-        assert_eq!(execution.into_raw(), raw);
+        assert_eq!(execution.workflow_id(), "workflow-id");
+        assert_eq!(execution.run_id(), "run-id");
+        assert_eq!(execution.raw().workflow_id, "workflow-id");
+        assert_eq!(execution.raw().run_id, "run-id");
     }
 }

--- a/crates/common-wasm/src/workflow_execution.rs
+++ b/crates/common-wasm/src/workflow_execution.rs
@@ -1,0 +1,88 @@
+use crate::protos::temporal::api::common::v1::WorkflowExecution as ProtoWorkflowExecution;
+
+/// Identifies a workflow execution by workflow and run ID.
+#[derive(Clone, Debug, Default, bon::Builder)]
+#[non_exhaustive]
+#[builder(on(String, into), state_mod(vis = "pub"))]
+pub struct WorkflowExecution {
+    /// The workflow ID.
+    pub workflow_id: String,
+    /// The run ID, or an empty string when targeting the latest run.
+    pub run_id: String,
+    #[builder(skip = ProtoWorkflowExecution {
+        workflow_id: workflow_id.clone(),
+        run_id: run_id.clone(),
+    })]
+    raw: ProtoWorkflowExecution,
+}
+
+impl WorkflowExecution {
+    /// Access the underlying workflow execution protobuf.
+    pub fn raw(&self) -> &ProtoWorkflowExecution {
+        &self.raw
+    }
+
+    /// Consume this wrapper and return the underlying workflow execution protobuf.
+    pub fn into_raw(mut self) -> ProtoWorkflowExecution {
+        self.raw.workflow_id = self.workflow_id;
+        self.raw.run_id = self.run_id;
+        self.raw
+    }
+}
+
+impl PartialEq for WorkflowExecution {
+    fn eq(&self, other: &Self) -> bool {
+        self.workflow_id == other.workflow_id && self.run_id == other.run_id
+    }
+}
+
+impl Eq for WorkflowExecution {}
+
+impl From<ProtoWorkflowExecution> for WorkflowExecution {
+    fn from(value: ProtoWorkflowExecution) -> Self {
+        Self {
+            workflow_id: value.workflow_id.clone(),
+            run_id: value.run_id.clone(),
+            raw: value,
+        }
+    }
+}
+
+impl From<WorkflowExecution> for ProtoWorkflowExecution {
+    fn from(value: WorkflowExecution) -> Self {
+        value.into_raw()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_and_proto_round_trip() {
+        let execution = WorkflowExecution::builder()
+            .workflow_id("workflow-id")
+            .run_id("run-id")
+            .build();
+
+        assert_eq!(execution.raw().workflow_id, "workflow-id");
+        assert_eq!(execution.raw().run_id, "run-id");
+
+        assert_eq!(
+            WorkflowExecution::from(ProtoWorkflowExecution::from(execution.clone())),
+            execution
+        );
+    }
+
+    #[test]
+    fn retains_source_proto() {
+        let raw = ProtoWorkflowExecution {
+            workflow_id: "workflow-id".to_owned(),
+            run_id: "run-id".to_owned(),
+        };
+        let execution = WorkflowExecution::from(raw.clone());
+
+        assert_eq!(execution.raw(), &raw);
+        assert_eq!(execution.into_raw(), raw);
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -20,7 +20,7 @@ pub mod worker;
 pub use temporalio_common_wasm::{
     ActivityDefinition, ActivityError, HasWorkflowDefinition, Priority, QueryDefinition,
     SignalDefinition, UntypedActivity, UntypedWorkflow, UpdateDefinition, WorkerDeploymentVersion,
-    WorkflowDefinition, data_converters, error, search_attributes,
+    WorkflowDefinition, WorkflowExecution, data_converters, error, search_attributes,
 };
 
 macro_rules! dbg_panic {

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -19,8 +19,9 @@ pub mod telemetry;
 pub mod worker;
 pub use temporalio_common_wasm::{
     ActivityDefinition, ActivityError, HasWorkflowDefinition, Priority, QueryDefinition,
-    SignalDefinition, UntypedActivity, UntypedWorkflow, UpdateDefinition, WorkerDeploymentVersion,
-    WorkflowDefinition, WorkflowExecution, data_converters, error, search_attributes,
+    RetryPolicy, SignalDefinition, UntypedActivity, UntypedWorkflow, UpdateDefinition,
+    WorkerDeploymentVersion, WorkflowDefinition, WorkflowExecution, data_converters, error,
+    search_attributes,
 };
 
 macro_rules! dbg_panic {

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -18,7 +18,7 @@ pub mod protos;
 pub mod telemetry;
 pub mod worker;
 pub use temporalio_common_wasm::{
-    ActivityDefinition, ActivityError, HasWorkflowDefinition, Priority, QueryDefinition,
+    ActivityDefinition, ActivityError, HasWorkflowDefinition, Memo, Priority, QueryDefinition,
     RetryPolicy, SignalDefinition, UntypedActivity, UntypedWorkflow, UpdateDefinition,
     WorkerDeploymentVersion, WorkflowDefinition, WorkflowExecution, data_converters, error,
     search_attributes,

--- a/crates/common/src/worker.rs
+++ b/crates/common/src/worker.rs
@@ -1,9 +1,7 @@
 //! Contains types that are needed by both the client and the sdk when configuring / interacting
 //! with workers.
 
-use crate::protos::temporal::api::enums::v1::{
-    TaskQueueType, VersioningBehavior as ProtoVersioningBehavior,
-};
+use crate::protos::temporal::api::enums::v1::VersioningBehavior as ProtoVersioningBehavior;
 use std::{
     fs::File,
     io::{self, BufReader, Read},
@@ -114,21 +112,6 @@ impl WorkerTaskTypes {
             || (self.enable_local_activities && other.enable_local_activities)
             || (self.enable_remote_activities && other.enable_remote_activities)
             || (self.enable_nexus && other.enable_nexus)
-    }
-
-    /// Converts the enabled task types into the corresponding [`TaskQueueType`] values.
-    pub fn to_task_queue_types(&self) -> Vec<TaskQueueType> {
-        let mut types = Vec::new();
-        if self.enable_workflows {
-            types.push(TaskQueueType::Workflow);
-        }
-        if self.enable_remote_activities {
-            types.push(TaskQueueType::Activity);
-        }
-        if self.enable_nexus {
-            types.push(TaskQueueType::Nexus);
-        }
-        types
     }
 }
 

--- a/crates/common/src/worker.rs
+++ b/crates/common/src/worker.rs
@@ -1,13 +1,48 @@
 //! Contains types that are needed by both the client and the sdk when configuring / interacting
 //! with workers.
 
-use crate::protos::temporal::api::enums::v1::{TaskQueueType, VersioningBehavior};
+use crate::protos::temporal::api::enums::v1::{
+    TaskQueueType, VersioningBehavior as ProtoVersioningBehavior,
+};
 use std::{
     fs::File,
     io::{self, BufReader, Read},
     sync::OnceLock,
 };
 pub use temporalio_common_wasm::worker::WorkerDeploymentVersion;
+
+/// Controls how a workflow moves between worker deployment versions.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum VersioningBehavior {
+    /// Do not opt into worker deployment versioning.
+    #[default]
+    Unspecified,
+    /// Pin the workflow to one deployment version.
+    Pinned,
+    /// Automatically move the workflow to its target version.
+    AutoUpgrade,
+}
+
+impl From<VersioningBehavior> for ProtoVersioningBehavior {
+    fn from(value: VersioningBehavior) -> Self {
+        match value {
+            VersioningBehavior::Unspecified => Self::Unspecified,
+            VersioningBehavior::Pinned => Self::Pinned,
+            VersioningBehavior::AutoUpgrade => Self::AutoUpgrade,
+        }
+    }
+}
+
+impl From<ProtoVersioningBehavior> for VersioningBehavior {
+    fn from(value: ProtoVersioningBehavior) -> Self {
+        match value {
+            ProtoVersioningBehavior::Unspecified => Self::Unspecified,
+            ProtoVersioningBehavior::Pinned => Self::Pinned,
+            ProtoVersioningBehavior::AutoUpgrade => Self::AutoUpgrade,
+        }
+    }
+}
 
 /// Specifies which task types a worker will poll for.
 ///

--- a/crates/sdk-core-c-bridge/src/worker.rs
+++ b/crates/sdk-core-c-bridge/src/worker.rs
@@ -16,7 +16,9 @@ use temporalio_common::protos::{
         ActivityHeartbeat, ActivityTaskCompletion, nexus::NexusTaskCompletion,
         workflow_completion::WorkflowActivationCompletion,
     },
-    temporal::api::history::v1::History,
+    temporal::api::{
+        enums::v1::VersioningBehavior as ProtoVersioningBehavior, history::v1::History,
+    },
 };
 use temporalio_sdk_core::{
     PollError, SlotInfoTrait, SlotKind, SlotMarkUsedContext, SlotReleaseContext,
@@ -1177,8 +1179,8 @@ impl TryFrom<&WorkerOptions> for temporalio_sdk_core::WorkerConfig {
                         let dvb = match dopts.default_versioning_behavior {
                             0 => None,
                             v => {
-                                if let Ok(behavior) = v.try_into() {
-                                    Some(behavior)
+                                if let Ok(behavior) = ProtoVersioningBehavior::try_from(v) {
+                                    Some(behavior.into())
                                 } else {
                                     bail!("Invalid default versioning behavior {}", v)
                                 }

--- a/crates/sdk-core/src/worker/client.rs
+++ b/crates/sdk-core/src/worker/client.rs
@@ -13,7 +13,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_client::{
-    Connection, Namespace, NamespacedClient, RetryOptions, SharedReplaceableClient,
+    Connection, NamespacedClient, RetryOptions, SharedReplaceableClient,
     grpc::WorkflowService,
     request_extensions::{IsWorkerTaskLongPoll, NoRetryOnMatching, RetryConfigForCall},
     worker::ClientWorkerSet,
@@ -738,9 +738,11 @@ impl WorkerClient for WorkerClientBag {
             .connection
             .clone()
             .describe_namespace(
-                Namespace::Name(self.namespace.clone())
-                    .into_describe_namespace_request()
-                    .into_request(),
+                DescribeNamespaceRequest {
+                    namespace: self.namespace.clone(),
+                    ..Default::default()
+                }
+                .into_request(),
             )
             .await?
             .into_inner())

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -1965,7 +1965,7 @@ impl WorkerVersioningStrategy {
     pub fn default_versioning_behavior(&self) -> Option<VersioningBehavior> {
         match self {
             WorkerVersioningStrategy::WorkerDeploymentBased(opts) => {
-                opts.default_versioning_behavior
+                opts.default_versioning_behavior.map(Into::into)
             }
             _ => None,
         }
@@ -2503,7 +2503,7 @@ mod tests {
                         build_id: "1.0".to_string(),
                     },
                     use_worker_versioning: false,
-                    default_versioning_behavior: Some(VersioningBehavior::AutoUpgrade),
+                    default_versioning_behavior: Some(VersioningBehavior::AutoUpgrade.into()),
                 },
             ))
             .task_types(WorkerTaskTypes::all())

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -93,7 +93,7 @@ use temporalio_common::{
         },
         temporal::api::{
             deployment,
-            enums::v1::{TaskQueueKind, WorkerStatus},
+            enums::v1::{TaskQueueKind, TaskQueueType, WorkerStatus},
             taskqueue::v1::{StickyExecutionAttributes, TaskQueue},
             worker::v1::{WorkerHeartbeat, WorkerHostInfo, WorkerPollerInfo, WorkerSlotsInfo},
         },
@@ -1456,7 +1456,16 @@ impl Worker {
             .and_then(|wf| wf.get_sticky_queue_name())
             .unwrap_or_default();
         let task_queue = self.config.task_queue.clone();
-        let task_queue_types = self.config.task_types.to_task_queue_types();
+        let mut task_queue_types = Vec::new();
+        if self.config.task_types.enable_workflows {
+            task_queue_types.push(TaskQueueType::Workflow);
+        }
+        if self.config.task_types.enable_remote_activities {
+            task_queue_types.push(TaskQueueType::Activity);
+        }
+        if self.config.task_types.enable_nexus {
+            task_queue_types.push(TaskQueueType::Nexus);
+        }
         let heartbeat = self
             .client_worker_registrator
             .heartbeat_manager

--- a/crates/sdk-core/tests/common/workflows.rs
+++ b/crates/sdk-core/tests/common/workflows.rs
@@ -23,7 +23,8 @@ impl LaProblemWorkflow {
                     maximum_interval: Some(prost_dur!(from_millis(1500))),
                     maximum_attempts: 4,
                     non_retryable_error_types: vec![],
-                },
+                }
+                .into(),
                 timer_backoff_threshold: Some(Duration::from_secs(1)),
                 ..Default::default()
             },

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -2,11 +2,11 @@ use crate::common::CoreWfStarter;
 use rstest::rstest;
 use std::{sync::Arc, time::Duration};
 use temporalio_client::{ActivityIdentifier, WorkflowStartOptions};
-use temporalio_common::protos::{
-    coresdk::{AsJsonPayloadExt, workflow_commands::ActivityCancellationType},
-    temporal::api::{
-        common::v1::RetryPolicy,
-        failure::v1::{ApplicationFailureInfo, Failure, failure::FailureInfo},
+use temporalio_common::{
+    error::ApplicationFailure,
+    protos::{
+        coresdk::workflow_commands::ActivityCancellationType,
+        temporal::api::common::v1::RetryPolicy,
     },
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
@@ -67,7 +67,7 @@ async fn async_activity_completions(
                 tokio::select! {
                     _ = async {
                         loop {
-                            ctx.record_heartbeat(vec![]);
+                            let _ = ctx.record_heartbeat(()).await;
                             tokio::time::sleep(Duration::from_millis(500)).await;
                         }
                     } => (),
@@ -183,29 +183,18 @@ async fn async_activity_completions(
         eprintln!("DEBUG: Calling {:?} on handle", outcome);
 
         let result = match outcome {
-            Outcome::Success => {
-                handle
-                    .complete(Some(async_response.as_json_payload().unwrap().into()))
-                    .await
-            }
+            Outcome::Success => handle.complete(Some(async_response.to_owned())).await,
             Outcome::Failure => {
                 handle
                     .fail(
-                        Failure {
-                            message: "async failure reason".to_string(),
-                            failure_info: Some(FailureInfo::ApplicationFailureInfo(
-                                ApplicationFailureInfo {
-                                    r#type: "TestFailure".to_string(),
-                                    ..Default::default()
-                                },
-                            )),
-                            ..Default::default()
-                        },
-                        None,
+                        ApplicationFailure::builder(std::io::Error::other("async failure reason"))
+                            .type_name("TestFailure".to_owned())
+                            .build(),
+                        None::<()>,
                     )
                     .await
             }
-            Outcome::Cancellation => handle.report_cancelation(None).await,
+            Outcome::Cancellation => handle.report_cancelation(None::<()>).await,
         };
         if let Err(e) = &result {
             eprintln!(

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -79,8 +79,8 @@ async fn async_activity_completions(
             let wf_exec = activity_info.workflow_execution.as_ref().unwrap();
             let info = SharedActivityInfo {
                 task_token: activity_info.task_token.clone(),
-                workflow_id: wf_exec.workflow_id.clone(),
-                run_id: wf_exec.run_id.clone(),
+                workflow_id: wf_exec.workflow_id().to_owned(),
+                run_id: wf_exec.run_id().to_owned(),
                 activity_id: activity_info.activity_id.clone(),
             };
             let _ = self.info_tx.send(info).await;

--- a/crates/sdk-core/tests/integ_tests/client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/client_tests.rs
@@ -22,7 +22,7 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    Connection, GrpcCompression, Namespace, RETRYABLE_ERROR_CODES, RetryOptions, UntypedWorkflow,
+    Connection, GrpcCompression, RETRYABLE_ERROR_CODES, RetryOptions, UntypedWorkflow,
     errors::ClientConnectError, grpc::WorkflowService, proxy::HttpConnectProxyOptions,
 };
 use temporalio_common::protos::temporal::api::{
@@ -476,9 +476,11 @@ async fn namespace_header_attached_to_relevant_calls() {
     assert_eq!("", val);
     let _ = WorkflowService::describe_namespace(
         &mut client.clone(),
-        Namespace::Name("Other".to_string())
-            .into_describe_namespace_request()
-            .into_request(),
+        DescribeNamespaceRequest {
+            namespace: "Other".to_string(),
+            ..Default::default()
+        }
+        .into_request(),
     )
     .await;
     let val = header_rx.recv().await.unwrap();

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -404,13 +404,13 @@ async fn custom_failure_converter_fallback_applied_to_workflow_failures() {
         err => panic!("unexpected workflow result error: {err:?}"),
     };
     assert_eq!(
-        failure.message,
+        failure.failure().message,
         format!(
             "Failed converting error to failure: Encoding error: {FAILURE_CONVERTER_ERROR_MESSAGE}, original error message: {WORKFLOW_FAILURE_MESSAGE}"
         )
     );
     assert!(matches!(
-        failure.failure_info,
+        failure.failure().failure_info.as_ref(),
         Some(FailureInfo::ApplicationFailureInfo(_))
     ));
 }

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -108,7 +108,7 @@ impl FailurePayloadActivities {
         loop {
             tokio::select! {
                 _ = ctx.cancelled() => break,
-                _ = ticker.tick() => ctx.record_heartbeat(vec![]),
+                _ = ticker.tick() => ctx.record_heartbeat(()).await?,
             }
         }
         Err(ActivityError::cancelled_with_details(
@@ -118,11 +118,10 @@ impl FailurePayloadActivities {
 
     #[activity]
     async fn heartbeat_then_timeout(ctx: ActivityContext) -> Result<(), ActivityError> {
-        ctx.record_heartbeat(vec![
-            TrackedValue::new("codec-heartbeat-details".to_string())
-                .as_json_payload()
-                .map_err(ActivityError::from)?,
-        ]);
+        ctx.record_heartbeat(TrackedWrapper(TrackedValue::new(
+            "codec-heartbeat-details".to_string(),
+        )))
+        .await?;
         tokio::time::sleep(Duration::from_secs(2)).await;
         Ok(())
     }

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -31,8 +31,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, CancellableFuture, SyncWorkflowContext, WorkflowContext, WorkflowContextView,
-    WorkflowResult,
+    ActivityOptions, CancellableFuture, MemoValue, SyncWorkflowContext, WorkflowContext,
+    WorkflowContextView, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 
@@ -209,7 +209,12 @@ impl DescribeDataConverterWorkflow {
         ctx: &mut WorkflowContext<Self>,
         input: TrackedWrapper,
     ) -> WorkflowResult<TrackedWrapper> {
-        ctx.upsert_memo([("tracked".to_string(), input.0.data.as_json_payload()?)]);
+        ctx.upsert_memo([
+            ("tracked", Some(MemoValue::new(input.0.data.clone()))),
+            ("wrapped", Some(MemoValue::new(input.clone()))),
+            ("removed", Some(MemoValue::new(true))),
+        ])?;
+        ctx.upsert_memo([("removed", None)])?;
         let output = ctx
             .start_activity(
                 TestActivities::process_tracked,
@@ -956,6 +961,14 @@ async fn describe_decodes_workflow_payload_fields() {
         desc.memo().get::<String>("tracked").unwrap(),
         Some("codec-describe".to_owned())
     );
+    assert_eq!(
+        desc.memo()
+            .get::<TrackedWrapper>("wrapped")
+            .unwrap()
+            .map(|value| value.0.data),
+        Some("codec-describe".to_owned())
+    );
+    assert!(!desc.memo().contains_key("removed"));
     let raw_user_metadata = desc
         .raw_description
         .execution_config
@@ -1025,6 +1038,13 @@ async fn describe_decodes_user_metadata_with_ungated_xor_codec() {
     );
     assert_eq!(
         desc.memo().get::<String>("tracked").unwrap(),
+        Some("codec-describe".to_owned())
+    );
+    assert_eq!(
+        desc.memo()
+            .get::<TrackedWrapper>("wrapped")
+            .unwrap()
+            .map(|value| value.0.data),
         Some("codec-describe".to_owned())
     );
     // Making sure codec isn't used when decoding user metadata

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -953,8 +953,8 @@ async fn describe_decodes_workflow_payload_fields() {
         "Describe should have decoded response payloads"
     );
     assert_eq!(
-        desc.memo().unwrap().fields["tracked"],
-        "codec-describe".as_json_payload().unwrap()
+        desc.memo().get::<String>("tracked").unwrap(),
+        Some("codec-describe".to_owned())
     );
     let raw_user_metadata = desc
         .raw_description
@@ -1024,8 +1024,8 @@ async fn describe_decodes_user_metadata_with_ungated_xor_codec() {
         "Describe should have decoded response payloads"
     );
     assert_eq!(
-        desc.memo().unwrap().fields["tracked"],
-        "codec-describe".as_json_payload().unwrap()
+        desc.memo().get::<String>("tracked").unwrap(),
+        Some("codec-describe".to_owned())
     );
     // Making sure codec isn't used when decoding user metadata
     assert_eq!(desc.static_summary(), Some("codec summary"));

--- a/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
@@ -13,13 +13,12 @@ use temporalio_common::protos::{
         workflow_commands::{ActivityCancellationType, ScheduleActivity},
         workflow_completion::WorkflowActivationCompletion,
     },
-    temporal::api::{
-        common::v1::{Payload, RetryPolicy},
-        enums::v1::TimeoutType,
-    },
+    temporal::api::common::v1::{Payload, RetryPolicy},
 };
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{ActivityExecutionError, ActivityOptions, WorkflowContext, WorkflowResult};
+use temporalio_sdk::{
+    ActivityExecutionError, ActivityOptions, TimeoutType, WorkflowContext, WorkflowResult,
+};
 use temporalio_sdk_core::{
     prost_dur,
     replay::DEFAULT_ACTIVITY_TYPE,

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -883,7 +883,8 @@ async fn activity_metrics() {
                     retry_policy: RetryPolicy {
                         maximum_attempts: 1,
                         ..Default::default()
-                    },
+                    }
+                    .into(),
                     ..Default::default()
                 },
             );
@@ -894,7 +895,8 @@ async fn activity_metrics() {
                     retry_policy: RetryPolicy {
                         maximum_attempts: 1,
                         ..Default::default()
-                    },
+                    }
+                    .into(),
                     ..Default::default()
                 },
             );

--- a/crates/sdk-core/tests/integ_tests/visibility_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/visibility_tests.rs
@@ -1,17 +1,15 @@
 use crate::common::{CoreWfStarter, NAMESPACE, eventually, get_integ_client};
 use assert_matches::assert_matches;
 use std::{sync::Arc, time::Duration};
-use temporalio_client::{
-    Namespace, NamespacedClient, RegisterNamespaceOptions, grpc::WorkflowService,
-};
+use temporalio_client::{NamespacedClient, RegisterNamespaceOptions, grpc::WorkflowService};
 use temporalio_common::protos::{
     coresdk::workflow_activation::{WorkflowActivationJob, workflow_activation_job},
     temporal::api::{
         filter::v1::{StartTimeFilter, WorkflowExecutionFilter},
         workflowservice::v1::{
-            ListClosedWorkflowExecutionsRequest, ListOpenWorkflowExecutionsRequest,
-            RegisterNamespaceRequest, list_closed_workflow_executions_request,
-            list_open_workflow_executions_request,
+            DescribeNamespaceRequest, ListClosedWorkflowExecutionsRequest,
+            ListOpenWorkflowExecutionsRequest, RegisterNamespaceRequest,
+            list_closed_workflow_executions_request, list_open_workflow_executions_request,
         },
     },
 };
@@ -152,9 +150,11 @@ async fn client_create_namespace() {
         attempts += 1;
         let resp = WorkflowService::describe_namespace(
             &mut client.as_ref().clone(),
-            Namespace::Name(register_options.namespace.clone())
-                .into_describe_namespace_request()
-                .into_request(),
+            DescribeNamespaceRequest {
+                namespace: register_options.namespace.clone(),
+                ..Default::default()
+            }
+            .into_request(),
         )
         .await;
 
@@ -181,9 +181,11 @@ async fn client_describe_namespace() {
 
     let namespace_result = WorkflowService::describe_namespace(
         &mut client.as_ref().clone(),
-        Namespace::Name(NAMESPACE.to_owned())
-            .into_describe_namespace_request()
-            .into_request(),
+        DescribeNamespaceRequest {
+            namespace: NAMESPACE.to_owned(),
+            ..Default::default()
+        }
+        .into_request(),
     )
     .await
     .unwrap()

--- a/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
@@ -11,7 +11,7 @@ use temporalio_common::{
         },
         temporal::api::{
             common::v1::WorkflowExecution,
-            enums::v1::{RoutingConfigUpdateState, VersioningBehavior},
+            enums::v1::{RoutingConfigUpdateState, VersioningBehavior as ProtoVersioningBehavior},
             history::v1::history_event::Attributes,
             workflowservice::v1::{
                 DescribeWorkerDeploymentRequest, DescribeWorkflowExecutionRequest,
@@ -19,7 +19,9 @@ use temporalio_common::{
             },
         },
     },
-    worker::{WorkerDeploymentOptions, WorkerDeploymentVersion, WorkerTaskTypes},
+    worker::{
+        VersioningBehavior, WorkerDeploymentOptions, WorkerDeploymentVersion, WorkerTaskTypes,
+    },
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
@@ -43,7 +45,7 @@ async fn sets_deployment_info_on_task_responses(#[values(true, false)] use_defau
     starter.sdk_config.deployment_options = WorkerDeploymentOptions {
         version: version.clone(),
         use_worker_versioning: true,
-        default_versioning_behavior: VersioningBehavior::AutoUpgrade.into(),
+        default_versioning_behavior: Some(VersioningBehavior::AutoUpgrade),
     };
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let core = starter.get_worker().await;
@@ -62,7 +64,7 @@ async fn sets_deployment_info_on_task_responses(#[values(true, false)] use_defau
             CompleteWorkflowExecution { result: None }.into(),
         ]);
         if !use_default {
-            success_complete.versioning_behavior = VersioningBehavior::Pinned.into();
+            success_complete.versioning_behavior = ProtoVersioningBehavior::Pinned.into();
         }
         core.complete_workflow_activation(WorkflowActivationCompletion {
             run_id: res.run_id.clone(),
@@ -133,12 +135,12 @@ async fn sets_deployment_info_on_task_responses(#[values(true, false)] use_defau
     if use_default {
         assert_eq!(
             wft_complete.versioning_behavior,
-            VersioningBehavior::AutoUpgrade as i32
+            ProtoVersioningBehavior::AutoUpgrade as i32
         );
     } else {
         assert_eq!(
             wft_complete.versioning_behavior,
-            VersioningBehavior::Pinned as i32
+            ProtoVersioningBehavior::Pinned as i32
         );
     }
     assert_eq!(wft_complete.worker_deployment_name, deploy_name);
@@ -177,7 +179,7 @@ async fn activity_has_deployment_stamp() {
             build_id: "1.0".to_string(),
         },
         use_worker_versioning: true,
-        default_versioning_behavior: VersioningBehavior::AutoUpgrade.into(),
+        default_versioning_behavior: Some(VersioningBehavior::AutoUpgrade),
     };
     starter.sdk_config.register_activities(StdActivities);
     let mut worker = starter.worker().await;
@@ -577,7 +579,7 @@ fn versioned_worker_options(version: WorkerDeploymentVersion) -> WorkerDeploymen
     WorkerDeploymentOptions {
         version,
         use_worker_versioning: true,
-        default_versioning_behavior: VersioningBehavior::Pinned.into(),
+        default_versioning_behavior: Some(VersioningBehavior::Pinned),
     }
 }
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1067,9 +1067,7 @@ async fn workflow_observes_non_retryable_activity() {
             };
             assert_eq!(fail_err.activity_id(), "non-retryable-act");
             assert_eq!(
-                fail_err
-                    .activity_type()
-                    .map(|activity_type| activity_type.name.as_str()),
+                fail_err.activity_type(),
                 Some(NonRetryableActivityErrorActivities::fail_non_retryable.name())
             );
             assert_eq!(fail_err.retry_state(), RetryState::NonRetryableFailure);
@@ -1963,9 +1961,7 @@ async fn activity_can_be_cancelled_by_local_timeout() {
             };
             assert_eq!(timeout.timeout_type(), TimeoutType::StartToClose);
             assert_eq!(
-                fail_err
-                    .activity_type()
-                    .map(|activity_type| activity_type.name.as_str()),
+                fail_err.activity_type(),
                 Some(CancellableEchoActivities::cancellable_echo.name())
             );
             Ok(())

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -42,7 +42,7 @@ use temporalio_common::{
             workflow_completion::WorkflowActivationCompletion,
         },
         temporal::api::{
-            common::v1::{ActivityType, Payload, Payloads, RetryPolicy},
+            common::v1::{ActivityType, Payload, RetryPolicy},
             enums::v1::{CommandType, EventType, RetryState as ProtoRetryState},
             failure::v1::{ActivityFailureInfo, Failure, failure::FailureInfo},
             sdk::v1::UserMetadata,
@@ -1537,9 +1537,7 @@ async fn async_activity_completion_workflow() {
         .get_client()
         .await
         .get_async_activity_handle(ActivityIdentifier::TaskToken(task.task_token.into()))
-        .complete(Some(Payloads {
-            payloads: vec![response_payload.clone()],
-        }))
+        .complete(Some(RawValue::new(vec![response_payload.clone()])))
         .await
         .unwrap();
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -43,7 +43,7 @@ use temporalio_common::{
         },
         temporal::api::{
             common::v1::{ActivityType, Payload, Payloads, RetryPolicy},
-            enums::v1::{CommandType, EventType, RetryState, TimeoutType},
+            enums::v1::{CommandType, EventType, RetryState as ProtoRetryState},
             failure::v1::{ActivityFailureInfo, Failure, failure::FailureInfo},
             sdk::v1::UserMetadata,
         },
@@ -51,8 +51,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityExecutionError, ActivityOptions, CancellableFuture, LocalActivityOptions,
-    WorkflowContext, WorkflowResult,
+    ActivityExecutionError, ActivityOptions, CancellableFuture, LocalActivityOptions, RetryState,
+    TimeoutType, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
     interceptors::{
         ActivityInboundInterceptor, ExecuteActivityInput, ExecuteActivityOutput,
@@ -955,7 +955,7 @@ async fn activity_non_retryable_failure() {
                     scheduled_event_id: 5,
                     started_event_id: 6,
                     identity: INTEG_CLIENT_IDENTITY.to_owned(),
-                    retry_state: RetryState::NonRetryableFailure as i32,
+                    retry_state: ProtoRetryState::NonRetryableFailure as i32,
                 })),
                 ..Default::default()
             });
@@ -1022,7 +1022,7 @@ async fn activity_non_retryable_failure_with_error() {
                     scheduled_event_id: 5,
                     started_event_id: 6,
                     identity: INTEG_CLIENT_IDENTITY.to_owned(),
-                    retry_state: RetryState::NonRetryableFailure as i32,
+                    retry_state: ProtoRetryState::NonRetryableFailure as i32,
                 })),
                 ..Default::default()
             });

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -630,9 +630,7 @@ impl GrandchildCancellationWf {
             panic!("child should fail with a child-workflow failure");
         };
         assert_eq!(
-            failure
-                .workflow_execution()
-                .map(|wf| wf.workflow_id.as_str()),
+            failure.workflow_execution().map(|wf| wf.workflow_id()),
             Some(child_workflow_id.as_str())
         );
         assert_eq!(
@@ -647,7 +645,7 @@ impl GrandchildCancellationWf {
         assert_eq!(
             grandchild_failure
                 .workflow_execution()
-                .map(|wf| wf.workflow_id.as_str()),
+                .map(|wf| wf.workflow_id()),
             Some(grandchild_workflow_id.as_str())
         );
         assert_eq!(grandchild_failure.workflow_type(), Some("grandchild_wf"));
@@ -936,9 +934,7 @@ impl ParentWf {
             (Expectation::Success, Ok(_)) => Ok(()),
             (Expectation::Failure, Err(ChildWorkflowExecutionError::Failed(failure))) => {
                 assert_eq!(
-                    failure
-                        .workflow_execution()
-                        .map(|wf| wf.workflow_id.as_str()),
+                    failure.workflow_execution().map(|wf| wf.workflow_id()),
                     Some("child-id-1")
                 );
                 assert_eq!(failure.workflow_type(), Some("child"));

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -11,7 +11,7 @@ use temporalio_common::{
         coresdk::{
             AsJsonPayloadExt,
             child_workflow::{
-                ChildWorkflowCancellationType, ParentClosePolicy,
+                ChildWorkflowCancellationType as ProtoChildWorkflowCancellationType,
                 StartChildWorkflowExecutionFailedCause,
             },
             workflow_activation::{WorkflowActivationJob, workflow_activation_job},
@@ -34,8 +34,9 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    CancellableFuture, ChildWorkflowExecutionError, ChildWorkflowOptions, ChildWorkflowStartError,
-    SyncWorkflowContext, WorkflowContext, WorkflowResult, WorkflowSignalError, WorkflowTermination,
+    CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowExecutionError,
+    ChildWorkflowOptions, ChildWorkflowStartError, ParentClosePolicy, SyncWorkflowContext,
+    WorkflowContext, WorkflowResult, WorkflowSignalError, WorkflowTermination,
 };
 use temporalio_sdk_core::{
     replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
@@ -1098,7 +1099,7 @@ async fn cancel_child_before_started_event() {
             seq: 1,
             workflow_id: "child-id-1".to_string(),
             workflow_type: "child".to_string(),
-            cancellation_type: ChildWorkflowCancellationType::WaitCancellationCompleted as i32,
+            cancellation_type: ProtoChildWorkflowCancellationType::WaitCancellationCompleted as i32,
             ..Default::default()
         }
         .into(),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -642,7 +642,7 @@ impl GrandchildCancellationWf {
             Some(child_workflow_id.as_str())
         );
         assert_eq!(
-            failure.workflow_type().map(|wf| wf.name.as_str()),
+            failure.workflow_type(),
             Some("child_propagates_cancellation")
         );
         let grandchild_workflow_id = format!("{}-grandchild", ctx.task_queue());
@@ -656,12 +656,7 @@ impl GrandchildCancellationWf {
                 .map(|wf| wf.workflow_id.as_str()),
             Some(grandchild_workflow_id.as_str())
         );
-        assert_eq!(
-            grandchild_failure
-                .workflow_type()
-                .map(|wf| wf.name.as_str()),
-            Some("grandchild_wf")
-        );
+        assert_eq!(grandchild_failure.workflow_type(), Some("grandchild_wf"));
         let Some(cancelled) = grandchild_failure.as_cancelled() else {
             panic!("grandchild failure should retain the cancelled reason");
         };
@@ -952,10 +947,7 @@ impl ParentWf {
                         .map(|wf| wf.workflow_id.as_str()),
                     Some("child-id-1")
                 );
-                assert_eq!(
-                    failure.workflow_type().map(|wf| wf.name.as_str()),
-                    Some("child")
-                );
+                assert_eq!(failure.workflow_type(), Some("child"));
                 Ok(())
             }
             _ => Err(anyhow!("Unexpected child WF status").into()),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -59,17 +59,10 @@ struct ChildWf;
 impl ChildWf {
     #[run(name = "child_wf")]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        let info = ctx.info();
         assert_eq!(
-            ctx.workflow_initial_info()
-                .parent_workflow_info
-                .as_ref()
-                .unwrap()
-                .workflow_id,
-            ctx.workflow_initial_info()
-                .root_workflow
-                .as_ref()
-                .unwrap()
-                .workflow_id
+            info.parent.as_ref().unwrap().workflow_id,
+            info.root.as_ref().unwrap().workflow_id
         );
         Ok(())
     }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -61,8 +61,8 @@ impl ChildWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let info = ctx.info();
         assert_eq!(
-            info.parent.as_ref().unwrap().workflow_id,
-            info.root.as_ref().unwrap().workflow_id
+            info.parent().as_ref().unwrap().workflow_id(),
+            info.root().as_ref().unwrap().workflow_id()
         );
         Ok(())
     }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/eager.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/eager.rs
@@ -114,7 +114,7 @@ pub(crate) async fn eager_start(
                 search_attributes: options.search_attributes.map(|d| d.into_proto()),
                 cron_schedule: options.cron_schedule.unwrap_or_default(),
                 request_eager_execution: options.enable_eager_workflow_start,
-                retry_policy: options.retry_policy,
+                retry_policy: options.retry_policy.map(Into::into),
                 links: options.links,
                 completion_callbacks: options.completion_callbacks,
                 priority: Some(options.priority.into()),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -37,7 +37,9 @@ use temporalio_common::{
         temporal::api::{
             command::v1::{RecordMarkerCommandAttributes, command},
             common::v1::RetryPolicy,
-            enums::v1::{CommandType, EventType, TimeoutType, WorkflowTaskFailedCause},
+            enums::v1::{
+                CommandType, EventType, TimeoutType as ProtoTimeoutType, WorkflowTaskFailedCause,
+            },
             failure::v1::Failure,
             history::v1::history_event::Attributes::MarkerRecordedEventAttributes,
             query::v1::WorkflowQuery,
@@ -47,7 +49,7 @@ use temporalio_common::{
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityExecutionError, ActivityOptions, ApplicationFailure, CancellableFuture,
-    LocalActivityOptions, WorkflowContext, WorkflowContextView, WorkflowResult,
+    LocalActivityOptions, TimeoutType, WorkflowContext, WorkflowContextView, WorkflowResult,
     activities::{ActivityContext, ActivityError},
     interceptors::{FailOnNondeterminismInterceptor, WorkerInterceptor},
 };
@@ -636,7 +638,7 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
         #[run]
         async fn run(
             ctx: &mut WorkflowContext<Self>,
-            (sched, start, timeout_type): (Option<Duration>, Option<Duration>, i32),
+            (sched, start, is_schedule): (Option<Duration>, Option<Duration>, bool),
         ) -> WorkflowResult<()> {
             let res = ctx
                 .start_local_activity(
@@ -659,10 +661,12 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
                 .await;
             let err = res.unwrap_err();
             let timeout = err.as_timeout().unwrap();
-            assert_eq!(
-                timeout.timeout_type(),
-                TimeoutType::try_from(timeout_type).unwrap()
-            );
+            let expected_timeout = if is_schedule {
+                TimeoutType::ScheduleToClose
+            } else {
+                TimeoutType::StartToClose
+            };
+            assert_eq!(timeout.timeout_type(), expected_timeout);
             Ok(())
         }
     }
@@ -673,18 +677,13 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
     } else {
         (None, Some(Duration::from_secs(2)))
     };
-    let timeout_type = if is_schedule {
-        TimeoutType::ScheduleToClose
-    } else {
-        TimeoutType::StartToClose
-    };
     worker.register_workflow::<XToCloseTimeoutWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
         .submit_workflow(
             XToCloseTimeoutWf::run,
-            (sched, start, timeout_type as i32),
+            (sched, start, is_schedule),
             WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
         )
         .await
@@ -2127,7 +2126,7 @@ async fn start_to_close_timeout_allows_retries(#[values(true, false)] la_complet
             1,
             "1",
             None,
-            Some(Failure::timeout(TimeoutType::StartToClose)),
+            Some(Failure::timeout(ProtoTimeoutType::StartToClose)),
             |_| {},
         );
     }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -2002,11 +2002,7 @@ async fn test_schedule_to_start_timeout() {
                     panic!("expected timeout cause, got {fail:?}");
                 };
                 assert_eq!(timeout.timeout_type(), TimeoutType::ScheduleToStart);
-                assert_eq!(
-                    fail.activity_type()
-                        .map(|activity_type| activity_type.name.as_str()),
-                    Some(StdActivities::echo.name())
-                );
+                assert_eq!(fail.activity_type(), Some(StdActivities::echo.name()));
             }
             Ok(())
         }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -300,7 +300,8 @@ impl LocalActRetryTimerBackoff {
                         maximum_interval: Some(prost_dur!(from_millis(1500))),
                         maximum_attempts: 4,
                         non_retryable_error_types: vec![],
-                    },
+                    }
+                    .into(),
                     timer_backoff_threshold: Some(Duration::from_secs(1)),
                     ..Default::default()
                 },
@@ -542,7 +543,8 @@ async fn cancel_after_act_starts(
                         maximum_interval: Some(bo_dur.try_into().unwrap()),
                         // Retry forever until cancelled
                         ..Default::default()
-                    },
+                    }
+                    .into(),
                     timer_backoff_threshold: Some(Duration::from_secs(1)),
                     cancel_type,
                     ..Default::default()
@@ -651,7 +653,8 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
                             maximum_interval: Some(prost_dur!(from_millis(1500))),
                             maximum_attempts: 4,
                             non_retryable_error_types: vec![],
-                        },
+                        }
+                        .into(),
                         timer_backoff_threshold: Some(Duration::from_secs(1)),
                         schedule_to_close_timeout: sched,
                         start_to_close_timeout: start,
@@ -724,7 +727,8 @@ async fn schedule_to_close_timeout_across_timer_backoff(#[case] cached: bool) {
                             maximum_interval: Some(prost_dur!(from_millis(1000))),
                             maximum_attempts: 40,
                             non_retryable_error_types: vec![],
-                        },
+                        }
+                        .into(),
                         timer_backoff_threshold: Some(Duration::from_millis(500)),
                         schedule_to_close_timeout: Some(Duration::from_secs(2)),
                         ..Default::default()
@@ -805,7 +809,8 @@ async fn timer_backoff_concurrent_with_non_timer_backoff() {
                         maximum_interval: Some(prost_dur!(from_millis(1500))),
                         maximum_attempts: 4,
                         non_retryable_error_types: vec![],
-                    },
+                    }
+                    .into(),
                     timer_backoff_threshold: Some(Duration::from_secs(1)),
                     ..Default::default()
                 },
@@ -820,7 +825,8 @@ async fn timer_backoff_concurrent_with_non_timer_backoff() {
                         maximum_interval: Some(prost_dur!(from_millis(1500))),
                         maximum_attempts: 4,
                         non_retryable_error_types: vec![],
-                    },
+                    }
+                    .into(),
                     timer_backoff_threshold: Some(Duration::from_secs(10)),
                     ..Default::default()
                 },
@@ -874,7 +880,8 @@ async fn repro_nondeterminism_with_timer_bug() {
                         maximum_interval: Some(prost_dur!(from_millis(1500))),
                         maximum_attempts: 4,
                         non_retryable_error_types: vec![],
-                    },
+                    }
+                    .into(),
                     timer_backoff_threshold: Some(Duration::from_secs(1)),
                     ..Default::default()
                 },
@@ -1520,7 +1527,8 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
                             maximum_interval: None,
                             maximum_attempts: 5,
                             non_retryable_error_types: vec![],
-                        },
+                        }
+                        .into(),
                         ..Default::default()
                     },
                 )
@@ -1621,7 +1629,8 @@ async fn local_act_retry_long_backoff_uses_timer() {
                             maximum_interval: Some(prost_dur!(from_secs(600))),
                             maximum_attempts: 3,
                             non_retryable_error_types: vec![],
-                        },
+                        }
+                        .into(),
                         ..Default::default()
                     },
                 )
@@ -2086,7 +2095,8 @@ async fn test_schedule_to_start_timeout_not_based_on_original_time(
                             maximum_interval: None,
                             maximum_attempts: 5,
                             non_retryable_error_types: vec![],
-                        },
+                        }
+                        .into(),
                         schedule_to_start_timeout: Some(Duration::from_secs(60)),
                         schedule_to_close_timeout,
                         ..Default::default()
@@ -2162,7 +2172,8 @@ async fn start_to_close_timeout_allows_retries(#[values(true, false)] la_complet
                             maximum_interval: None,
                             maximum_attempts: 5,
                             non_retryable_error_types: vec![],
-                        },
+                        }
+                        .into(),
                         start_to_close_timeout: Some(prost_dur!(from_millis(25))),
                         ..Default::default()
                     },
@@ -2379,7 +2390,8 @@ async fn local_act_records_nonfirst_attempts_ok() {
                         maximum_interval: None,
                         maximum_attempts: 0,
                         non_retryable_error_types: vec![],
-                    },
+                    }
+                    .into(),
                     ..Default::default()
                 },
             )
@@ -2697,7 +2709,8 @@ async fn local_act_retry_explicit_delay() {
                             backoff_coefficient: 1.0,
                             maximum_attempts: 5,
                             ..Default::default()
-                        },
+                        }
+                        .into(),
                         ..Default::default()
                     },
                 )
@@ -2761,7 +2774,8 @@ impl LaWf {
                     retry_policy: RetryPolicy {
                         maximum_attempts: 1,
                         ..Default::default()
-                    },
+                    }
+                    .into(),
                     ..Default::default()
                 },
             )

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -28,7 +28,8 @@ use temporalio_common::{
             activity_result::ActivityExecutionResult,
             workflow_activation::{WorkflowActivationJob, workflow_activation_job},
             workflow_commands::{
-                ActivityCancellationType, ScheduleLocalActivity, workflow_command::Variant,
+                ActivityCancellationType as ProtoActivityCancellationType, ScheduleLocalActivity,
+                workflow_command::Variant,
             },
             workflow_completion::{
                 self, WorkflowActivationCompletion, workflow_activation_completion,
@@ -48,8 +49,9 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityExecutionError, ActivityOptions, ApplicationFailure, CancellableFuture,
-    LocalActivityOptions, TimeoutType, WorkflowContext, WorkflowContextView, WorkflowResult,
+    ActivityCancellationType, ActivityExecutionError, ActivityOptions, ApplicationFailure,
+    CancellableFuture, LocalActivityOptions, TimeoutType, WorkflowContext, WorkflowContextView,
+    WorkflowResult,
     activities::{ActivityContext, ActivityError},
     interceptors::{FailOnNondeterminismInterceptor, WorkerInterceptor},
 };
@@ -341,8 +343,6 @@ async fn local_act_retry_timer_backoff() {
 #[case::abandon(ActivityCancellationType::Abandon)]
 #[tokio::test]
 async fn cancel_immediate(#[case] cancel_type: ActivityCancellationType) {
-    use temporalio_sdk::WorkflowContextView;
-
     let wf_name = format!("cancel_immediate_{cancel_type:?}");
     // If we don't use this, we'd hang on shutdown for abandon cancel modes.
     let manual_cancel = CancellationToken::new();
@@ -1764,7 +1764,7 @@ async fn query_during_wft_heartbeat_doesnt_accidentally_fail_to_continue_heartbe
             schedule_local_activity_cmd(
                 1,
                 "1",
-                ActivityCancellationType::TryCancel,
+                ProtoActivityCancellationType::TryCancel,
                 Duration::from_secs(60),
             ),
         ))
@@ -1907,7 +1907,7 @@ async fn la_resolve_during_legacy_query_does_not_combine(#[case] impossible_quer
             schedule_local_activity_cmd(
                 1,
                 "act-id",
-                ActivityCancellationType::TryCancel,
+                ProtoActivityCancellationType::TryCancel,
                 Duration::from_secs(60),
             ),
         ))
@@ -2521,7 +2521,7 @@ async fn queries_can_be_received_while_heartbeating() {
         schedule_local_activity_cmd(
             1,
             "act-id",
-            ActivityCancellationType::TryCancel,
+            ProtoActivityCancellationType::TryCancel,
             Duration::from_secs(60),
         ),
     ))

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/modify_wf_properties.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/modify_wf_properties.rs
@@ -4,17 +4,16 @@ use temporalio_client::{
 };
 use temporalio_common::{
     protos::{
-        coresdk::{AsJsonPayloadExt, FromJsonPayloadExt},
+        coresdk::FromJsonPayloadExt,
         temporal::api::{
             command::v1::{Command, command},
-            common::v1::Payload,
             enums::v1::EventType,
         },
     },
     worker::WorkerTaskTypes,
 };
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{WorkflowContext, WorkflowResult};
+use temporalio_sdk::{MemoValue, WorkflowContext, WorkflowResult};
 use temporalio_sdk_core::{
     replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
     test_help::MockPollCfg,
@@ -23,6 +22,7 @@ use uuid::Uuid;
 
 static FIELD_A: &str = "cat_name";
 static FIELD_B: &str = "cute_level";
+static REMOVED_FIELD: &str = "temporary";
 
 #[workflow]
 #[derive(Default)]
@@ -33,9 +33,14 @@ impl MemoUpserter {
     #[run(name = "can_upsert_memo")]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.upsert_memo([
-            (FIELD_A.to_string(), "enchi".as_json_payload().unwrap()),
-            (FIELD_B.to_string(), 9001.as_json_payload().unwrap()),
-        ]);
+            (FIELD_A, Some(MemoValue::new("enchi".to_string()))),
+            (FIELD_B, Some(MemoValue::new(9001))),
+            (REMOVED_FIELD, Some(MemoValue::new(true))),
+        ])?;
+        assert_eq!(ctx.memo().get::<bool>(REMOVED_FIELD)?, Some(true));
+
+        ctx.upsert_memo([(REMOVED_FIELD, None)])?;
+        assert!(!ctx.memo().contains_key(REMOVED_FIELD));
         Ok(())
     }
 }
@@ -61,7 +66,7 @@ async fn sends_modify_wf_props() {
     worker.run_until_done().await.unwrap();
 
     let client = starter.get_client().await;
-    let memo = WorkflowExecutionInfo {
+    let description = WorkflowExecutionInfo {
         namespace: client.namespace(),
         workflow_id: wf_id.to_string(),
         run_id: Some(run_id),
@@ -70,20 +75,16 @@ async fn sends_modify_wf_props() {
     .bind_untyped(client.clone())
     .describe(WorkflowDescribeOptions::default())
     .await
-    .unwrap()
-    .raw_description
-    .workflow_execution_info
-    .unwrap()
-    .memo
-    .unwrap()
-    .fields;
-    let catname = memo.get(FIELD_A).unwrap();
-    let cuteness = memo.get(FIELD_B).unwrap();
-    for payload in [catname, cuteness] {
-        assert!(payload.is_json_payload());
-    }
-    assert_eq!("enchi", String::from_json_payload(catname).unwrap());
-    assert_eq!(9001, usize::from_json_payload(cuteness).unwrap());
+    .unwrap();
+    assert_eq!(
+        description.memo().get::<String>(FIELD_A).unwrap(),
+        Some("enchi".to_string())
+    );
+    assert_eq!(
+        description.memo().get::<usize>(FIELD_B).unwrap(),
+        Some(9001)
+    );
+    assert!(!description.memo().contains_key(REMOVED_FIELD));
 }
 
 #[workflow]
@@ -95,21 +96,9 @@ impl ModifyPropsWf {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.upsert_memo([
-            (
-                String::from("foo"),
-                Payload {
-                    data: vec![0x01],
-                    ..Default::default()
-                },
-            ),
-            (
-                String::from("bar"),
-                Payload {
-                    data: vec![0x02],
-                    ..Default::default()
-                },
-            ),
-        ]);
+            ("foo", Some(MemoValue::new(1_u8))),
+            ("bar", Some(MemoValue::new(2_u8))),
+        ])?;
         Ok(())
     }
 }
@@ -137,8 +126,8 @@ async fn workflow_modify_props() {
                     let fields = &msg.upserted_memo.as_ref().unwrap().fields;
                     let payload1 = fields.get(k1).unwrap();
                     let payload2 = fields.get(k2).unwrap();
-                    assert_eq!(payload1.data[0], 0x01);
-                    assert_eq!(payload2.data[0], 0x02);
+                    assert_eq!(u8::from_json_payload(payload1).unwrap(), 1);
+                    assert_eq!(u8::from_json_payload(payload2).unwrap(), 2);
                     assert_eq!(fields.len(), 2);
                 }
             );

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
@@ -24,8 +24,8 @@ use temporalio_common::{
         coresdk::{
             FromJsonPayloadExt,
             nexus::{
-                NexusOperationCancellationType, NexusOperationResult, NexusTaskCancelReason,
-                NexusTaskCompletion, nexus_operation_result, nexus_task, nexus_task_completion,
+                NexusOperationResult, NexusTaskCancelReason, NexusTaskCompletion,
+                nexus_operation_result, nexus_task, nexus_task_completion,
             },
         },
         temporal::api::{
@@ -43,8 +43,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    CancellableFuture, NexusOperationOptions, SyncWorkflowContext, WorkflowContext,
-    WorkflowContextView, WorkflowResult, WorkflowTermination,
+    CancellableFuture, NexusOperationCancellationType, NexusOperationOptions, SyncWorkflowContext,
+    WorkflowContext, WorkflowContextView, WorkflowResult, WorkflowTermination,
 };
 use temporalio_sdk_core::PollError;
 use tokio::{
@@ -922,6 +922,7 @@ async fn nexus_cancellation_types(
                 // The nexus op future should have been resolved
                 assert!(*caller_op_future_rx.borrow())
             }
+            _ => unreachable!("test only supplies known cancellation types"),
         }
         let (cancel_handler_responded_tx, _cancel_handler_responded_rx) = watch::channel(false);
         if cancellation_type != NexusOperationCancellationType::Abandon {
@@ -1038,6 +1039,7 @@ async fn nexus_cancellation_types(
         | NexusOperationCancellationType::WaitCancellationCompleted => {
             assert!(*cancellation_rx.borrow())
         }
+        _ => unreachable!("test only supplies known cancellation types"),
     }
 
     let res = client
@@ -1070,6 +1072,7 @@ async fn nexus_cancellation_types(
             assert_eq!(f.message, "nexus operation completed unsuccessfully");
             assert_eq!(f.cause.unwrap().message, "operation canceled");
         }
+        _ => unreachable!("test only supplies known cancellation types"),
     }
 
     wf_handle

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/queries.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/queries.rs
@@ -317,12 +317,12 @@ struct WorkflowInfo {
 impl<'a> From<&'a WorkflowContextView> for WorkflowInfo {
     fn from(ctx: &'a WorkflowContextView) -> Self {
         Self {
-            workflow_id: ctx.workflow_id.clone(),
-            workflow_type: ctx.workflow_type.clone(),
-            task_queue: ctx.task_queue.clone(),
-            namespace: ctx.namespace.clone(),
-            attempt: ctx.attempt,
-            first_execution_run_id: ctx.first_execution_run_id.clone(),
+            workflow_id: ctx.workflow_id().to_owned(),
+            workflow_type: ctx.workflow_type().to_owned(),
+            task_queue: ctx.task_queue().to_owned(),
+            namespace: ctx.namespace().to_owned(),
+            attempt: ctx.attempt(),
+            first_execution_run_id: ctx.first_execution_run_id().to_owned(),
         }
     }
 }

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -2,9 +2,8 @@ use crate::common::CoreWfStarter;
 use std::time::Duration;
 use temporalio_client::{Priority, WorkflowGetResultOptions};
 use temporalio_common::{
-    UntypedWorkflow,
-    data_converters::RawValue,
-    protos::temporal::api::{common, history::v1::history_event::Attributes},
+    UntypedWorkflow, data_converters::RawValue,
+    protos::temporal::api::history::v1::history_event::Attributes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
@@ -98,12 +97,12 @@ pub(crate) async fn priority_values_sent_to_server() {
         #[run(name = "child-wf")]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             assert_eq!(
-                ctx.workflow_initial_info().priority,
-                Some(common::v1::Priority {
-                    priority_key: 4,
-                    fairness_key: "fair-child".to_string(),
-                    fairness_weight: 1.23
-                })
+                ctx.info().priority,
+                Priority {
+                    priority_key: Some(4),
+                    fairness_key: Some("fair-child".to_string()),
+                    fairness_weight: Some(1.23)
+                }
             );
             Ok(())
         }

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -97,7 +97,7 @@ pub(crate) async fn priority_values_sent_to_server() {
         #[run(name = "child-wf")]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             assert_eq!(
-                ctx.info().priority,
+                ctx.info().priority(),
                 Priority {
                     priority_key: Some(4),
                     fairness_key: Some("fair-child".to_string()),

--- a/crates/sdk/examples/activity_heartbeating/workflows.rs
+++ b/crates/sdk/examples/activity_heartbeating/workflows.rs
@@ -1,6 +1,5 @@
 #![allow(unreachable_pub)]
 use std::time::Duration;
-use temporalio_common::protos::coresdk::AsJsonPayloadExt;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, WorkflowContext, WorkflowResult,
@@ -18,18 +17,14 @@ impl HeartbeatingActivities {
         ctx: ActivityContext,
         total_steps: u32,
     ) -> Result<String, ActivityError> {
-        let start_step: u32 = ctx
-            .heartbeat_details()
-            .first()
-            .and_then(|p| serde_json::from_slice(&p.data).ok())
-            .unwrap_or(0);
+        let start_step: u32 = ctx.heartbeat_details().deserialize()?.unwrap_or(0);
 
         for step in start_step..total_steps {
             if ctx.is_cancelled() {
                 return Err(ActivityError::cancelled());
             }
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            ctx.record_heartbeat(vec![step.as_json_payload().unwrap()]);
+            ctx.record_heartbeat(step).await?;
         }
 
         Ok(format!("Completed {total_steps} steps"))

--- a/crates/sdk/examples/cancellation/workflows.rs
+++ b/crates/sdk/examples/cancellation/workflows.rs
@@ -19,7 +19,7 @@ impl CancellationActivities {
             if ctx.is_cancelled() {
                 return Err(ActivityError::cancelled());
             }
-            ctx.record_heartbeat(vec![]);
+            ctx.record_heartbeat(()).await?;
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         }
     }

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -72,14 +72,14 @@ use std::{
 use temporalio_client::{Client, ClientOptions, Priority, WorkflowExecutionInfo, WorkflowHandle};
 pub use temporalio_common::ActivityError;
 use temporalio_common::{
-    ActivityDefinition, HasWorkflowDefinition, WorkflowExecution,
+    ActivityDefinition, HasWorkflowDefinition, RetryPolicy, WorkflowExecution,
     data_converters::{
         DataConverter, GenericPayloadConverter, SerializationContext, SerializationContextData,
     },
     error::ApplicationFailure,
     protos::{
         coresdk::{ActivityHeartbeat, activity_result::ActivityExecutionResult, activity_task},
-        temporal::api::common::v1::{Payload, RetryPolicy},
+        temporal::api::common::v1::Payload,
         utilities::TryIntoOrNone,
     },
 };
@@ -157,7 +157,7 @@ impl ActivityContext {
                     attempt,
                     current_attempt_scheduled_time: current_attempt_scheduled_time
                         .try_into_or_none(),
-                    retry_policy,
+                    retry_policy: retry_policy.map(Into::into),
                     is_local,
                     priority: priority.map(Into::into).unwrap_or_default(),
                     run_id: (!run_id.is_empty()).then_some(run_id),

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -74,7 +74,9 @@ pub use temporalio_common::ActivityError;
 use temporalio_common::{
     ActivityDefinition, HasWorkflowDefinition, RetryPolicy, WorkflowExecution,
     data_converters::{
-        DataConverter, GenericPayloadConverter, SerializationContext, SerializationContextData,
+        DataConverter, DecodablePayloads, GenericPayloadConverter, PayloadConversionError,
+        PayloadConverter, RawValue, SerializationContext, SerializationContextData,
+        TemporalDeserializable, TemporalSerializable,
     },
     error::ApplicationFailure,
     protos::{
@@ -92,14 +94,13 @@ pub struct ActivityContext {
     worker: Arc<CoreWorker>,
     client_options: ClientOptions,
     cancellation_token: CancellationToken,
-    heartbeat_details: Vec<Payload>,
+    heartbeat_details: ActivityHeartbeatDetails,
     header_fields: HashMap<String, Payload>,
     info: ActivityInfo,
 }
 
 impl ActivityContext {
-    /// Construct new Activity Context, returning the context and all arguments to the activity.
-    pub fn new(
+    pub(crate) fn new(
         worker: Arc<CoreWorker>,
         client_options: ClientOptions,
         cancellation_token: CancellationToken,
@@ -133,6 +134,10 @@ impl ActivityContext {
             started_time.as_ref(),
             start_to_close_timeout.as_ref(),
             schedule_to_close_timeout.as_ref(),
+        );
+        let heartbeat_details = ActivityHeartbeatDetails::new(
+            heartbeat_details,
+            client_options.data_converter.payload_converter().clone(),
         );
 
         (
@@ -180,18 +185,27 @@ impl ActivityContext {
 
     /// Extract heartbeat details from last failed attempt. This is used in combination with retry
     /// policy.
-    pub fn heartbeat_details(&self) -> &[Payload] {
+    pub fn heartbeat_details(&self) -> &ActivityHeartbeatDetails {
         &self.heartbeat_details
     }
 
-    /// RecordHeartbeat sends heartbeat for the currently executing activity
-    pub fn record_heartbeat(&self, details: Vec<Payload>) {
+    /// Record a heartbeat with typed progress details for the currently executing activity.
+    pub async fn record_heartbeat<T>(&self, details: T) -> Result<(), PayloadConversionError>
+    where
+        T: TemporalSerializable + 'static,
+    {
         if !self.info.is_local {
+            let details = self
+                .client_options
+                .data_converter
+                .to_payloads(&SerializationContextData::Activity, &details)
+                .await?;
             self.worker.record_activity_heartbeat(ActivityHeartbeat {
                 task_token: self.info.task_token.clone(),
                 details,
             })
         }
+        Ok(())
     }
 
     /// Returns activity info of the executing activity
@@ -232,6 +246,46 @@ impl ActivityContext {
 
     pub(crate) fn headers_mut(&mut self) -> &mut HashMap<String, Payload> {
         &mut self.header_fields
+    }
+}
+
+/// Heartbeat details supplied by the previous activity attempt.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct ActivityHeartbeatDetails {
+    payloads: DecodablePayloads,
+}
+
+impl ActivityHeartbeatDetails {
+    fn new(payloads: Vec<Payload>, payload_converter: PayloadConverter) -> Self {
+        Self {
+            payloads: DecodablePayloads::new(
+                payloads,
+                payload_converter,
+                SerializationContextData::Activity,
+            ),
+        }
+    }
+
+    /// Deserialize the previous heartbeat details, or return `None` when there are none.
+    pub fn deserialize<T: TemporalDeserializable + 'static>(
+        &self,
+    ) -> Result<Option<T>, PayloadConversionError> {
+        if self.payloads.raw().is_empty() {
+            Ok(None)
+        } else {
+            self.payloads.deserialize().map(Some)
+        }
+    }
+
+    /// Returns the codec-decoded raw heartbeat payloads.
+    pub fn raw(&self) -> &[Payload] {
+        self.payloads.raw()
+    }
+
+    /// Consume these details and return their codec-decoded payloads.
+    pub fn into_raw(self) -> RawValue {
+        self.payloads.into_raw()
     }
 }
 
@@ -522,6 +576,35 @@ mod test {
     use super::*;
     use rstest::rstest;
     use temporalio_common::error::{ApplicationErrorCategory, ApplicationFailure};
+
+    #[test]
+    fn activity_heartbeat_details_support_typed_decoding() {
+        let payload_converter = PayloadConverter::default();
+        let payload = payload_converter
+            .to_payload(
+                &SerializationContext {
+                    data: &SerializationContextData::Activity,
+                    converter: &payload_converter,
+                },
+                &"progress".to_owned(),
+            )
+            .unwrap();
+        let details = ActivityHeartbeatDetails::new(vec![payload.clone()], payload_converter);
+
+        assert_eq!(details.raw(), &[payload]);
+        assert_eq!(
+            details.deserialize::<String>().unwrap(),
+            Some("progress".to_owned())
+        );
+    }
+
+    #[test]
+    fn empty_activity_heartbeat_details_decode_to_none() {
+        let details = ActivityHeartbeatDetails::new(Vec::new(), PayloadConverter::default());
+
+        assert_eq!(details.deserialize::<String>().unwrap(), None);
+        assert!(details.into_raw().payloads.is_empty());
+    }
 
     #[rstest]
     #[case(true)]

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -226,13 +226,13 @@ impl ActivityContext {
     /// Return a workflow handle for the workflow execution that started this activity, if any.
     pub fn workflow_handle<W: HasWorkflowDefinition>(&self) -> Option<WorkflowHandle<Client, W>> {
         let workflow_execution = self.info.workflow_execution.as_ref()?;
-        let run_id =
-            (!workflow_execution.run_id.is_empty()).then_some(workflow_execution.run_id.clone());
+        let run_id = (!workflow_execution.run_id().is_empty())
+            .then(|| workflow_execution.run_id().to_owned());
         Some(WorkflowHandle::new(
             self.client(),
             WorkflowExecutionInfo {
                 namespace: self.client_options.namespace.clone(),
-                workflow_id: workflow_execution.workflow_id.clone(),
+                workflow_id: workflow_execution.workflow_id().to_owned(),
                 run_id: run_id.clone(),
                 first_execution_run_id: run_id,
             },

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -72,14 +72,14 @@ use std::{
 use temporalio_client::{Client, ClientOptions, Priority, WorkflowExecutionInfo, WorkflowHandle};
 pub use temporalio_common::ActivityError;
 use temporalio_common::{
-    ActivityDefinition, HasWorkflowDefinition,
+    ActivityDefinition, HasWorkflowDefinition, WorkflowExecution,
     data_converters::{
         DataConverter, GenericPayloadConverter, SerializationContext, SerializationContextData,
     },
     error::ApplicationFailure,
     protos::{
         coresdk::{ActivityHeartbeat, activity_result::ActivityExecutionResult, activity_task},
-        temporal::api::common::v1::{Payload, RetryPolicy, WorkflowExecution},
+        temporal::api::common::v1::{Payload, RetryPolicy},
         utilities::TryIntoOrNone,
     },
 };
@@ -147,7 +147,7 @@ impl ActivityContext {
                     task_queue,
                     workflow_type,
                     workflow_namespace,
-                    workflow_execution,
+                    workflow_execution: workflow_execution.map(Into::into),
                     activity_id,
                     activity_type,
                     heartbeat_timeout: heartbeat_timeout.try_into_or_none(),

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -4,5 +4,5 @@ pub use crate::workflow_registry::WorkflowRegistrationError;
 pub use temporalio_common::error::{
     ActivityExecutionError, ApplicationErrorCategory, ApplicationFailure,
     ChildWorkflowExecutionError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,
-    OutgoingWorkflowError, WorkflowSignalError,
+    OutgoingWorkflowError, RetryState, TimeoutType, WorkflowSignalError,
 };

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -89,12 +89,14 @@ pub use crate::error::{
 };
 pub use temporalio_client::Namespace;
 pub use temporalio_workflow::{
-    ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext, CancellableFuture,
-    ChildWorkflowOptions, ContinueAsNewOptions, ContinueAsNewVersioningBehavior,
-    ExternalWorkflowHandle, LocalActivityOptions, NexusOperationOptions, ParentWorkflowInfo,
+    ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
+    CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
+    ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions,
+    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy, ParentWorkflowInfo,
     RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
-    StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult, WorkflowContext,
-    WorkflowContextView, WorkflowResult, WorkflowTermination,
+    StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult, VersioningIntent,
+    WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy, WorkflowResult,
+    WorkflowTermination,
 };
 #[cfg(feature = "wasm-workflows")]
 pub use workflow_wasm::WasmWorkflowComponent;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1068,8 +1068,8 @@ impl ActivityHalf {
                     let act_fut = async move {
                         if let Some(info) = &ctx.info().workflow_execution {
                             Span::current()
-                                .record("temporalWorkflowID", &info.workflow_id)
-                                .record("temporalRunID", &info.run_id);
+                                .record("temporalWorkflowID", info.workflow_id())
+                                .record("temporalRunID", info.run_id());
                         }
                         (act_fn)(args, data_converter, ctx, activity_inbound_interceptors).await
                     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -91,7 +91,7 @@ pub use temporalio_client::Namespace;
 pub use temporalio_workflow::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
     CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
-    ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions,
+    ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions, Memo,
     NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy, ParentWorkflowInfo,
     RetryPolicy, RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
     StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult, VersioningIntent,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -85,7 +85,7 @@ pub mod workflows;
 pub use crate::error::{
     ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
     ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
-    WorkflowRegistrationError, WorkflowSignalError,
+    RetryState, TimeoutType, WorkflowRegistrationError, WorkflowSignalError,
 };
 pub use temporalio_client::Namespace;
 pub use temporalio_workflow::{

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -92,11 +92,11 @@ pub use temporalio_workflow::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
     CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
     ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions, Memo, MemoValue,
-    MemoValues, NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy,
-    ParentWorkflowInfo, RetryPolicy, RootWorkflowInfo, Signal, SignalData,
-    StartChildWorkflowExecutionFailedCause, StartedChildWorkflow, SyncWorkflowContext,
-    TimerOptions, TimerResult, VersioningIntent, WorkflowContext, WorkflowContextView,
-    WorkflowIdReusePolicy, WorkflowResult, WorkflowTermination,
+    MemoValues, NamespacedWorkflowInfo, NexusOperationCancellationType, NexusOperationOptions,
+    ParentClosePolicy, RetryPolicy, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
+    StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult, VersioningIntent,
+    WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy, WorkflowResult,
+    WorkflowTermination,
 };
 #[cfg(feature = "wasm-workflows")]
 pub use workflow_wasm::WasmWorkflowComponent;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -91,12 +91,12 @@ pub use temporalio_client::Namespace;
 pub use temporalio_workflow::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
     CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
-    ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions, Memo,
-    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy, ParentWorkflowInfo,
-    RetryPolicy, RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
-    StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult, VersioningIntent,
-    WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy, WorkflowResult,
-    WorkflowTermination,
+    ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions, Memo, MemoValue,
+    MemoValues, NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy,
+    ParentWorkflowInfo, RetryPolicy, RootWorkflowInfo, Signal, SignalData,
+    StartChildWorkflowExecutionFailedCause, StartedChildWorkflow, SyncWorkflowContext,
+    TimerOptions, TimerResult, VersioningIntent, WorkflowContext, WorkflowContextView,
+    WorkflowIdReusePolicy, WorkflowResult, WorkflowTermination,
 };
 #[cfg(feature = "wasm-workflows")]
 pub use workflow_wasm::WasmWorkflowComponent;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -93,7 +93,7 @@ pub use temporalio_workflow::{
     CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
     ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions,
     NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy, ParentWorkflowInfo,
-    RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
+    RetryPolicy, RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
     StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult, VersioningIntent,
     WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy, WorkflowResult,
     WorkflowTermination,

--- a/crates/sdk/src/workflow_registry.rs
+++ b/crates/sdk/src/workflow_registry.rs
@@ -184,7 +184,7 @@ fn workflow_input_parts(
     } = input;
     let payloads = init_workflow_job.arguments.clone();
     let payload_converter = data_converter.payload_converter().clone();
-    let base_ctx = BaseWorkflowContext::new(
+    let base_ctx = BaseWorkflowContext::from_raw(
         namespace,
         task_queue,
         run_id,

--- a/crates/workflow/src/component.rs
+++ b/crates/workflow/src/component.rs
@@ -211,7 +211,7 @@ where
     let args = init.initialize_workflow.arguments.clone();
     let data_converter = DataConverter::default();
     let payload_converter = data_converter.payload_converter().clone();
-    let base_ctx = BaseWorkflowContext::new(
+    let base_ctx = BaseWorkflowContext::from_raw(
         init.namespace,
         init.task_queue,
         init.run_id,

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -26,9 +26,12 @@ pub use runtime::model::{CancellableID, UnblockEvent};
 pub use runtime::model::{TimerResult, WorkflowResult, WorkflowTermination};
 #[doc(hidden)]
 pub use runtime::{SdkWakeGuard, is_sdk_wake};
-pub use temporalio_common_wasm::error::{
-    ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError, RetryState,
-    TimeoutType, WorkflowSignalError,
+pub use temporalio_common_wasm::{
+    RetryPolicy,
+    error::{
+        ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError, RetryState,
+        TimeoutType, WorkflowSignalError,
+    },
 };
 pub use workflow_context::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -16,11 +16,13 @@ pub mod __private {
 
 #[doc(hidden)]
 pub mod component;
+mod memo;
 #[doc(hidden)]
 pub mod runtime;
 mod workflow_context;
 pub mod workflows;
 
+pub use memo::{MemoValue, MemoValues};
 #[doc(hidden)]
 pub use runtime::model::{CancellableID, UnblockEvent};
 pub use runtime::model::{TimerResult, WorkflowResult, WorkflowTermination};

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -39,8 +39,8 @@ pub use workflow_context::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
     CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
     ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions,
-    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy, ParentWorkflowInfo,
-    RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
+    NamespacedWorkflowInfo, NexusOperationCancellationType, NexusOperationOptions,
+    ParentClosePolicy, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
     StartedChildWorkflow, SyncWorkflowContext, TimerOptions, VersioningIntent, WorkflowContext,
     WorkflowContextView, WorkflowIdReusePolicy,
 };

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -27,7 +27,7 @@ pub use runtime::model::{TimerResult, WorkflowResult, WorkflowTermination};
 #[doc(hidden)]
 pub use runtime::{SdkWakeGuard, is_sdk_wake};
 pub use temporalio_common_wasm::{
-    RetryPolicy,
+    Memo, RetryPolicy,
     error::{
         ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError, RetryState,
         TimeoutType, WorkflowSignalError,

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -31,11 +31,13 @@ pub use temporalio_common_wasm::error::{
     TimeoutType, WorkflowSignalError,
 };
 pub use workflow_context::{
-    ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext, CancellableFuture,
-    ChildWorkflowOptions, ContinueAsNewOptions, ContinueAsNewVersioningBehavior,
-    ExternalWorkflowHandle, LocalActivityOptions, NexusOperationOptions, ParentWorkflowInfo,
+    ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
+    CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
+    ContinueAsNewVersioningBehavior, ExternalWorkflowHandle, LocalActivityOptions,
+    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy, ParentWorkflowInfo,
     RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
-    StartedChildWorkflow, SyncWorkflowContext, TimerOptions, WorkflowContext, WorkflowContextView,
+    StartedChildWorkflow, SyncWorkflowContext, TimerOptions, VersioningIntent, WorkflowContext,
+    WorkflowContextView, WorkflowIdReusePolicy,
 };
 pub use workflows::{join, join_all, select};
 

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -27,8 +27,8 @@ pub use runtime::model::{TimerResult, WorkflowResult, WorkflowTermination};
 #[doc(hidden)]
 pub use runtime::{SdkWakeGuard, is_sdk_wake};
 pub use temporalio_common_wasm::error::{
-    ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
-    WorkflowSignalError,
+    ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError, RetryState,
+    TimeoutType, WorkflowSignalError,
 };
 pub use workflow_context::{
     ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext, CancellableFuture,

--- a/crates/workflow/src/memo.rs
+++ b/crates/workflow/src/memo.rs
@@ -1,0 +1,124 @@
+use std::{collections::BTreeMap, rc::Rc};
+
+use temporalio_common_wasm::{
+    data_converters::{
+        GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
+        SerializationContextData, TemporalSerializable,
+    },
+    protos::temporal::api::common::v1::Payload,
+};
+
+trait SerializableMemoValue {
+    fn to_payload(
+        &self,
+        payload_converter: &PayloadConverter,
+    ) -> Result<Payload, PayloadConversionError>;
+}
+
+impl<T> SerializableMemoValue for T
+where
+    T: TemporalSerializable + 'static,
+{
+    fn to_payload(
+        &self,
+        payload_converter: &PayloadConverter,
+    ) -> Result<Payload, PayloadConversionError> {
+        payload_converter.to_payload(
+            &SerializationContext {
+                data: &SerializationContextData::Workflow,
+                converter: payload_converter,
+            },
+            self,
+        )
+    }
+}
+
+/// A typed value used in a workflow memo update.
+#[derive(Clone, derive_more::Debug)]
+#[non_exhaustive]
+pub struct MemoValue {
+    #[debug(skip)]
+    value: Rc<dyn SerializableMemoValue>,
+}
+
+impl MemoValue {
+    /// Create a memo value that will be serialized with the workflow's data converter.
+    pub fn new<T: TemporalSerializable + 'static>(value: T) -> Self {
+        Self {
+            value: Rc::new(value),
+        }
+    }
+
+    pub(crate) fn to_payload(
+        &self,
+        payload_converter: &PayloadConverter,
+    ) -> Result<Payload, PayloadConversionError> {
+        self.value.to_payload(payload_converter)
+    }
+}
+
+/// A complete set of memo values for a new workflow execution.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct MemoValues {
+    values: BTreeMap<String, MemoValue>,
+}
+
+impl MemoValues {
+    /// Create an empty set of memo values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add or replace a memo value.
+    pub fn insert<T>(&mut self, key: impl Into<String>, value: T) -> &mut Self
+    where
+        T: TemporalSerializable + 'static,
+    {
+        self.values.insert(key.into(), MemoValue::new(value));
+        self
+    }
+
+    pub(crate) fn encode(
+        &self,
+        payload_converter: &PayloadConverter,
+    ) -> Result<std::collections::HashMap<String, Payload>, PayloadConversionError> {
+        self.values
+            .iter()
+            .map(|(key, value)| {
+                value
+                    .to_payload(payload_converter)
+                    .map(|payload| (key.clone(), payload))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use temporalio_common_wasm::{Memo, protos::temporal::api::common::v1::Memo as ProtoMemo};
+
+    #[test]
+    fn memo_values_serialize_heterogeneous_values() {
+        let payload_converter = PayloadConverter::default();
+        let mut values = MemoValues::new();
+        values
+            .insert("count", 7_u32)
+            .insert("label", "hello".to_string());
+
+        let memo = Memo::from_raw(
+            Some(ProtoMemo {
+                fields: values.encode(&payload_converter).unwrap(),
+            }),
+            payload_converter,
+            SerializationContextData::Workflow,
+        );
+
+        assert_eq!(memo.get::<u32>("count").unwrap(), Some(7));
+        assert_eq!(
+            memo.get::<String>("label").unwrap(),
+            Some("hello".to_string())
+        );
+    }
+}

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -39,7 +39,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_common_wasm::{
-    ActivityDefinition, Memo, RetryPolicy, SignalDefinition, WorkflowDefinition,
+    ActivityDefinition, Memo, Priority, RetryPolicy, SignalDefinition, WorkflowDefinition,
     data_converters::{
         ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
         ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter,
@@ -119,7 +119,7 @@ impl BaseWorkflowContext {
             self.inner.namespace.clone(),
             self.inner.task_queue.clone(),
             self.inner.run_id.clone(),
-            &self.inner.inital_information,
+            &self.inner.initial_information,
             &shared.memo,
             self.inner.data_converter.payload_converter().clone(),
         )
@@ -220,7 +220,7 @@ struct WorkflowContextInner {
     namespace: String,
     task_queue: String,
     run_id: String,
-    inital_information: InitializeWorkflow,
+    initial_information: InitializeWorkflow,
     runtime: WorkflowRuntimeState,
     cancelled_reason: RefCell<Option<String>>,
     cancel_wakers: RefCell<Vec<Waker>>,
@@ -320,10 +320,13 @@ pub struct WorkflowContextView {
     pub retry_policy: Option<RetryPolicy>,
     /// If this workflow runs on a cron schedule
     pub cron_schedule: Option<String>,
+    /// Priority and fairness configuration for this workflow execution.
+    pub priority: Priority,
     /// User-defined memo values.
     pub memo: Memo,
     /// Initial search attributes as a typed collection.
     pub search_attributes: Option<SearchAttributes>,
+    raw: InitializeWorkflow,
 }
 
 /// Information about a parent workflow.
@@ -403,6 +406,7 @@ impl WorkflowContextView {
             root,
             retry_policy: init.retry_policy.clone().map(Into::into),
             cron_schedule,
+            priority: init.priority.clone().unwrap_or_default().into(),
             memo: Memo::from_raw(
                 Some(memo.clone()),
                 payload_converter,
@@ -412,14 +416,25 @@ impl WorkflowContextView {
                 .search_attributes
                 .as_ref()
                 .map(SearchAttributes::from_proto),
+            raw: init.clone(),
         }
+    }
+
+    /// Access the underlying workflow initialization protobuf.
+    pub fn raw(&self) -> &InitializeWorkflow {
+        &self.raw
+    }
+
+    /// Consume this view and return the underlying workflow initialization protobuf.
+    pub fn into_raw(self) -> InitializeWorkflow {
+        self.raw
     }
 }
 
 impl BaseWorkflowContext {
-    /// Create a new base context backed by the provided runtime host.
+    /// Construct a base context from raw workflow activation initialization data.
     #[doc(hidden)]
-    pub fn new(
+    pub fn from_raw(
         namespace: String,
         task_queue: String,
         run_id: String,
@@ -441,7 +456,7 @@ impl BaseWorkflowContext {
                         .unwrap_or_default(),
                     ..Default::default()
                 }),
-                inital_information: init_workflow_job,
+                initial_information: init_workflow_job,
                 runtime: WorkflowRuntimeState::new(host),
                 cancelled_reason: RefCell::new(None),
                 cancel_wakers: RefCell::new(Vec::new()),
@@ -759,7 +774,7 @@ impl BaseWorkflowContext {
 impl<W> SyncWorkflowContext<W> {
     /// Return the workflow's unique identifier
     pub fn workflow_id(&self) -> &str {
-        &self.base.inner.inital_information.workflow_id
+        &self.base.inner.initial_information.workflow_id
     }
 
     /// Return the run id of this workflow execution
@@ -866,10 +881,9 @@ impl<W> SyncWorkflowContext<W> {
         self.base.inner.data_converter.payload_converter()
     }
 
-    /// Return various information that the workflow was initialized with. Will eventually become
-    /// a proper non-proto workflow info struct.
-    pub fn workflow_initial_info(&self) -> &InitializeWorkflow {
-        &self.base.inner.inital_information
+    /// Return Rust-native information about this workflow execution.
+    pub fn info(&self) -> WorkflowContextView {
+        self.view()
     }
 
     /// A future that resolves if/when the workflow is cancelled, with the user provided cause
@@ -906,7 +920,7 @@ impl<W> SyncWorkflowContext<W> {
         let arguments = pc
             .to_payloads(&ctx, input)
             .map_err(WorkflowTermination::from)?;
-        let workflow_type = self.workflow_initial_info().workflow_type.clone();
+        let workflow_type = self.base.inner.initial_information.workflow_type.clone();
         let request = opts
             .into_request(workflow_type, arguments, pc)
             .map_err(WorkflowTermination::from)?;
@@ -1277,9 +1291,9 @@ impl<W> WorkflowContext<W> {
         self.sync.payload_converter()
     }
 
-    /// Return various information that the workflow was initialized with.
-    pub fn workflow_initial_info(&self) -> &InitializeWorkflow {
-        self.sync.workflow_initial_info()
+    /// Return Rust-native information about this workflow execution.
+    pub fn info(&self) -> WorkflowContextView {
+        self.sync.info()
     }
 
     /// A future that resolves if/when the workflow is cancelled, with the user provided cause
@@ -2484,7 +2498,7 @@ mod tests {
             workflow_type: TestWorkflow.name().to_string(),
             ..Default::default()
         };
-        let base = BaseWorkflowContext::new(
+        let base = BaseWorkflowContext::from_raw(
             "default".to_string(),
             "orig-task-queue".to_string(),
             "run-id".to_string(),
@@ -2705,7 +2719,7 @@ mod tests {
             workflow_type: "failing-workflow".to_string(),
             ..Default::default()
         };
-        let base = BaseWorkflowContext::new(
+        let base = BaseWorkflowContext::from_raw(
             "default".to_string(),
             "orig-task-queue".to_string(),
             "run-id".to_string(),
@@ -2774,7 +2788,7 @@ mod tests {
             ..Default::default()
         };
         let host = Rc::new(RecordingHost::default());
-        let base = BaseWorkflowContext::new(
+        let base = BaseWorkflowContext::from_raw(
             "default".to_string(),
             "orig-task-queue".to_string(),
             "run-id".to_string(),
@@ -2821,7 +2835,7 @@ mod tests {
             workflow_type: TestWorkflow.name().to_string(),
             ..Default::default()
         };
-        let base = BaseWorkflowContext::new(
+        let base = BaseWorkflowContext::from_raw(
             "default".to_string(),
             "orig-task-queue".to_string(),
             "run-id".to_string(),
@@ -2886,7 +2900,7 @@ mod tests {
             search_attributes: Some(init_sa),
             ..Default::default()
         };
-        let base = BaseWorkflowContext::new(
+        let base = BaseWorkflowContext::from_raw(
             "default".to_string(),
             "tq".to_string(),
             "run-id".to_string(),
@@ -2916,7 +2930,7 @@ mod tests {
             search_attributes: Some(init_sa),
             ..Default::default()
         };
-        let base = BaseWorkflowContext::new(
+        let base = BaseWorkflowContext::from_raw(
             "default".to_string(),
             "tq".to_string(),
             "run-id".to_string(),
@@ -2931,5 +2945,29 @@ mod tests {
             .search_attributes
             .expect("should have search attributes");
         assert_eq!(sa.get(&K), Some(true));
+    }
+
+    #[test]
+    fn workflow_info_retains_raw_initialization() {
+        let init = InitializeWorkflow {
+            workflow_type: TestWorkflow.name().to_string(),
+            identity: "raw-only-identity".to_owned(),
+            ..Default::default()
+        };
+        let expected = init.clone();
+        let base = BaseWorkflowContext::from_raw(
+            "default".to_string(),
+            "tq".to_string(),
+            "run-id".to_string(),
+            init,
+            DataConverter::default(),
+            Rc::new(NoopHost),
+        );
+        let ctx = WorkflowContext::from_base(base, Rc::new(RefCell::new(TestWorkflow)));
+        let info = ctx.info();
+
+        assert_eq!(info.raw().identity, "raw-only-identity");
+        assert_eq!(info.raw(), &expected);
+        assert_eq!(info.into_raw(), expected);
     }
 }

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -36,7 +36,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_common_wasm::{
-    ActivityDefinition, SignalDefinition, WorkflowDefinition,
+    ActivityDefinition, RetryPolicy, SignalDefinition, WorkflowDefinition,
     data_converters::{
         ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
         ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter, PayloadConverter,
@@ -311,8 +311,7 @@ pub struct WorkflowContextView {
     pub root: Option<RootWorkflowInfo>,
 
     /// The workflow's retry policy
-    pub retry_policy:
-        Option<temporalio_common_wasm::protos::temporal::api::common::v1::RetryPolicy>,
+    pub retry_policy: Option<RetryPolicy>,
     /// If this workflow runs on a cron schedule
     pub cron_schedule: Option<String>,
     /// User-defined memo
@@ -394,7 +393,7 @@ impl WorkflowContextView {
             task_timeout: init.workflow_task_timeout.and_then(|d| d.try_into().ok()),
             parent,
             root,
-            retry_policy: init.retry_policy.clone(),
+            retry_policy: init.retry_policy.clone().map(Into::into),
             cron_schedule,
             memo: init.memo.clone(),
             search_attributes: init
@@ -2461,10 +2460,13 @@ mod tests {
                     memo: Some(memo.clone()),
                     headers: Some(headers.clone()),
                     search_attributes: Some(search_attributes.clone()),
-                    retry_policy: Some(RetryPolicy {
-                        maximum_attempts: 5,
-                        ..Default::default()
-                    }),
+                    retry_policy: Some(
+                        RetryPolicy {
+                            maximum_attempts: 5,
+                            ..Default::default()
+                        }
+                        .into(),
+                    ),
                     versioning_intent: Some(ProtoVersioningIntent::Compatible.into()),
                     initial_versioning_behavior: Some(
                         ContinueAsNewVersioningBehavior::UseRampingVersion,
@@ -2493,6 +2495,8 @@ mod tests {
                 headers,
                 search_attributes: Some(proto_search_attributes),
                 retry_policy: Some(RetryPolicy {
+                    initial_interval: Some(Duration::from_secs(1).try_into().unwrap()),
+                    backoff_coefficient: 2.0,
                     maximum_attempts: 5,
                     ..Default::default()
                 }),

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -1,9 +1,11 @@
 mod options;
 
 pub use options::{
-    ActivityCloseTimeouts, ActivityOptions, ChildWorkflowOptions, ContinueAsNewOptions,
-    ContinueAsNewVersioningBehavior, LocalActivityOptions, NexusOperationOptions, Signal,
-    SignalData, TimerOptions,
+    ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions,
+    ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
+    ContinueAsNewVersioningBehavior, LocalActivityOptions, NexusOperationCancellationType,
+    NexusOperationOptions, ParentClosePolicy, Signal, SignalData, TimerOptions, VersioningIntent,
+    WorkflowIdReusePolicy,
 };
 pub use temporalio_common_wasm::protos::coresdk::child_workflow::StartChildWorkflowExecutionFailedCause;
 
@@ -2463,7 +2465,7 @@ mod tests {
                         maximum_attempts: 5,
                         ..Default::default()
                     }),
-                    versioning_intent: Some(ProtoVersioningIntent::Compatible),
+                    versioning_intent: Some(ProtoVersioningIntent::Compatible.into()),
                     initial_versioning_behavior: Some(
                         ContinueAsNewVersioningBehavior::UseRampingVersion,
                     ),

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -1,4 +1,5 @@
 mod options;
+mod view;
 
 pub use options::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions,
@@ -8,6 +9,7 @@ pub use options::{
     WorkflowIdReusePolicy,
 };
 pub use temporalio_common_wasm::protos::coresdk::child_workflow::StartChildWorkflowExecutionFailedCause;
+pub use view::{NamespacedWorkflowInfo, WorkflowContextView};
 
 use crate::{
     MemoValue,
@@ -39,7 +41,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_common_wasm::{
-    ActivityDefinition, Memo, Priority, RetryPolicy, SignalDefinition, WorkflowDefinition,
+    ActivityDefinition, Memo, SignalDefinition, WorkflowDefinition,
     data_converters::{
         ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
         ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter,
@@ -115,12 +117,15 @@ impl BaseWorkflowContext {
     /// Create a read-only view of this context.
     pub(crate) fn view(&self) -> WorkflowContextView {
         let shared = self.inner.shared.borrow();
+        let mut initial_information = self.inner.initial_information.clone();
+        if initial_information.memo.is_some() || !shared.memo.fields.is_empty() {
+            initial_information.memo = Some(shared.memo.clone());
+        }
         WorkflowContextView::new(
             self.inner.namespace.clone(),
             self.inner.task_queue.clone(),
             self.inner.run_id.clone(),
-            &self.inner.initial_information,
-            &shared.memo,
+            initial_information,
             self.inner.data_converter.payload_converter().clone(),
         )
     }
@@ -275,159 +280,6 @@ impl<W> Clone for WorkflowContext<W> {
             workflow_state: self.workflow_state.clone(),
             condition_wakers: self.condition_wakers.clone(),
         }
-    }
-}
-
-/// Read-only view of workflow context for use in init and query handlers.
-///
-/// This provides access to workflow information but cannot issue commands.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct WorkflowContextView {
-    /// The workflow's unique identifier
-    pub workflow_id: String,
-    /// The run id of this workflow execution
-    pub run_id: String,
-    /// The workflow type name
-    pub workflow_type: String,
-    /// The task queue this workflow is executing on
-    pub task_queue: String,
-    /// The namespace this workflow is executing in
-    pub namespace: String,
-
-    /// The current attempt number (starting from 1)
-    pub attempt: u32,
-    /// The run id of the very first execution in the chain
-    pub first_execution_run_id: String,
-    /// The run id of the previous execution if this is a continuation
-    pub continued_from_run_id: Option<String>,
-
-    /// When the workflow execution started
-    pub start_time: Option<SystemTime>,
-    /// Total workflow execution timeout including retries and continue as new
-    pub execution_timeout: Option<Duration>,
-    /// Timeout of a single workflow run
-    pub run_timeout: Option<Duration>,
-    /// Timeout of a single workflow task
-    pub task_timeout: Option<Duration>,
-
-    /// Information about the parent workflow, if this is a child workflow
-    pub parent: Option<ParentWorkflowInfo>,
-    /// Information about the root workflow in the execution chain
-    pub root: Option<RootWorkflowInfo>,
-
-    /// The workflow's retry policy
-    pub retry_policy: Option<RetryPolicy>,
-    /// If this workflow runs on a cron schedule
-    pub cron_schedule: Option<String>,
-    /// Priority and fairness configuration for this workflow execution.
-    pub priority: Priority,
-    /// User-defined memo values.
-    pub memo: Memo,
-    /// Initial search attributes as a typed collection.
-    pub search_attributes: Option<SearchAttributes>,
-    raw: InitializeWorkflow,
-}
-
-/// Information about a parent workflow.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct ParentWorkflowInfo {
-    /// The parent workflow's unique identifier
-    pub workflow_id: String,
-    /// The parent workflow's run id
-    pub run_id: String,
-    /// The parent workflow's namespace
-    pub namespace: String,
-}
-
-/// Information about the root workflow in an execution chain.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct RootWorkflowInfo {
-    /// The root workflow's unique identifier
-    pub workflow_id: String,
-    /// The root workflow's run id
-    pub run_id: String,
-}
-
-impl WorkflowContextView {
-    /// Create a new view from workflow initialization data.
-    pub(crate) fn new(
-        namespace: String,
-        task_queue: String,
-        run_id: String,
-        init: &InitializeWorkflow,
-        memo: &ProtoMemo,
-        payload_converter: PayloadConverter,
-    ) -> Self {
-        let parent = init
-            .parent_workflow_info
-            .as_ref()
-            .map(|p| ParentWorkflowInfo {
-                workflow_id: p.workflow_id.clone(),
-                run_id: p.run_id.clone(),
-                namespace: p.namespace.clone(),
-            });
-
-        let root = init.root_workflow.as_ref().map(|r| RootWorkflowInfo {
-            workflow_id: r.workflow_id.clone(),
-            run_id: r.run_id.clone(),
-        });
-
-        let continued_from_run_id = if init.continued_from_execution_run_id.is_empty() {
-            None
-        } else {
-            Some(init.continued_from_execution_run_id.clone())
-        };
-
-        let cron_schedule = if init.cron_schedule.is_empty() {
-            None
-        } else {
-            Some(init.cron_schedule.clone())
-        };
-
-        Self {
-            workflow_id: init.workflow_id.clone(),
-            run_id,
-            workflow_type: init.workflow_type.clone(),
-            task_queue,
-            namespace,
-            attempt: init.attempt as u32,
-            first_execution_run_id: init.first_execution_run_id.clone(),
-            continued_from_run_id,
-            start_time: init.start_time.and_then(|t| t.try_into().ok()),
-            execution_timeout: init
-                .workflow_execution_timeout
-                .and_then(|d| d.try_into().ok()),
-            run_timeout: init.workflow_run_timeout.and_then(|d| d.try_into().ok()),
-            task_timeout: init.workflow_task_timeout.and_then(|d| d.try_into().ok()),
-            parent,
-            root,
-            retry_policy: init.retry_policy.clone().map(Into::into),
-            cron_schedule,
-            priority: init.priority.clone().unwrap_or_default().into(),
-            memo: Memo::from_raw(
-                Some(memo.clone()),
-                payload_converter,
-                SerializationContextData::Workflow,
-            ),
-            search_attributes: init
-                .search_attributes
-                .as_ref()
-                .map(SearchAttributes::from_proto),
-            raw: init.clone(),
-        }
-    }
-
-    /// Access the underlying workflow initialization protobuf.
-    pub fn raw(&self) -> &InitializeWorkflow {
-        &self.raw
-    }
-
-    /// Consume this view and return the underlying workflow initialization protobuf.
-    pub fn into_raw(self) -> InitializeWorkflow {
-        self.raw
     }
 }
 
@@ -2803,7 +2655,15 @@ mod tests {
         let current = ctx.memo();
         assert_eq!(current.get::<u32>("new").unwrap(), Some(42));
         assert_eq!(current.get::<String>("old").unwrap(), None);
-        assert_eq!(ctx.view().memo.get::<u32>("new").unwrap(), Some(42));
+        let view = ctx.view();
+        assert_eq!(view.memo().get::<u32>("new").unwrap(), Some(42));
+        assert_eq!(
+            view.memo().raw(),
+            view.raw()
+                .memo
+                .as_ref()
+                .expect("view memo should be present")
+        );
 
         let commands = host.commands.borrow();
         let [command] = commands.as_slice() else {
@@ -2937,7 +2797,7 @@ mod tests {
 
         let view = ctx.view();
         let sa = view
-            .search_attributes
+            .search_attributes()
             .expect("should have search attributes");
         assert_eq!(sa.get(&K), Some(true));
     }

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -2428,6 +2428,7 @@ mod tests {
     use crate::MemoValues;
     use std::collections::HashMap;
     use temporalio_common_wasm::{
+        RetryPolicy,
         data_converters::{TemporalDeserializable, TemporalSerializable},
         protos::{
             coresdk::{
@@ -2436,7 +2437,7 @@ mod tests {
                 workflow_commands::WorkflowCommand,
             },
             temporal::api::{
-                common::v1::{Payload, RetryPolicy},
+                common::v1::{Payload, RetryPolicy as ProtoRetryPolicy},
                 enums::v1::ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior,
             },
         },
@@ -2574,13 +2575,7 @@ mod tests {
                     memo: Some(memo.clone()),
                     headers: Some(headers.clone()),
                     search_attributes: Some(search_attributes.clone()),
-                    retry_policy: Some(
-                        RetryPolicy {
-                            maximum_attempts: 5,
-                            ..Default::default()
-                        }
-                        .into(),
-                    ),
+                    retry_policy: Some(RetryPolicy::builder().maximum_attempts(5).build()),
                     versioning_intent: Some(ProtoVersioningIntent::Compatible.into()),
                     initial_versioning_behavior: Some(
                         ContinueAsNewVersioningBehavior::UseRampingVersion,
@@ -2611,7 +2606,7 @@ mod tests {
                 )]),
                 headers,
                 search_attributes: Some(proto_search_attributes),
-                retry_policy: Some(RetryPolicy {
+                retry_policy: Some(ProtoRetryPolicy {
                     initial_interval: Some(Duration::from_secs(1).try_into().unwrap()),
                     backoff_coefficient: 2.0,
                     maximum_attempts: 5,

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -9,13 +9,16 @@ pub use options::{
 };
 pub use temporalio_common_wasm::protos::coresdk::child_workflow::StartChildWorkflowExecutionFailedCause;
 
-use crate::runtime::{
-    SdkGuardedFuture, SdkWakeGuard,
-    entry::WorkflowImplementation,
-    host::WorkflowHost,
-    model::{
-        CancelExternalWfResult, CancellableID, NexusStartResult, SignalExternalWfResult,
-        TimerResult, UnblockEvent, Unblockable, WorkflowTermination,
+use crate::{
+    MemoValue,
+    runtime::{
+        SdkGuardedFuture, SdkWakeGuard,
+        entry::WorkflowImplementation,
+        host::WorkflowHost,
+        model::{
+            CancelExternalWfResult, CancellableID, NexusStartResult, SignalExternalWfResult,
+            TimerResult, UnblockEvent, Unblockable, WorkflowTermination,
+        },
     },
 };
 use futures_channel::oneshot;
@@ -36,12 +39,12 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_common_wasm::{
-    ActivityDefinition, RetryPolicy, SignalDefinition, WorkflowDefinition,
+    ActivityDefinition, Memo, RetryPolicy, SignalDefinition, WorkflowDefinition,
     data_converters::{
         ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
-        ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter, PayloadConverter,
-        SerializationContext, SerializationContextData, TemporalDeserializable,
-        WorkflowSignalDecodeHint,
+        ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter,
+        PayloadConversionError, PayloadConverter, SerializationContext, SerializationContextData,
+        TemporalDeserializable, WorkflowSignalDecodeHint,
     },
     error::{
         ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
@@ -68,7 +71,7 @@ use temporalio_common_wasm::{
             },
         },
         temporal::api::{
-            common::v1::{Memo, Payload, SearchAttributes as ProtoSearchAttributes},
+            common::v1::{Memo as ProtoMemo, Payload, SearchAttributes as ProtoSearchAttributes},
             failure::v1::{CanceledFailureInfo, Failure, failure::FailureInfo},
         },
         utilities::TryIntoOrNone,
@@ -111,11 +114,14 @@ impl BaseWorkflowContext {
 
     /// Create a read-only view of this context.
     pub(crate) fn view(&self) -> WorkflowContextView {
+        let shared = self.inner.shared.borrow();
         WorkflowContextView::new(
             self.inner.namespace.clone(),
             self.inner.task_queue.clone(),
             self.inner.run_id.clone(),
             &self.inner.inital_information,
+            &shared.memo,
+            self.inner.data_converter.payload_converter().clone(),
         )
     }
 }
@@ -314,8 +320,8 @@ pub struct WorkflowContextView {
     pub retry_policy: Option<RetryPolicy>,
     /// If this workflow runs on a cron schedule
     pub cron_schedule: Option<String>,
-    /// User-defined memo
-    pub memo: Option<Memo>,
+    /// User-defined memo values.
+    pub memo: Memo,
     /// Initial search attributes as a typed collection.
     pub search_attributes: Option<SearchAttributes>,
 }
@@ -349,6 +355,8 @@ impl WorkflowContextView {
         task_queue: String,
         run_id: String,
         init: &InitializeWorkflow,
+        memo: &ProtoMemo,
+        payload_converter: PayloadConverter,
     ) -> Self {
         let parent = init
             .parent_workflow_info
@@ -395,7 +403,11 @@ impl WorkflowContextView {
             root,
             retry_policy: init.retry_policy.clone().map(Into::into),
             cron_schedule,
-            memo: init.memo.clone(),
+            memo: Memo::from_raw(
+                Some(memo.clone()),
+                payload_converter,
+                SerializationContextData::Workflow,
+            ),
             search_attributes: init
                 .search_attributes
                 .as_ref()
@@ -422,6 +434,7 @@ impl BaseWorkflowContext {
                 run_id,
                 shared: RefCell::new(WorkflowContextSharedData {
                     random_seed: init_workflow_job.randomness_seed,
+                    memo: init_workflow_job.memo.clone().unwrap_or_default(),
                     search_attributes: init_workflow_job
                         .search_attributes
                         .clone()
@@ -799,6 +812,15 @@ impl<W> SyncWorkflowContext<W> {
         SearchAttributes::from_proto(&self.base.inner.shared.borrow().search_attributes)
     }
 
+    /// Return the current workflow memo values.
+    pub fn memo(&self) -> Memo {
+        Memo::from_raw(
+            Some(self.base.inner.shared.borrow().memo.clone()),
+            self.payload_converter().clone(),
+            SerializationContextData::Workflow,
+        )
+    }
+
     /// Return the workflow's randomness seed
     pub fn random_seed(&self) -> u64 {
         self.base.inner.shared.borrow().random_seed
@@ -885,7 +907,9 @@ impl<W> SyncWorkflowContext<W> {
             .to_payloads(&ctx, input)
             .map_err(WorkflowTermination::from)?;
         let workflow_type = self.workflow_initial_info().workflow_type.clone();
-        let request = opts.into_request(workflow_type, arguments);
+        let request = opts
+            .into_request(workflow_type, arguments, pc)
+            .map_err(WorkflowTermination::from)?;
         Err(WorkflowTermination::continue_as_new(request))
     }
 
@@ -1035,16 +1059,51 @@ impl<W> SyncWorkflowContext<W> {
         );
     }
 
-    /// Add or create a set of search attributes
-    pub fn upsert_memo(&self, attr_iter: impl IntoIterator<Item = (String, Payload)>) {
+    /// Add or replace memo values with `Some`; remove memo keys with `None`.
+    pub fn upsert_memo<K>(
+        &self,
+        updates: impl IntoIterator<Item = (K, Option<MemoValue>)>,
+    ) -> Result<(), PayloadConversionError>
+    where
+        K: Into<String>,
+    {
+        let mut fields = HashMap::new();
+        let mut local_updates = Vec::new();
+        for (key, value) in updates {
+            let key = key.into();
+            let (command_payload, local_payload) = match value {
+                Some(value) => {
+                    let payload = value.to_payload(self.payload_converter())?;
+                    (payload.clone(), Some(payload))
+                }
+                None => (
+                    MemoValue::new(()).to_payload(self.payload_converter())?,
+                    None,
+                ),
+            };
+            fields.insert(key.clone(), command_payload);
+            local_updates.push((key, local_payload));
+        }
+        {
+            let mut shared = self.base.inner.shared.borrow_mut();
+            for (key, payload) in local_updates {
+                match payload {
+                    Some(payload) => {
+                        shared.memo.fields.insert(key, payload);
+                    }
+                    None => {
+                        shared.memo.fields.remove(&key);
+                    }
+                }
+            }
+        }
         self.base.inner.runtime.host.push_command(
             workflow_command::Variant::ModifyWorkflowProperties(ModifyWorkflowProperties {
-                upserted_memo: Some(Memo {
-                    fields: attr_iter.into_iter().collect(),
-                }),
+                upserted_memo: Some(ProtoMemo { fields }),
             })
             .into(),
         );
+        Ok(())
     }
 
     /// Set the current details string for this workflow execution.
@@ -1181,6 +1240,11 @@ impl<W> WorkflowContext<W> {
         self.sync.search_attributes()
     }
 
+    /// Return the current workflow memo values.
+    pub fn memo(&self) -> Memo {
+        self.sync.memo()
+    }
+
     /// Return the workflow's randomness seed
     pub fn random_seed(&self) -> u64 {
         self.sync.random_seed()
@@ -1309,9 +1373,15 @@ impl<W> WorkflowContext<W> {
         self.sync.upsert_search_attributes(updates)
     }
 
-    /// Add or create a set of memo fields
-    pub fn upsert_memo(&self, attr_iter: impl IntoIterator<Item = (String, Payload)>) {
-        self.sync.upsert_memo(attr_iter)
+    /// Add or replace memo values with `Some`; remove memo keys with `None`.
+    pub fn upsert_memo<K>(
+        &self,
+        updates: impl IntoIterator<Item = (K, Option<MemoValue>)>,
+    ) -> Result<(), PayloadConversionError>
+    where
+        K: Into<String>,
+    {
+        self.sync.upsert_memo(updates)
     }
 
     /// Set the current details string for this workflow execution.
@@ -1442,6 +1512,7 @@ struct WorkflowContextSharedData {
     /// Maps change ids -> resolved status
     changes: HashMap<String, bool>,
     activation: CoreWorkflowActivation,
+    memo: ProtoMemo,
     search_attributes: ProtoSearchAttributes,
     random_seed: u64,
     /// Current details string, surfaced via the workflow metadata query.
@@ -2340,12 +2411,14 @@ impl StartedNexusOperation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MemoValues;
     use std::collections::HashMap;
     use temporalio_common_wasm::{
         data_converters::{TemporalDeserializable, TemporalSerializable},
         protos::{
             coresdk::{
-                AsJsonPayloadExt, common::VersioningIntent as ProtoVersioningIntent,
+                AsJsonPayloadExt, FromJsonPayloadExt,
+                common::VersioningIntent as ProtoVersioningIntent,
                 workflow_commands::WorkflowCommand,
             },
             temporal::api::{
@@ -2362,6 +2435,36 @@ mod tests {
     impl WorkflowHost for NoopHost {
         fn set_current_details(&self, _details: String) {}
         fn push_command(&self, _command: WorkflowCommand) {}
+    }
+
+    #[derive(Default)]
+    struct RecordingHost {
+        commands: RefCell<Vec<WorkflowCommand>>,
+    }
+
+    impl WorkflowHost for RecordingHost {
+        fn set_current_details(&self, _details: String) {}
+
+        fn push_command(&self, command: WorkflowCommand) {
+            self.commands.borrow_mut().push(command);
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingMemoValue;
+
+    impl TemporalSerializable for FailingMemoValue {
+        fn to_payload(
+            &self,
+            _ctx: &temporalio_common_wasm::data_converters::SerializationContext<'_>,
+        ) -> Result<Payload, temporalio_common_wasm::data_converters::PayloadConversionError>
+        {
+            Err(
+                temporalio_common_wasm::data_converters::PayloadConversionError::EncodingError(
+                    std::io::Error::other("memo serialization failure").into(),
+                ),
+            )
+        }
     }
 
     #[workflow]
@@ -2431,11 +2534,8 @@ mod tests {
     fn sync_workflow_context_continue_as_new_applies_options() {
         let ctx = test_context();
         let sync = ctx.sync_context();
-        let mut memo = HashMap::new();
-        memo.insert(
-            "memo-key".to_string(),
-            Payload::from(b"memo-value".as_slice()),
-        );
+        let mut memo = MemoValues::new();
+        memo.insert("memo-key", "memo-value".to_string());
         let mut headers = HashMap::new();
         headers.insert(
             "header-key".to_string(),
@@ -2491,7 +2591,10 @@ mod tests {
                 workflow_run_timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                 workflow_task_timeout: Some(Duration::from_secs(3).try_into().unwrap()),
                 backoff_start_interval: Some(Duration::from_secs(4).try_into().unwrap()),
-                memo,
+                memo: HashMap::from([(
+                    "memo-key".to_string(),
+                    "memo-value".as_json_payload().unwrap(),
+                )]),
                 headers,
                 search_attributes: Some(proto_search_attributes),
                 retry_policy: Some(RetryPolicy {
@@ -2623,6 +2726,31 @@ mod tests {
     }
 
     #[test]
+    fn continue_as_new_reports_memo_serialization_errors() {
+        let ctx = test_context();
+        let mut memo = MemoValues::new();
+        memo.insert("invalid", FailingMemoValue);
+
+        let err = ctx
+            .continue_as_new(
+                &7,
+                ContinueAsNewOptions {
+                    memo: Some(memo),
+                    ..Default::default()
+                },
+            )
+            .expect_err("memo serialization errors should be surfaced");
+
+        let WorkflowTermination::Failed(err) = err else {
+            panic!("expected failed termination, got {err:?}");
+        };
+        assert_eq!(
+            err.to_string(),
+            "Encoding error: memo serialization failure"
+        );
+    }
+
+    #[test]
     fn upsert_search_attributes_updates_local_state() {
         use temporalio_common_wasm::search_attributes::SearchAttributeKey;
 
@@ -2634,6 +2762,87 @@ mod tests {
         ctx.upsert_search_attributes([K.value_set(42)]);
         let attrs = ctx.search_attributes();
         assert_eq!(attrs.get(&K), Some(42));
+    }
+
+    #[test]
+    fn upsert_memo_updates_local_state_and_encodes_removals() {
+        let init = InitializeWorkflow {
+            workflow_type: TestWorkflow.name().to_string(),
+            memo: Some(ProtoMemo {
+                fields: HashMap::from([("old".to_string(), "before".as_json_payload().unwrap())]),
+            }),
+            ..Default::default()
+        };
+        let host = Rc::new(RecordingHost::default());
+        let base = BaseWorkflowContext::new(
+            "default".to_string(),
+            "orig-task-queue".to_string(),
+            "run-id".to_string(),
+            init,
+            DataConverter::default(),
+            host.clone(),
+        );
+        let ctx = WorkflowContext::from_base(base, Rc::new(RefCell::new(TestWorkflow)));
+
+        assert_eq!(
+            ctx.memo().get::<String>("old").unwrap(),
+            Some("before".to_string())
+        );
+        ctx.upsert_memo([("new", Some(MemoValue::new(42_u32))), ("old", None)])
+            .unwrap();
+
+        let current = ctx.memo();
+        assert_eq!(current.get::<u32>("new").unwrap(), Some(42));
+        assert_eq!(current.get::<String>("old").unwrap(), None);
+        assert_eq!(ctx.view().memo.get::<u32>("new").unwrap(), Some(42));
+
+        let commands = host.commands.borrow();
+        let [command] = commands.as_slice() else {
+            panic!("expected one modify-properties command");
+        };
+        let Some(workflow_command::Variant::ModifyWorkflowProperties(command)) = &command.variant
+        else {
+            panic!("expected a modify-properties command");
+        };
+        let fields = &command.upserted_memo.as_ref().unwrap().fields;
+        let payload_converter = PayloadConverter::default();
+        let removal_payload = MemoValue::new(()).to_payload(&payload_converter).unwrap();
+        assert_eq!(fields.get("old"), Some(&removal_payload));
+        assert_eq!(
+            u32::from_json_payload(fields.get("new").unwrap()).unwrap(),
+            42
+        );
+    }
+
+    #[test]
+    fn upsert_memo_conversion_failure_does_not_mutate_or_emit_command() {
+        let host = Rc::new(RecordingHost::default());
+        let init = InitializeWorkflow {
+            workflow_type: TestWorkflow.name().to_string(),
+            ..Default::default()
+        };
+        let base = BaseWorkflowContext::new(
+            "default".to_string(),
+            "orig-task-queue".to_string(),
+            "run-id".to_string(),
+            init,
+            DataConverter::default(),
+            host.clone(),
+        );
+        let ctx = WorkflowContext::from_base(base, Rc::new(RefCell::new(TestWorkflow)));
+        let err = ctx
+            .upsert_memo([
+                ("valid", Some(MemoValue::new("value".to_string()))),
+                ("invalid", Some(MemoValue::new(FailingMemoValue))),
+            ])
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Encoding error: memo serialization failure"
+        );
+        assert_eq!(ctx.memo().get::<String>("valid").unwrap(), None);
+        assert!(host.commands.borrow().is_empty());
     }
 
     #[test]

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, time::Duration};
 
-use crate::runtime::types::ContinueAsNewRequest;
+use crate::{MemoValues, runtime::types::ContinueAsNewRequest};
 use temporalio_common_wasm::{
     Priority, RetryPolicy,
     data_converters::{
-        GenericPayloadConverter, PayloadConverter, SerializationContext, SerializationContextData,
+        GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
+        SerializationContextData,
     },
     protos::{
         coresdk::{
@@ -808,8 +809,8 @@ pub struct ContinueAsNewOptions {
     pub task_timeout: Option<Duration>,
     /// Delay before the first workflow task of the continued run is scheduled.
     pub backoff_start_interval: Option<Duration>,
-    /// If set, the new workflow will have this memo. If `None`, reuses the current memo.
-    pub memo: Option<HashMap<String, Payload>>,
+    /// If set, the new workflow will have these memo values. If `None`, reuses the current memo.
+    pub memo: Option<MemoValues>,
     /// If set, the new workflow will have these headers.
     pub headers: Option<HashMap<String, Payload>>,
     /// If set, the new workflow will have these search attributes. If `None`, reuses the current
@@ -833,8 +834,14 @@ impl ContinueAsNewOptions {
         self,
         workflow_type: String,
         arguments: Vec<Payload>,
-    ) -> ContinueAsNewRequest {
-        ContinueAsNewWorkflowExecution {
+        payload_converter: &PayloadConverter,
+    ) -> Result<ContinueAsNewRequest, PayloadConversionError> {
+        let memo = self
+            .memo
+            .map(|memo| memo.encode(payload_converter))
+            .transpose()?
+            .unwrap_or_default();
+        Ok(ContinueAsNewWorkflowExecution {
             workflow_type: self.workflow_type.unwrap_or(workflow_type),
             task_queue: self.task_queue.unwrap_or_default(),
             arguments,
@@ -847,7 +854,7 @@ impl ContinueAsNewOptions {
             backoff_start_interval: self
                 .backoff_start_interval
                 .and_then(|duration| duration.try_into().ok()),
-            memo: self.memo.unwrap_or_default(),
+            memo,
             headers: self.headers.unwrap_or_default(),
             search_attributes: self.search_attributes.map(|t| t.into_proto()),
             retry_policy: self.retry_policy.map(Into::into),
@@ -861,7 +868,7 @@ impl ContinueAsNewOptions {
                     .unwrap_or(ContinueAsNewVersioningBehavior::Unspecified),
             )
             .into(),
-        }
+        })
     }
 }
 
@@ -949,7 +956,12 @@ mod tests {
             versioning_intent: Some(VersioningIntent::Compatible),
             ..Default::default()
         }
-        .into_request("test-workflow".to_string(), vec![]);
+        .into_request(
+            "test-workflow".to_string(),
+            vec![],
+            &PayloadConverter::default(),
+        )
+        .unwrap();
 
         let backoff = req
             .backoff_start_interval

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use crate::runtime::types::ContinueAsNewRequest;
 use temporalio_common_wasm::{
-    Priority,
+    Priority, RetryPolicy,
     data_converters::{
         GenericPayloadConverter, PayloadConverter, SerializationContext, SerializationContextData,
     },
@@ -23,7 +23,7 @@ use temporalio_common_wasm::{
             },
         },
         temporal::api::{
-            common::v1::{Payload, RetryPolicy},
+            common::v1::Payload,
             enums::v1::{
                 ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior,
                 WorkflowIdReusePolicy as ProtoWorkflowIdReusePolicy,
@@ -311,6 +311,7 @@ pub struct ActivityOptions {
     #[builder(default, into)]
     pub cancellation_type: ActivityCancellationType,
     /// Activity retry policy
+    #[builder(into)]
     pub retry_policy: Option<RetryPolicy>,
     /// Summary of the activity
     pub summary: Option<String>,
@@ -412,7 +413,7 @@ impl ActivityOptions {
                     .and_then(|duration| duration.try_into().ok()),
                 cancellation_type: ProtoActivityCancellationType::from(self.cancellation_type)
                     .into(),
-                retry_policy: self.retry_policy,
+                retry_policy: self.retry_policy.map(Into::into),
                 priority: self.priority.map(Into::into),
                 do_not_eagerly_execute: self.do_not_eagerly_execute,
                 ..Default::default()
@@ -480,7 +481,7 @@ impl LocalActivityOptions {
                 activity_type,
                 activity_id: self.activity_id.unwrap_or_else(|| seq.to_string()),
                 arguments: args,
-                retry_policy: Some(self.retry_policy),
+                retry_policy: Some(self.retry_policy.into()),
                 attempt: self.attempt.unwrap_or(1),
                 original_schedule_time: self.original_schedule_time,
                 local_retry_threshold: self
@@ -815,6 +816,7 @@ pub struct ContinueAsNewOptions {
     /// search attributes.
     pub search_attributes: Option<SearchAttributes>,
     /// If set, the new workflow will have this retry policy. If `None`, reuses the current policy.
+    #[builder(into)]
     pub retry_policy: Option<RetryPolicy>,
     /// Whether the new workflow should run on a worker with a compatible build id.
     pub versioning_intent: Option<VersioningIntent>,
@@ -848,7 +850,7 @@ impl ContinueAsNewOptions {
             memo: self.memo.unwrap_or_default(),
             headers: self.headers.unwrap_or_default(),
             search_attributes: self.search_attributes.map(|t| t.into_proto()),
-            retry_policy: self.retry_policy,
+            retry_policy: self.retry_policy.map(Into::into),
             versioning_intent: ProtoVersioningIntent::from(
                 self.versioning_intent
                     .unwrap_or(VersioningIntent::Unspecified),

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -8,27 +8,275 @@ use temporalio_common_wasm::{
     },
     protos::{
         coresdk::{
-            child_workflow::{ChildWorkflowCancellationType, ParentClosePolicy},
-            common::VersioningIntent,
-            nexus::NexusOperationCancellationType,
+            child_workflow::{
+                ChildWorkflowCancellationType as ProtoChildWorkflowCancellationType,
+                ParentClosePolicy as ProtoParentClosePolicy,
+            },
+            common::VersioningIntent as ProtoVersioningIntent,
+            nexus::NexusOperationCancellationType as ProtoNexusOperationCancellationType,
             workflow_activation::SignalWorkflow,
             workflow_commands::{
-                ActivityCancellationType, ContinueAsNewWorkflowExecution, ScheduleActivity,
-                ScheduleLocalActivity, ScheduleNexusOperation, StartChildWorkflowExecution,
-                StartTimer, WorkflowCommand, workflow_command,
+                ActivityCancellationType as ProtoActivityCancellationType,
+                ContinueAsNewWorkflowExecution, ScheduleActivity, ScheduleLocalActivity,
+                ScheduleNexusOperation, StartChildWorkflowExecution, StartTimer, WorkflowCommand,
+                workflow_command,
             },
         },
         temporal::api::{
             common::v1::{Payload, RetryPolicy},
             enums::v1::{
                 ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior,
-                WorkflowIdReusePolicy,
+                WorkflowIdReusePolicy as ProtoWorkflowIdReusePolicy,
             },
             sdk::v1::UserMetadata,
         },
     },
     search_attributes::SearchAttributes,
 };
+
+/// Controls when activity cancellation is reported back to a workflow.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+#[non_exhaustive]
+pub enum ActivityCancellationType {
+    /// Request cancellation and report it immediately.
+    #[default]
+    TryCancel,
+    /// Wait until cancellation has completed.
+    WaitCancellationCompleted,
+    /// Do not request cancellation.
+    Abandon,
+}
+
+impl From<ActivityCancellationType> for ProtoActivityCancellationType {
+    fn from(value: ActivityCancellationType) -> Self {
+        match value {
+            ActivityCancellationType::TryCancel => Self::TryCancel,
+            ActivityCancellationType::WaitCancellationCompleted => Self::WaitCancellationCompleted,
+            ActivityCancellationType::Abandon => Self::Abandon,
+        }
+    }
+}
+
+impl From<ProtoActivityCancellationType> for ActivityCancellationType {
+    fn from(value: ProtoActivityCancellationType) -> Self {
+        match value {
+            ProtoActivityCancellationType::TryCancel => Self::TryCancel,
+            ProtoActivityCancellationType::WaitCancellationCompleted => {
+                Self::WaitCancellationCompleted
+            }
+            ProtoActivityCancellationType::Abandon => Self::Abandon,
+        }
+    }
+}
+
+/// Controls when child-workflow cancellation is reported to its parent.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+#[non_exhaustive]
+pub enum ChildWorkflowCancellationType {
+    /// Do not request cancellation.
+    Abandon,
+    /// Request cancellation and report it immediately.
+    TryCancel,
+    /// Wait until cancellation has completed.
+    #[default]
+    WaitCancellationCompleted,
+    /// Wait until the cancellation request is acknowledged.
+    WaitCancellationRequested,
+}
+
+impl From<ChildWorkflowCancellationType> for ProtoChildWorkflowCancellationType {
+    fn from(value: ChildWorkflowCancellationType) -> Self {
+        match value {
+            ChildWorkflowCancellationType::Abandon => Self::Abandon,
+            ChildWorkflowCancellationType::TryCancel => Self::TryCancel,
+            ChildWorkflowCancellationType::WaitCancellationCompleted => {
+                Self::WaitCancellationCompleted
+            }
+            ChildWorkflowCancellationType::WaitCancellationRequested => {
+                Self::WaitCancellationRequested
+            }
+        }
+    }
+}
+
+impl From<ProtoChildWorkflowCancellationType> for ChildWorkflowCancellationType {
+    fn from(value: ProtoChildWorkflowCancellationType) -> Self {
+        match value {
+            ProtoChildWorkflowCancellationType::Abandon => Self::Abandon,
+            ProtoChildWorkflowCancellationType::TryCancel => Self::TryCancel,
+            ProtoChildWorkflowCancellationType::WaitCancellationCompleted => {
+                Self::WaitCancellationCompleted
+            }
+            ProtoChildWorkflowCancellationType::WaitCancellationRequested => {
+                Self::WaitCancellationRequested
+            }
+        }
+    }
+}
+
+/// Controls what happens to a child workflow when its parent closes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum ParentClosePolicy {
+    /// Let the server choose its default.
+    #[default]
+    Unspecified,
+    /// Terminate the child workflow.
+    Terminate,
+    /// Leave the child workflow running.
+    Abandon,
+    /// Request cancellation of the child workflow.
+    RequestCancel,
+}
+
+impl From<ParentClosePolicy> for ProtoParentClosePolicy {
+    fn from(value: ParentClosePolicy) -> Self {
+        match value {
+            ParentClosePolicy::Unspecified => Self::Unspecified,
+            ParentClosePolicy::Terminate => Self::Terminate,
+            ParentClosePolicy::Abandon => Self::Abandon,
+            ParentClosePolicy::RequestCancel => Self::RequestCancel,
+        }
+    }
+}
+
+impl From<ProtoParentClosePolicy> for ParentClosePolicy {
+    fn from(value: ProtoParentClosePolicy) -> Self {
+        match value {
+            ProtoParentClosePolicy::Unspecified => Self::Unspecified,
+            ProtoParentClosePolicy::Terminate => Self::Terminate,
+            ProtoParentClosePolicy::Abandon => Self::Abandon,
+            ProtoParentClosePolicy::RequestCancel => Self::RequestCancel,
+        }
+    }
+}
+
+/// Controls whether a closed workflow ID may be reused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum WorkflowIdReusePolicy {
+    /// Use the SDK default of allowing duplicate IDs.
+    #[default]
+    Unspecified,
+    /// Allow the workflow ID to be reused.
+    AllowDuplicate,
+    /// Allow reuse only when the previous execution failed.
+    AllowDuplicateFailedOnly,
+    /// Reject reuse of the workflow ID.
+    RejectDuplicate,
+    /// Terminate a running execution before reusing the ID.
+    TerminateIfRunning,
+}
+
+impl From<WorkflowIdReusePolicy> for ProtoWorkflowIdReusePolicy {
+    #[allow(deprecated)]
+    fn from(value: WorkflowIdReusePolicy) -> Self {
+        match value {
+            WorkflowIdReusePolicy::Unspecified => Self::Unspecified,
+            WorkflowIdReusePolicy::AllowDuplicate => Self::AllowDuplicate,
+            WorkflowIdReusePolicy::AllowDuplicateFailedOnly => Self::AllowDuplicateFailedOnly,
+            WorkflowIdReusePolicy::RejectDuplicate => Self::RejectDuplicate,
+            WorkflowIdReusePolicy::TerminateIfRunning => Self::TerminateIfRunning,
+        }
+    }
+}
+
+impl From<ProtoWorkflowIdReusePolicy> for WorkflowIdReusePolicy {
+    #[allow(deprecated)]
+    fn from(value: ProtoWorkflowIdReusePolicy) -> Self {
+        match value {
+            ProtoWorkflowIdReusePolicy::Unspecified => Self::Unspecified,
+            ProtoWorkflowIdReusePolicy::AllowDuplicate => Self::AllowDuplicate,
+            ProtoWorkflowIdReusePolicy::AllowDuplicateFailedOnly => Self::AllowDuplicateFailedOnly,
+            ProtoWorkflowIdReusePolicy::RejectDuplicate => Self::RejectDuplicate,
+            ProtoWorkflowIdReusePolicy::TerminateIfRunning => Self::TerminateIfRunning,
+        }
+    }
+}
+
+/// Selects the worker versioning behavior intended for a command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum VersioningIntent {
+    /// Let Core choose the appropriate behavior.
+    #[default]
+    Unspecified,
+    /// Prefer a worker compatible with the current worker.
+    Compatible,
+    /// Use the target task queue's default worker version.
+    Default,
+}
+
+impl From<VersioningIntent> for ProtoVersioningIntent {
+    fn from(value: VersioningIntent) -> Self {
+        match value {
+            VersioningIntent::Unspecified => Self::Unspecified,
+            VersioningIntent::Compatible => Self::Compatible,
+            VersioningIntent::Default => Self::Default,
+        }
+    }
+}
+
+impl From<ProtoVersioningIntent> for VersioningIntent {
+    fn from(value: ProtoVersioningIntent) -> Self {
+        match value {
+            ProtoVersioningIntent::Unspecified => Self::Unspecified,
+            ProtoVersioningIntent::Compatible => Self::Compatible,
+            ProtoVersioningIntent::Default => Self::Default,
+        }
+    }
+}
+
+/// Controls when Nexus operation cancellation is reported to a workflow.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+#[non_exhaustive]
+pub enum NexusOperationCancellationType {
+    /// Wait until cancellation has completed.
+    #[default]
+    WaitCancellationCompleted,
+    /// Do not request cancellation.
+    Abandon,
+    /// Request cancellation and report it immediately.
+    TryCancel,
+    /// Wait until the cancellation request is acknowledged.
+    WaitCancellationRequested,
+}
+
+impl From<NexusOperationCancellationType> for ProtoNexusOperationCancellationType {
+    fn from(value: NexusOperationCancellationType) -> Self {
+        match value {
+            NexusOperationCancellationType::WaitCancellationCompleted => {
+                Self::WaitCancellationCompleted
+            }
+            NexusOperationCancellationType::Abandon => Self::Abandon,
+            NexusOperationCancellationType::TryCancel => Self::TryCancel,
+            NexusOperationCancellationType::WaitCancellationRequested => {
+                Self::WaitCancellationRequested
+            }
+        }
+    }
+}
+
+impl From<ProtoNexusOperationCancellationType> for NexusOperationCancellationType {
+    fn from(value: ProtoNexusOperationCancellationType) -> Self {
+        match value {
+            ProtoNexusOperationCancellationType::WaitCancellationCompleted => {
+                Self::WaitCancellationCompleted
+            }
+            ProtoNexusOperationCancellationType::Abandon => Self::Abandon,
+            ProtoNexusOperationCancellationType::TryCancel => Self::TryCancel,
+            ProtoNexusOperationCancellationType::WaitCancellationRequested => {
+                Self::WaitCancellationRequested
+            }
+        }
+    }
+}
 /// Options for scheduling an activity
 #[derive(Debug, bon::Builder, Clone)]
 #[non_exhaustive]
@@ -60,7 +308,7 @@ pub struct ActivityOptions {
     /// heartbeat or activity start.
     pub heartbeat_timeout: Option<Duration>,
     /// Determines what the SDK does when the Activity is cancelled.
-    #[builder(default)]
+    #[builder(default, into)]
     pub cancellation_type: ActivityCancellationType,
     /// Activity retry policy
     pub retry_policy: Option<RetryPolicy>,
@@ -162,7 +410,8 @@ impl ActivityOptions {
                 heartbeat_timeout: self
                     .heartbeat_timeout
                     .and_then(|duration| duration.try_into().ok()),
-                cancellation_type: self.cancellation_type.into(),
+                cancellation_type: ProtoActivityCancellationType::from(self.cancellation_type)
+                    .into(),
                 retry_policy: self.retry_policy,
                 priority: self.priority.map(Into::into),
                 do_not_eagerly_execute: self.do_not_eagerly_execute,
@@ -237,7 +486,7 @@ impl LocalActivityOptions {
                 local_retry_threshold: self
                     .timer_backoff_threshold
                     .and_then(|duration| duration.try_into().ok()),
-                cancellation_type: self.cancel_type.into(),
+                cancellation_type: ProtoActivityCancellationType::from(self.cancel_type).into(),
                 schedule_to_close_timeout: self
                     .schedule_to_close_timeout
                     .and_then(|duration| duration.try_into().ok()),
@@ -302,12 +551,15 @@ impl ChildWorkflowOptions {
                 workflow_id: self.workflow_id,
                 task_queue: self.task_queue.unwrap_or_default(),
                 input: args,
-                cancellation_type: self.cancel_type.into(),
-                parent_close_policy: self.parent_close_policy.into(),
-                workflow_id_reuse_policy: match self.id_reuse_policy {
-                    WorkflowIdReusePolicy::Unspecified => WorkflowIdReusePolicy::AllowDuplicate,
-                    policy => policy,
-                }
+                cancellation_type: ProtoChildWorkflowCancellationType::from(self.cancel_type)
+                    .into(),
+                parent_close_policy: ProtoParentClosePolicy::from(self.parent_close_policy).into(),
+                workflow_id_reuse_policy: ProtoWorkflowIdReusePolicy::from(
+                    match self.id_reuse_policy {
+                        WorkflowIdReusePolicy::Unspecified => WorkflowIdReusePolicy::AllowDuplicate,
+                        policy => policy,
+                    },
+                )
                 .into(),
                 workflow_execution_timeout: self
                     .execution_timeout
@@ -484,10 +736,11 @@ impl NexusOperationOptions {
                 .start_to_close_timeout
                 .and_then(|duration| duration.try_into().ok()),
             nexus_header: self.nexus_header,
-            cancellation_type: self
-                .cancellation_type
-                .unwrap_or(NexusOperationCancellationType::WaitCancellationCompleted)
-                .into(),
+            cancellation_type: ProtoNexusOperationCancellationType::from(
+                self.cancellation_type
+                    .unwrap_or(NexusOperationCancellationType::WaitCancellationCompleted),
+            )
+            .into(),
         })
         .into()
     }
@@ -596,10 +849,11 @@ impl ContinueAsNewOptions {
             headers: self.headers.unwrap_or_default(),
             search_attributes: self.search_attributes.map(|t| t.into_proto()),
             retry_policy: self.retry_policy,
-            versioning_intent: self
-                .versioning_intent
-                .unwrap_or(VersioningIntent::Unspecified)
-                .into(),
+            versioning_intent: ProtoVersioningIntent::from(
+                self.versioning_intent
+                    .unwrap_or(VersioningIntent::Unspecified),
+            )
+            .into(),
             initial_versioning_behavior: ProtoContinueAsNewVersioningBehavior::from(
                 self.initial_versioning_behavior
                     .unwrap_or(ContinueAsNewVersioningBehavior::Unspecified),
@@ -648,9 +902,49 @@ mod tests {
     use super::*;
 
     #[test]
+    fn activity_cancellation_default_preserves_sdk_behavior() {
+        assert_eq!(
+            ActivityCancellationType::default(),
+            ActivityCancellationType::TryCancel
+        );
+    }
+
+    #[test]
+    fn child_workflow_cancellation_defaults_to_wait_for_completion() {
+        assert_eq!(
+            ChildWorkflowOptions::default().cancel_type,
+            ChildWorkflowCancellationType::WaitCancellationCompleted
+        );
+        let command = ChildWorkflowOptions::default().into_command(1, "child".to_string(), vec![]);
+        let Some(workflow_command::Variant::StartChildWorkflowExecution(command)) = command.variant
+        else {
+            panic!("expected StartChildWorkflowExecution command");
+        };
+        assert_eq!(
+            command.cancellation_type,
+            ProtoChildWorkflowCancellationType::WaitCancellationCompleted as i32
+        );
+    }
+
+    #[test]
+    fn other_policy_defaults_preserve_sdk_behavior() {
+        assert_eq!(ParentClosePolicy::default(), ParentClosePolicy::Unspecified);
+        assert_eq!(
+            WorkflowIdReusePolicy::default(),
+            WorkflowIdReusePolicy::Unspecified
+        );
+        assert_eq!(VersioningIntent::default(), VersioningIntent::Unspecified);
+        assert_eq!(
+            NexusOperationCancellationType::default(),
+            NexusOperationCancellationType::WaitCancellationCompleted
+        );
+    }
+
+    #[test]
     fn continue_as_new_options_maps_backoff_start_interval_to_request() {
         let req = ContinueAsNewOptions {
             backoff_start_interval: Some(Duration::from_secs(7)),
+            versioning_intent: Some(VersioningIntent::Compatible),
             ..Default::default()
         }
         .into_request("test-workflow".to_string(), vec![]);
@@ -660,6 +954,10 @@ mod tests {
             .expect("backoff_start_interval should be set");
         assert_eq!(backoff.seconds, 7);
         assert_eq!(backoff.nanos, 0);
+        assert_eq!(
+            req.versioning_intent,
+            ProtoVersioningIntent::Compatible as i32
+        );
     }
 
     #[test]
@@ -694,6 +992,7 @@ mod tests {
             start_to_close: Duration::from_secs(3),
             schedule_to_close: Duration::from_secs(8),
         })
+        .cancellation_type(ActivityCancellationType::Abandon)
         .build()
         .into_command(7, "test".to_string(), vec![]);
         let Some(workflow_command::Variant::ScheduleActivity(req)) = req.variant else {
@@ -701,12 +1000,19 @@ mod tests {
         };
         assert_eq!(req.start_to_close_timeout.unwrap().seconds, 3);
         assert_eq!(req.schedule_to_close_timeout.unwrap().seconds, 8);
+        assert_eq!(
+            req.cancellation_type,
+            ProtoActivityCancellationType::Abandon as i32
+        );
     }
 
     #[test]
     fn child_workflow_run_timeout_uses_run_timeout_field() {
         let opts = ChildWorkflowOptions {
             workflow_id: "test-wf".to_string(),
+            cancel_type: ChildWorkflowCancellationType::WaitCancellationRequested,
+            parent_close_policy: ParentClosePolicy::RequestCancel,
+            id_reuse_policy: WorkflowIdReusePolicy::RejectDuplicate,
             execution_timeout: Some(Duration::from_secs(60)),
             run_timeout: Some(Duration::from_secs(10)),
             ..Default::default()
@@ -720,6 +1026,18 @@ mod tests {
         let run_timeout = req.workflow_run_timeout.unwrap();
         assert_eq!(exec_timeout.seconds, 60);
         assert_eq!(run_timeout.seconds, 10);
+        assert_eq!(
+            req.cancellation_type,
+            ProtoChildWorkflowCancellationType::WaitCancellationRequested as i32
+        );
+        assert_eq!(
+            req.parent_close_policy,
+            ProtoParentClosePolicy::RequestCancel as i32
+        );
+        assert_eq!(
+            req.workflow_id_reuse_policy,
+            ProtoWorkflowIdReusePolicy::RejectDuplicate as i32
+        );
     }
 
     #[test]

--- a/crates/workflow/src/workflow_context/view.rs
+++ b/crates/workflow/src/workflow_context/view.rs
@@ -1,0 +1,202 @@
+use std::time::{Duration, SystemTime};
+
+use temporalio_common_wasm::{
+    Memo, Priority, RetryPolicy, WorkflowExecution,
+    data_converters::{PayloadConverter, SerializationContextData},
+    protos::coresdk::{
+        common::NamespacedWorkflowExecution, workflow_activation::InitializeWorkflow,
+    },
+    search_attributes::SearchAttributes,
+};
+
+/// Read-only view of workflow context for use in init and query handlers.
+///
+/// This provides access to workflow information but cannot issue commands.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct WorkflowContextView {
+    raw: InitializeWorkflow,
+    namespace: String,
+    task_queue: String,
+    run_id: String,
+    payload_converter: PayloadConverter,
+}
+
+impl WorkflowContextView {
+    /// Create a new view from workflow initialization data.
+    pub(crate) fn new(
+        namespace: String,
+        task_queue: String,
+        run_id: String,
+        raw: InitializeWorkflow,
+        payload_converter: PayloadConverter,
+    ) -> Self {
+        Self {
+            raw,
+            namespace,
+            task_queue,
+            run_id,
+            payload_converter,
+        }
+    }
+
+    /// Returns the workflow's unique identifier.
+    pub fn workflow_id(&self) -> &str {
+        &self.raw.workflow_id
+    }
+
+    /// Returns the run ID of this workflow execution.
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    /// Returns the workflow type name.
+    pub fn workflow_type(&self) -> &str {
+        &self.raw.workflow_type
+    }
+
+    /// Returns the task queue this workflow is executing on.
+    pub fn task_queue(&self) -> &str {
+        &self.task_queue
+    }
+
+    /// Returns the namespace this workflow is executing in.
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// Returns the current attempt number, starting from one.
+    pub fn attempt(&self) -> u32 {
+        self.raw.attempt as u32
+    }
+
+    /// Returns the run ID of the first execution in the chain.
+    pub fn first_execution_run_id(&self) -> &str {
+        &self.raw.first_execution_run_id
+    }
+
+    /// Returns the run ID of the previous execution when this is a continuation.
+    pub fn continued_from_run_id(&self) -> Option<&str> {
+        (!self.raw.continued_from_execution_run_id.is_empty())
+            .then_some(self.raw.continued_from_execution_run_id.as_str())
+    }
+
+    /// Returns when the workflow execution started.
+    pub fn start_time(&self) -> Option<SystemTime> {
+        self.raw.start_time.and_then(|time| time.try_into().ok())
+    }
+
+    /// Returns the total workflow execution timeout, including retries and continue-as-new.
+    pub fn execution_timeout(&self) -> Option<Duration> {
+        self.raw
+            .workflow_execution_timeout
+            .and_then(|timeout| timeout.try_into().ok())
+    }
+
+    /// Returns the timeout of a single workflow run.
+    pub fn run_timeout(&self) -> Option<Duration> {
+        self.raw
+            .workflow_run_timeout
+            .and_then(|timeout| timeout.try_into().ok())
+    }
+
+    /// Returns the timeout of a single workflow task.
+    pub fn task_timeout(&self) -> Option<Duration> {
+        self.raw
+            .workflow_task_timeout
+            .and_then(|timeout| timeout.try_into().ok())
+    }
+
+    /// Returns information about the parent workflow when this is a child workflow.
+    pub fn parent(&self) -> Option<NamespacedWorkflowInfo> {
+        self.raw
+            .parent_workflow_info
+            .clone()
+            .map(NamespacedWorkflowInfo::from_raw)
+    }
+
+    /// Returns information about the root workflow in the execution chain.
+    pub fn root(&self) -> Option<WorkflowExecution> {
+        self.raw.root_workflow.clone().map(Into::into)
+    }
+
+    /// Returns the workflow's retry policy.
+    pub fn retry_policy(&self) -> Option<RetryPolicy> {
+        self.raw.retry_policy.clone().map(Into::into)
+    }
+
+    /// Returns the cron schedule when this workflow runs on one.
+    pub fn cron_schedule(&self) -> Option<&str> {
+        (!self.raw.cron_schedule.is_empty()).then_some(self.raw.cron_schedule.as_str())
+    }
+
+    /// Returns priority and fairness configuration for this workflow execution.
+    pub fn priority(&self) -> Priority {
+        self.raw.priority.clone().unwrap_or_default().into()
+    }
+
+    /// Returns user-defined memo values.
+    pub fn memo(&self) -> Memo {
+        Memo::from_raw(
+            self.raw.memo.clone(),
+            self.payload_converter.clone(),
+            SerializationContextData::Workflow,
+        )
+    }
+
+    /// Returns initial search attributes as a typed collection.
+    pub fn search_attributes(&self) -> Option<SearchAttributes> {
+        self.raw
+            .search_attributes
+            .as_ref()
+            .map(SearchAttributes::from_proto)
+    }
+
+    /// Accesses the underlying workflow initialization protobuf.
+    pub fn raw(&self) -> &InitializeWorkflow {
+        &self.raw
+    }
+
+    /// Consumes this view and returns the underlying workflow initialization protobuf.
+    pub fn into_raw(self) -> InitializeWorkflow {
+        self.raw
+    }
+}
+
+/// Information about a parent workflow.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct NamespacedWorkflowInfo {
+    raw: NamespacedWorkflowExecution,
+}
+
+impl NamespacedWorkflowInfo {
+    fn from_raw(raw: NamespacedWorkflowExecution) -> Self {
+        Self { raw }
+    }
+
+    /// Returns the parent workflow's unique identifier.
+    pub fn workflow_id(&self) -> &str {
+        &self.raw.workflow_id
+    }
+
+    /// Returns the parent workflow's run ID.
+    pub fn run_id(&self) -> &str {
+        &self.raw.run_id
+    }
+
+    /// Returns the parent workflow's namespace.
+    pub fn namespace(&self) -> &str {
+        &self.raw.namespace
+    }
+
+    /// Accesses the underlying parent workflow protobuf.
+    pub fn raw(&self) -> &NamespacedWorkflowExecution {
+        &self.raw
+    }
+
+    /// Consumes this wrapper and returns the underlying parent workflow protobuf.
+    pub fn into_raw(self) -> NamespacedWorkflowExecution {
+        self.raw
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
See changelog changes. TL;DR removed most* raw protos in the APIs.

This PR was generated by:
 - first building up a list of public fields/methods outside of `temporalio-protos`
 - filtered out methods with `raw` as these indicated protos were expected
 - filtered out those that took `Payloads` in an expected manner e.g. headers or payload converters
 - a few methods where we explicitly surface protos e.g. workflow history events

Review each commit individually.

* There are 2 more on the list that should be addressed: `WorkflowCountAggregationGroup` and `start_nexus_operation`. Both have some design work that deserves independent PR.

## Why?
In all other SDKs we prefer custom types over the raw ones that translate directly to protobuf messages. This PR does the same for the remaining Rust API surfaces. These changes were grouped in a single PR as many of the changes are purely mechanical. If we feel these should be independent PRs I can break it up.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-rust/issues/1403
2. How was this tested:
Added tests.

3. Any docs updates needed?
Yes, will have to update a few usages in the docsite where we were referencing raw protos.
