### PR TITLE
chore(ci): add fake cloud tests job

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -248,6 +248,15 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --features=test-utilities --test cloud_tests
 
+  skipped-cloud-tests:
+    if: github.event.pull_request.head.repo.full_name != '' && github.event.pull_request.head.repo.full_name != 'temporalio/sdk-rust'
+    name: Cloud tests
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip Cloud tests for external pull requests
+        run: echo 'Cloud tests are not run for external pull requests.'
+
   docker-integ-tests:
     name: Docker integ tests
     env:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add a fake cloud tests job that runs if the real one is skipped.

## Why?
We recently made Cloud tests blocking which I think is a good move so maintainers don't accidentally merge something that would break against cloud. Downside is that we cannot merge external PRs now. We add a fake passing job with the same name for external PRs now.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
