### PR TITLE
Only set worker control task queue field in polls when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,3 +119,5 @@ to docs, or any other relevant information.
   metric reader reports an export error.
 * Worker heartbeat now samples host CPU/memory at the heartbeat interval (only when enabled) rather
   than every 100ms.
+* Workers no longer advertise a worker control task queue unless the namespace supports worker
+  heartbeats and commands and the built-in Nexus command worker is running.

--- a/crates/client/src/worker.rs
+++ b/crates/client/src/worker.rs
@@ -122,6 +122,12 @@ impl ClientWorkerSetImpl {
         None
     }
 
+    fn worker_control_task_queue_enabled(&self, namespace: &str) -> bool {
+        self.shared_worker
+            .get(namespace)
+            .is_some_and(|worker| worker.worker_control_task_queue_enabled())
+    }
+
     fn worker_ids_in_selection_order(worker_list: &[&RegisteredWorkerInfo]) -> Vec<Uuid> {
         // For tests we return workers in the order they're registered, so we can test
         // the retry mechanism deterministically
@@ -302,6 +308,11 @@ pub trait SharedNamespaceWorkerTrait {
 
     /// Returns the number of workers registered to this shared worker.
     fn num_workers(&self) -> usize;
+
+    /// Returns whether this shared worker is polling the worker control task queue.
+    fn worker_control_task_queue_enabled(&self) -> bool {
+        false
+    }
 }
 
 /// Enables local workers to make themselves visible to a shared client instance.
@@ -375,6 +386,13 @@ impl ClientWorkerSet {
     /// Returns the worker grouping key, which is unique for each worker.
     pub fn worker_grouping_key(&self) -> Uuid {
         self.worker_grouping_key
+    }
+
+    /// Returns whether the shared worker for `namespace` is polling the worker control task queue.
+    pub fn worker_control_task_queue_enabled(&self, namespace: &str) -> bool {
+        self.worker_manager
+            .read()
+            .worker_control_task_queue_enabled(namespace)
     }
 
     #[cfg(test)]
@@ -737,6 +755,7 @@ mod tests {
     struct MockSharedNamespaceWorker {
         namespace: String,
         callbacks: Arc<RwLock<HashMap<Uuid, WorkerCallbacks>>>,
+        worker_control_task_queue_enabled: bool,
     }
 
     impl std::fmt::Debug for MockSharedNamespaceWorker {
@@ -753,7 +772,13 @@ mod tests {
             Self {
                 namespace,
                 callbacks: Arc::new(RwLock::new(HashMap::new())),
+                worker_control_task_queue_enabled: false,
             }
+        }
+
+        fn with_worker_control_task_queue_enabled(mut self) -> Self {
+            self.worker_control_task_queue_enabled = true;
+            self
         }
     }
 
@@ -781,6 +806,29 @@ mod tests {
         fn num_workers(&self) -> usize {
             self.callbacks.read().len()
         }
+
+        fn worker_control_task_queue_enabled(&self) -> bool {
+            self.worker_control_task_queue_enabled
+        }
+    }
+
+    #[test]
+    fn worker_control_task_queue_enabled_reflects_shared_worker() {
+        let manager = ClientWorkerSet::new();
+        let namespace = "test_namespace";
+
+        assert!(!manager.worker_control_task_queue_enabled(namespace));
+
+        manager.worker_manager.write().shared_worker.insert(
+            namespace.to_string(),
+            Box::new(
+                MockSharedNamespaceWorker::new(namespace.to_string())
+                    .with_worker_control_task_queue_enabled(),
+            ),
+        );
+
+        assert!(manager.worker_control_task_queue_enabled(namespace));
+        assert!(!manager.worker_control_task_queue_enabled("other_namespace"));
     }
 
     fn new_mock_provider_with_heartbeat(

--- a/crates/sdk-core/src/worker/client.rs
+++ b/crates/sdk-core/src/worker/client.rs
@@ -146,7 +146,12 @@ impl WorkerClientBag {
     }
 
     fn worker_control_task_queue(&self) -> String {
-        worker_control_task_queue(&self.namespace, &self.worker_grouping_key().to_string())
+        let workers = self.connection.inner_cow().workers();
+        if workers.worker_control_task_queue_enabled(&self.namespace) {
+            worker_control_task_queue(&self.namespace, &workers.worker_grouping_key().to_string())
+        } else {
+            String::new()
+        }
     }
 }
 

--- a/crates/sdk-core/src/worker/heartbeat.rs
+++ b/crates/sdk-core/src/worker/heartbeat.rs
@@ -7,7 +7,14 @@ use crate::{
 };
 use parking_lot::RwLock;
 use prost::Message;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 use temporalio_client::worker::{SharedNamespaceWorkerTrait, WorkerCallbacks};
 use temporalio_common::{
     protos::{
@@ -39,6 +46,7 @@ pub(crate) struct SharedNamespaceWorker {
     callbacks_map: Arc<RwLock<HashMap<Uuid, WorkerCallbacks>>>,
     namespace: String,
     cancel: CancellationToken,
+    worker_control_task_queue_enabled: Arc<AtomicBool>,
 }
 
 impl SharedNamespaceWorker {
@@ -51,12 +59,14 @@ impl SharedNamespaceWorker {
         let reset_notify = Arc::new(Notify::new());
         let cancel = CancellationToken::new();
         let callbacks_map = Arc::new(RwLock::new(HashMap::<Uuid, WorkerCallbacks>::new()));
+        let worker_control_task_queue_enabled = Arc::new(AtomicBool::new(false));
 
         tokio::spawn({
             let client = client.clone();
             let namespace = namespace.clone();
             let callbacks_map = callbacks_map.clone();
             let cancel = cancel.clone();
+            let worker_control_task_queue_enabled = worker_control_task_queue_enabled.clone();
             async move {
                 let worker_commands_supported = match client.describe_namespace().await {
                     Ok(namespace_resp) => {
@@ -153,9 +163,12 @@ impl SharedNamespaceWorker {
                         true,
                     ) {
                         Ok(worker) => {
+                            worker_control_task_queue_enabled.store(true, Ordering::Relaxed);
                             tokio::spawn({
                                 let cm = callbacks_map.clone();
                                 let cancel = cancel.clone();
+                                let worker_control_task_queue_enabled =
+                                    worker_control_task_queue_enabled.clone();
                                 async move {
                                     loop {
                                         tokio::select! {
@@ -167,6 +180,8 @@ impl SharedNamespaceWorker {
                                             _ = cancel.cancelled() => break,
                                         }
                                     }
+                                    worker_control_task_queue_enabled
+                                        .store(false, Ordering::Relaxed);
                                     worker.shutdown().await;
                                 }
                             });
@@ -198,6 +213,7 @@ impl SharedNamespaceWorker {
             callbacks_map,
             namespace,
             cancel,
+            worker_control_task_queue_enabled,
         })
     }
 }
@@ -224,6 +240,11 @@ impl SharedNamespaceWorkerTrait for SharedNamespaceWorker {
 
     fn num_workers(&self) -> usize {
         self.callbacks_map.read().len()
+    }
+
+    fn worker_control_task_queue_enabled(&self) -> bool {
+        self.worker_control_task_queue_enabled
+            .load(Ordering::Relaxed)
     }
 }
 
@@ -323,6 +344,7 @@ async fn handle_worker_command_task(
 #[cfg(test)]
 mod tests {
     use crate::{
+        WorkerClient,
         test_help::{WorkerExt, test_worker_cfg},
         worker,
         worker::{PollerBehavior, client::mocks::mock_worker_client},
@@ -468,6 +490,12 @@ mod tests {
             .await
             .expect("worker heartbeat was not recorded in time")
             .expect("heartbeat sender was dropped");
+        assert!(
+            !shared_worker
+                .worker_control_task_queue_enabled
+                .load(Ordering::Relaxed),
+            "control task queue must stay disabled without the worker_commands capability"
+        );
         shared_worker.cancel.cancel();
 
         assert!(
@@ -571,7 +599,7 @@ mod tests {
             .max_outstanding_activities(1_usize)
             .build()
             .unwrap();
-        config.namespace = namespace;
+        config.namespace = namespace.clone();
         config.task_types = WorkerTaskTypes::activity_only();
 
         let client = Arc::new(mock);
@@ -588,7 +616,19 @@ mod tests {
             .await
             .expect("nexus task was not completed in time")
             .expect("completion sender was dropped");
-        worker.drain_activity_poller_and_shutdown().await;
+        assert!(
+            client
+                .workers()
+                .worker_control_task_queue_enabled(&namespace),
+            "control task queue must be enabled while the command worker is polling"
+        );
+        worker.drain_pollers_and_shutdown().await;
+        assert!(
+            !client
+                .workers()
+                .worker_control_task_queue_enabled(&namespace),
+            "control task queue must be disabled after the command worker shuts down"
+        );
 
         let start_op = match response.variant {
             Some(response::Variant::StartOperation(s)) => s,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
See title

## Why?
Otherwise server can send activity cancels that may not be handled

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
