### PR TITLE
Allow resource controllers to be shared across tuners

### DIFF
--- a/crates/sdk-core-c-bridge/src/worker.rs
+++ b/crates/sdk-core-c-bridge/src/worker.rs
@@ -1345,11 +1345,13 @@ impl TryFrom<&TunerHolder> for temporalio_sdk_core::TunerHolder {
             .activity_slot_options(holder.activity_slot_supplier.try_into()?)
             .local_activity_slot_options(holder.local_activity_slot_supplier.try_into()?)
             .nexus_slot_options(holder.nexus_task_slot_supplier.try_into()?)
-            .maybe_resource_based_options(first.map(|f| {
-                temporalio_sdk_core::ResourceBasedSlotsOptions::builder()
-                    .target_mem_usage(f.target_memory_usage)
-                    .target_cpu_usage(f.target_cpu_usage)
-                    .build()
+            .maybe_resource_based_config(first.map(|f| {
+                temporalio_sdk_core::ResourceBasedTunerConfig::Options(
+                    temporalio_sdk_core::ResourceBasedSlotsOptions::builder()
+                        .target_mem_usage(f.target_memory_usage)
+                        .target_cpu_usage(f.target_cpu_usage)
+                        .build(),
+                )
             }))
             .build()
             .map_err(|e| anyhow::anyhow!("Failed building tuner holder options: {}", e))?

--- a/crates/sdk-core/src/lib.rs
+++ b/crates/sdk-core/src/lib.rs
@@ -44,11 +44,12 @@ pub use worker::{
     ActivitySlotKind, CompleteActivityError, CompleteNexusError, CompleteWfError,
     FixedSizeSlotSupplier, LocalActivitySlotKind, NamespaceCapabilities, NexusSlotKind, PollError,
     PollerBehavior, ResourceBasedSlotsOptions, ResourceBasedSlotsOptionsBuilder,
-    ResourceBasedTuner, ResourceSlotOptions, SlotInfo, SlotInfoTrait, SlotKind, SlotKindType,
-    SlotMarkUsedContext, SlotReleaseContext, SlotReservationContext, SlotSupplier,
-    SlotSupplierOptions, SlotSupplierPermit, TunerBuilder, TunerHolder, TunerHolderOptions,
-    TunerHolderOptionsBuilder, Worker, WorkerConfig, WorkerConfigBuilder, WorkerTuner,
-    WorkerValidationError, WorkerVersioningStrategy, WorkflowErrorType, WorkflowSlotKind,
+    ResourceBasedTuner, ResourceBasedTunerConfig, ResourceController, ResourceSlotOptions,
+    SlotInfo, SlotInfoTrait, SlotKind, SlotKindType, SlotMarkUsedContext, SlotReleaseContext,
+    SlotReservationContext, SlotSupplier, SlotSupplierOptions, SlotSupplierPermit, TunerBuilder,
+    TunerHolder, TunerHolderOptions, TunerHolderOptionsBuilder, Worker, WorkerConfig,
+    WorkerConfigBuilder, WorkerTuner, WorkerValidationError, WorkerVersioningStrategy,
+    WorkflowErrorType, WorkflowSlotKind,
 };
 
 use crate::{

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -23,8 +23,8 @@ use temporalio_common::{
 };
 pub use tuner::{
     FixedSizeSlotSupplier, ResourceBasedSlotsOptions, ResourceBasedSlotsOptionsBuilder,
-    ResourceBasedTuner, ResourceSlotOptions, SlotSupplierOptions, TunerBuilder, TunerHolder,
-    TunerHolderOptions,
+    ResourceBasedTuner, ResourceBasedTunerConfig, ResourceController, ResourceSlotOptions,
+    SlotSupplierOptions, TunerBuilder, TunerHolder, TunerHolderOptions,
 };
 // Re-export the generated builder (it's in the tuner module)
 pub use tuner::TunerHolderOptionsBuilder;

--- a/crates/sdk-core/src/worker/tuner.rs
+++ b/crates/sdk-core/src/worker/tuner.rs
@@ -2,12 +2,11 @@ mod fixed_size;
 mod resource_based;
 
 pub use fixed_size::FixedSizeSlotSupplier;
+pub(crate) use resource_based::{RealSysInfo, SystemResourceInfo};
 pub use resource_based::{
     ResourceBasedSlotsOptions, ResourceBasedSlotsOptionsBuilder, ResourceBasedTuner,
-    ResourceSlotOptions,
+    ResourceController, ResourceSlotOptions,
 };
-
-pub(crate) use resource_based::{RealSysInfo, SystemResourceInfo};
 
 use crate::{
     WorkerConfig,
@@ -57,20 +56,34 @@ pub struct TunerHolderOptions {
     pub local_activity_slot_options: Option<SlotSupplierOptions<LocalActivitySlotKind>>,
     /// Options for nexus slots
     pub nexus_slot_options: Option<SlotSupplierOptions<NexusSlotKind>>,
-    /// Options that will apply to all resource based slot suppliers. Must be set if any slot
-    /// options are [SlotSupplierOptions::ResourceBased]
-    pub resource_based_options: Option<ResourceBasedSlotsOptions>,
+    /// Configuration shared by all resource-based slot suppliers.
+    pub resource_based_config: Option<ResourceBasedTunerConfig>,
+}
+
+/// Selects whether a tuner holder creates a controller or uses an existing shared controller.
+#[derive(Clone, Debug)]
+pub enum ResourceBasedTunerConfig {
+    /// Create a controller from these options.
+    Options(ResourceBasedSlotsOptions),
+    /// Use this controller for every resource-based slot supplier in the holder.
+    Controller(Arc<ResourceController>),
 }
 
 impl TunerHolderOptions {
     /// Create a [TunerHolder] from these options
     pub fn build_tuner_holder(self) -> Result<TunerHolder, anyhow::Error> {
+        validate_tuner_holder_options(&self).map_err(anyhow::Error::msg)?;
         let mut builder = TunerBuilder::default();
-        // safety note: unwraps here are OK since the builder validator guarantees options for
-        // a resource based tuner are present if any supplier is resource based
-        let mut rb_tuner = self
-            .resource_based_options
-            .map(ResourceBasedTuner::new_from_options);
+        // safety note: unwraps here are OK since the builder validator guarantees config for a
+        // resource-based tuner is present
+        let mut rb_tuner = self.resource_based_config.map(|config| match config {
+            ResourceBasedTunerConfig::Options(options) => {
+                ResourceBasedTuner::new_from_options(options)
+            }
+            ResourceBasedTunerConfig::Controller(controller) => {
+                ResourceBasedTuner::new_from_shared_controller(controller)
+            }
+        });
         match self.workflow_slot_options {
             Some(SlotSupplierOptions::FixedSize { slots }) => {
                 builder.workflow_slot_supplier(Arc::new(FixedSizeSlotSupplier::new(slots)));
@@ -194,10 +207,9 @@ fn validate_tuner_holder_options(options: &TunerHolderOptions) -> Result<(), Str
         options.nexus_slot_options,
         Some(SlotSupplierOptions::ResourceBased(_))
     );
-    if any_is_resource_based && options.resource_based_options.is_none() {
+    if any_is_resource_based && options.resource_based_config.is_none() {
         return Err(
-            "`resource_based_options` must be set if any slot options are ResourceBased"
-                .to_string(),
+            "`resource_based_config` must be set if any slot options are ResourceBased".to_string(),
         );
     }
     Ok(())
@@ -360,7 +372,7 @@ mod tests {
             activity_slot_options: None,
             local_activity_slot_options: None,
             nexus_slot_options: Some(SlotSupplierOptions::FixedSize { slots: 50 }),
-            resource_based_options: None,
+            resource_based_config: None,
         };
 
         let tuner = options.build_tuner_holder().unwrap();
@@ -382,7 +394,7 @@ mod tests {
             nexus_slot_options: Some(SlotSupplierOptions::ResourceBased(
                 ResourceSlotOptions::new(5, 100, Duration::from_millis(100)),
             )),
-            resource_based_options: Some(resource_opts),
+            resource_based_config: Some(ResourceBasedTunerConfig::Options(resource_opts)),
         };
 
         let tuner = options.build_tuner_holder().unwrap();
@@ -400,7 +412,7 @@ mod tests {
             activity_slot_options: None,
             local_activity_slot_options: None,
             nexus_slot_options: Some(SlotSupplierOptions::Custom(custom_supplier.clone())),
-            resource_based_options: None,
+            resource_based_config: None,
         };
 
         let tuner = options.build_tuner_holder().unwrap();
@@ -423,7 +435,7 @@ mod tests {
 
     #[test]
     fn tuner_holder_options_builder_validates_resource_based_requirements() {
-        // Should fail when nexus uses ResourceBased but resource_based_options is not set
+        // Should fail when nexus uses ResourceBased but resource_based_config is not set
         let result = TunerHolderOptions::builder()
             .nexus_slot_options(SlotSupplierOptions::ResourceBased(
                 ResourceSlotOptions::new(5, 100, Duration::from_millis(100)),
@@ -435,7 +447,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("resource_based_options")
+                .contains("resource_based_config")
         );
     }
 
@@ -455,7 +467,7 @@ mod tests {
             nexus_slot_options: Some(SlotSupplierOptions::ResourceBased(
                 ResourceSlotOptions::new(5, 100, Duration::from_millis(100)),
             )),
-            resource_based_options: Some(resource_opts),
+            resource_based_config: Some(ResourceBasedTunerConfig::Options(resource_opts)),
         };
 
         let tuner = options.build_tuner_holder().unwrap();

--- a/crates/sdk-core/src/worker/tuner/resource_based.rs
+++ b/crates/sdk-core/src/worker/tuner/resource_based.rs
@@ -27,6 +27,9 @@ use tokio::{sync::watch, task::JoinHandle};
 /// current usage levels of their respective resource as measurements. The user specifies a target
 /// threshold for each, and slots are handed out if the output of both PID controllers is above some
 /// defined threshold. See [ResourceBasedSlotsOptions] for the default PID controller settings.
+///
+/// Note that different slot types make decisions independently of each other, though they use the
+/// same underlying system information.
 pub struct ResourceBasedTuner<MI> {
     slots: Arc<ResourceController<MI>>,
     wf_opts: Option<ResourceSlotOptions>,
@@ -64,9 +67,13 @@ impl ResourceBasedTuner<RealSysInfo> {
 
 impl<MI> ResourceBasedTuner<MI> {
     fn new_from_controller(controller: ResourceController<MI>) -> Self {
-        let sys_info = controller.sys_info_supplier.clone();
+        Self::new_from_shared_controller(Arc::new(controller))
+    }
+
+    pub(crate) fn new_from_shared_controller(slots: Arc<ResourceController<MI>>) -> Self {
+        let sys_info = slots.sys_info_supplier.clone();
         Self {
-            slots: Arc::new(controller),
+            slots,
             wf_opts: None,
             act_opts: None,
             la_opts: None,
@@ -135,7 +142,8 @@ pub struct ResourceSlotOptions {
     ramp_throttle: Duration,
 }
 
-struct ResourceController<MI> {
+/// Coordinates resource-based slot decisions using a shared resource sampler and PID controllers.
+pub struct ResourceController<MI = RealSysInfo> {
     options: ResourceBasedSlotsOptions,
     sys_info_supplier: Arc<MI>,
     metrics: OnceLock<JoinHandle<()>>,
@@ -417,6 +425,22 @@ impl<MI: SystemResourceInfo + Sync + Send + 'static> WorkerTuner for ResourceBas
     ) -> Arc<dyn SlotSupplier<SlotKind = NexusSlotKind> + Send + Sync> {
         let o = self.nexus_opts.unwrap_or(DEFAULT_NEXUS_SLOT_OPTS);
         self.slots.as_kind(o)
+    }
+}
+
+impl<MI> std::fmt::Debug for ResourceController<MI> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResourceController").finish_non_exhaustive()
+    }
+}
+
+impl ResourceController<RealSysInfo> {
+    /// Create a resource controller using the default system resource sampler.
+    pub fn new(options: ResourceBasedSlotsOptions) -> Self {
+        Self::new_with_sysinfo(
+            options,
+            Arc::new(RealSysInfo::new(RealSysInfo::MIN_REFRESH_INTERVAL)),
+        )
     }
 }
 
@@ -863,6 +887,45 @@ mod tests {
         used.store(0, Ordering::Release);
         // Now it's willing to hand out slots again when usage is zero
         assert!(rbs.try_reserve_slot(&pd).is_some());
+    }
+
+    #[test]
+    fn shared_controller_has_same_behavior_across_tuners() {
+        let (fmis, used) = FakeMIS::new();
+        let controller = Arc::new(ResourceController::new_with_sysinfo(test_options(), fmis));
+        let slot_options = ResourceSlotOptions {
+            min_slots: 0,
+            max_slots: 100,
+            ramp_throttle: Duration::from_millis(0),
+        };
+        let mut first_tuner = ResourceBasedTuner::new_from_shared_controller(controller.clone());
+        first_tuner.with_activity_slots_options(slot_options);
+        let mut second_tuner = ResourceBasedTuner::new_from_shared_controller(controller);
+        second_tuner.with_activity_slots_options(slot_options);
+        let first_supplier = first_tuner.activity_task_slot_supplier();
+        let second_supplier = second_tuner.activity_task_slot_supplier();
+        let first_context = MeteredPermitDealer::new(
+            first_supplier.clone(),
+            MetricsContext::no_op(),
+            None,
+            Arc::new(Default::default()),
+            None,
+        );
+        let second_context = MeteredPermitDealer::new(
+            second_supplier.clone(),
+            MetricsContext::no_op(),
+            None,
+            Arc::new(Default::default()),
+            None,
+        );
+
+        used.store(90_000, Ordering::Release);
+        assert!(first_supplier.try_reserve_slot(&first_context).is_none());
+        assert!(second_supplier.try_reserve_slot(&second_context).is_none());
+
+        used.store(0, Ordering::Release);
+        assert!(first_supplier.try_reserve_slot(&first_context).is_some());
+        assert!(second_supplier.try_reserve_slot(&second_context).is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- expose the existing generic `ResourceController`, with `RealSysInfo` as its default sampler type
- add `ResourceBasedTunerConfig::{Options, Controller}` so `TunerHolderOptions` can either construct a controller or receive a shared `Arc<ResourceController>`
- update the C bridge's declarative resource-tuner path for the new enum

## Why

Language bridges currently pass only `ResourceBasedSlotsOptions` into `TunerHolderOptions`, which constructs a fresh resource controller, sampler, and PID state for every holder. That prevents a language SDK from sharing one controller across multiple Workers in the same process, as requested in temporalio/sdk-typescript#2159.

Making the existing controller injectable lets a bridge retain one `Arc<ResourceController>` and use it for multiple tuner holders. The enum keeps the declarative and injected-controller forms mutually exclusive by construction. Declarative options still create exactly one controller shared by all resource-based slot suppliers in that holder.

Worker heartbeat resource sampling remains independent of the tuner.

## Testing

- `cargo +nightly fmt --all`
- `cargo lint`
- `cargo test-lint`
- `cargo test -p temporalio-sdk-core worker::tuner`
