### PR TITLE
Gate ResourceBasedTuner on anonymous memory instead of cgroup memory.current

### DIFF
--- a/crates/sdk-core/src/worker/tuner/resource_based.rs
+++ b/crates/sdk-core/src/worker/tuner/resource_based.rs
@@ -522,10 +522,6 @@ struct RealSysInfoInner {
     cgroup_cpu_info: CGroupCpuInfo<CgroupV2CpuFileSystem>,
 }
 
-fn cgroup_used_mem(limits: &sysinfo::CGroupLimits) -> u64 {
-    limits.rss
-}
-
 impl RealSysInfoInner {
     fn refresh(&self) {
         let mut lock = self.sys.lock();
@@ -533,8 +529,11 @@ impl RealSysInfoInner {
         if let Some(cgroup_limits) = lock.cgroup_limits() {
             self.total_mem
                 .store(cgroup_limits.total_memory, Ordering::Release);
+            // Gate on anonymous memory (`rss`) rather than `memory.current`
+            // (`total - free`), which includes reclaimable page cache and can
+            // permanently starve slot admission.
             self.cur_mem_usage
-                .store(cgroup_used_mem(&cgroup_limits), Ordering::Release);
+                .store(cgroup_limits.rss, Ordering::Release);
 
             let cpu = self.cgroup_cpu_info.calc_cpu_percent().unwrap_or_else(|| {
                 // There won't be a cgroup cpu usage if there is no limit applied to the cgroup
@@ -810,22 +809,6 @@ mod tests {
             .target_mem_usage(0.8)
             .target_cpu_usage(1.0)
             .build()
-    }
-
-    #[test]
-    fn cgroup_used_mem_excludes_page_cache() {
-        const MIB: u64 = 1024 * 1024;
-        // 2 GiB limit; memory.current pinned at 1300 MiB by reclaimable page
-        // cache, but only 600 MiB is anonymous. free_memory = total - current.
-        let limits = sysinfo::CGroupLimits {
-            total_memory: 2048 * MIB,
-            free_memory: 2048 * MIB - 1300 * MIB,
-            rss: 600 * MIB,
-            ..Default::default()
-        };
-        // Stock code used total - free == memory.current (1300 MiB); we gate on
-        // anonymous memory so reclaimable cache can't starve admission.
-        assert_eq!(cgroup_used_mem(&limits), 600 * MIB);
     }
 
     #[test]
@@ -1209,9 +1192,9 @@ mod tests {
             "RealSysInfo total_mem should equal min(cgroup limit, host total)"
         );
 
-        let cur_used = current_mem
-            .total_memory
-            .saturating_sub(current_mem.free_memory);
+        // Usage is gated on anonymous memory, not `memory.current`, so page
+        // cache doesn't count against the limit.
+        let cur_used = current_mem.rss;
         let half_total = current_mem.total_memory / 2;
         let expected_percentage = if cur_used > half_total {
             cur_used as f64 / current_mem.total_memory as f64

--- a/crates/sdk-core/src/worker/tuner/resource_based.rs
+++ b/crates/sdk-core/src/worker/tuner/resource_based.rs
@@ -522,6 +522,10 @@ struct RealSysInfoInner {
     cgroup_cpu_info: CGroupCpuInfo<CgroupV2CpuFileSystem>,
 }
 
+fn cgroup_used_mem(limits: &sysinfo::CGroupLimits) -> u64 {
+    limits.rss
+}
+
 impl RealSysInfoInner {
     fn refresh(&self) {
         let mut lock = self.sys.lock();
@@ -529,10 +533,8 @@ impl RealSysInfoInner {
         if let Some(cgroup_limits) = lock.cgroup_limits() {
             self.total_mem
                 .store(cgroup_limits.total_memory, Ordering::Release);
-            self.cur_mem_usage.store(
-                cgroup_limits.total_memory - cgroup_limits.free_memory,
-                Ordering::Release,
-            );
+            self.cur_mem_usage
+                .store(cgroup_used_mem(&cgroup_limits), Ordering::Release);
 
             let cpu = self.cgroup_cpu_info.calc_cpu_percent().unwrap_or_else(|| {
                 // There won't be a cgroup cpu usage if there is no limit applied to the cgroup
@@ -808,6 +810,22 @@ mod tests {
             .target_mem_usage(0.8)
             .target_cpu_usage(1.0)
             .build()
+    }
+
+    #[test]
+    fn cgroup_used_mem_excludes_page_cache() {
+        const MIB: u64 = 1024 * 1024;
+        // 2 GiB limit; memory.current pinned at 1300 MiB by reclaimable page
+        // cache, but only 600 MiB is anonymous. free_memory = total - current.
+        let limits = sysinfo::CGroupLimits {
+            total_memory: 2048 * MIB,
+            free_memory: 2048 * MIB - 1300 * MIB,
+            rss: 600 * MIB,
+            ..Default::default()
+        };
+        // Stock code used total - free == memory.current (1300 MiB); we gate on
+        // anonymous memory so reclaimable cache can't starve admission.
+        assert_eq!(cgroup_used_mem(&limits), 600 * MIB);
     }
 
     #[test]


### PR DESCRIPTION
## What & why

`ResourceBasedTuner` feeds `total_memory - free_memory` into its memory PID controller. In the cgroup path that value is exactly **`memory.current`**, which **includes reclaimable page cache**.

In a memory-limited, no-swap container, a file-heavy activity (for us: a ~700 MB terraform provider mmap'd per activity) inflates page cache that **does not fall when the activity finishes** — page cache is reclaimable, so it poses no OOM risk, but it also isn't released on an idle worker. The tuner therefore stays pinned above `target_memory_usage` on an otherwise-idle pod and **freezes slot admission for minutes**, starving small activities, even though anonymous (real) memory is low the whole time.

This is a measurement bug: the controller is fed the wrong signal. Full analysis + repro in #1408.

## The change

Feed **anonymous (non-reclaimable) memory** into the tuner instead. `sysinfo` already parses `memory.stat`'s `anon` into `CGroupLimits::rss` — the code just wasn't using it:

```rust
// was: total_memory - free_memory  == memory.current (incl. page cache)
fn cgroup_used_mem(limits: &sysinfo::CGroupLimits) -> u64 {
    limits.rss
}
```

Extracted into a small pure fn so the derivation is unit-testable (it wasn't before — the existing `FakeMIS` fakes `used_mem()` directly, above this code).

## Test

Added `cgroup_used_mem_excludes_page_cache`, which constructs the pathological case (2 GiB limit, `memory.current` pinned at 1300 MiB by page cache, only 600 MiB anonymous) and asserts the tuner sees 600 MiB, not 1300 MiB. Verified locally: `cargo test -p temporalio-sdk-core` → passes; `rustfmt --check` clean.

## Repro evidence (live pod, 2 GiB limit, cgroup v2, no swap)

Reading a 674 MiB file into cache, then dropping it with `posix_fadvise(DONTNEED)`:

```
                        memory.current   anon    file(cache)
baseline                    621 MiB       573      24
after reading a file       1279 MiB       581     674   <- tuner sees +658 MiB "used", admission freezes
after fadvise DONTNEED       627 MiB       581      21   <- real usage was flat the whole time
```

## Open question for maintainers

This changes the metric for **all language SDKs**, so I kept the change minimal but I'm happy to adjust to whichever shape you prefer (also raised in #1408):

1. **Anonymous only** (this PR) — simplest; correct on no-swap; ignores swap and active file cache.
2. **Working set** (`memory.current - inactive_file`) — matches the kubelet's eviction metric; arguably the best general default; needs `inactive_file` surfaced.
3. **Configurable** `memory_metric` on `ResourceBasedTunerOptions`, defaulting to current behavior — zero behavior change for existing users, opt-in for the fix.

Glad to convert this to (2) or (3) — including gating behind a config option for backwards compatibility — if that's the direction you'd accept.

Related: companion to the deadlock fix in temporalio/sdk-python#1643 (same workload; different bug).
