### PR TITLE
chore(deps): replace unmaintained backoff crate with backon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ to docs, or any other relevant information.
   and then kept running (e.g. parked on a `wait_condition`) would fail its workflow task whenever it
   was replayed — breaking queries and durable recovery for that execution.
 
+### Security
+* Replaced the unmaintained `backoff` dependency with `backon` for exponential retry and poll
+  backoff, clearing [RUSTSEC-2025-0012](https://rustsec.org/advisories/RUSTSEC-2025-0012) from
+  downstream security audits. Retry timing is preserved: exponential growth,
+  `randomization_factor` jitter, and the total retry-time budget behave as before.
+
 ### Breaking Changes
 * The `ActivityContext` constructor now requires `ClientOptions`.
 ### Breaking Changes

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -22,7 +22,7 @@ envconfig = ["temporalio-common/envconfig"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-backoff = "0.4"
+backon = { version = "1.6", default-features = false }
 base64 = "0.22"
 bon = { version = "3", default-features = false, features = ["alloc"] }
 derive_more = { workspace = true }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -39,6 +39,8 @@ pub use crate::{
 pub use async_activity_handle::{
     ActivityHeartbeatResponse, ActivityIdentifier, AsyncActivityHandle,
 };
+#[doc(hidden)]
+pub use retry::jittered;
 
 pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use options_structs::*;

--- a/crates/client/src/retry.rs
+++ b/crates/client/src/retry.rs
@@ -3,11 +3,7 @@ use crate::{
     grpc::IsUserLongPoll,
     request_extensions::{IsWorkerTaskLongPoll, NoRetryOnMatching, RetryConfigForCall},
 };
-use backoff::{
-    Clock, SystemClock,
-    backoff::Backoff,
-    exponential::{self, ExponentialBackoff},
-};
+use backon::{BackoffBuilder, ExponentialBuilder};
 use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
 use std::{
     error::Error,
@@ -131,30 +127,26 @@ impl RetryOptions {
         }
     }
 
-    pub(crate) fn into_exp_backoff<C>(self, clock: C) -> exponential::ExponentialBackoff<C> {
-        exponential::ExponentialBackoff {
-            current_interval: self.initial_interval,
-            initial_interval: self.initial_interval,
+    fn jittered_backoff(&self) -> JitteredBackoff {
+        let inner = ExponentialBuilder::new()
+            .with_min_delay(self.initial_interval)
+            .with_factor(self.multiplier as f32)
+            .with_max_delay(self.max_interval)
+            .without_max_times()
+            .build();
+        JitteredBackoff {
+            inner,
             randomization_factor: self.randomization_factor,
-            multiplier: self.multiplier,
-            max_interval: self.max_interval,
             max_elapsed_time: self.max_elapsed_time,
-            clock,
-            start_time: Instant::now(),
+            started_at: Instant::now(),
         }
-    }
-}
-
-impl From<RetryOptions> for backoff::ExponentialBackoff {
-    fn from(c: RetryOptions) -> Self {
-        c.into_exp_backoff(SystemClock::default())
     }
 }
 
 pub(crate) fn make_future_retry<R, F, Fut>(
     info: CallInfo,
     factory: F,
-) -> FutureRetry<F, TonicErrorHandler<SystemClock>>
+) -> FutureRetry<F, TonicErrorHandler>
 where
     F: FnMut() -> Fut + Unpin,
     Fut: Future<Output = Result<R, tonic::Status>>,
@@ -165,41 +157,67 @@ where
     )
 }
 
+#[doc(hidden)]
+pub fn jittered(base: Duration, randomization_factor: f64) -> Duration {
+    if randomization_factor <= 0.0 {
+        return base;
+    }
+    // Reproduce the `backoff` crate's documented jitter for backward compatibility:
+    //   randomized interval = retry_interval * (random value in range [1 - randomization_factor, 1 + randomization_factor])
+    // Docs: https://github.com/ihrwein/backoff/blob/587e2da8fb2dcfc65ca544cb9249022c51f1406e/src/lib.rs#L4
+    // Algorithm (`get_random_value_from_interval`): https://github.com/ihrwein/backoff/blob/587e2da8fb2dcfc65ca544cb9249022c51f1406e/src/exponential.rs#L61
+    let base_secs = base.as_secs_f64();
+    let spread = randomization_factor * base_secs;
+    let offset = spread * (2.0 * rand::random::<f64>() - 1.0);
+    Duration::try_from_secs_f64((base_secs + offset).max(0.0)).unwrap_or(base)
+}
+
 #[derive(Debug)]
-pub(crate) struct TonicErrorHandler<C: Clock> {
-    backoff: ExponentialBackoff<C>,
-    throttle_backoff: ExponentialBackoff<C>,
+struct JitteredBackoff {
+    inner: backon::ExponentialBackoff,
+    randomization_factor: f64,
+    max_elapsed_time: Option<Duration>,
+    started_at: Instant,
+}
+
+impl JitteredBackoff {
+    fn next_backoff(&mut self) -> Option<Duration> {
+        // `inner` never stops on its own; the total retry budget is enforced here
+        // against wall-clock time so the jittered delay we actually return is what
+        // counts toward `max_elapsed_time`.
+        let base = self.inner.next()?;
+        let delay = jittered(base, self.randomization_factor);
+        if let Some(max_elapsed_time) = self.max_elapsed_time
+            && self.started_at.elapsed() + delay > max_elapsed_time
+        {
+            return None;
+        }
+        Some(delay)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TonicErrorHandler {
+    backoff: JitteredBackoff,
+    throttle_backoff: JitteredBackoff,
+    max_interval: Duration,
+    retry_started_at: Instant,
     max_retries: usize,
     call_type: CallType,
     call_name: &'static str,
     retry_short_circuit: Option<NoRetryOnMatching>,
 }
-impl TonicErrorHandler<SystemClock> {
+
+impl TonicErrorHandler {
     fn new(call_info: CallInfo, throttle_cfg: RetryOptions) -> Self {
-        Self::new_with_clock(
-            call_info,
-            throttle_cfg,
-            SystemClock::default(),
-            SystemClock::default(),
-        )
-    }
-}
-impl<C> TonicErrorHandler<C>
-where
-    C: Clock,
-{
-    fn new_with_clock(
-        call_info: CallInfo,
-        throttle_cfg: RetryOptions,
-        clock: C,
-        throttle_clock: C,
-    ) -> Self {
         Self {
             call_type: call_info.call_type,
             call_name: call_info.call_name,
             max_retries: call_info.retry_cfg.max_retries,
-            backoff: call_info.retry_cfg.into_exp_backoff(clock),
-            throttle_backoff: throttle_cfg.into_exp_backoff(throttle_clock),
+            max_interval: call_info.retry_cfg.max_interval,
+            backoff: call_info.retry_cfg.jittered_backoff(),
+            throttle_backoff: throttle_cfg.jittered_backoff(),
+            retry_started_at: Instant::now(),
             retry_short_circuit: call_info.retry_short_circuit,
         }
     }
@@ -250,10 +268,7 @@ impl CallType {
     }
 }
 
-impl<C> ErrorHandler<tonic::Status> for TonicErrorHandler<C>
-where
-    C: Clock,
-{
+impl ErrorHandler<tonic::Status> for TonicErrorHandler {
     type OutError = tonic::Status;
 
     fn handle(
@@ -331,11 +346,11 @@ where
                 }
             }
         } else if self.call_type == CallType::TaskLongPoll
-            && self.backoff.get_elapsed_time() <= LONG_POLL_FATAL_GRACE
+            && self.retry_started_at.elapsed() <= LONG_POLL_FATAL_GRACE
         {
             // We permit "fatal" errors while long polling for a while, because some proxies return
             // stupid error codes while getting ready, among other weird infra issues
-            RetryPolicy::WaitRetry(self.backoff.max_interval)
+            RetryPolicy::WaitRetry(self.max_interval)
         } else {
             RetryPolicy::ForwardError(e)
         }
@@ -359,8 +374,7 @@ fn is_transport_cancelled(status: &tonic::Status) -> bool {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use backoff::Clock;
-    use std::{ops::Add, time::Instant};
+    use std::time::Instant;
     use temporalio_common::protos::temporal::api::workflowservice::v1::{
         PollActivityTaskQueueRequest, PollNexusTaskQueueRequest, PollWorkflowTaskQueueRequest,
     };
@@ -380,13 +394,6 @@ mod tests {
     const POLL_ACTIVITY_METH_NAME: &str = "poll_activity_task_queue";
     const POLL_NEXUS_METH_NAME: &str = "poll_nexus_task_queue";
 
-    struct FixedClock(Instant);
-    impl Clock for FixedClock {
-        fn now(&self) -> Instant {
-            self.0
-        }
-    }
-
     #[tokio::test]
     async fn long_poll_non_retryable_errors() {
         for code in [
@@ -399,7 +406,7 @@ mod tests {
             Code::Unimplemented,
         ] {
             for call_name in [POLL_WORKFLOW_METH_NAME, POLL_ACTIVITY_METH_NAME] {
-                let mut err_handler = TonicErrorHandler::new_with_clock(
+                let mut err_handler = TonicErrorHandler::new(
                     CallInfo {
                         call_type: CallType::TaskLongPoll,
                         call_name,
@@ -407,16 +414,11 @@ mod tests {
                         retry_short_circuit: None,
                     },
                     TEST_RETRY_CONFIG,
-                    FixedClock(Instant::now()),
-                    FixedClock(Instant::now()),
                 );
                 let result = err_handler.handle(1, Status::new(code, "Ahh"));
                 assert_matches!(result, RetryPolicy::WaitRetry(_));
-                err_handler.backoff.clock.0 = err_handler
-                    .backoff
-                    .clock
-                    .0
-                    .add(LONG_POLL_FATAL_GRACE + Duration::from_secs(1));
+                err_handler.retry_started_at =
+                    Instant::now() - LONG_POLL_FATAL_GRACE - Duration::from_secs(1);
                 let result = err_handler.handle(2, Status::new(code, "Ahh"));
                 assert_matches!(result, RetryPolicy::ForwardError(_));
             }
@@ -427,7 +429,7 @@ mod tests {
     async fn long_poll_retryable_errors_never_fatal() {
         for code in RETRYABLE_ERROR_CODES {
             for call_name in [POLL_WORKFLOW_METH_NAME, POLL_ACTIVITY_METH_NAME] {
-                let mut err_handler = TonicErrorHandler::new_with_clock(
+                let mut err_handler = TonicErrorHandler::new(
                     CallInfo {
                         call_type: CallType::TaskLongPoll,
                         call_name,
@@ -435,16 +437,11 @@ mod tests {
                         retry_short_circuit: None,
                     },
                     TEST_RETRY_CONFIG,
-                    FixedClock(Instant::now()),
-                    FixedClock(Instant::now()),
                 );
                 let result = err_handler.handle(1, Status::new(code, "Ahh"));
                 assert_matches!(result, RetryPolicy::WaitRetry(_));
-                err_handler.backoff.clock.0 = err_handler
-                    .backoff
-                    .clock
-                    .0
-                    .add(LONG_POLL_FATAL_GRACE + Duration::from_secs(1));
+                err_handler.retry_started_at =
+                    Instant::now() - LONG_POLL_FATAL_GRACE - Duration::from_secs(1);
                 let result = err_handler.handle(2, Status::new(code, "Ahh"));
                 assert_matches!(result, RetryPolicy::WaitRetry(_));
             }
@@ -453,7 +450,7 @@ mod tests {
 
     #[tokio::test]
     async fn retry_resource_exhausted() {
-        let mut err_handler = TonicErrorHandler::new_with_clock(
+        let mut err_handler = TonicErrorHandler::new(
             CallInfo {
                 call_type: CallType::TaskLongPoll,
                 call_name: POLL_WORKFLOW_METH_NAME,
@@ -468,20 +465,12 @@ mod tests {
                 max_elapsed_time: None,
                 max_retries: 10,
             },
-            FixedClock(Instant::now()),
-            FixedClock(Instant::now()),
         );
         let result = err_handler.handle(1, Status::new(Code::ResourceExhausted, "leave me alone"));
         match result {
             RetryPolicy::WaitRetry(duration) => assert_eq!(duration, Duration::from_millis(2)),
             _ => panic!(),
         }
-        err_handler.backoff.clock.0 = err_handler.backoff.clock.0.add(Duration::from_millis(10));
-        err_handler.throttle_backoff.clock.0 = err_handler
-            .throttle_backoff
-            .clock
-            .0
-            .add(Duration::from_millis(10));
         let result = err_handler.handle(2, Status::new(Code::ResourceExhausted, "leave me alone"));
         match result {
             RetryPolicy::WaitRetry(duration) => assert_eq!(duration, Duration::from_millis(8)),
@@ -491,7 +480,7 @@ mod tests {
 
     #[tokio::test]
     async fn retry_short_circuit() {
-        let mut err_handler = TonicErrorHandler::new_with_clock(
+        let mut err_handler = TonicErrorHandler::new(
             CallInfo {
                 call_type: CallType::TaskLongPoll,
                 call_name: POLL_WORKFLOW_METH_NAME,
@@ -501,8 +490,6 @@ mod tests {
                 }),
             },
             TEST_RETRY_CONFIG,
-            FixedClock(Instant::now()),
-            FixedClock(Instant::now()),
         );
         let result = err_handler.handle(1, Status::new(Code::ResourceExhausted, "leave me alone"));
         let e = assert_matches!(result, RetryPolicy::ForwardError(e) => e);
@@ -515,7 +502,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_too_large_not_retried() {
-        let mut err_handler = TonicErrorHandler::new_with_clock(
+        let mut err_handler = TonicErrorHandler::new(
             CallInfo {
                 call_type: CallType::TaskLongPoll,
                 call_name: POLL_WORKFLOW_METH_NAME,
@@ -523,8 +510,6 @@ mod tests {
                 retry_short_circuit: None,
             },
             TEST_RETRY_CONFIG,
-            FixedClock(Instant::now()),
-            FixedClock(Instant::now()),
         );
         let result = err_handler.handle(
             1,
@@ -625,7 +610,7 @@ mod tests {
     async fn plain_cancelled_not_retried_on_normal_call() {
         // A plain Code::Cancelled (no transport error in source chain) on a Normal call
         // must NOT be retried — this is spec-correct behavior for application-level cancels.
-        let mut err_handler = TonicErrorHandler::new_with_clock(
+        let mut err_handler = TonicErrorHandler::new(
             CallInfo {
                 call_type: CallType::Normal,
                 call_name: "respond_activity_task_completed",
@@ -633,8 +618,6 @@ mod tests {
                 retry_short_circuit: None,
             },
             TEST_RETRY_CONFIG,
-            FixedClock(Instant::now()),
-            FixedClock(Instant::now()),
         );
         let result = err_handler.handle(1, Status::new(Code::Cancelled, "caller cancelled"));
         assert_matches!(result, RetryPolicy::ForwardError(_));
@@ -660,7 +643,7 @@ mod tests {
         // For this test, we verify through the `handle` method that a transport-sourced
         // Cancelled status (created via from_error, which sets Code::Unknown but preserves
         // the transport source chain) IS retried multiple times on the standard budget.
-        let mut err_handler = TonicErrorHandler::new_with_clock(
+        let mut err_handler = TonicErrorHandler::new(
             CallInfo {
                 call_type: CallType::Normal,
                 call_name: "respond_activity_task_completed",
@@ -668,8 +651,6 @@ mod tests {
                 retry_short_circuit: None,
             },
             TEST_RETRY_CONFIG,
-            FixedClock(Instant::now()),
-            FixedClock(Instant::now()),
         );
 
         // Code::Unknown with a transport source IS retried (it's in RETRYABLE_ERROR_CODES)

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -52,7 +52,7 @@ antithesis_sdk = { version = "0.2.1", optional = true, default-features = false,
   "full",
 ] }
 assert_matches = { version = "1.5", optional = true }
-backoff = "0.4"
+backon = { version = "1.6", default-features = false }
 bimap = { version = "0.6.3", optional = true }
 async-trait = "0.1"
 bon = { workspace = true }

--- a/crates/sdk-core/src/pollers/poll_buffer.rs
+++ b/crates/sdk-core/src/pollers/poll_buffer.rs
@@ -9,7 +9,7 @@ use crate::{
         },
     },
 };
-use backoff::{SystemClock, backoff::Backoff, exponential::ExponentialBackoff};
+use backon::{BackoffBuilder, ExponentialBuilder};
 use crossbeam_utils::atomic::AtomicCell;
 use futures_util::{FutureExt, StreamExt, future::BoxFuture};
 use std::{
@@ -23,7 +23,7 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 use temporalio_client::{
-    ERROR_RETURNED_DUE_TO_SHORT_CIRCUIT, request_extensions::NoRetryOnMatching,
+    ERROR_RETURNED_DUE_TO_SHORT_CIRCUIT, jittered, request_extensions::NoRetryOnMatching,
 };
 use temporalio_common::protos::temporal::api::{
     taskqueue::v1::PollerScalingDecision,
@@ -43,6 +43,22 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tonic::Code;
 use tracing::Instrument;
+
+// Mirror the retry client's `RetryOptions::task_poll_retry_policy` and
+// `throttle_retry_policy` so poller autoscaling backs off on the same schedule.
+// Jitter is applied via `jittered` rather than backon's `with_jitter` to keep the
+// symmetric +/- factor behavior the retry client uses.
+const POLL_BACKOFF_RANDOMIZATION: f64 = 0.2;
+const TASK_POLL_BACKOFF: ExponentialBuilder = ExponentialBuilder::new()
+    .with_min_delay(Duration::from_millis(200))
+    .with_factor(2.0)
+    .with_max_delay(Duration::from_secs(10))
+    .without_max_times();
+const THROTTLE_POLL_BACKOFF: ExponentialBuilder = ExponentialBuilder::new()
+    .with_min_delay(Duration::from_secs(1))
+    .with_factor(2.0)
+    .with_max_delay(Duration::from_secs(10))
+    .without_max_times();
 
 type PollReceiver<T, SK> =
     Mutex<UnboundedReceiver<pollers::Result<(T, OwnedMeteredSemPermit<SK>)>>>;
@@ -534,28 +550,8 @@ where
             ingested_last_period: Default::default(),
             scale_up_allowed: AtomicBool::new(true),
             last_successful_poll_time,
-            exponential_backoff: parking_lot::Mutex::new(ExponentialBackoff {
-                // Copied from RetryOptions::task_poll_retry_policy()
-                current_interval: Duration::from_millis(200),
-                initial_interval: Duration::from_millis(200),
-                randomization_factor: 0.2,
-                multiplier: 2.0,
-                max_interval: Duration::from_secs(10),
-                max_elapsed_time: None,
-                clock: SystemClock::default(),
-                start_time: std::time::Instant::now(),
-            }),
-            resource_exhausted_backoff: parking_lot::Mutex::new(ExponentialBackoff {
-                // Copied from RetryOptions::throttle_retry_policy()
-                current_interval: Duration::from_secs(1),
-                initial_interval: Duration::from_secs(1),
-                randomization_factor: 0.2,
-                multiplier: 2.0,
-                max_interval: Duration::from_secs(10),
-                max_elapsed_time: None,
-                clock: SystemClock::default(),
-                start_time: std::time::Instant::now(),
-            }),
+            exponential_backoff: parking_lot::Mutex::new(TASK_POLL_BACKOFF.build()),
+            resource_exhausted_backoff: parking_lot::Mutex::new(THROTTLE_POLL_BACKOFF.build()),
         });
         let rhc = report_handle.clone();
         let ingestor_task = if behavior.is_autoscaling() {
@@ -622,8 +618,8 @@ struct PollScalerReportHandle {
     last_successful_poll_time: Arc<AtomicCell<Option<SystemTime>>>,
 
     // Exponential backoff for normal errors and resource exhausted errors
-    exponential_backoff: parking_lot::Mutex<ExponentialBackoff<SystemClock>>,
-    resource_exhausted_backoff: parking_lot::Mutex<ExponentialBackoff<SystemClock>>,
+    exponential_backoff: parking_lot::Mutex<backon::ExponentialBackoff>,
+    resource_exhausted_backoff: parking_lot::Mutex<backon::ExponentialBackoff>,
 }
 
 impl PollScalerReportHandle {
@@ -640,8 +636,8 @@ impl PollScalerReportHandle {
                     .store(Some(SystemTime::now()));
 
                 // Reset backoff on successful poll
-                self.exponential_backoff.lock().reset();
-                self.resource_exhausted_backoff.lock().reset();
+                *self.exponential_backoff.lock() = TASK_POLL_BACKOFF.build();
+                *self.resource_exhausted_backoff.lock() = THROTTLE_POLL_BACKOFF.build();
 
                 if let PollerBehavior::SimpleMaximum(_) = self.behavior {
                     // We don't do auto-scaling with the simple max
@@ -678,9 +674,17 @@ impl PollScalerReportHandle {
             Err(e) => {
                 if matches!(self.behavior, PollerBehavior::Autoscaling { .. }) {
                     // Follow the same backoff logic as the retry client
-                    let mut backoff_duration = self.exponential_backoff.lock().next_backoff();
+                    let mut backoff_duration = self
+                        .exponential_backoff
+                        .lock()
+                        .next()
+                        .map(|d| jittered(d, POLL_BACKOFF_RANDOMIZATION));
                     if e.code() == Code::ResourceExhausted {
-                        backoff_duration = self.resource_exhausted_backoff.lock().next_backoff();
+                        backoff_duration = self
+                            .resource_exhausted_backoff
+                            .lock()
+                            .next()
+                            .map(|d| jittered(d, POLL_BACKOFF_RANDOMIZATION));
                     };
 
                     // Only propagate errors out if they weren't because of the short-circuiting
@@ -1280,8 +1284,8 @@ mod tests {
             ingested_last_period: Default::default(),
             scale_up_allowed: AtomicBool::new(true),
             last_successful_poll_time: Arc::new(AtomicCell::new(None)),
-            exponential_backoff: parking_lot::Mutex::new(ExponentialBackoff::default()),
-            resource_exhausted_backoff: parking_lot::Mutex::new(ExponentialBackoff::default()),
+            exponential_backoff: parking_lot::Mutex::new(TASK_POLL_BACKOFF.build()),
+            resource_exhausted_backoff: parking_lot::Mutex::new(THROTTLE_POLL_BACKOFF.build()),
         });
 
         for _ in 0..20 {


### PR DESCRIPTION
## What was changed

The SDK depended on the unmaintained [`backoff`](https://crates.io/crates/backoff) crate ([RUSTSEC-2025-0012](https://rustsec.org/advisories/RUSTSEC-2025-0012)) for exponential retry/poll backoff in:

- `temporalio-client` — gRPC call retry (`TonicErrorHandler` in `retry.rs`)
- `temporalio-sdk-core` — poller autoscaling error backoff (`poll_buffer.rs`)

Both crates now depend on [`backon`](https://crates.io/crates/backon) directly (`default-features = false` — we only need the iterator, not backon's sleep runtime). `backon`'s `ExponentialBuilder` / `ExponentialBackoff` drives the exponential sequence, and the existing retry semantics are preserved on top of it:

- **Jitter** — `randomization_factor` keeps its documented meaning of symmetric `+/-` jitter (the `0.2` default is still `+/-20%`). `backon`'s built-in `with_jitter` is intentionally **not** used because it is asymmetric (`+(0, delay)`) and ignores the configured `randomization_factor` magnitude, which would silently reduce the public field to an on/off flag; jitter is applied manually via `rand` instead. `randomization_factor == 0.0` stays fully deterministic.
- **Total retry budget** — `max_elapsed_time` is enforced against wall-clock elapsed time plus the jittered delay (as the old implementation did), rather than `backon`'s cumulative-sleep `total_delay`, so positive jitter cannot overshoot the budget.
- **Long-poll fatal grace** — still measured against wall-clock elapsed time.

`sdk-core`'s poll backoff uses module-level `const ExponentialBuilder`s that mirror `RetryOptions::task_poll_retry_policy()` / `throttle_retry_policy()`; on a successful poll the state resets by rebuilding from the consts.

## Why

Fixes #1292 and clears [RUSTSEC-2025-0012](https://rustsec.org/advisories/RUSTSEC-2025-0012) from downstream `cargo audit` runs. `cargo tree -i backoff` now reports no matching package, and `backon` is a direct dependency of both crates.

This supersedes the abandoned #1291 and addresses its review comments:

- Public `RetryOptions` docs stay dependency-neutral and unchanged (the abandoned PR's `backon` reference is dropped), since preserving the `+/-` jitter semantics keeps the original wording accurate.
- The `randomization_factor: 0.2, // +-20% jitter.` default line is left unchanged and stays correct.
- `sdk-core` no longer stores the builders as struct fields; the `const` builders are used directly.

## Checklist

1. Closes #1292

2. How was this tested:
   - `cargo test -p temporalio-client retry::`
   - `cargo test -p temporalio-sdk-core pollers::poll_buffer`
   - `cargo integ-test out_of_order_completion_doesnt_hang`
   - `cargo fmt --all --check`, `cargo lint`, `cargo test-lint`, `cargo check`, and `cargo doc --workspace --all-features --no-deps` (with `-D warnings`)

3. Any docs updates needed?
   CHANGELOG updated under a new `### Security` entry. Public API is unchanged.
