### PR TITLE
feat(sdk): provide typed accessor for workflow count group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ to docs, or any other relevant information.
   `info()`, which returns the Rust-native `WorkflowContextView` and includes typed workflow
   priority. The internal `BaseWorkflowContext::new` raw-protobuf boundary is now explicitly named
   `from_raw`.
+* Workflow count aggregation groups now provide positional typed `get` and `try_get` accessors
+  for search attribute group values over raw payload access.
+
 
 ### Fixed
 * Workflow tasks no longer livelock when a burst of ready async operations exhausts Tokio's

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -94,7 +94,7 @@ use temporalio_common::{
         proto_ts_to_system_time,
         temporal::api::{
             cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
-            common::v1::{Payload, WorkflowType},
+            common::v1::WorkflowType,
             enums::v1::TaskQueueKind,
             errordetails::v1::WorkflowExecutionAlreadyStartedFailure,
             operatorservice::v1::operator_service_client::OperatorServiceClient,
@@ -109,7 +109,7 @@ use temporalio_common::{
         },
         utilities::decode_status_detail,
     },
-    search_attributes::SearchAttributes,
+    search_attributes::{SearchAttributeError, SearchAttributeValue, SearchAttributes},
 };
 use tonic::{
     Code, IntoRequest,
@@ -1081,26 +1081,40 @@ impl WorkflowExecutionCount {
 /// Aggregation group from a workflow count query with a group-by clause.
 #[derive(Debug, Clone)]
 pub struct WorkflowCountAggregationGroup {
-    group_values: Vec<Payload>,
-    count: usize,
+    raw: count_workflow_executions_response::AggregationGroup,
 }
 
 impl WorkflowCountAggregationGroup {
     fn from_proto(proto: count_workflow_executions_response::AggregationGroup) -> Self {
-        Self {
-            group_values: proto.group_values,
-            count: proto.count as usize,
-        }
+        Self { raw: proto }
     }
 
-    /// The search attribute values for this group.
-    pub fn group_values(&self) -> &[Payload] {
-        &self.group_values
+    /// Retrieve a typed group value at `index`.
+    ///
+    ///  Returns `None` if the index is out of bounds or deserialization fails.
+    ///  Use [`Self::try_get`] for explicit error handling.
+    pub fn get<T: SearchAttributeValue>(&self, index: usize) -> Option<T> {
+        self.try_get(index).ok().flatten()
+    }
+
+    /// Retrieve a typed group value at `index`, preserving deserialization
+    /// errors.
+    ///
+    /// Returns `Ok(None)` if the index is out of bounds and `Err` if the
+    /// payload cannot be deserialized.
+    pub fn try_get<T: SearchAttributeValue>(
+        &self,
+        index: usize,
+    ) -> Result<Option<T>, SearchAttributeError> {
+        match self.raw.group_values.get(index) {
+            Some(payload) => T::from_search_attribute_payload(payload).map(Some),
+            None => Ok(None),
+        }
     }
 
     /// The approximate number of workflows matching for this group.
     pub fn count(&self) -> usize {
-        self.count
+        self.raw.count as usize
     }
 }
 
@@ -1408,8 +1422,25 @@ mod tests {
     use super::*;
     use crate::callback_based::CallbackBasedGrpcService;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use temporalio_common::search_attributes::SearchAttributeKey;
     use tonic::{Status, metadata::Ascii};
     use url::Url;
+
+    #[test]
+    fn count_aggregation_group_gets_typed_value() {
+        let attrs = SearchAttributes::new([SearchAttributeKey::int("group").value_set(42)]);
+        let group = WorkflowCountAggregationGroup {
+            raw: count_workflow_executions_response::AggregationGroup {
+                group_values: vec![attrs.raw_payload("group").unwrap().clone()],
+                count: 1,
+            },
+        };
+
+        assert_eq!(group.get::<i64>(0), Some(42));
+        assert_eq!(group.get::<i64>(1), None);
+        assert!(group.try_get::<String>(0).is_err());
+        assert_eq!(group.try_get::<i64>(1).unwrap(), None);
+    }
 
     fn connection_options_for_system_info_test(
         service_override: CallbackBasedGrpcService,
@@ -1752,7 +1783,7 @@ mod tests {
         use temporalio_common::{
             data_converters::DefaultFailureConverter,
             protos::temporal::api::common::v1::{
-                Memo as ProtoMemo, WorkflowExecution as ProtoWorkflowExecution,
+                Memo as ProtoMemo, Payload, WorkflowExecution as ProtoWorkflowExecution,
             },
         };
         use tonic::{Request, Response};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Provide `get`/`try_get` accessor for the groups of `WorkflowCountAggregationGroup` to allow specifying type that is attempted to be accessed.

## Why?
Remove direct `Payload` usage for inspecting these values.
Matches `SearchAttributes` API shape.

## Checklist
<!--- add/delete as needed --->

1. Closes #1404 

2. How was this tested:
Small unit test, primarily 👀 

3. Any docs updates needed?
N/A
