### PR TITLE
chore(sdk): rename start_activity to execute_activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ to docs, or any other relevant information.
 * Added the experimental `WorkerOptions::patch_activation_callback` option for controlling whether
   newly introduced patches activate during rolling deployments.
 
+### Changed
+ * Renamed `start_activity` and `start_local_activity` to `execute_activity` and `execute_local_activity`
+   to better explain semantics. Original methods remain as deprecated aliases for the new execute
+   variants.
+
 ### Breaking Changes
 * `WorkflowExecution::search_attributes`, `WorkflowExecutionDescription::search_attributes`,
   `ScheduleDescription::search_attributes`, and `ScheduleSummary::search_attributes` now return

--- a/crates/sdk-core/tests/common/workflows.rs
+++ b/crates/sdk-core/tests/common/workflows.rs
@@ -13,7 +13,7 @@ pub(crate) struct LaProblemWorkflow;
 impl LaProblemWorkflow {
     #[run(name = "evict_while_la_running_no_interference")]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        ctx.start_local_activity(
+        ctx.execute_local_activity(
             StdActivities::delay,
             Duration::from_secs(15),
             LocalActivityOptions {

--- a/crates/sdk-core/tests/common/workflows.rs
+++ b/crates/sdk-core/tests/common/workflows.rs
@@ -31,7 +31,7 @@ impl LaProblemWorkflow {
         )
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-        ctx.start_activity(
+        ctx.execute_activity(
             StdActivities::delay,
             Duration::from_secs(15),
             ActivityOptions::start_to_close_timeout(Duration::from_secs(20)),

--- a/crates/sdk-core/tests/heavy_tests.rs
+++ b/crates/sdk-core/tests/heavy_tests.rs
@@ -57,7 +57,7 @@ impl ActivityLoadWf {
     async fn run(ctx: &mut WorkflowContext<Self>, tq: String) -> WorkflowResult<()> {
         let input_str = "yo".to_string();
         let res = ctx
-            .start_activity(
+            .execute_activity(
                 StdActivities::echo,
                 input_str.clone(),
                 ActivityOptions::with_close_timeouts(ActivityCloseTimeouts::Both {
@@ -126,7 +126,7 @@ impl ChunkyActivityWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let input_str = "yo".to_string();
         let res = ctx
-            .start_activity(
+            .execute_activity(
                 ChunkyActivities::chunky_echo,
                 input_str.clone(),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(30))
@@ -217,7 +217,7 @@ impl WorkflowLoadWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         for _ in 0..5 {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     StdActivities::echo,
                     "hi!".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -433,7 +433,7 @@ impl PollerLoadWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         for _ in 0..5 {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     JitteryActivities::jittery_echo,
                     "hi!".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
+++ b/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
@@ -60,7 +60,7 @@ impl FuzzyWf {
             }
             FuzzyWfAction::DoLocalAct => {
                 let _ = ctx
-                    .start_local_activity(
+                    .execute_local_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
                         LocalActivityOptions {

--- a/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
+++ b/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
@@ -51,7 +51,7 @@ impl FuzzyWf {
             FuzzyWfAction::Shutdown => ctx.state_mut(|s| s.done = true),
             FuzzyWfAction::DoAct => {
                 let _ = ctx
-                    .start_activity(
+                    .execute_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
                         ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -107,7 +107,7 @@ async fn async_activity_completions(
             expected_outcome: Outcome,
         ) -> WorkflowResult<()> {
             let async_response = "agence";
-            let activity_future = ctx.start_activity(
+            let activity_future = ctx.execute_activity(
                 AsyncActivities::complete_async_activity,
                 expected_outcome,
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(30))

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -188,7 +188,7 @@ impl DataConverterTestWorkflow {
         input: TrackedWrapper,
     ) -> WorkflowResult<TrackedWrapper> {
         let output = ctx
-            .start_activity(
+            .execute_activity(
                 TestActivities::process_tracked,
                 input,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -216,7 +216,7 @@ impl DescribeDataConverterWorkflow {
         ])?;
         ctx.upsert_memo([("removed", None)])?;
         let output = ctx
-            .start_activity(
+            .execute_activity(
                 TestActivities::process_tracked,
                 input,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -234,7 +234,7 @@ struct CancellationDetailsWorkflow;
 impl CancellationDetailsWorkflow {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<TrackedWrapper> {
-        let act = ctx.start_activity(
+        let act = ctx.execute_activity(
             FailurePayloadActivities::cancel_with_tracked_details,
             (),
             ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -268,7 +268,7 @@ impl HeartbeatDetailsWorkflow {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<TrackedWrapper> {
         let err = ctx
-            .start_activity(
+            .execute_activity(
                 FailurePayloadActivities::heartbeat_then_timeout,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -317,7 +317,7 @@ impl ActivityPanicFallbackWorkflow {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let _ = ctx
-            .start_activity(
+            .execute_activity(
                 PanicActivities::panic_activity,
                 String::new(),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))

--- a/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
@@ -35,7 +35,7 @@ impl ActivityDoesntHeartbeatHitsTimeoutThenCompletesWf {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let res: Result<(), ActivityExecutionError> = ctx
-            .start_activity(
+            .execute_activity(
                 StdActivities::delay,
                 Duration::from_secs(4),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(10))

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -507,7 +507,7 @@ async fn idle_activity_worker_reports_zero_slots_used() {
     impl OneActivity {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(
+            ctx.execute_activity(
                 BlockingActivity::run,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -1028,12 +1028,12 @@ async fn activity_metrics() {
     impl ActivityMetricsWf {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            let normal_act_pass = ctx.start_activity(
+            let normal_act_pass = ctx.execute_activity(
                 PassFailActivities::pass_fail_act,
                 "pass".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(1)),
             );
-            let normal_act_fail = ctx.start_activity(
+            let normal_act_fail = ctx.execute_activity(
                 PassFailActivities::pass_fail_act,
                 "fail".to_string(),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(1))

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -1044,12 +1044,12 @@ async fn activity_metrics() {
                     .build(),
             );
             let _ = join!(normal_act_pass, normal_act_fail);
-            let local_act_pass = ctx.start_local_activity(
+            let local_act_pass = ctx.execute_local_activity(
                 PassFailActivities::pass_fail_act,
                 "pass".to_string(),
                 LocalActivityOptions::default(),
             );
-            let local_act_fail = ctx.start_local_activity(
+            let local_act_fail = ctx.execute_local_activity(
                 PassFailActivities::pass_fail_act,
                 "fail".to_string(),
                 LocalActivityOptions {
@@ -1061,7 +1061,7 @@ async fn activity_metrics() {
                     ..Default::default()
                 },
             );
-            let local_act_cancel = ctx.start_local_activity(
+            let local_act_cancel = ctx.execute_local_activity(
                 PassFailActivities::pass_fail_act,
                 "cancel".to_string(),
                 LocalActivityOptions {

--- a/crates/sdk-core/tests/integ_tests/polling_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/polling_tests.rs
@@ -260,7 +260,7 @@ impl OnlyOneWorkflowSlotAndTwoPollers {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         for _ in 0..3 {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     StdActivities::echo,
                     "hi!".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -686,7 +686,7 @@ async fn update_with_local_acts() {
             ctx: &mut WorkflowContext<Self>,
             _: (),
         ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-            ctx.start_local_activity(
+            ctx.execute_local_activity(
                 StdActivities::delay,
                 Duration::from_secs(3),
                 LocalActivityOptions::default(),

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -1193,7 +1193,7 @@ async fn worker_restarted_in_middle_of_update() {
             ctx: &mut WorkflowContext<Self>,
             _: (),
         ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            ctx.start_activity(
+            ctx.execute_activity(
                 BlockingActivities::blocks,
                 "hi!".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
@@ -1296,7 +1296,7 @@ async fn update_after_empty_wft() {
                 ctx.wait_condition(|s| s.signal_received).await;
                 ACT_STARTED.store(true, Ordering::Release);
                 let _ = ctx
-                    .start_activity(
+                    .execute_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
                         ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
@@ -1321,7 +1321,7 @@ async fn update_after_empty_wft() {
                 return;
             }
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     StdActivities::echo,
                     "hi!".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
@@ -1391,7 +1391,7 @@ async fn update_lost_on_activity_mismatch() {
             for _ in 1..=3 {
                 ctx.wait_condition(|s| s.can_run > 0).await;
                 let _ = ctx
-                    .start_activity(
+                    .execute_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
                         ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -201,7 +201,7 @@ async fn docker_worker_heartbeat_basic(#[values("otel", "prom", "no_metrics")] b
         #[allow(dead_code)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     NotifyActivities::pass_fail_act,
                     "pass".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -376,7 +376,7 @@ async fn docker_worker_heartbeat_tuner() {
         #[allow(dead_code)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     StdActivities::echo,
                     "pass".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(1)),
@@ -662,7 +662,7 @@ async fn worker_heartbeat_sticky_cache_miss() {
         #[allow(dead_code)]
         async fn run(ctx: &mut WorkflowContext<Self>, wf_marker: String) -> WorkflowResult<()> {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     StickyCacheActivities::sticky_cache_history_act,
                     wf_marker.clone(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -903,7 +903,7 @@ async fn worker_heartbeat_failure_metrics() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     FailingActivities::failing_act,
                     "boom".to_string(),
                     ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -1045,7 +1045,7 @@ async fn worker_heartbeat_no_runtime_heartbeat() {
         #[allow(dead_code)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     StdActivities::echo,
                     "pass".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(1)),
@@ -1116,7 +1116,7 @@ async fn worker_heartbeat_skip_client_worker_set_check() {
         #[allow(dead_code)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     StdActivities::echo,
                     "pass".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(1)),

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -1174,7 +1174,7 @@ async fn test_custom_slot_supplier_simple() {
                 )
                 .await;
             let _result = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     StdActivities::no_op,
                     (),
                     LocalActivityOptions {

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -410,7 +410,7 @@ async fn oversize_activity_result_fails_retryably_then_completes() {
     impl OversizeActResultWf {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(
+            ctx.execute_activity(
                 OversizeResultActs::maybe_oversize,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(10))
@@ -492,7 +492,7 @@ async fn oversize_activity_heartbeat_fails_retryably_then_completes() {
     impl OversizeHbWf {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(
+            ctx.execute_activity(
                 OversizeHbActs::maybe_oversize_heartbeat,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(60))
@@ -628,7 +628,7 @@ async fn disabled_error_limit_lets_server_hard_fail() {
     impl DisabledOversizeWf {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(
+            ctx.execute_activity(
                 DisabledOversizeActs::always_oversize,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(10))
@@ -794,13 +794,13 @@ async fn activity_tasks_from_completion_reserve_slots() {
     impl ActivityTasksCompletionWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(
+            ctx.execute_activity(
                 FakeAct::act1,
                 (),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await?;
-            ctx.start_activity(
+            ctx.execute_activity(
                 FakeAct::act2,
                 (),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -1167,7 +1167,7 @@ async fn test_custom_slot_supplier_simple() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let _result = ctx
-                .start_activity(
+                .execute_activity(
                     StdActivities::no_op,
                     (),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),

--- a/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
@@ -158,7 +158,7 @@ impl ActivityHasDeploymentStampWf {
     #[run(name = "activity_has_deployment_stamp")]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let _ = ctx
-            .start_activity(
+            .execute_activity(
                 StdActivities::echo,
                 "hi!".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -948,7 +948,7 @@ async fn history_out_of_order_on_restart() {
     impl HistoryOutOfOrderWf1 {
         #[run(name = HISTORY_OUT_OF_ORDER_WF_NAME)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_local_activity(
+            ctx.execute_local_activity(
                 StdActivities::echo,
                 "hi".to_string(),
                 LocalActivityOptions {
@@ -977,7 +977,7 @@ async fn history_out_of_order_on_restart() {
     impl HistoryOutOfOrderWf2 {
         #[run(name = HISTORY_OUT_OF_ORDER_WF_NAME)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_local_activity(
+            ctx.execute_local_activity(
                 StdActivities::echo,
                 "hi".to_string(),
                 LocalActivityOptions {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -500,7 +500,7 @@ impl SlowCompletesWf {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         for _ in 0..3 {
-            ctx.start_activity(
+            ctx.execute_activity(
                 StdActivities::echo,
                 "hi!".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -875,7 +875,7 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
     impl NondeterminismActivityWf {
         #[run(name = NONDETERMINISM_WF_NAME)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(
+            ctx.execute_activity(
                 StdActivities::echo,
                 "hi".to_owned(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -957,7 +957,7 @@ async fn history_out_of_order_on_restart() {
                 },
             )
             .await?;
-            ctx.start_activity(
+            ctx.execute_activity(
                 StdActivities::echo,
                 "hi".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -988,7 +988,7 @@ async fn history_out_of_order_on_restart() {
             .await?;
             // Timer is added after restarting workflow
             ctx.timer(Duration::from_secs(1)).await;
-            ctx.start_activity(
+            ctx.execute_activity(
                 StdActivities::echo,
                 "hi".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -97,7 +97,7 @@ impl OneLocalActivityWorkflow {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<String> {
         let r = ctx
-            .start_local_activity(StdActivities::echo, input, LocalActivityOptions::default())
+            .execute_local_activity(StdActivities::echo, input, LocalActivityOptions::default())
             .await?;
         Ok(r)
     }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -78,7 +78,7 @@ impl OneActivityWorkflow {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<String> {
         let r = ctx
-            .start_activity(
+            .execute_activity(
                 StdActivities::echo,
                 input,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -113,7 +113,7 @@ impl UntypedActivityWorkflow {
     async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<String> {
         let raw_input = RawValue::from_value(&input, ctx.payload_converter());
         let raw_output = ctx
-            .start_activity(
+            .execute_activity(
                 UntypedActivity::new("StdActivities::echo"),
                 raw_input,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -219,7 +219,7 @@ impl MultiArgActivityWorkflow {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<String> {
         let r = ctx
-            .start_activity(
+            .execute_activity(
                 StdActivities::concat,
                 (input, " world".to_string()),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -518,7 +518,7 @@ async fn activity_interceptor_observes_activity_error() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<()> {
             let result: Result<String, ActivityExecutionError> = ctx
-                .start_activity(
+                .execute_activity(
                     FailingActivities::fail,
                     input,
                     ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -615,7 +615,7 @@ async fn activity_interceptor_observes_activity_panic() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>, input: String) -> WorkflowResult<()> {
             let result: Result<String, ActivityExecutionError> = ctx
-                .start_activity(
+                .execute_activity(
                     PanickingActivities::panic_activity,
                     input,
                     ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -713,7 +713,7 @@ async fn activity_panics_are_retryable() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<u32> {
             let result = ctx
-                .start_activity(
+                .execute_activity(
                     PanicOnceActivities::panic_once,
                     (),
                     ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -774,7 +774,7 @@ async fn unregistered_activity_type_fails_activity_task_not_worker() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<Option<(String, String)>> {
             let result = ctx
-                .start_activity(
+                .execute_activity(
                     MissingActivities::missing,
                     (),
                     ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -1048,7 +1048,7 @@ async fn workflow_observes_non_retryable_activity() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let err = ctx
-                .start_activity(
+                .execute_activity(
                     NonRetryableActivityErrorActivities::fail_non_retryable,
                     (),
                     ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -1715,7 +1715,7 @@ struct OneActivityAbandonCancelledBeforeStarted;
 impl OneActivityAbandonCancelledBeforeStarted {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        let act_fut = ctx.start_activity(
+        let act_fut = ctx.execute_activity(
             StdActivities::delay,
             Duration::from_secs(2),
             ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -1760,7 +1760,7 @@ struct OneActivityAbandonCancelledAfterComplete;
 impl OneActivityAbandonCancelledAfterComplete {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        let act_fut = ctx.start_activity(
+        let act_fut = ctx.execute_activity(
             StdActivities::delay,
             Duration::from_secs(2),
             ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -1844,7 +1844,7 @@ async fn graceful_shutdown() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let act_futs = (1..=10).map(|_| {
-                ctx.start_activity(
+                ctx.execute_activity(
                     SleeperActivities::sleeper,
                     "hi".to_string(),
                     ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -1938,7 +1938,7 @@ async fn activity_can_be_cancelled_by_local_timeout() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let res = ctx
-                .start_activity(
+                .execute_activity(
                     CancellableEchoActivities::cancellable_echo,
                     "hi!".to_string(),
                     ActivityOptions::with_start_to_close_timeout(Duration::from_secs(1))
@@ -2016,7 +2016,7 @@ async fn long_activity_timeout_repro() {
             let mut iter = 1;
             loop {
                 let res = ctx
-                    .start_activity(
+                    .execute_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
                         ActivityOptions::with_start_to_close_timeout(Duration::from_secs(1))
@@ -2084,7 +2084,7 @@ async fn pass_activity_summary_to_metadata() {
     impl ActivitySummaryWorkflow {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_activity(
+            ctx.execute_activity(
                 StdActivities::default,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -2147,7 +2147,7 @@ async fn abandoned_activities_ignore_start_and_complete(hist_batches: &'static [
     impl AbandonedActivitiesWorkflow {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            let act_fut = ctx.start_activity(
+            let act_fut = ctx.execute_activity(
                 StdActivities::default,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -2194,7 +2194,7 @@ struct ImmediateActivityCancelationWorkflow;
 impl ImmediateActivityCancelationWorkflow {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        let cancel_activity_future = ctx.start_activity(
+        let cancel_activity_future = ctx.execute_activity(
             StdActivities::default,
             (),
             ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -289,7 +289,7 @@ impl ActivityIdOrTypeChangeWf {
     ) -> WorkflowResult<()> {
         if local_act {
             if id_change {
-                ctx.start_local_activity(
+                ctx.execute_local_activity(
                     StdActivities::default,
                     (),
                     LocalActivityOptions {
@@ -299,7 +299,7 @@ impl ActivityIdOrTypeChangeWf {
                 )
                 .await?;
             } else {
-                ctx.start_local_activity(StdActivities::no_op, (), Default::default())
+                ctx.execute_local_activity(StdActivities::no_op, (), Default::default())
                     .await?;
             }
         } else if id_change {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -52,7 +52,7 @@ impl TimerWfNondeterministic {
                 }
             }
             2 => {
-                ctx.start_activity(
+                ctx.execute_activity(
                     StdActivities::default,
                     (),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -105,7 +105,7 @@ impl TaskFailReplayWf {
             assert!(ctx.is_replaying());
         }
         let _ = ctx
-            .start_activity(
+            .execute_activity(
                 StdActivities::echo,
                 "hi!".to_string(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(2)),
@@ -303,7 +303,7 @@ impl ActivityIdOrTypeChangeWf {
                     .await?;
             }
         } else if id_change {
-            ctx.start_activity(
+            ctx.execute_activity(
                 StdActivities::default,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -312,7 +312,7 @@ impl ActivityIdOrTypeChangeWf {
             )
             .await?;
         } else {
-            ctx.start_activity(
+            ctx.execute_activity(
                 StdActivities::no_op,
                 (),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -79,7 +79,7 @@ impl OneLocalActivityWf {
     #[run]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let initial_workflow_time = ctx.workflow_time().expect("Workflow time should be set");
-        ctx.start_local_activity(
+        ctx.execute_local_activity(
             StdActivities::echo,
             "hi!".to_string(),
             LocalActivityOptions::default(),
@@ -122,7 +122,7 @@ pub(crate) struct LocalActConcurrentWithTimerWf;
 impl LocalActConcurrentWithTimerWf {
     #[run]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        let la = ctx.start_local_activity(
+        let la = ctx.execute_local_activity(
             StdActivities::echo,
             "hi!".to_string(),
             LocalActivityOptions::default(),
@@ -163,7 +163,7 @@ struct LocalActThenTimerThenWaitResult;
 impl LocalActThenTimerThenWaitResult {
     #[run]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        let la = ctx.start_local_activity(
+        let la = ctx.execute_local_activity(
             StdActivities::echo,
             "hi!".to_string(),
             LocalActivityOptions::default(),
@@ -205,7 +205,7 @@ pub(crate) struct LocalActThenTimerThenWait;
 impl LocalActThenTimerThenWait {
     #[run]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        let la = ctx.start_local_activity(
+        let la = ctx.execute_local_activity(
             StdActivities::delay,
             Duration::from_secs(4),
             LocalActivityOptions::default(),
@@ -250,7 +250,11 @@ impl LocalActFanoutWf {
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let las: Vec<_> = (1..=50)
             .map(|i| {
-                ctx.start_local_activity(StdActivities::echo, format!("Hi {i}"), Default::default())
+                ctx.execute_local_activity(
+                    StdActivities::echo,
+                    format!("Hi {i}"),
+                    Default::default(),
+                )
             })
             .collect();
         ctx.timer(Duration::from_secs(1)).await;
@@ -289,7 +293,7 @@ impl LocalActRetryTimerBackoff {
     #[run]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let res = ctx
-            .start_local_activity(
+            .execute_local_activity(
                 StdActivities::always_fail,
                 (),
                 LocalActivityOptions {
@@ -392,7 +396,7 @@ async fn cancel_immediate(#[case] cancel_type: ActivityCancellationType) {
         #[run]
         pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let cancel_type = ctx.state(|wf| wf.cancel_type);
-            let la = ctx.start_local_activity(
+            let la = ctx.execute_local_activity(
                 EchoWithManualCancel::echo,
                 "hi".to_string(),
                 LocalActivityOptions {
@@ -533,7 +537,7 @@ async fn cancel_after_act_starts(
             ctx: &mut WorkflowContext<Self>,
             (bo_dur, cancel_type): (Duration, ActivityCancellationType),
         ) -> WorkflowResult<()> {
-            let la = ctx.start_local_activity(
+            let la = ctx.execute_local_activity(
                 EchoWithManualCancelAndBackoff::echo,
                 "hi".to_string(),
                 LocalActivityOptions {
@@ -643,7 +647,7 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
             (sched, start, is_schedule): (Option<Duration>, Option<Duration>, bool),
         ) -> WorkflowResult<()> {
             let res = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     LongRunningWithCancellation::go,
                     (),
                     LocalActivityOptions {
@@ -717,7 +721,7 @@ async fn schedule_to_close_timeout_across_timer_backoff(#[case] cached: bool) {
         #[run]
         pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let res = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     FailWithAtomicCounter::go,
                     "hi".to_string(),
                     LocalActivityOptions {
@@ -799,7 +803,7 @@ async fn timer_backoff_concurrent_with_non_timer_backoff() {
     impl TimerBackoffConcurrentWf {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            let r1 = ctx.start_local_activity(
+            let r1 = ctx.execute_local_activity(
                 StdActivities::always_fail,
                 (),
                 LocalActivityOptions {
@@ -815,7 +819,7 @@ async fn timer_backoff_concurrent_with_non_timer_backoff() {
                     ..Default::default()
                 },
             );
-            let r2 = ctx.start_local_activity(
+            let r2 = ctx.execute_local_activity(
                 StdActivities::always_fail,
                 (),
                 LocalActivityOptions {
@@ -870,7 +874,7 @@ async fn repro_nondeterminism_with_timer_bug() {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let mut t1 = ctx.timer(Duration::from_secs(30));
-            let mut r1 = ctx.start_local_activity(
+            let mut r1 = ctx.execute_local_activity(
                 StdActivities::delay,
                 Duration::from_secs(2),
                 LocalActivityOptions {
@@ -1037,7 +1041,7 @@ async fn la_resolve_same_time_as_other_cancel() {
             ctx.timer(Duration::from_millis(1)).await;
 
             // Start LA and cancel the activity at the same time
-            let mut local_act = ctx.start_local_activity(
+            let mut local_act = ctx.execute_local_activity(
                 DelayWithCancellation::delay,
                 Duration::from_millis(100),
                 LocalActivityOptions {
@@ -1120,7 +1124,7 @@ async fn long_local_activity_with_update(
 
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<usize> {
-            ctx.start_local_activity(
+            ctx.execute_local_activity(
                 StdActivities::delay,
                 Duration::from_secs(6),
                 LocalActivityOptions::default(),
@@ -1216,7 +1220,7 @@ async fn local_activity_with_heartbeat_only_causes_one_wakeup() {
             // TODO [rust-sdk-branch] - See if we can fix this and know that we should re-poll.
             temporalio_sdk::workflows::join!(
                 async {
-                    ctx.start_local_activity(
+                    ctx.execute_local_activity(
                         StdActivities::delay,
                         Duration::from_secs(6),
                         LocalActivityOptions::default(),
@@ -1265,7 +1269,7 @@ pub(crate) struct LocalActivityWithSummaryWf;
 impl LocalActivityWithSummaryWf {
     #[run(name = "local_activity_with_summary")]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        ctx.start_local_activity(
+        ctx.execute_local_activity(
             StdActivities::echo,
             "hi".to_string(),
             LocalActivityOptions {
@@ -1360,7 +1364,7 @@ async fn local_act_two_wfts_before_marker(#[case] replay: bool, #[case] cached: 
     impl LocalActTwoWftsBeforeMarkerWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            let la = ctx.start_local_activity(StdActivities::default, (), Default::default());
+            let la = ctx.execute_local_activity(StdActivities::default, (), Default::default());
             ctx.timer(Duration::from_secs(1)).await;
             let _ = la.await;
             Ok(())
@@ -1438,7 +1442,7 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             dbg!("dafuq");
-            ctx.start_local_activity(
+            ctx.execute_local_activity(
                 EchoWithConditionalBarrier::echo,
                 "hi".to_string(),
                 LocalActivityOptions::default(),
@@ -1517,7 +1521,7 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>, eventually_pass: bool) -> WorkflowResult<()> {
             let la_res = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     EventuallyPassingActivity::echo,
                     "hi".to_string(),
                     LocalActivityOptions {
@@ -1619,7 +1623,7 @@ async fn local_act_retry_long_backoff_uses_timer() {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let la_res = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     StdActivities::always_fail,
                     (),
                     LocalActivityOptions {
@@ -1669,7 +1673,7 @@ async fn local_act_null_result() {
     impl LocalActNullResultWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
+            ctx.execute_local_activity(StdActivities::default, (), LocalActivityOptions::default())
                 .await?;
             Ok(())
         }
@@ -1705,7 +1709,7 @@ async fn local_act_command_immediately_follows_la_marker() {
     impl LocalActCommandImmediatelyFollowsLaMarkerWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
+            ctx.execute_local_activity(StdActivities::default, (), LocalActivityOptions::default())
                 .await?;
             ctx.timer(Duration::from_secs(1)).await;
             Ok(())
@@ -1995,7 +1999,7 @@ async fn test_schedule_to_start_timeout() {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let la_res = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     StdActivities::echo,
                     "hi".to_string(),
                     LocalActivityOptions {
@@ -2085,7 +2089,7 @@ async fn test_schedule_to_start_timeout_not_based_on_original_time(
         ) -> WorkflowResult<()> {
             let (is_sched_to_start, schedule_to_close_timeout) = input;
             let la_res = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     StdActivities::echo,
                     "hi".to_string(),
                     LocalActivityOptions {
@@ -2162,7 +2166,7 @@ async fn start_to_close_timeout_allows_retries(#[values(true, false)] la_complet
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>, la_completes: bool) -> WorkflowResult<()> {
             let la_res = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     ActivityWithRetriesAndCancellation::go,
                     (),
                     LocalActivityOptions {
@@ -2254,7 +2258,7 @@ async fn wft_failure_cancels_running_las() {
     impl WftFailureCancelsRunningLasWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            let la_handle = ctx.start_local_activity(
+            let la_handle = ctx.execute_local_activity(
                 ActivityThatExpectsCancellation::go,
                 (),
                 Default::default(),
@@ -2326,7 +2330,7 @@ async fn resolved_las_not_recorded_if_wft_fails_many_times() {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         #[allow(unreachable_code)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_local_activity(
+            ctx.execute_local_activity(
                 StdActivities::echo,
                 "hi".to_string(),
                 LocalActivityOptions {
@@ -2380,7 +2384,7 @@ async fn local_act_records_nonfirst_attempts_ok() {
     impl LocalActRecordsNonfirstAttemptsOkWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.start_local_activity(
+            ctx.execute_local_activity(
                 StdActivities::always_fail,
                 (),
                 LocalActivityOptions {
@@ -2700,7 +2704,7 @@ async fn local_act_retry_explicit_delay() {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
             let la_res = ctx
-                .start_local_activity(
+                .execute_local_activity(
                     ActivityWithExplicitBackoff::go,
                     (),
                     LocalActivityOptions {
@@ -2767,7 +2771,7 @@ impl LaWf {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let _ = ctx
-            .start_local_activity(
+            .execute_local_activity(
                 StdActivities::default,
                 (),
                 LocalActivityOptions {
@@ -2891,9 +2895,9 @@ struct TwoLaWf;
 impl TwoLaWf {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
+        ctx.execute_local_activity(StdActivities::default, (), LocalActivityOptions::default())
             .await?;
-        ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
+        ctx.execute_local_activity(StdActivities::default, (), LocalActivityOptions::default())
             .await?;
         Ok(())
     }
@@ -2908,8 +2912,8 @@ impl TwoLaWfParallel {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let _ = temporalio_sdk::workflows::join!(
-            ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default()),
-            ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
+            ctx.execute_local_activity(StdActivities::default, (), LocalActivityOptions::default()),
+            ctx.execute_local_activity(StdActivities::default, (), LocalActivityOptions::default())
         );
         Ok(())
     }
@@ -3026,10 +3030,10 @@ struct LaTimerLaWf;
 impl LaTimerLaWf {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
+        ctx.execute_local_activity(StdActivities::default, (), LocalActivityOptions::default())
             .await?;
         ctx.timer(Duration::from_secs(5)).await;
-        ctx.start_local_activity(StdActivities::default, (), LocalActivityOptions::default())
+        ctx.execute_local_activity(StdActivities::default, (), LocalActivityOptions::default())
             .await?;
         Ok(())
     }
@@ -3184,7 +3188,7 @@ async fn immediate_cancel(
             ctx: &mut WorkflowContext<Self>,
             cancel_type: ActivityCancellationType,
         ) -> WorkflowResult<()> {
-            let la = ctx.start_local_activity(
+            let la = ctx.execute_local_activity(
                 StdActivities::default,
                 (),
                 LocalActivityOptions {
@@ -3301,7 +3305,7 @@ async fn cancel_after_act_starts_canned(
             ctx: &mut WorkflowContext<Self>,
             cancel_type: ActivityCancellationType,
         ) -> WorkflowResult<()> {
-            let la = ctx.start_local_activity(
+            let la = ctx.execute_local_activity(
                 ActivityWithConditionalCancelWait::echo,
                 (),
                 LocalActivityOptions {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -1026,7 +1026,7 @@ async fn la_resolve_same_time_as_other_cancel() {
     impl LaResolveSameTimeAsOtherCancelWf {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            let mut normal_act = ctx.start_activity(
+            let mut normal_act = ctx.execute_activity(
                 DelayWithCancellation::delay,
                 Duration::from_secs(9),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(9000))

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -660,7 +660,7 @@ impl FakeAct {
 
 async fn v1(ctx: &mut WorkflowContext<PatchWf>) {
     let _ = ctx
-        .start_activity(
+        .execute_activity(
             FakeAct::nameless,
             (),
             ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -673,7 +673,7 @@ async fn v1(ctx: &mut WorkflowContext<PatchWf>) {
 async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
     if ctx.patched(MY_PATCH_ID) {
         let _ = ctx
-            .start_activity(
+            .execute_activity(
                 FakeAct::nameless,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -684,7 +684,7 @@ async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
         true
     } else {
         let _ = ctx
-            .start_activity(
+            .execute_activity(
                 FakeAct::nameless,
                 (),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -699,7 +699,7 @@ async fn v2(ctx: &mut WorkflowContext<PatchWf>) -> bool {
 async fn v3(ctx: &mut WorkflowContext<PatchWf>) {
     ctx.deprecate_patch(MY_PATCH_ID);
     let _ = ctx
-        .start_activity(
+        .execute_activity(
             FakeAct::nameless,
             (),
             ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -711,7 +711,7 @@ async fn v3(ctx: &mut WorkflowContext<PatchWf>) {
 
 async fn v4(ctx: &mut WorkflowContext<PatchWf>) {
     let _ = ctx
-        .start_activity(
+        .execute_activity(
             FakeAct::nameless,
             (),
             ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
@@ -934,7 +934,7 @@ impl SameChangeMultipleSpotsWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         if ctx.patched(MY_PATCH_ID) {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     FakeAct::nameless,
                     (),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -946,7 +946,7 @@ impl SameChangeMultipleSpotsWf {
         ctx.timer(ONE_SECOND).await;
         if ctx.patched(MY_PATCH_ID) {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     FakeAct::nameless,
                     (),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
@@ -153,7 +153,7 @@ impl ResetRandomseedWf {
             ctx.state(|wf| {
                 wf.saw_updated_seed.store(true, Ordering::Relaxed);
             });
-            ctx.start_local_activity(
+            ctx.execute_local_activity(
                 StdActivities::echo,
                 "hi!".to_string(),
                 LocalActivityOptions::default(),

--- a/crates/sdk-core/tests/manual_tests.rs
+++ b/crates/sdk-core/tests/manual_tests.rs
@@ -57,7 +57,7 @@ impl PollerLoadSpikyWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         for _ in 0..5 {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     JitteryEchoActivities::echo,
                     "hi!".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
@@ -104,7 +104,7 @@ impl PollerLoadSpikeThenSustainedWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         for _ in 0..5 {
             let _ = ctx
-                .start_activity(
+                .execute_activity(
                     JitteryEchoActivities::echo,
                     "hi!".to_string(),
                     ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -301,7 +301,7 @@ impl ShutdownTimerActivityLoopWf {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         loop {
             ctx.timer(Duration::from_millis(10)).await;
-            ctx.start_activity(
+            ctx.execute_activity(
                 StdActivities::no_op,
                 (),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
@@ -461,7 +461,7 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat() {
     impl CancelWithoutHeartbeatWorkflow {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            let act_fut = ctx.start_activity(
+            let act_fut = ctx.execute_activity(
                 WaitForCancelActivities::wait_for_cancel,
                 "hi".to_string(),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(30))

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -70,7 +70,7 @@ pub(crate) async fn priority_values_sent_to_server() {
                     },
                 )
                 .await?;
-            let activity = ctx.start_activity(
+            let activity = ctx.execute_activity(
                 PriorityActivities::echo,
                 "hello".to_string(),
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -65,7 +65,7 @@ impl GreetingWorkflow {
         let name = ctx.state(|s| s.name.clone());
 
         // Execute an activity
-        let greeting = ctx.start_activity(
+        let greeting = ctx.execute_activity(
             MyActivities::greet,
             name,
             ActivityOptions::start_to_close_timeout(Duration::from_secs(10))

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -300,7 +300,7 @@ Activities return `Result<T, ActivityError>` with the following error types:
 For short-lived activities that you want to run on the same worker as the workflow:
 
 ```rust
-ctx.start_local_activity(
+ctx.execute_local_activity(
     MyActivities::quick_operation,
     input,
     LocalActivityOptions {

--- a/crates/sdk/examples/activity_heartbeating/workflows.rs
+++ b/crates/sdk/examples/activity_heartbeating/workflows.rs
@@ -40,7 +40,7 @@ impl HeartbeatingWorkflow {
     #[run]
     pub async fn run(ctx: &mut WorkflowContext<Self>, total_steps: u32) -> WorkflowResult<String> {
         let result = ctx
-            .start_activity(
+            .execute_activity(
                 HeartbeatingActivities::long_running_activity,
                 total_steps,
                 ActivityOptions::with_start_to_close_timeout(Duration::from_secs(30))

--- a/crates/sdk/examples/activity_interceptor/workflows.rs
+++ b/crates/sdk/examples/activity_interceptor/workflows.rs
@@ -26,14 +26,14 @@ impl ActivityInterceptorWorkflow {
     #[run]
     pub async fn run(ctx: &mut WorkflowContext<Self>, name: String) -> WorkflowResult<String> {
         let greet = ctx
-            .start_activity(
+            .execute_activity(
                 GreetingActivities::greet,
                 GreetingRequest { name: name.clone() },
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
             )
             .await?;
         let shout = ctx
-            .start_activity(
+            .execute_activity(
                 GreetingActivities::shout,
                 GreetingRequest { name },
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),

--- a/crates/sdk/examples/cancellation/workflows.rs
+++ b/crates/sdk/examples/cancellation/workflows.rs
@@ -44,7 +44,7 @@ pub struct CancellationWorkflow;
 impl CancellationWorkflow {
     #[run]
     pub async fn run(ctx: &mut WorkflowContext<Self>, _input: ()) -> WorkflowResult<String> {
-        let mut activity_fut = ctx.start_activity(
+        let mut activity_fut = ctx.execute_activity(
             CancellationActivities::long_running_activity,
             (),
             activity_opts(),
@@ -59,7 +59,7 @@ impl CancellationWorkflow {
                 activity_fut.cancel();
 
                 let cleanup_result = ctx
-                    .start_activity(
+                    .execute_activity(
                         CancellationActivities::cleanup,
                         (),
                         ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),

--- a/crates/sdk/examples/hello_world/workflows.rs
+++ b/crates/sdk/examples/hello_world/workflows.rs
@@ -15,7 +15,7 @@ impl HelloWorldWorkflow {
     #[run]
     pub async fn run(ctx: &mut WorkflowContext<Self>, name: String) -> WorkflowResult<String> {
         let greeting = ctx
-            .start_activity(
+            .execute_activity(
                 GreetingActivities::greet,
                 name,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),

--- a/crates/sdk/examples/local_activities/workflows.rs
+++ b/crates/sdk/examples/local_activities/workflows.rs
@@ -36,7 +36,7 @@ impl LocalActivitiesWorkflow {
             .await?;
 
         let local_result = ctx
-            .start_local_activity(
+            .execute_local_activity(
                 GreetingActivities::greet,
                 name,
                 LocalActivityOptions {

--- a/crates/sdk/examples/local_activities/workflows.rs
+++ b/crates/sdk/examples/local_activities/workflows.rs
@@ -28,7 +28,7 @@ impl LocalActivitiesWorkflow {
         name: String,
     ) -> WorkflowResult<(String, String)> {
         let remote_result = ctx
-            .start_activity(
+            .execute_activity(
                 GreetingActivities::greet,
                 name.clone(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),

--- a/crates/sdk/examples/polling/workflows.rs
+++ b/crates/sdk/examples/polling/workflows.rs
@@ -33,7 +33,7 @@ impl PollingWorkflow {
     pub async fn run(ctx: &mut WorkflowContext<Self>, max_attempts: u32) -> WorkflowResult<String> {
         for attempt in 1..=max_attempts {
             let is_ready = ctx
-                .start_activity(PollingActivities::check_condition, attempt, activity_opts())
+                .execute_activity(PollingActivities::check_condition, attempt, activity_opts())
                 .await?;
 
             if is_ready {

--- a/crates/sdk/examples/saga/workflows.rs
+++ b/crates/sdk/examples/saga/workflows.rs
@@ -87,14 +87,14 @@ impl Saga {
     {
         let out = self
             .ctx
-            .start_activity(forward, input, self.opts.clone())
+            .execute_activity(forward, input, self.opts.clone())
             .await?;
         let cmp_input: Compensation::Input = out.clone().into();
         let ctx = self.ctx.clone();
         let opts = self.opts.clone();
         let compensation_name = compensate.name().to_owned();
         self.compensations.push(Box::pin(async move {
-            if let Err(e) = ctx.start_activity(compensate, cmp_input, opts).await {
+            if let Err(e) = ctx.execute_activity(compensate, cmp_input, opts).await {
                 eprintln!("Compensation {compensation_name} failed: {e}");
             }
         }));

--- a/crates/sdk/examples/schedules/workflows.rs
+++ b/crates/sdk/examples/schedules/workflows.rs
@@ -25,7 +25,7 @@ impl ScheduledWorkflow {
     #[run]
     pub async fn run(ctx: &mut WorkflowContext<Self>, name: String) -> WorkflowResult<String> {
         let greeting = ctx
-            .start_activity(
+            .execute_activity(
                 ScheduledActivities::greet,
                 name,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),

--- a/crates/sdk/examples/timer_examples/workflows.rs
+++ b/crates/sdk/examples/timer_examples/workflows.rs
@@ -32,7 +32,7 @@ impl TimerWorkflow {
 
         let winner = temporalio_sdk::workflows::select! {
             _ = ctx.timer(Duration::from_secs(10)) => "timer",
-            result = ctx.start_activity(
+            result = ctx.execute_activity(
                 TimerActivities::slow_activity,
                 100u64,
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(30)),

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1246,22 +1246,22 @@ mod tests {
     #[allow(unused, clippy::diverging_sub_expression)]
     fn test_activity_via_workflow_context() {
         let wf_ctx: WorkflowContext<MyWorkflow> = unimplemented!();
-        wf_ctx.start_activity(
+        wf_ctx.execute_activity(
             MyActivities::my_activity,
             (),
             ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
         );
-        wf_ctx.start_activity(
+        wf_ctx.execute_activity(
             SharedActivities::greet,
             "Hi".to_owned(),
             ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
         );
-        wf_ctx.start_activity(
+        wf_ctx.execute_activity(
             MyActivities::greet,
             "Hi".to_owned(),
             ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
         );
-        wf_ctx.start_activity(
+        wf_ctx.execute_activity(
             MyActivities::takes_self,
             "Hi".to_owned(),
             ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -536,7 +536,7 @@ impl BaseWorkflowContext {
     }
 
     /// Request to run a local activity
-    pub fn start_local_activity<AD: ActivityDefinition>(
+    pub fn execute_local_activity<AD: ActivityDefinition>(
         &self,
         activity: AD,
         input: impl Into<AD::Input>,
@@ -873,6 +873,22 @@ impl<W> SyncWorkflowContext<W> {
     }
 
     /// Request to run a local activity
+    pub fn execute_local_activity<AD: ActivityDefinition>(
+        &self,
+        activity: AD,
+        input: impl Into<AD::Input>,
+        opts: LocalActivityOptions,
+    ) -> impl CancellableFuture<Result<AD::Output, ActivityExecutionError>>
+    where
+        AD::Output: TemporalDeserializable,
+    {
+        self.base.execute_local_activity(activity, input, opts)
+    }
+
+    /// Request to run a local activity
+    ///
+    /// Deprecated alias for [`SyncWorkflowContext::execute_local_activity`].
+    #[deprecated(note = "use `execute_local_activity` instead")]
     pub fn start_local_activity<AD: ActivityDefinition>(
         &self,
         activity: AD,
@@ -882,7 +898,7 @@ impl<W> SyncWorkflowContext<W> {
     where
         AD::Output: TemporalDeserializable,
     {
-        self.base.start_local_activity(activity, input, opts)
+        self.execute_local_activity(activity, input, opts)
     }
 
     /// Start a child workflow. Returns a future that resolves to a [StartedChildWorkflow]
@@ -1282,6 +1298,22 @@ impl<W> WorkflowContext<W> {
     }
 
     /// Request to run a local activity
+    pub fn execute_local_activity<AD: ActivityDefinition>(
+        &self,
+        activity: AD,
+        input: impl Into<AD::Input>,
+        opts: LocalActivityOptions,
+    ) -> impl CancellableFuture<Result<AD::Output, ActivityExecutionError>>
+    where
+        AD::Output: TemporalDeserializable,
+    {
+        self.sync.execute_local_activity(activity, input, opts)
+    }
+
+    /// Request to run a local activity
+    ///
+    /// Deprecated alias for [`WorkflowContext::execute_local_activity`].
+    #[deprecated(note = "use `execute_local_activity` instead")]
     pub fn start_local_activity<AD: ActivityDefinition>(
         &self,
         activity: AD,
@@ -1291,7 +1323,7 @@ impl<W> WorkflowContext<W> {
     where
         AD::Output: TemporalDeserializable,
     {
-        self.sync.start_local_activity(activity, input, opts)
+        self.execute_local_activity(activity, input, opts)
     }
 
     /// Start a child workflow. See [SyncWorkflowContext::start_child_workflow] for details.

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -497,7 +497,7 @@ impl BaseWorkflowContext {
     }
 
     /// Request to run an activity
-    pub fn start_activity<AD: ActivityDefinition>(
+    pub fn execute_activity<AD: ActivityDefinition>(
         &self,
         activity: AD,
         input: impl Into<AD::Input>,
@@ -844,6 +844,22 @@ impl<W> SyncWorkflowContext<W> {
     }
 
     /// Request to run an activity
+    pub fn execute_activity<AD: ActivityDefinition>(
+        &self,
+        activity: AD,
+        input: impl Into<AD::Input>,
+        opts: ActivityOptions,
+    ) -> impl CancellableFuture<Result<AD::Output, ActivityExecutionError>>
+    where
+        AD::Output: TemporalDeserializable,
+    {
+        self.base.execute_activity(activity, input, opts)
+    }
+
+    /// Request to run an activity
+    ///
+    /// Deprecated alias for [`SyncWorkflowContext::execute_activity`].
+    #[deprecated(note = "use `execute_activity` instead")]
     pub fn start_activity<AD: ActivityDefinition>(
         &self,
         activity: AD,
@@ -853,7 +869,7 @@ impl<W> SyncWorkflowContext<W> {
     where
         AD::Output: TemporalDeserializable,
     {
-        self.base.start_activity(activity, input, opts)
+        self.execute_activity(activity, input, opts)
     }
 
     /// Request to run a local activity
@@ -1237,6 +1253,22 @@ impl<W> WorkflowContext<W> {
     }
 
     /// Request to run an activity
+    pub fn execute_activity<AD: ActivityDefinition>(
+        &self,
+        activity: AD,
+        input: impl Into<AD::Input>,
+        opts: ActivityOptions,
+    ) -> impl CancellableFuture<Result<AD::Output, ActivityExecutionError>>
+    where
+        AD::Output: TemporalDeserializable,
+    {
+        self.sync.execute_activity(activity, input, opts)
+    }
+
+    /// Request to run an activity
+    ///
+    /// Deprecated alias for [`WorkflowContext::execute_activity`].
+    #[deprecated(note = "use `execute_activity` instead")]
     pub fn start_activity<AD: ActivityDefinition>(
         &self,
         activity: AD,
@@ -1246,7 +1278,7 @@ impl<W> WorkflowContext<W> {
     where
         AD::Output: TemporalDeserializable,
     {
-        self.sync.start_activity(activity, input, opts)
+        self.execute_activity(activity, input, opts)
     }
 
     /// Request to run a local activity


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Rename `start_activity` to `execute_activity` and `start_local_activity` to `execute_local_activity`

## Why?
Execute is more accurate to what the method does i.e. `await` will wait until the activity completes execution, not until when it starts.

This matches other newer SDKs like Ruby that only expose an execute variant instead of start and execute.

Deprecating instead of full removal since this is heavily used.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
👀 

3. Any docs updates needed?
Will want to redo docs site to use `execute_activity`
