### PR TITLE
chore(ci): use github backend for temporal cli

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: 'Common setup: checkout, Rust toolchain, mise tools, PROTOC env, Ru
 
 inputs:
   mise-install-args:
-    description: 'Tools to install (e.g. "protoc" or "protoc aqua:temporalio/cli"). Empty installs all.'
+    description: 'Tools to install (e.g. "protoc" or "protoc github:temporalio/cli"). Empty installs all.'
     required: false
     default: ''
   rust-cache-key:

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
         with:
-          mise-install-args: protoc aqua:temporalio/cli
+          mise-install-args: protoc github:temporalio/cli
       - name: Build examples
         run: cargo build --examples -p temporalio-sdk --features examples
       - name: Start Temporal dev server

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
 protoc = "23.4"
-"aqua:temporalio/cli" = "1.8.0"
+"github:temporalio/cli" = "1.8.0"
 "cargo:cargo-component" = "0.21.1"
 "cargo:cargo-msrv" = "0.19.3"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Switch from `aqua` backend to `github` backend for providing temporal cli.

## Why?
`aqua` backend doesn't contain full version history of the CLI. Most problematically it only keeps the [latest 1.x version](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/temporalio/cli/pkg.yaml) so anytime the registry updates we will end up breaking.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
CI

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
