### PR TITLE
Auto-enroll pollers into autoscaling on PollerAutoscalingAutoEnroll (Rust SDK) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ to docs, or any other relevant information.
 ## [0.5.0]
 
 ### Added
+* Workers are now automatically enrolled into poller autoscaling when the namespace advertises the
+  `poller_autoscaling_auto_enroll` capability. This only applies to poller types left at their
+  default (the worker set neither a fixed poller count nor a poller behavior); explicitly
+  configured pollers are left unchanged.
 * `client()` and `workflow_handle()` helpers to `ActivityContext` for easily obtaining a Temporal client
 * Exposed `backoff_start_interval` when continuing as new, which will delay the first task of the
   continued workflow by the configured interval.

--- a/crates/sdk-core-c-bridge/src/worker.rs
+++ b/crates/sdk-core-c-bridge/src/worker.rs
@@ -115,6 +115,30 @@ impl TryFrom<&PollerBehavior> for temporalio_sdk_core::PollerBehavior {
     }
 }
 
+/// Converts an FFI poller behavior into an optional core poller behavior. Both fields null means
+/// the poller was left unset by lang: the caller should apply the default behavior and treat the
+/// poller as eligible for automatic enrollment into poller autoscaling.
+fn ffi_poller_behavior_opt(
+    value: &PollerBehavior,
+) -> anyhow::Result<Option<temporalio_sdk_core::PollerBehavior>> {
+    if !value.simple_maximum.is_null() && !value.autoscaling.is_null() {
+        bail!("simple_maximum and autoscaling cannot both be non-null values");
+    }
+    if let Some(sm) = unsafe { value.simple_maximum.as_ref() } {
+        Ok(Some(temporalio_sdk_core::PollerBehavior::SimpleMaximum(
+            sm.simple_maximum,
+        )))
+    } else if let Some(a) = unsafe { value.autoscaling.as_ref() } {
+        Ok(Some(temporalio_sdk_core::PollerBehavior::Autoscaling {
+            minimum: a.minimum,
+            maximum: a.maximum,
+            initial: a.initial,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
 #[repr(C)]
 pub enum WorkerVersioningStrategy {
     None(WorkerVersioningNone),
@@ -1235,16 +1259,28 @@ impl TryFrom<&WorkerOptions> for temporalio_sdk_core::WorkerConfig {
             // auto-cancel-activity behavior or shutdown will not occur, so we
             // always set it even if 0.
             .graceful_shutdown_period(Duration::from_millis(opt.graceful_shutdown_period_millis))
-            .workflow_task_poller_behavior(temporalio_sdk_core::PollerBehavior::try_from(
-                &opt.workflow_task_poller_behavior,
-            )?)
+            .workflow_task_poller_behavior(
+                ffi_poller_behavior_opt(&opt.workflow_task_poller_behavior)?
+                    .unwrap_or(temporalio_sdk_core::PollerBehavior::SimpleMaximum(5)),
+            )
+            .workflow_task_poller_behavior_auto_enroll(
+                ffi_poller_behavior_opt(&opt.workflow_task_poller_behavior)?.is_none(),
+            )
             .nonsticky_to_sticky_poll_ratio(opt.nonsticky_to_sticky_poll_ratio)
-            .activity_task_poller_behavior(temporalio_sdk_core::PollerBehavior::try_from(
-                &opt.activity_task_poller_behavior,
-            )?)
-            .nexus_task_poller_behavior(temporalio_sdk_core::PollerBehavior::try_from(
-                &opt.nexus_task_poller_behavior,
-            )?)
+            .activity_task_poller_behavior(
+                ffi_poller_behavior_opt(&opt.activity_task_poller_behavior)?
+                    .unwrap_or(temporalio_sdk_core::PollerBehavior::SimpleMaximum(5)),
+            )
+            .activity_task_poller_behavior_auto_enroll(
+                ffi_poller_behavior_opt(&opt.activity_task_poller_behavior)?.is_none(),
+            )
+            .nexus_task_poller_behavior(
+                ffi_poller_behavior_opt(&opt.nexus_task_poller_behavior)?
+                    .unwrap_or(temporalio_sdk_core::PollerBehavior::SimpleMaximum(5)),
+            )
+            .nexus_task_poller_behavior_auto_enroll(
+                ffi_poller_behavior_opt(&opt.nexus_task_poller_behavior)?.is_none(),
+            )
             .workflow_failure_errors(if opt.nondeterminism_as_workflow_fail {
                 HashSet::from([WorkflowErrorType::Nondeterminism])
             } else {
@@ -1403,6 +1439,55 @@ mod tests {
             simple_maximum: simple as *const _,
             autoscaling: std::ptr::null(),
         }
+    }
+
+    #[test]
+    fn ffi_poller_behavior_opt_maps_unset_to_none() {
+        let unset = PollerBehavior {
+            simple_maximum: std::ptr::null(),
+            autoscaling: std::ptr::null(),
+        };
+        assert!(ffi_poller_behavior_opt(&unset).unwrap().is_none());
+    }
+
+    #[test]
+    fn ffi_poller_behavior_opt_maps_configured_behaviors() {
+        assert_eq!(
+            ffi_poller_behavior_opt(&simple_poller_behavior(3)).unwrap(),
+            Some(temporalio_sdk_core::PollerBehavior::SimpleMaximum(3)),
+        );
+        let autoscaling = Box::leak(Box::new(PollerBehaviorAutoscaling {
+            minimum: 2,
+            maximum: 20,
+            initial: 4,
+        }));
+        let pb = PollerBehavior {
+            simple_maximum: std::ptr::null(),
+            autoscaling: autoscaling as *const _,
+        };
+        assert_eq!(
+            ffi_poller_behavior_opt(&pb).unwrap(),
+            Some(temporalio_sdk_core::PollerBehavior::Autoscaling {
+                minimum: 2,
+                maximum: 20,
+                initial: 4,
+            }),
+        );
+    }
+
+    #[test]
+    fn ffi_poller_behavior_opt_rejects_both_set() {
+        let simple = Box::leak(Box::new(PollerBehaviorSimpleMaximum { simple_maximum: 1 }));
+        let autoscaling = Box::leak(Box::new(PollerBehaviorAutoscaling {
+            minimum: 1,
+            maximum: 2,
+            initial: 1,
+        }));
+        let pb = PollerBehavior {
+            simple_maximum: simple as *const _,
+            autoscaling: autoscaling as *const _,
+        };
+        assert!(ffi_poller_behavior_opt(&pb).is_err());
     }
 
     fn base_worker_options(

--- a/crates/sdk-core/src/core_tests/workers.rs
+++ b/crates/sdk-core/src/core_tests/workers.rs
@@ -1326,3 +1326,60 @@ async fn graceful_shutdown_sends_shutdown_worker_rpc_during_initiate() {
 
     worker.finalize_shutdown().await;
 }
+
+#[tokio::test]
+async fn validate_enables_auto_enroll_and_forces_autoscaling_capability() {
+    let mut mock = mock_worker_client();
+    mock.expect_describe_namespace().returning(|| {
+        Ok(DescribeNamespaceResponse {
+            namespace_info: Some(NamespaceInfo {
+                capabilities: Some(Capabilities {
+                    poller_autoscaling_auto_enroll: true,
+                    ..Capabilities::default()
+                }),
+                ..NamespaceInfo::default()
+            }),
+            ..DescribeNamespaceResponse::default()
+        })
+    });
+    let t = canned_histories::single_timer("1");
+    let mut mh = MockPollCfg::from_resp_batches("fakeid", t, [1], mock);
+    mh.enforce_correct_number_of_polls = false;
+    let worker = mock_worker(build_mock_pollers(mh));
+
+    worker.validate().await.unwrap();
+    let caps = worker.get_namespace_capabilities();
+    assert!(caps.poller_autoscaling_auto_enroll());
+    // Auto-enroll implies full autoscaling support, so poller_autoscaling is forced on too.
+    assert!(caps.poller_autoscaling());
+
+    worker.drain_pollers_and_shutdown().await;
+}
+
+#[tokio::test]
+async fn validate_without_auto_enroll_leaves_capabilities_off() {
+    let mut mock = mock_worker_client();
+    mock.expect_describe_namespace().returning(|| {
+        Ok(DescribeNamespaceResponse {
+            namespace_info: Some(NamespaceInfo {
+                capabilities: Some(Capabilities {
+                    poller_autoscaling_auto_enroll: false,
+                    ..Capabilities::default()
+                }),
+                ..NamespaceInfo::default()
+            }),
+            ..DescribeNamespaceResponse::default()
+        })
+    });
+    let t = canned_histories::single_timer("1");
+    let mut mh = MockPollCfg::from_resp_batches("fakeid", t, [1], mock);
+    mh.enforce_correct_number_of_polls = false;
+    let worker = mock_worker(build_mock_pollers(mh));
+
+    worker.validate().await.unwrap();
+    let caps = worker.get_namespace_capabilities();
+    assert!(!caps.poller_autoscaling_auto_enroll());
+    assert!(!caps.poller_autoscaling());
+
+    worker.drain_pollers_and_shutdown().await;
+}

--- a/crates/sdk-core/src/pollers/poll_buffer.rs
+++ b/crates/sdk-core/src/pollers/poll_buffer.rs
@@ -99,6 +99,7 @@ impl LongPollBuffer<PollWorkflowTaskQueueResponse, WorkflowSlotKind> {
         task_queue: String,
         sticky_queue: Option<String>,
         poller_behavior: PollerBehavior,
+        auto_enroll_eligible: bool,
         permit_dealer: MeteredPermitDealer<WorkflowSlotKind>,
         shutdown: CancellationToken,
         num_pollers_handler: Option<impl Fn(usize) + Send + Sync + 'static>,
@@ -107,12 +108,15 @@ impl LongPollBuffer<PollWorkflowTaskQueueResponse, WorkflowSlotKind> {
         capabilities: Arc<NamespaceCapabilities>,
     ) -> Self {
         let is_sticky = sticky_queue.is_some();
+        let autoscaling_active = Arc::new(AtomicBool::new(false));
         let poll_scaler = PollScaler::new(
             poller_behavior,
+            auto_enroll_eligible,
             num_pollers_handler,
             shutdown.clone(),
             last_successful_poll_time,
             capabilities.clone(),
+            autoscaling_active.clone(),
         );
         if let Some(wftps) = options.wft_poller_shared.as_ref() {
             if is_sticky {
@@ -137,17 +141,18 @@ impl LongPollBuffer<PollWorkflowTaskQueueResponse, WorkflowSlotKind> {
                 }
             }
         });
-        let no_retry = if matches!(poller_behavior, PollerBehavior::Autoscaling { .. }) {
-            Some(NoRetryOnMatching {
-                predicate: poll_scaling_error_matcher,
-            })
-        } else {
-            None
-        };
         let poll_fn = move |timeout_override: Option<Duration>| {
             let client = client.clone();
             let task_queue = task_queue.clone();
             let sticky_queue_name = sticky_queue.clone();
+            // Resolved by `PollScaler::activate` before the first poll; recomputed per call so a
+            // default poller auto-enrolled into autoscaling gets the poller-managed backoff.
+            let no_retry =
+                autoscaling_active
+                    .load(Ordering::Relaxed)
+                    .then_some(NoRetryOnMatching {
+                        predicate: poll_scaling_error_matcher,
+                    });
             async move {
                 client
                     .poll_workflow_task(
@@ -179,6 +184,7 @@ impl LongPollBuffer<PollActivityTaskQueueResponse, ActivitySlotKind> {
         client: Arc<dyn WorkerClient>,
         task_queue: String,
         poller_behavior: PollerBehavior,
+        auto_enroll_eligible: bool,
         permit_dealer: MeteredPermitDealer<ActivitySlotKind>,
         shutdown: CancellationToken,
         num_pollers_handler: Option<impl Fn(usize) + Send + Sync + 'static>,
@@ -195,38 +201,44 @@ impl LongPollBuffer<PollActivityTaskQueueResponse, ActivitySlotKind> {
                     async move { rl.wait().await }.boxed()
                 }
             });
-        let no_retry = if matches!(poller_behavior, PollerBehavior::Autoscaling { .. }) {
-            Some(NoRetryOnMatching {
-                predicate: poll_scaling_error_matcher,
-            })
-        } else {
-            None
-        };
-        let poll_fn = move |timeout_override: Option<Duration>| {
-            let client = client.clone();
-            let task_queue = task_queue.clone();
-            async move {
-                client
-                    .poll_activity_task(
-                        PollOptions {
-                            task_queue,
-                            no_retry,
-                            timeout_override,
-                        },
-                        PollActivityOptions {
-                            max_tasks_per_sec: options.max_tps,
-                        },
-                    )
-                    .await
+        let autoscaling_active = Arc::new(AtomicBool::new(false));
+        let poll_fn = {
+            let autoscaling_active = autoscaling_active.clone();
+            move |timeout_override: Option<Duration>| {
+                let client = client.clone();
+                let task_queue = task_queue.clone();
+                // Resolved by `PollScaler::activate` before the first poll; recomputed per call.
+                let no_retry =
+                    autoscaling_active
+                        .load(Ordering::Relaxed)
+                        .then_some(NoRetryOnMatching {
+                            predicate: poll_scaling_error_matcher,
+                        });
+                async move {
+                    client
+                        .poll_activity_task(
+                            PollOptions {
+                                task_queue,
+                                no_retry,
+                                timeout_override,
+                            },
+                            PollActivityOptions {
+                                max_tasks_per_sec: options.max_tps,
+                            },
+                        )
+                        .await
+                }
             }
         };
 
         let poll_scaler = PollScaler::new(
             poller_behavior,
+            auto_enroll_eligible,
             num_pollers_handler,
             shutdown.clone(),
             last_successful_poll_time,
             capabilities.clone(),
+            autoscaling_active,
         );
         Self::new(
             poll_fn,
@@ -246,6 +258,7 @@ impl LongPollBuffer<PollNexusTaskQueueResponse, NexusSlotKind> {
         client: Arc<dyn WorkerClient>,
         task_queue: String,
         poller_behavior: PollerBehavior,
+        auto_enroll_eligible: bool,
         permit_dealer: MeteredPermitDealer<NexusSlotKind>,
         shutdown: CancellationToken,
         num_pollers_handler: Option<impl Fn(usize) + Send + Sync + 'static>,
@@ -253,29 +266,33 @@ impl LongPollBuffer<PollNexusTaskQueueResponse, NexusSlotKind> {
         capabilities: Arc<NamespaceCapabilities>,
         worker_commands_queue: bool,
     ) -> Self {
-        let no_retry = if matches!(poller_behavior, PollerBehavior::Autoscaling { .. }) {
-            Some(NoRetryOnMatching {
-                predicate: poll_scaling_error_matcher,
-            })
-        } else {
-            None
-        };
-        let poll_fn = move |timeout_override: Option<Duration>| {
-            let client = client.clone();
-            let task_queue = task_queue.clone();
-            async move {
-                client
-                    .poll_nexus_task(
-                        PollOptions {
-                            task_queue,
-                            no_retry,
-                            timeout_override,
-                        },
-                        PollNexusOptions {
-                            worker_commands_queue,
-                        },
-                    )
-                    .await
+        let autoscaling_active = Arc::new(AtomicBool::new(false));
+        let poll_fn = {
+            let autoscaling_active = autoscaling_active.clone();
+            move |timeout_override: Option<Duration>| {
+                let client = client.clone();
+                let task_queue = task_queue.clone();
+                // Resolved by `PollScaler::activate` before the first poll; recomputed per call.
+                let no_retry =
+                    autoscaling_active
+                        .load(Ordering::Relaxed)
+                        .then_some(NoRetryOnMatching {
+                            predicate: poll_scaling_error_matcher,
+                        });
+                async move {
+                    client
+                        .poll_nexus_task(
+                            PollOptions {
+                                task_queue,
+                                no_retry,
+                                timeout_override,
+                            },
+                            PollNexusOptions {
+                                worker_commands_queue,
+                            },
+                        )
+                        .await
+                }
             }
         };
         Self::new(
@@ -284,10 +301,12 @@ impl LongPollBuffer<PollNexusTaskQueueResponse, NexusSlotKind> {
             shutdown.clone(),
             PollScaler::new(
                 poller_behavior,
+                auto_enroll_eligible,
                 num_pollers_handler,
                 shutdown,
                 last_successful_poll_time,
                 capabilities.clone(),
+                autoscaling_active,
             ),
             None::<fn() -> BoxFuture<'static, ()>>,
             None::<fn(&PollNexusTaskQueueResponse)>,
@@ -345,6 +364,12 @@ where
                     _ = shutdown_clone.cancelled() => return,
                 }
                 drop(wait_for_start);
+
+                // At this point the worker has started polling, which lang only does after
+                // `Worker::validate` has populated the namespace capabilities. Resolve the
+                // effective poller behavior now (this may auto-enroll a default poller into
+                // autoscaling) before issuing any poll.
+                poll_scaler.activate();
 
                 let (spawned_tx, spawned_rx) = unbounded_channel();
                 // This is needed to ensure we don't exit this task before all received polls have
@@ -494,11 +519,44 @@ async fn handle_task_panic(t: JoinHandle<()>) {
 /// always respect scale down decisions (until the number of pollers reaches the minimum), but may
 /// choose to ignore scale up decisions if it appears that adding more pollers is not contributing
 /// to increased task throughput. See more detailed comments in the implementation.
+/// Resolves the effective poller behavior for a poller, applying automatic enrollment into
+/// autoscaling when the poller was left at its default and the namespace advertises the
+/// `poller_autoscaling_auto_enroll` capability. Otherwise the configured behavior is used as-is.
+fn resolve_effective_behavior(
+    configured: PollerBehavior,
+    auto_enroll_eligible: bool,
+    capabilities: &NamespaceCapabilities,
+) -> PollerBehavior {
+    if auto_enroll_eligible && capabilities.poller_autoscaling_auto_enroll() {
+        // Mirrors the Go SDK's auto-enroll autoscaling defaults.
+        PollerBehavior::Autoscaling {
+            minimum: 1,
+            maximum: 100,
+            initial: 5,
+        }
+    } else {
+        configured
+    }
+}
+
 struct PollScaler<F> {
-    report_handle: Arc<PollScalerReportHandle>,
+    // The watch channel is created eagerly because `WFTPollerShared` needs `active_rx` before the
+    // poller task starts.
     active_tx: watch::Sender<usize>,
     active_rx: watch::Receiver<usize>,
     num_pollers_handler: Option<Arc<F>>,
+    // Inputs captured so the effective behavior can be resolved lazily in `activate`, once the
+    // namespace capabilities discovered by `Worker::validate` are known (which is guaranteed to be
+    // before polling begins).
+    configured_behavior: PollerBehavior,
+    auto_enroll_eligible: bool,
+    capabilities: Arc<NamespaceCapabilities>,
+    last_successful_poll_time: Arc<AtomicCell<Option<SystemTime>>>,
+    shutdown: CancellationToken,
+    /// Shared with the poll function so `no_retry` tracks the resolved (post-`activate`) behavior.
+    autoscaling_active: Arc<AtomicBool>,
+    // Resolved by `activate`, before the poll loop issues any poll.
+    report_handle: Option<Arc<PollScalerReportHandle>>,
     ingestor_task: Option<JoinHandle<()>>,
 }
 
@@ -507,14 +565,43 @@ where
     F: Fn(usize),
 {
     fn new(
-        behavior: PollerBehavior,
+        configured_behavior: PollerBehavior,
+        auto_enroll_eligible: bool,
         num_pollers_handler: Option<F>,
         shutdown: CancellationToken,
         last_successful_poll_time: Arc<AtomicCell<Option<SystemTime>>>,
         capabilities: Arc<NamespaceCapabilities>,
+        autoscaling_active: Arc<AtomicBool>,
     ) -> Self {
         let (active_tx, active_rx) = watch::channel(0);
         let num_pollers_handler = num_pollers_handler.map(Arc::new);
+        Self {
+            active_tx,
+            active_rx,
+            num_pollers_handler,
+            configured_behavior,
+            auto_enroll_eligible,
+            capabilities,
+            last_successful_poll_time,
+            shutdown,
+            autoscaling_active,
+            report_handle: None,
+            ingestor_task: None,
+        }
+    }
+
+    /// Resolves the effective poller behavior and builds the (immutable) report handle plus, when
+    /// autoscaling, the ingestor task. Must be called from within the poller task, after the start
+    /// signal is received (so `Worker::validate` has populated the namespace capabilities) and
+    /// before the poll loop issues any poll.
+    fn activate(&mut self) {
+        let behavior = resolve_effective_behavior(
+            self.configured_behavior,
+            self.auto_enroll_eligible,
+            &self.capabilities,
+        );
+        self.autoscaling_active
+            .store(behavior.is_autoscaling(), Ordering::Relaxed);
         let (min, max, target) = match behavior {
             PollerBehavior::SimpleMaximum(m) => (1, m, m),
             PollerBehavior::Autoscaling {
@@ -523,6 +610,8 @@ where
                 initial,
             } => (minimum, maximum, initial),
         };
+        let capabilities = self.capabilities.clone();
+        let last_successful_poll_time = self.last_successful_poll_time.clone();
         let report_handle = Arc::new(PollScalerReportHandle {
             max,
             min,
@@ -558,14 +647,15 @@ where
             }),
         });
         let rhc = report_handle.clone();
-        let ingestor_task = if behavior.is_autoscaling() {
+        let shutdown = self.shutdown.clone();
+        self.ingestor_task = behavior.is_autoscaling().then(|| {
             // Here we spawn a task to periodically check if we should permit increasing the
             // poller count further. We do this by comparing the number of ingested items in the
             // current period with the number of ingested items in the previous period. If we
             // are successfully ingesting more items, then it makes sense to allow scaling up.
             // If we aren't, then we're probably limited by how fast we can process the tasks
             // and it's not worth increasing the poller count further.
-            Some(tokio::task::spawn(async move {
+            tokio::task::spawn(async move {
                 let mut interval = tokio::time::interval(Duration::from_millis(100));
                 loop {
                     tokio::select! {
@@ -579,24 +669,19 @@ where
                         Ordering::Relaxed,
                     );
                 }
-            }))
-        } else {
-            None
-        };
-        Self {
-            report_handle,
-            active_tx,
-            active_rx,
-            num_pollers_handler,
-            ingestor_task,
-        }
+            })
+        });
+        self.report_handle = Some(report_handle);
     }
 
     async fn wait_until_allowed(&mut self) -> ActiveCounter<impl Fn(usize) + use<F>> {
+        let report_handle = self
+            .report_handle
+            .clone()
+            .expect("PollScaler must be activated before polling");
         self.active_rx
             .wait_for(|v| {
-                *v < self.report_handle.max
-                    && *v < self.report_handle.target.load(Ordering::Relaxed)
+                *v < report_handle.max && *v < report_handle.target.load(Ordering::Relaxed)
             })
             .await
             .expect("Poll allow does not panic");
@@ -604,7 +689,9 @@ where
     }
 
     fn get_report_handle(&self) -> Arc<PollScalerReportHandle> {
-        self.report_handle.clone()
+        self.report_handle
+            .clone()
+            .expect("PollScaler must be activated before polling")
     }
 }
 
@@ -862,6 +949,61 @@ mod tests {
     use std::time::Duration;
     use tokio::{select, sync::Notify};
 
+    fn caps(auto_enroll: bool) -> NamespaceCapabilities {
+        let caps = NamespaceCapabilities::default();
+        caps.poller_autoscaling_auto_enroll
+            .store(auto_enroll, Ordering::Relaxed);
+        caps
+    }
+
+    const AUTO_ENROLLED: PollerBehavior = PollerBehavior::Autoscaling {
+        minimum: 1,
+        maximum: 100,
+        initial: 5,
+    };
+
+    #[test]
+    fn auto_enroll_switches_eligible_default_poller_to_autoscaling() {
+        assert_eq!(
+            resolve_effective_behavior(PollerBehavior::SimpleMaximum(5), true, &caps(true)),
+            AUTO_ENROLLED,
+        );
+    }
+
+    #[test]
+    fn no_auto_enroll_capability_leaves_eligible_poller_at_configured() {
+        assert_eq!(
+            resolve_effective_behavior(PollerBehavior::SimpleMaximum(5), true, &caps(false)),
+            PollerBehavior::SimpleMaximum(5),
+        );
+    }
+
+    #[test]
+    fn explicitly_configured_poller_is_never_auto_enrolled() {
+        // Not eligible: user explicitly set the behavior, so it is left unchanged even when the
+        // namespace advertises auto-enroll.
+        assert_eq!(
+            resolve_effective_behavior(PollerBehavior::SimpleMaximum(3), false, &caps(true)),
+            PollerBehavior::SimpleMaximum(3),
+        );
+        assert_eq!(
+            resolve_effective_behavior(
+                PollerBehavior::Autoscaling {
+                    minimum: 2,
+                    maximum: 20,
+                    initial: 4,
+                },
+                false,
+                &caps(true),
+            ),
+            PollerBehavior::Autoscaling {
+                minimum: 2,
+                maximum: 20,
+                initial: 4,
+            },
+        );
+    }
+
     #[tokio::test]
     async fn only_polls_once_with_1_poller() {
         let mut mock_client = mock_manual_worker_client();
@@ -881,6 +1023,7 @@ mod tests {
             "sometq".to_string(),
             None,
             PollerBehavior::SimpleMaximum(1),
+            false,
             fixed_size_permit_dealer(10),
             CancellationToken::new(),
             None::<fn(usize)>,
@@ -938,6 +1081,7 @@ mod tests {
                 maximum: 1,
                 initial: 1,
             },
+            false,
             fixed_size_permit_dealer(1),
             CancellationToken::new(),
             None::<fn(usize)>,
@@ -1015,6 +1159,7 @@ mod tests {
             "sometq".to_string(),
             None,
             PollerBehavior::SimpleMaximum(3),
+            false,
             fixed_size_permit_dealer(10),
             shutdown_token.clone(),
             None::<fn(usize)>,
@@ -1121,6 +1266,7 @@ mod tests {
                 maximum: 100,
                 initial: 10,
             },
+            false,
             fixed_size_permit_dealer(10),
             CancellationToken::new(),
             None::<fn(usize)>,
@@ -1202,6 +1348,7 @@ mod tests {
             "sometq".to_string(),
             None,
             PollerBehavior::SimpleMaximum(1),
+            false,
             fixed_size_permit_dealer(10),
             shutdown_token.clone(),
             None::<fn(usize)>,

--- a/crates/sdk-core/src/worker/activities.rs
+++ b/crates/sdk-core/src/worker/activities.rs
@@ -868,6 +868,7 @@ mod tests {
             mock_client.clone(),
             "tq".to_string(),
             PollerBehavior::SimpleMaximum(1),
+            false,
             sem.clone(),
             shutdown_token,
             None::<fn(usize)>,
@@ -955,6 +956,7 @@ mod tests {
             "tq".to_string(),
             // Lots of concurrent pollers, to ensure we don't poll to much when that's the case
             PollerBehavior::SimpleMaximum(5),
+            false,
             sem.clone(),
             shutdown_token.clone(),
             None::<fn(usize)>,

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -147,6 +147,13 @@ pub struct WorkerConfig {
     /// If using SimpleMaximum, Must be at least 2 when `max_cached_workflows` > 0, or is an error.
     #[builder(default = PollerBehavior::SimpleMaximum(5))]
     pub workflow_task_poller_behavior: PollerBehavior,
+    /// True if [WorkerConfig::workflow_task_poller_behavior] was left at its default (the user
+    /// configured neither a fixed poller count nor an explicit behavior). Such pollers are eligible
+    /// for automatic enrollment into poller autoscaling when the namespace advertises the
+    /// `poller_autoscaling_auto_enroll` capability. Layers above core (the Rust SDK, the c-bridge)
+    /// set this; direct core users leave it `false`.
+    #[builder(default = false)]
+    pub workflow_task_poller_behavior_auto_enroll: bool,
     /// Only applies when using [PollerBehavior::SimpleMaximum]
     ///
     /// (max workflow task polls * this number) = the number of max pollers that will be allowed for
@@ -160,10 +167,18 @@ pub struct WorkerConfig {
     /// worker's task queue
     #[builder(default = PollerBehavior::SimpleMaximum(5))]
     pub activity_task_poller_behavior: PollerBehavior,
+    /// True if [WorkerConfig::activity_task_poller_behavior] was left at its default. See
+    /// [WorkerConfig::workflow_task_poller_behavior_auto_enroll].
+    #[builder(default = false)]
+    pub activity_task_poller_behavior_auto_enroll: bool,
     /// Maximum number of concurrent poll nexus task requests we will perform at a time on this
     /// worker's task queue
     #[builder(default = PollerBehavior::SimpleMaximum(5))]
     pub nexus_task_poller_behavior: PollerBehavior,
+    /// True if [WorkerConfig::nexus_task_poller_behavior] was left at its default. See
+    /// [WorkerConfig::workflow_task_poller_behavior_auto_enroll].
+    #[builder(default = false)]
+    pub nexus_task_poller_behavior_auto_enroll: bool,
     /// Specifies which task types this worker will poll for.
     ///
     /// Note: At least one task type must be specified or the worker will fail validation.
@@ -438,6 +453,7 @@ pub struct Worker {
 pub struct NamespaceCapabilities {
     pub(crate) graceful_poll_shutdown: AtomicBool,
     pub(crate) poller_autoscaling: AtomicBool,
+    pub(crate) poller_autoscaling_auto_enroll: AtomicBool,
     pub(crate) worker_commands: AtomicBool,
 }
 
@@ -452,6 +468,12 @@ impl NamespaceCapabilities {
     /// decision from the server.
     pub fn poller_autoscaling(&self) -> bool {
         self.poller_autoscaling.load(Ordering::Relaxed)
+    }
+
+    /// Returns true if the namespace opts workers into poller autoscaling by default. Poller types
+    /// left at their default are automatically enrolled into autoscaling when this is set.
+    pub fn poller_autoscaling_auto_enroll(&self) -> bool {
+        self.poller_autoscaling_auto_enroll.load(Ordering::Relaxed)
     }
 
     /// Returns true if worker commands are supported in this namespace.
@@ -538,6 +560,17 @@ impl Worker {
                             .store(true, Ordering::Relaxed);
                     }
                     if caps.poller_autoscaling {
+                        self.capabilities
+                            .poller_autoscaling
+                            .store(true, Ordering::Relaxed);
+                    }
+                    if caps.poller_autoscaling_auto_enroll {
+                        self.capabilities
+                            .poller_autoscaling_auto_enroll
+                            .store(true, Ordering::Relaxed);
+                        // Auto-enroll implies full autoscaling support (including scaling down on
+                        // empty polls before any server scaling decision), so enable the
+                        // poller_autoscaling capability too. See `can_scale_down`.
                         self.capabilities
                             .poller_autoscaling
                             .store(true, Ordering::Relaxed);
@@ -670,6 +703,7 @@ impl Worker {
         let capabilities = Arc::new(NamespaceCapabilities {
             graceful_poll_shutdown: AtomicBool::new(false),
             poller_autoscaling: AtomicBool::new(false),
+            poller_autoscaling_auto_enroll: AtomicBool::new(false),
             worker_commands: AtomicBool::new(false),
         });
 
@@ -714,6 +748,7 @@ impl Worker {
                         client.clone(),
                         config.task_queue.clone(),
                         config.activity_task_poller_behavior,
+                        config.activity_task_poller_behavior_auto_enroll,
                         act_slots.clone(),
                         shutdown_token.child_token(),
                         Some(move |np| act_metrics.record_num_pollers(np)),
@@ -735,6 +770,7 @@ impl Worker {
                         client.clone(),
                         config.task_queue.clone(),
                         config.nexus_task_poller_behavior,
+                        config.nexus_task_poller_behavior_auto_enroll,
                         nexus_slots.clone(),
                         shutdown_token.child_token(),
                         Some(move |np| np_metrics.record_num_pollers(np)),

--- a/crates/sdk-core/src/worker/workflow/wft_poller.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_poller.rs
@@ -51,6 +51,7 @@ pub(crate) fn make_wft_poller(
         config.task_queue.clone(),
         None,
         poller_behavior,
+        config.workflow_task_poller_behavior_auto_enroll,
         wft_slots.clone(),
         shutdown_token.child_token(),
         Some(move |np| {
@@ -69,6 +70,7 @@ pub(crate) fn make_wft_poller(
             config.task_queue.clone(),
             Some(sqn.clone()),
             wft_poller_behavior(config, true),
+            config.workflow_task_poller_behavior_auto_enroll,
             wft_slots.clone().into_sticky(),
             shutdown_token.child_token(),
             Some(move |np| {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -196,8 +196,10 @@ pub struct WorkerOptions {
     /// Controls how polling for Workflow tasks will happen on this worker's task queue. See also
     /// [WorkerConfig::nonsticky_to_sticky_poll_ratio]. If using SimpleMaximum, Must be at least 2
     /// when `max_cached_workflows` > 0, or is an error.
-    #[builder(default = PollerBehavior::SimpleMaximum(5))]
-    pub workflow_task_poller_behavior: PollerBehavior,
+    ///
+    /// If left unset, the worker uses `SimpleMaximum(5)` and becomes eligible for automatic
+    /// enrollment into poller autoscaling when the namespace advertises support for it.
+    pub workflow_task_poller_behavior: Option<PollerBehavior>,
     /// Only applies when using [PollerBehavior::SimpleMaximum]
     ///
     /// (max workflow task polls * this number) = the number of max pollers that will be allowed for
@@ -208,11 +210,15 @@ pub struct WorkerOptions {
     #[builder(default = 0.2)]
     pub nonsticky_to_sticky_poll_ratio: f32,
     /// Controls how polling for Activity tasks will happen on this worker's task queue.
-    #[builder(default = PollerBehavior::SimpleMaximum(5))]
-    pub activity_task_poller_behavior: PollerBehavior,
+    ///
+    /// If left unset, the worker uses `SimpleMaximum(5)` and becomes eligible for automatic
+    /// enrollment into poller autoscaling when the namespace advertises support for it.
+    pub activity_task_poller_behavior: Option<PollerBehavior>,
     /// Controls how polling for Nexus tasks will happen on this worker's task queue.
-    #[builder(default = PollerBehavior::SimpleMaximum(5))]
-    pub nexus_task_poller_behavior: PollerBehavior,
+    ///
+    /// If left unset, the worker uses `SimpleMaximum(5)` and becomes eligible for automatic
+    /// enrollment into poller autoscaling when the namespace advertises support for it.
+    pub nexus_task_poller_behavior: Option<PollerBehavior>,
     // TODO [rust-sdk-branch]: Will go away once workflow registration can only happen in here.
     //   Then it can be auto-determined.
     /// Specifies which task types this worker will poll for.
@@ -415,9 +421,21 @@ impl WorkerOptions {
             }))
             .max_cached_workflows(self.max_cached_workflows)
             .tuner(self.tuner.clone())
-            .workflow_task_poller_behavior(self.workflow_task_poller_behavior)
-            .activity_task_poller_behavior(self.activity_task_poller_behavior)
-            .nexus_task_poller_behavior(self.nexus_task_poller_behavior)
+            .workflow_task_poller_behavior(
+                self.workflow_task_poller_behavior
+                    .unwrap_or(PollerBehavior::SimpleMaximum(5)),
+            )
+            .workflow_task_poller_behavior_auto_enroll(self.workflow_task_poller_behavior.is_none())
+            .activity_task_poller_behavior(
+                self.activity_task_poller_behavior
+                    .unwrap_or(PollerBehavior::SimpleMaximum(5)),
+            )
+            .activity_task_poller_behavior_auto_enroll(self.activity_task_poller_behavior.is_none())
+            .nexus_task_poller_behavior(
+                self.nexus_task_poller_behavior
+                    .unwrap_or(PollerBehavior::SimpleMaximum(5)),
+            )
+            .nexus_task_poller_behavior_auto_enroll(self.nexus_task_poller_behavior.is_none())
             .task_types(self.task_types)
             .sticky_queue_schedule_to_start_timeout(self.sticky_queue_schedule_to_start_timeout)
             .max_heartbeat_throttle_interval(self.max_heartbeat_throttle_interval)


### PR DESCRIPTION
Ports [temporalio/sdk-go#2442](https://github.com/temporalio/sdk-go/pull/2442) to `sdk-core`, so it's shared by every SDK on top of it (Rust directly; TS/Python/.NET/Ruby via the c-bridge).

## What

When a namespace advertises the `poller_autoscaling_auto_enroll` capability, workers automatically switch their workflow, activity, and nexus pollers to **autoscaling** — but only for poller types the user left at their default. Pollers with an explicitly configured count or behavior are left alone.

## Why it's implemented this way

The capability is only known after `Worker::validate()` (an async namespace lookup), but pollers are built earlier, synchronously. Instead of reordering that, the `PollScaler` resolves its behavior **lazily**, when polling starts — which always happens after `validate()`. Alternatives (blocking network I/O during construction, or rebuilding pollers afterward) were more invasive.

## Key changes

- **`Worker::validate()`** reads the new capability and also enables `poller_autoscaling` so enrolled pollers can scale down.
- **`WorkerConfig`** gains three per-type "eligibility" flags (default `false` — nothing auto-enrolls unless a layer above opts in).
- **`PollScaler`** defers its setup into `activate()` and, if the poller is eligible and the capability is present, uses `Autoscaling { min: 1, max: 100, initial: 5 }` (matching Go).
- **High-level SDK / c-bridge** signal eligibility by leaving the poller behavior unset (SDK: `Option::None`; c-bridge: both FFI pointers null).

## Notes

- Two intentional differences from the Go PR: no session-worker case and no heartbeat change — neither exists in `sdk-core`.
- The SDK `WorkerOptions` poller fields become `Option<PollerBehavior>` (minor pre-1.0 break; existing `.foo(x)` calls still compile).
- Other lang SDKs need a small follow-up to pass the unset signal through the FFI.

## Testing

New unit tests for behavior resolution, `validate()` plumbing, and the c-bridge conversion. Full `sdk-core` lib suite passes (368 tests); fmt + clippy clean.