### PR TITLE
Add `connect_timeout` option to `ConnectionOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ to docs, or any other relevant information.
 * `WorkflowContext::random` and `WorkflowContext::uuid4` for deterministic randomness in workflow.
 * `ChildWorkflowOptions::builder` and `ChildWorkflowOptions::workflow_id` for constructing
   child workflow options.
+* Added `connect_timeout: Option<Duration>` to ConnectionOptions and implemented in 
+  `Connection::connect_once()`, `dns::build_endpoint()` and `dns::create_balanced_channel()`.
 
 ### Changed
  * Renamed `start_activity` and `start_local_activity` to `execute_activity` and `execute_local_activity`

--- a/crates/client/src/dns.rs
+++ b/crates/client/src/dns.rs
@@ -75,9 +75,16 @@ async fn build_endpoint(
     tls_options: Option<&TlsOptions>,
     keep_alive: Option<&ClientKeepAliveOptions>,
     override_origin: Option<&Uri>,
+    connect_timeout: Option<Duration>,
 ) -> Result<Endpoint, ClientConnectError> {
     let uri = endpoint_uri(addr, scheme);
     let channel = Channel::from_shared(uri)?;
+
+    let channel = if let Some(timeout) = connect_timeout {
+        channel.connect_timeout(timeout)
+    } else {
+        channel
+    };
 
     // When connecting to an IP with TLS, SNI must use the original hostname.
     let tls_for_ip = tls_options.map(|tls| {
@@ -146,6 +153,7 @@ pub(crate) async fn create_balanced_channel(
             options.tls_options.as_ref(),
             options.keep_alive.as_ref(),
             options.override_origin.as_ref(),
+            options.connect_timeout,
         )
         .await?;
         // Unbounded-ish send into the freshly-created channel; can't realistically fail.
@@ -174,6 +182,7 @@ pub(crate) fn spawn_dns_reresolution(
     keep_alive: Option<ClientKeepAliveOptions>,
     override_origin: Option<Uri>,
     resolution_interval: Duration,
+    connect_timeout: Option<Duration>,
 ) -> Arc<DnsReresolutionHandle> {
     let host = target.host_str().unwrap_or("").to_owned();
     let port = target.port_or_known_default().unwrap_or(7233);
@@ -225,6 +234,7 @@ pub(crate) fn spawn_dns_reresolution(
                     tls_options.as_ref(),
                     keep_alive.as_ref(),
                     override_origin.as_ref(),
+                    connect_timeout,
                 )
                 .await
                 {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -82,7 +82,7 @@ use std::{
     str::FromStr,
     sync::{Arc, OnceLock},
     task::{Context, Poll},
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, SystemTime},
 };
 use temporalio_common::{
     HasWorkflowDefinition,
@@ -1466,6 +1466,7 @@ mod tests {
     use super::*;
     use crate::callback_based::CallbackBasedGrpcService;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
     use temporalio_common::search_attributes::SearchAttributeKey;
     use tonic::{Status, metadata::Ascii};
     use url::Url;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -82,7 +82,7 @@ use std::{
     str::FromStr,
     sync::{Arc, OnceLock},
     task::{Context, Poll},
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 use temporalio_common::{
     HasWorkflowDefinition,
@@ -240,6 +240,7 @@ impl Connection {
                 options.keep_alive.clone(),
                 options.override_origin.clone(),
                 dns_opts.resolution_interval,
+                options.connect_timeout,
             );
             (
                 ServiceBuilder::new()
@@ -253,6 +254,11 @@ impl Connection {
             )
         } else {
             let channel = Endpoint::from_shared(options.target.to_string())?;
+            let channel = if let Some(timeout) = options.connect_timeout {
+                channel.connect_timeout(timeout)
+            } else {
+                channel
+            };
             let channel = add_tls_to_channel(options.tls_options.as_ref(), channel).await?;
             let channel = if let Some(keep_alive) = options.keep_alive.as_ref() {
                 channel
@@ -1708,6 +1714,18 @@ mod tests {
                     && status.message() == "backend temporarily unimplemented"
         ));
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_bounds_connection_attempt() {
+        let url = Url::parse("http://10.255.255.1:7233").unwrap();
+        let opts = ConnectionOptions::new(url)
+            .connect_timeout(Duration::from_millis(500))
+            .build();
+        let start = Instant::now();
+        let result = Connection::connect(opts).await;
+        assert!(result.is_err(), "connection should fail");
+        assert!(start.elapsed() < Duration::from_secs(2));
     }
 
     mod tls_custom_verifier_tests {

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -49,6 +49,11 @@ pub struct ConnectionOptions {
     /// An API key to use for auth. If set, TLS will be enabled by default, but without any mTLS
     /// specific settings.
     pub api_key: Option<String>,
+    /// When set, limits the time allowed to establish the initial TCP/TLS connection to the
+    /// server. If the connection cannot be established within this duration, `connect` will
+    /// return an error. When `None` (the default), no explicit timeout is applied and the
+    /// connection attempt may block indefinitely (subject to OS-level TCP timeouts).
+    pub connect_timeout: Option<Duration>,
     /// Retry configuration for the server client. Default is [RetryOptions::default]
     #[builder(default)]
     pub retry_options: RetryOptions,


### PR DESCRIPTION
Adds a `connect_timeout: Option<Duration>` field to `ConnectionOptions` that bounds how long TCP/TLS connection establishment can take. Without this, connection attempts to unreachable hosts block indefinitely (or until OS-level TCP timeouts kick in, typically 30–120s), which makes it difficult for callers to implement responsive failure handling.

### Changes
* Added `connect_timeout` field to `ConnectionOptions` with documentation
* Applied the timeout in `Connection::connect_once()` for direct (non-DNS) connections
* Threaded through `dns::build_endpoint()` and `dns::spawn_dns_reresolution()` so DNS-balanced connections also respect the timeout on initial connect and during background re-resolution
* Added a test that verifies a 500ms timeout properly bounds a connection attempt to a non-routable IP

### Usage

```
let opts = ConnectionOptions::new(url)
    .connect_timeout(Duration::from_millis(5_000))
    .build();
let conn = Connection::connect(opts).await?;
```

When `connect_timeout` is `None` (the default), behavior is unchanged — no explicit timeout is applied.