### PR TITLE
feat(sdk): client interceptor

### DIFF
--- a/crates/client/src/async_activity_handle.rs
+++ b/crates/client/src/async_activity_handle.rs
@@ -1,8 +1,13 @@
 //! Handle for completing activities asynchronously via a client.
 
-use crate::{NamespacedClient, errors::AsyncActivityError, grpc::WorkflowService};
+use crate::{
+    CompleteAsyncActivityInput, FailAsyncActivityInput, HeartbeatAsyncActivityInput,
+    NamespacedClient, Next, ReportAsyncActivityCancellationInput, RpcOptions, TemporalClientValue,
+    errors::AsyncActivityError, grpc::WorkflowService, interceptors,
+};
+use futures_util::future::BoxFuture;
 use temporalio_common::{
-    data_converters::{SerializationContextData, TemporalSerializable},
+    data_converters::{SerializationContext, SerializationContextData, TemporalSerializable},
     error::{ApplicationFailure, OutgoingActivityError, OutgoingError},
     payload_visitor::encode_payloads,
     protos::{
@@ -20,6 +25,29 @@ use temporalio_common::{
     },
 };
 use tonic::IntoRequest;
+
+async fn encode_optional_value(
+    value: Option<Box<dyn TemporalClientValue>>,
+    data_converter: &temporalio_common::data_converters::DataConverter,
+) -> Result<Option<Payloads>, AsyncActivityError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let unencoded_payloads = {
+        let payload_converter = data_converter.payload_converter();
+        let context = SerializationContext {
+            data: &SerializationContextData::Activity,
+            converter: payload_converter,
+        };
+        value.serialize_payloads(&context)?
+    };
+    drop(value);
+    let payloads = data_converter
+        .codec()
+        .encode(&SerializationContextData::Activity, unencoded_payloads)
+        .await;
+    Ok(Some(Payloads { payloads }))
+}
 
 /// Identifies an async activity for completion outside a worker.
 #[derive(Debug, Clone)]
@@ -83,60 +111,74 @@ impl<CT> AsyncActivityHandle<CT> {
 
 impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
     /// Complete the activity with a successful result.
-    pub async fn complete<T>(&self, result: Option<T>) -> Result<(), AsyncActivityError>
+    pub async fn complete<T>(
+        &self,
+        result: Option<T>,
+        rpc_options: RpcOptions,
+    ) -> Result<(), AsyncActivityError>
     where
-        T: TemporalSerializable + 'static,
+        T: TemporalSerializable + Send + 'static,
     {
-        let result = match result {
-            Some(result) => Some(Payloads {
-                payloads: vec![
-                    self.client
-                        .data_converter()
-                        .to_payload(&SerializationContextData::Activity, &result)
-                        .await?,
-                ],
+        interceptors::call_complete_async_activity(
+            self.client.client_interceptors(),
+            CompleteAsyncActivityInput::new(self.identifier.clone(), result, rpc_options),
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: CompleteAsyncActivityInput| -> BoxFuture<
+                    '_,
+                    Result<(), AsyncActivityError>,
+                > {
+                    Box::pin(async move {
+                        let (identifier, result, rpc_options) = input.into_parts();
+                        let result = encode_optional_value(result, client.data_converter()).await?;
+                        match identifier {
+                            ActivityIdentifier::TaskToken(token) => {
+                                let mut request = RespondActivityTaskCompletedRequest {
+                                    task_token: token.0,
+                                    result,
+                                    identity: client.identity(),
+                                    namespace: client.namespace(),
+                                    ..Default::default()
+                                }
+                                .into_request();
+                                rpc_options.apply_to(&mut request);
+                                WorkflowService::respond_activity_task_completed(
+                                    &mut client,
+                                    request,
+                                )
+                                .await
+                                .map_err(AsyncActivityError::from_status)?;
+                            }
+                            ActivityIdentifier::ById {
+                                workflow_id,
+                                run_id,
+                                activity_id,
+                            } => {
+                                let mut request = RespondActivityTaskCompletedByIdRequest {
+                                    namespace: client.namespace(),
+                                    workflow_id,
+                                    run_id,
+                                    activity_id,
+                                    result,
+                                    identity: client.identity(),
+                                    resource_id: Default::default(),
+                                }
+                                .into_request();
+                                rpc_options.apply_to(&mut request);
+                                WorkflowService::respond_activity_task_completed_by_id(
+                                    &mut client,
+                                    request,
+                                )
+                                .await
+                                .map_err(AsyncActivityError::from_status)?;
+                            }
+                        }
+                        Ok(())
+                    })
+                }
             }),
-            None => None,
-        };
-        match &self.identifier {
-            ActivityIdentifier::TaskToken(token) => {
-                WorkflowService::respond_activity_task_completed(
-                    &mut self.client.clone(),
-                    RespondActivityTaskCompletedRequest {
-                        task_token: token.0.clone(),
-                        result,
-                        identity: self.client.identity(),
-                        namespace: self.client.namespace(),
-                        ..Default::default()
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(AsyncActivityError::from_status)?;
-            }
-            ActivityIdentifier::ById {
-                workflow_id,
-                run_id,
-                activity_id,
-            } => {
-                WorkflowService::respond_activity_task_completed_by_id(
-                    &mut self.client.clone(),
-                    RespondActivityTaskCompletedByIdRequest {
-                        namespace: self.client.namespace(),
-                        workflow_id: workflow_id.clone(),
-                        run_id: run_id.clone(),
-                        activity_id: activity_id.clone(),
-                        result,
-                        identity: self.client.identity(),
-                        resource_id: Default::default(),
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(AsyncActivityError::from_status)?;
-            }
-        }
-        Ok(())
+        )
+        .await
     }
 
     /// Fail the activity with a failure.
@@ -144,129 +186,169 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
         &self,
         failure: E,
         last_heartbeat_details: Option<T>,
+        rpc_options: RpcOptions,
     ) -> Result<(), AsyncActivityError>
     where
         E: Into<ApplicationFailure>,
-        T: TemporalSerializable + 'static,
+        T: TemporalSerializable + Send + 'static,
     {
-        let data_converter = self.client.data_converter();
-        let mut failure = data_converter.to_failure(
-            &SerializationContextData::Activity,
-            OutgoingError::Activity(OutgoingActivityError::Application(Box::new(failure.into()))),
-        );
-        encode_payloads(
-            &mut failure,
-            data_converter.codec(),
-            &SerializationContextData::Activity,
-        )
-        .await;
-        let last_heartbeat_details = match last_heartbeat_details {
-            Some(details) => Some(Payloads {
-                payloads: self
-                    .client
-                    .data_converter()
-                    .to_payloads(&SerializationContextData::Activity, &details)
-                    .await?,
+        interceptors::call_fail_async_activity(
+            self.client.client_interceptors(),
+            FailAsyncActivityInput::new(
+                self.identifier.clone(),
+                failure.into(),
+                last_heartbeat_details,
+                rpc_options,
+            ),
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: FailAsyncActivityInput| -> BoxFuture<
+                    '_,
+                    Result<(), AsyncActivityError>,
+                > {
+                    Box::pin(async move {
+                        let (identifier, application_failure, details, rpc_options) =
+                            input.into_parts();
+                        let data_converter = client.data_converter().clone();
+                        let mut failure = data_converter.to_failure(
+                            &SerializationContextData::Activity,
+                            OutgoingError::Activity(OutgoingActivityError::Application(Box::new(
+                                application_failure,
+                            ))),
+                        );
+                        encode_payloads(
+                            &mut failure,
+                            data_converter.codec(),
+                            &SerializationContextData::Activity,
+                        )
+                        .await;
+                        let last_heartbeat_details =
+                            encode_optional_value(details, &data_converter).await?;
+                        match identifier {
+                            ActivityIdentifier::TaskToken(token) => {
+                                let mut request = RespondActivityTaskFailedRequest {
+                                    task_token: token.0,
+                                    failure: Some(failure),
+                                    identity: client.identity(),
+                                    namespace: client.namespace(),
+                                    last_heartbeat_details,
+                                    ..Default::default()
+                                }
+                                .into_request();
+                                rpc_options.apply_to(&mut request);
+                                WorkflowService::respond_activity_task_failed(
+                                    &mut client,
+                                    request,
+                                )
+                                .await
+                                .map_err(AsyncActivityError::from_status)?;
+                            }
+                            ActivityIdentifier::ById {
+                                workflow_id,
+                                run_id,
+                                activity_id,
+                            } => {
+                                let mut request = RespondActivityTaskFailedByIdRequest {
+                                    namespace: client.namespace(),
+                                    workflow_id,
+                                    run_id,
+                                    activity_id,
+                                    failure: Some(failure),
+                                    identity: client.identity(),
+                                    last_heartbeat_details,
+                                    resource_id: Default::default(),
+                                }
+                                .into_request();
+                                rpc_options.apply_to(&mut request);
+                                WorkflowService::respond_activity_task_failed_by_id(
+                                    &mut client,
+                                    request,
+                                )
+                                .await
+                                .map_err(AsyncActivityError::from_status)?;
+                            }
+                        }
+                        Ok(())
+                    })
+                }
             }),
-            None => None,
-        };
-        match &self.identifier {
-            ActivityIdentifier::TaskToken(token) => {
-                WorkflowService::respond_activity_task_failed(
-                    &mut self.client.clone(),
-                    RespondActivityTaskFailedRequest {
-                        task_token: token.0.clone(),
-                        failure: Some(failure),
-                        identity: self.client.identity(),
-                        namespace: self.client.namespace(),
-                        last_heartbeat_details,
-                        ..Default::default()
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(AsyncActivityError::from_status)?;
-            }
-            ActivityIdentifier::ById {
-                workflow_id,
-                run_id,
-                activity_id,
-            } => {
-                WorkflowService::respond_activity_task_failed_by_id(
-                    &mut self.client.clone(),
-                    RespondActivityTaskFailedByIdRequest {
-                        namespace: self.client.namespace(),
-                        workflow_id: workflow_id.clone(),
-                        run_id: run_id.clone(),
-                        activity_id: activity_id.clone(),
-                        failure: Some(failure),
-                        identity: self.client.identity(),
-                        last_heartbeat_details,
-                        resource_id: Default::default(),
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(AsyncActivityError::from_status)?;
-            }
-        }
-        Ok(())
+        )
+        .await
     }
 
     /// Reports the activity as canceled.
-    pub async fn report_cancelation<T>(&self, details: Option<T>) -> Result<(), AsyncActivityError>
+    pub async fn report_cancelation<T>(
+        &self,
+        details: Option<T>,
+        rpc_options: RpcOptions,
+    ) -> Result<(), AsyncActivityError>
     where
-        T: TemporalSerializable + 'static,
+        T: TemporalSerializable + Send + 'static,
     {
-        let details = match details {
-            Some(details) => Some(Payloads {
-                payloads: self
-                    .client
-                    .data_converter()
-                    .to_payloads(&SerializationContextData::Activity, &details)
-                    .await?,
+        interceptors::call_report_async_activity_cancellation(
+            self.client.client_interceptors(),
+            ReportAsyncActivityCancellationInput::new(
+                self.identifier.clone(),
+                details,
+                rpc_options,
+            ),
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: ReportAsyncActivityCancellationInput| -> BoxFuture<
+                    '_,
+                    Result<(), AsyncActivityError>,
+                > {
+                    Box::pin(async move {
+                        let (identifier, details, rpc_options) = input.into_parts();
+                        let details = encode_optional_value(details, client.data_converter()).await?;
+                        match identifier {
+                            ActivityIdentifier::TaskToken(token) => {
+                                let mut request = RespondActivityTaskCanceledRequest {
+                                    task_token: token.0,
+                                    details,
+                                    identity: client.identity(),
+                                    namespace: client.namespace(),
+                                    ..Default::default()
+                                }
+                                .into_request();
+                                rpc_options.apply_to(&mut request);
+                                WorkflowService::respond_activity_task_canceled(
+                                    &mut client,
+                                    request,
+                                )
+                                .await
+                                .map_err(AsyncActivityError::from_status)?;
+                            }
+                            ActivityIdentifier::ById {
+                                workflow_id,
+                                run_id,
+                                activity_id,
+                            } => {
+                                let mut request = RespondActivityTaskCanceledByIdRequest {
+                                    namespace: client.namespace(),
+                                    workflow_id,
+                                    run_id,
+                                    activity_id,
+                                    details,
+                                    identity: client.identity(),
+                                    ..Default::default()
+                                }
+                                .into_request();
+                                rpc_options.apply_to(&mut request);
+                                WorkflowService::respond_activity_task_canceled_by_id(
+                                    &mut client,
+                                    request,
+                                )
+                                .await
+                                .map_err(AsyncActivityError::from_status)?;
+                            }
+                        }
+                        Ok(())
+                    })
+                }
             }),
-            None => None,
-        };
-        match &self.identifier {
-            ActivityIdentifier::TaskToken(token) => {
-                WorkflowService::respond_activity_task_canceled(
-                    &mut self.client.clone(),
-                    RespondActivityTaskCanceledRequest {
-                        task_token: token.0.clone(),
-                        details,
-                        identity: self.client.identity(),
-                        namespace: self.client.namespace(),
-                        ..Default::default()
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(AsyncActivityError::from_status)?;
-            }
-            ActivityIdentifier::ById {
-                workflow_id,
-                run_id,
-                activity_id,
-            } => {
-                WorkflowService::respond_activity_task_canceled_by_id(
-                    &mut self.client.clone(),
-                    RespondActivityTaskCanceledByIdRequest {
-                        namespace: self.client.namespace(),
-                        workflow_id: workflow_id.clone(),
-                        run_id: run_id.clone(),
-                        activity_id: activity_id.clone(),
-                        details,
-                        identity: self.client.identity(),
-                        ..Default::default()
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(AsyncActivityError::from_status)?;
-            }
-        }
-        Ok(())
+        )
+        .await
     }
 
     /// Record a heartbeat for the activity.
@@ -276,62 +358,75 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
     pub async fn heartbeat<T>(
         &self,
         details: Option<T>,
+        rpc_options: RpcOptions,
     ) -> Result<ActivityHeartbeatResponse, AsyncActivityError>
     where
-        T: TemporalSerializable + 'static,
+        T: TemporalSerializable + Send + 'static,
     {
-        let details = match details {
-            Some(details) => Some(Payloads {
-                payloads: self
-                    .client
-                    .data_converter()
-                    .to_payloads(&SerializationContextData::Activity, &details)
-                    .await?,
+        interceptors::call_heartbeat_async_activity(
+            self.client.client_interceptors(),
+            HeartbeatAsyncActivityInput::new(self.identifier.clone(), details, rpc_options),
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: HeartbeatAsyncActivityInput| -> BoxFuture<
+                    '_,
+                    Result<ActivityHeartbeatResponse, AsyncActivityError>,
+                > {
+                    Box::pin(async move {
+                        let (identifier, details, rpc_options) = input.into_parts();
+                        let details = encode_optional_value(details, client.data_converter()).await?;
+                        match identifier {
+                            ActivityIdentifier::TaskToken(token) => {
+                                let mut request = RecordActivityTaskHeartbeatRequest {
+                                    task_token: token.0,
+                                    details,
+                                    identity: client.identity(),
+                                    namespace: client.namespace(),
+                                    resource_id: Default::default(),
+                                }
+                                .into_request();
+                                rpc_options.apply_to(&mut request);
+                                let response = WorkflowService::record_activity_task_heartbeat(
+                                    &mut client,
+                                    request,
+                                )
+                                .await
+                                .map_err(AsyncActivityError::from_status)?
+                                .into_inner();
+                                Ok(ActivityHeartbeatResponse::from(response))
+                            }
+                            ActivityIdentifier::ById {
+                                workflow_id,
+                                run_id,
+                                activity_id,
+                            } => {
+                                let mut request = RecordActivityTaskHeartbeatByIdRequest {
+                                    namespace: client.namespace(),
+                                    workflow_id,
+                                    run_id,
+                                    activity_id,
+                                    details,
+                                    identity: client.identity(),
+                                    resource_id: Default::default(),
+                                }
+                                .into_request();
+                                rpc_options.apply_to(&mut request);
+                                let response =
+                                    WorkflowService::record_activity_task_heartbeat_by_id(
+                                        &mut client,
+                                        request,
+                                    )
+                                    .await
+                                    .map_err(AsyncActivityError::from_status)?
+                                    .into_inner();
+                                Ok(ActivityHeartbeatResponse::from(response))
+                            }
+                        }
+                    })
+                }
             }),
-            None => None,
-        };
-        match &self.identifier {
-            ActivityIdentifier::TaskToken(token) => {
-                let resp = WorkflowService::record_activity_task_heartbeat(
-                    &mut self.client.clone(),
-                    RecordActivityTaskHeartbeatRequest {
-                        task_token: token.0.clone(),
-                        details,
-                        identity: self.client.identity(),
-                        namespace: self.client.namespace(),
-                        resource_id: Default::default(),
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(AsyncActivityError::from_status)?
-                .into_inner();
-                Ok(ActivityHeartbeatResponse::from(resp))
-            }
-            ActivityIdentifier::ById {
-                workflow_id,
-                run_id,
-                activity_id,
-            } => {
-                let resp = WorkflowService::record_activity_task_heartbeat_by_id(
-                    &mut self.client.clone(),
-                    RecordActivityTaskHeartbeatByIdRequest {
-                        namespace: self.client.namespace(),
-                        workflow_id: workflow_id.clone(),
-                        run_id: run_id.clone(),
-                        activity_id: activity_id.clone(),
-                        details,
-                        identity: self.client.identity(),
-                        resource_id: Default::default(),
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(AsyncActivityError::from_status)?
-                .into_inner();
-                Ok(ActivityHeartbeatResponse::from(resp))
-            }
-        }
+        )
+        .await
     }
 }
 

--- a/crates/client/src/interceptors.rs
+++ b/crates/client/src/interceptors.rs
@@ -1045,7 +1045,7 @@ impl HeartbeatAsyncActivityInput {
 /// }
 ///
 /// let _options = ClientOptions::new("my-namespace")
-///     .client_interceptors(vec![Arc::new(StartTimeout) as Arc<dyn ClientInterceptor>])
+///     .client_interceptors(vec![Arc::new(StartTimeout)])
 ///     .build();
 /// ```
 pub trait ClientInterceptor: Send + Sync + 'static {

--- a/crates/client/src/interceptors.rs
+++ b/crates/client/src/interceptors.rs
@@ -1,0 +1,1549 @@
+//! Interceptors for high-level client operations.
+
+use crate::{
+    ActivityHeartbeatResponse, ActivityIdentifier, WorkflowCancelOptions, WorkflowCountOptions,
+    WorkflowDescribeOptions, WorkflowFetchHistoryOptions, WorkflowQueryOptions,
+    WorkflowSignalOptions, WorkflowStartError, WorkflowStartOptions, WorkflowStartUpdateOptions,
+    WorkflowTerminateOptions,
+    errors::{
+        AsyncActivityError, ClientError, WorkflowInteractionError, WorkflowQueryError,
+        WorkflowUpdateError,
+    },
+    schedules::{
+        CreateScheduleOptions, ScheduleBackfill, ScheduleError, ScheduleOverlapPolicy,
+        ScheduleUpdate,
+    },
+};
+use futures_util::future::BoxFuture;
+use std::{any::Any, sync::Arc};
+use temporalio_common::{
+    data_converters::{
+        GenericPayloadConverter, PayloadConversionError, SerializationContext, TemporalSerializable,
+    },
+    protos::temporal::api::{
+        common::v1::Payload,
+        history::v1::HistoryEvent,
+        schedule::v1::ScheduleListEntry,
+        update::v1::Outcome,
+        workflow::v1::WorkflowExecutionInfo,
+        workflowservice::v1::{
+            CountWorkflowExecutionsResponse, DescribeScheduleResponse,
+            DescribeWorkflowExecutionResponse, QueryWorkflowResponse,
+        },
+    },
+};
+
+mod temporal_client_value {
+    use super::*;
+
+    pub trait Sealed {
+        fn serialize_client_payloads(
+            &self,
+            context: &SerializationContext<'_>,
+        ) -> Result<Vec<Payload>, PayloadConversionError>;
+    }
+
+    impl<T> Sealed for T
+    where
+        T: Any + TemporalSerializable + Send,
+    {
+        fn serialize_client_payloads(
+            &self,
+            context: &SerializationContext<'_>,
+        ) -> Result<Vec<Payload>, PayloadConversionError> {
+            context.converter.to_payloads(context, self)
+        }
+    }
+}
+
+/// Type-erased input carried through the client interceptor chain.
+pub trait TemporalClientValue: Any + Send + temporal_client_value::Sealed {
+    /// Access this value as [`Any`] for type-specific inspection.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Access this value as mutable [`Any`] for type-specific mutation.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl<T> TemporalClientValue for T
+where
+    T: Any + TemporalSerializable + Send,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl dyn TemporalClientValue {
+    pub(crate) fn serialize_payloads(
+        &self,
+        context: &SerializationContext<'_>,
+    ) -> Result<Vec<Payload>, PayloadConversionError> {
+        temporal_client_value::Sealed::serialize_client_payloads(self, context)
+    }
+}
+
+/// Continuation for an intercepted client operation.
+///
+/// A continuation can be invoked at most once because [`run`](Self::run) consumes it.
+pub struct Next<'a, I, O> {
+    inner: Box<dyn FnOnce(I) -> O + Send + 'a>,
+}
+
+impl<'a, I, O> Next<'a, I, O> {
+    pub(crate) fn new(f: impl FnOnce(I) -> O + Send + 'a) -> Self {
+        Self { inner: Box::new(f) }
+    }
+
+    /// Continue the interceptor chain with the provided input.
+    pub fn run(self, input: I) -> O {
+        (self.inner)(input)
+    }
+}
+
+/// Input to [`ClientInterceptor::start_workflow`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct StartWorkflowInput {
+    /// The workflow type sent to the server.
+    pub workflow_type: String,
+    /// Options for the workflow start.
+    pub options: WorkflowStartOptions,
+    /// Controls for the start RPC.
+    pub rpc_options: crate::RpcOptions,
+    #[debug(skip)]
+    args: Box<dyn TemporalClientValue>,
+}
+
+impl StartWorkflowInput {
+    pub(crate) fn new<T>(workflow_type: String, args: T, mut options: WorkflowStartOptions) -> Self
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        let rpc_options = std::mem::take(&mut options.rpc_options);
+        Self {
+            workflow_type,
+            options,
+            rpc_options,
+            args: Box::new(args),
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        String,
+        Box<dyn TemporalClientValue>,
+        WorkflowStartOptions,
+        crate::RpcOptions,
+    ) {
+        (
+            self.workflow_type,
+            self.args,
+            self.options,
+            self.rpc_options,
+        )
+    }
+
+    /// Attempt to access the workflow arguments as a concrete type.
+    pub fn args_ref<T: Any>(&self) -> Option<&T> {
+        self.args.as_any().downcast_ref()
+    }
+
+    /// Attempt to mutably access the workflow arguments as a concrete type.
+    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.args.as_any_mut().downcast_mut()
+    }
+
+    /// Replace the workflow arguments with another serializable value.
+    pub fn replace_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.args = Box::new(args);
+    }
+}
+
+/// Result of a successful intercepted workflow start.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StartWorkflowOutput {
+    /// The workflow ID used by the start operation.
+    pub workflow_id: String,
+    /// The run ID returned by the service or a short-circuiting interceptor.
+    pub run_id: String,
+}
+
+impl StartWorkflowOutput {
+    pub(crate) fn new(workflow_id: impl Into<String>, run_id: impl Into<String>) -> Self {
+        Self {
+            workflow_id: workflow_id.into(),
+            run_id: run_id.into(),
+        }
+    }
+}
+
+/// Input to [`ClientInterceptor::list_workflows_page`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct ListWorkflowsPageInput {
+    /// Visibility query used to select workflows.
+    pub query: String,
+    /// Token identifying the page to retrieve, or empty for the first page.
+    pub next_page_token: Vec<u8>,
+    /// Controls for this page RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Result of one intercepted workflow-list page.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct ListWorkflowsPageOutput {
+    /// Workflow executions returned by the service.
+    pub executions: Vec<WorkflowExecutionInfo>,
+    /// Token identifying the next page, or empty when no pages remain.
+    pub next_page_token: Vec<u8>,
+}
+
+impl ListWorkflowsPageOutput {
+    pub(crate) fn new(executions: Vec<WorkflowExecutionInfo>, next_page_token: Vec<u8>) -> Self {
+        Self {
+            executions,
+            next_page_token,
+        }
+    }
+}
+
+/// Input to [`ClientInterceptor::count_workflows`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct CountWorkflowsInput {
+    /// Visibility query used to count workflows.
+    pub query: String,
+    /// Count options, including per-call RPC controls.
+    pub options: WorkflowCountOptions,
+}
+
+/// Result of an intercepted workflow count.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct CountWorkflowsOutput {
+    /// Raw service response used to assemble the high-level count result.
+    pub response: CountWorkflowExecutionsResponse,
+}
+
+impl CountWorkflowsOutput {
+    pub(crate) fn new(response: CountWorkflowExecutionsResponse) -> Self {
+        Self { response }
+    }
+}
+
+/// Input to [`ClientInterceptor::describe_workflow`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct DescribeWorkflowInput {
+    /// Workflow ID to describe.
+    pub workflow_id: String,
+    /// Run ID to describe, or empty for the latest run.
+    pub run_id: String,
+    /// Describe options, including per-call RPC controls.
+    pub options: WorkflowDescribeOptions,
+}
+
+/// Result of an intercepted workflow describe.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct DescribeWorkflowOutput {
+    /// Raw service response decoded after interceptor dispatch.
+    pub response: DescribeWorkflowExecutionResponse,
+}
+
+impl DescribeWorkflowOutput {
+    pub(crate) fn new(response: DescribeWorkflowExecutionResponse) -> Self {
+        Self { response }
+    }
+}
+
+/// Input to [`ClientInterceptor::fetch_workflow_history_page`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct FetchWorkflowHistoryPageInput {
+    /// Workflow ID whose history is being retrieved.
+    pub workflow_id: String,
+    /// Run ID whose history is being retrieved.
+    pub run_id: String,
+    /// Token identifying the page to retrieve, or empty for the first page.
+    pub next_page_token: Vec<u8>,
+    /// History options, including per-page RPC controls.
+    pub options: WorkflowFetchHistoryOptions,
+}
+
+/// Result of one intercepted workflow-history page.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct FetchWorkflowHistoryPageOutput {
+    /// History events returned on this page.
+    pub events: Vec<HistoryEvent>,
+    /// Token identifying the next page, or empty when no pages remain.
+    pub next_page_token: Vec<u8>,
+}
+
+impl FetchWorkflowHistoryPageOutput {
+    pub(crate) fn new(events: Vec<HistoryEvent>, next_page_token: Vec<u8>) -> Self {
+        Self {
+            events,
+            next_page_token,
+        }
+    }
+}
+
+/// Input to [`ClientInterceptor::signal_workflow`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct SignalWorkflowInput {
+    /// Workflow ID to signal.
+    pub workflow_id: String,
+    /// Run ID to signal, or empty for the latest run.
+    pub run_id: String,
+    /// Signal name sent to the workflow.
+    pub signal_name: String,
+    /// Signal options, including per-call RPC controls.
+    pub options: WorkflowSignalOptions,
+    #[debug(skip)]
+    args: Box<dyn TemporalClientValue>,
+}
+
+impl SignalWorkflowInput {
+    pub(crate) fn new<T>(
+        workflow_id: String,
+        run_id: String,
+        signal_name: String,
+        args: T,
+        options: WorkflowSignalOptions,
+    ) -> Self
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        Self {
+            workflow_id,
+            run_id,
+            signal_name,
+            options,
+            args: Box::new(args),
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        String,
+        String,
+        String,
+        Box<dyn TemporalClientValue>,
+        WorkflowSignalOptions,
+    ) {
+        (
+            self.workflow_id,
+            self.run_id,
+            self.signal_name,
+            self.args,
+            self.options,
+        )
+    }
+
+    /// Attempt to access the signal arguments as a concrete type.
+    pub fn args_ref<T: Any>(&self) -> Option<&T> {
+        self.args.as_any().downcast_ref()
+    }
+
+    /// Attempt to mutably access the signal arguments as a concrete type.
+    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.args.as_any_mut().downcast_mut()
+    }
+
+    /// Replace the signal arguments with another serializable value.
+    pub fn replace_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.args = Box::new(args);
+    }
+}
+
+/// Input to [`ClientInterceptor::query_workflow`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct QueryWorkflowInput {
+    /// Workflow ID to query.
+    pub workflow_id: String,
+    /// Run ID to query, or empty for the latest run.
+    pub run_id: String,
+    /// Query name sent to the workflow.
+    pub query_name: String,
+    /// Query options, including per-call RPC controls.
+    pub options: WorkflowQueryOptions,
+    #[debug(skip)]
+    args: Box<dyn TemporalClientValue>,
+}
+
+impl QueryWorkflowInput {
+    pub(crate) fn new<T>(
+        workflow_id: String,
+        run_id: String,
+        query_name: String,
+        args: T,
+        options: WorkflowQueryOptions,
+    ) -> Self
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        Self {
+            workflow_id,
+            run_id,
+            query_name,
+            options,
+            args: Box::new(args),
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        String,
+        String,
+        String,
+        Box<dyn TemporalClientValue>,
+        WorkflowQueryOptions,
+    ) {
+        (
+            self.workflow_id,
+            self.run_id,
+            self.query_name,
+            self.args,
+            self.options,
+        )
+    }
+
+    /// Attempt to access the query arguments as a concrete type.
+    pub fn args_ref<T: Any>(&self) -> Option<&T> {
+        self.args.as_any().downcast_ref()
+    }
+
+    /// Attempt to mutably access the query arguments as a concrete type.
+    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.args.as_any_mut().downcast_mut()
+    }
+
+    /// Replace the query arguments with another serializable value.
+    pub fn replace_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.args = Box::new(args);
+    }
+}
+
+/// Result of an intercepted workflow query before typed result conversion.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct QueryWorkflowOutput {
+    /// Raw service response decoded after interceptor dispatch.
+    pub response: QueryWorkflowResponse,
+}
+
+impl QueryWorkflowOutput {
+    pub(crate) fn new(response: QueryWorkflowResponse) -> Self {
+        Self { response }
+    }
+}
+
+/// Input to [`ClientInterceptor::start_workflow_update`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct StartWorkflowUpdateInput {
+    /// Workflow ID to update.
+    pub workflow_id: String,
+    /// Run ID to update, or empty for the latest run.
+    pub run_id: String,
+    /// Update name sent to the workflow.
+    pub update_name: String,
+    /// Update options, including per-call RPC controls.
+    pub options: WorkflowStartUpdateOptions,
+    #[debug(skip)]
+    args: Box<dyn TemporalClientValue>,
+}
+
+impl StartWorkflowUpdateInput {
+    pub(crate) fn new<T>(
+        workflow_id: String,
+        run_id: String,
+        update_name: String,
+        args: T,
+        options: WorkflowStartUpdateOptions,
+    ) -> Self
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        Self {
+            workflow_id,
+            run_id,
+            update_name,
+            options,
+            args: Box::new(args),
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        String,
+        String,
+        String,
+        Box<dyn TemporalClientValue>,
+        WorkflowStartUpdateOptions,
+    ) {
+        (
+            self.workflow_id,
+            self.run_id,
+            self.update_name,
+            self.args,
+            self.options,
+        )
+    }
+
+    /// Attempt to access the update arguments as a concrete type.
+    pub fn args_ref<T: Any>(&self) -> Option<&T> {
+        self.args.as_any().downcast_ref()
+    }
+
+    /// Attempt to mutably access the update arguments as a concrete type.
+    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.args.as_any_mut().downcast_mut()
+    }
+
+    /// Replace the update arguments with another serializable value.
+    pub fn replace_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.args = Box::new(args);
+    }
+}
+
+/// Result of an intercepted workflow-update start.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct StartWorkflowUpdateOutput {
+    /// Update ID used by the operation.
+    pub update_id: String,
+    /// Workflow ID associated with the update.
+    pub workflow_id: String,
+    /// Run ID returned by the service, when available.
+    pub run_id: Option<String>,
+    /// Outcome returned when the requested wait stage completed the update.
+    pub known_outcome: Option<Outcome>,
+}
+
+impl StartWorkflowUpdateOutput {
+    pub(crate) fn new(
+        update_id: impl Into<String>,
+        workflow_id: impl Into<String>,
+        run_id: Option<String>,
+        known_outcome: Option<Outcome>,
+    ) -> Self {
+        Self {
+            update_id: update_id.into(),
+            workflow_id: workflow_id.into(),
+            run_id,
+            known_outcome,
+        }
+    }
+}
+
+/// Input to [`ClientInterceptor::poll_workflow_update`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct PollWorkflowUpdateInput {
+    /// Update ID being polled.
+    pub update_id: String,
+    /// Workflow ID associated with the update.
+    pub workflow_id: String,
+    /// Run ID associated with the update, or empty for the latest run.
+    pub run_id: String,
+    /// Controls for every RPC in the polling loop.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Result of an intercepted workflow-update poll.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct PollWorkflowUpdateOutput {
+    /// Completed update outcome.
+    pub outcome: Outcome,
+}
+
+impl PollWorkflowUpdateOutput {
+    pub(crate) fn new(outcome: Outcome) -> Self {
+        Self { outcome }
+    }
+}
+
+/// Input to [`ClientInterceptor::cancel_workflow`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct CancelWorkflowInput {
+    /// Workflow ID to cancel.
+    pub workflow_id: String,
+    /// Run ID to cancel, or empty for the latest run.
+    pub run_id: String,
+    /// First execution run ID used to constrain the cancellation.
+    pub first_execution_run_id: String,
+    /// Cancellation options, including per-call RPC controls.
+    pub options: WorkflowCancelOptions,
+}
+
+/// Input to [`ClientInterceptor::terminate_workflow`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct TerminateWorkflowInput {
+    /// Workflow ID to terminate.
+    pub workflow_id: String,
+    /// Run ID to terminate, or empty for the latest run.
+    pub run_id: String,
+    /// First execution run ID used to constrain the termination.
+    pub first_execution_run_id: String,
+    /// Termination options, including per-call RPC controls.
+    pub options: WorkflowTerminateOptions,
+}
+
+/// Input to [`ClientInterceptor::create_schedule`].
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct CreateScheduleInput {
+    /// Schedule ID to create.
+    pub schedule_id: String,
+    /// Schedule definition and per-call RPC controls.
+    pub options: CreateScheduleOptions,
+}
+
+/// Result of an intercepted schedule create.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CreateScheduleOutput {
+    /// Schedule ID associated with the created handle.
+    pub schedule_id: String,
+}
+
+impl CreateScheduleOutput {
+    pub(crate) fn new(schedule_id: impl Into<String>) -> Self {
+        Self {
+            schedule_id: schedule_id.into(),
+        }
+    }
+}
+
+/// Input to [`ClientInterceptor::list_schedules_page`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct ListSchedulesPageInput {
+    /// Maximum number of results requested from the service.
+    pub maximum_page_size: i32,
+    /// Visibility query used to select schedules.
+    pub query: String,
+    /// Token identifying the page to retrieve, or empty for the first page.
+    pub next_page_token: Vec<u8>,
+    /// Controls for this page RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Result of one intercepted schedule-list page.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct ListSchedulesPageOutput {
+    /// Schedule entries returned by the service.
+    pub schedules: Vec<ScheduleListEntry>,
+    /// Token identifying the next page, or empty when no pages remain.
+    pub next_page_token: Vec<u8>,
+}
+
+impl ListSchedulesPageOutput {
+    pub(crate) fn new(schedules: Vec<ScheduleListEntry>, next_page_token: Vec<u8>) -> Self {
+        Self {
+            schedules,
+            next_page_token,
+        }
+    }
+}
+
+/// Input to [`ClientInterceptor::describe_schedule`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct DescribeScheduleInput {
+    /// Schedule ID to describe.
+    pub schedule_id: String,
+    /// Controls for the describe RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Result of an intercepted schedule describe.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct DescribeScheduleOutput {
+    /// Raw service response decoded after interceptor dispatch.
+    pub response: DescribeScheduleResponse,
+}
+
+impl DescribeScheduleOutput {
+    pub(crate) fn new(response: DescribeScheduleResponse) -> Self {
+        Self { response }
+    }
+}
+
+/// Input to [`ClientInterceptor::update_schedule`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct UpdateScheduleInput {
+    /// Schedule ID to update.
+    pub schedule_id: String,
+    /// Controls shared by the describe and update RPCs.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Input to [`ClientInterceptor::send_schedule_update`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct SendScheduleUpdateInput {
+    /// Schedule ID to update.
+    pub schedule_id: String,
+    /// Pre-built schedule update.
+    pub update: ScheduleUpdate,
+    /// Controls for the update RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Input to [`ClientInterceptor::delete_schedule`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct DeleteScheduleInput {
+    /// Schedule ID to delete.
+    pub schedule_id: String,
+    /// Controls for the delete RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Input to [`ClientInterceptor::pause_schedule`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct PauseScheduleInput {
+    /// Schedule ID to pause.
+    pub schedule_id: String,
+    /// Note attached to the pause operation.
+    pub note: String,
+    /// Controls for the patch RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Input to [`ClientInterceptor::unpause_schedule`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct UnpauseScheduleInput {
+    /// Schedule ID to unpause.
+    pub schedule_id: String,
+    /// Note attached to the unpause operation.
+    pub note: String,
+    /// Controls for the patch RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Input to [`ClientInterceptor::trigger_schedule`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct TriggerScheduleInput {
+    /// Schedule ID to trigger.
+    pub schedule_id: String,
+    /// Overlap policy for the immediate action.
+    pub overlap_policy: ScheduleOverlapPolicy,
+    /// Controls for the patch RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Input to [`ClientInterceptor::backfill_schedule`].
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct BackfillScheduleInput {
+    /// Schedule ID to backfill.
+    pub schedule_id: String,
+    /// Backfill ranges requested by the caller.
+    pub backfills: Vec<ScheduleBackfill>,
+    /// Controls for the patch RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+/// Input to [`ClientInterceptor::complete_async_activity`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct CompleteAsyncActivityInput {
+    /// Activity being completed.
+    pub identifier: ActivityIdentifier,
+    #[debug(skip)]
+    result: Option<Box<dyn TemporalClientValue>>,
+    /// Controls for the completion RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+impl CompleteAsyncActivityInput {
+    pub(crate) fn new<T>(
+        identifier: ActivityIdentifier,
+        result: Option<T>,
+        rpc_options: crate::RpcOptions,
+    ) -> Self
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        Self {
+            identifier,
+            result: result.map(|value| Box::new(value) as Box<dyn TemporalClientValue>),
+            rpc_options,
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        ActivityIdentifier,
+        Option<Box<dyn TemporalClientValue>>,
+        crate::RpcOptions,
+    ) {
+        (self.identifier, self.result, self.rpc_options)
+    }
+
+    /// Attempt to access the activity result as a concrete type.
+    pub fn result_ref<T: Any>(&self) -> Option<&T> {
+        self.result
+            .as_ref()
+            .and_then(|result| result.as_any().downcast_ref())
+    }
+
+    /// Attempt to mutably access the activity result as a concrete type.
+    pub fn result_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.result
+            .as_mut()
+            .and_then(|result| result.as_any_mut().downcast_mut())
+    }
+
+    /// Replace or clear the activity result.
+    pub fn replace_result<T>(&mut self, result: Option<T>)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.result = result.map(|value| Box::new(value) as Box<dyn TemporalClientValue>);
+    }
+}
+
+/// Input to [`ClientInterceptor::fail_async_activity`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct FailAsyncActivityInput {
+    /// Activity being failed.
+    pub identifier: ActivityIdentifier,
+    /// Application failure reported for the activity.
+    pub failure: temporalio_common::error::ApplicationFailure,
+    #[debug(skip)]
+    last_heartbeat_details: Option<Box<dyn TemporalClientValue>>,
+    /// Controls for the failure RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+impl FailAsyncActivityInput {
+    pub(crate) fn new<T>(
+        identifier: ActivityIdentifier,
+        failure: temporalio_common::error::ApplicationFailure,
+        last_heartbeat_details: Option<T>,
+        rpc_options: crate::RpcOptions,
+    ) -> Self
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        Self {
+            identifier,
+            failure,
+            last_heartbeat_details: last_heartbeat_details
+                .map(|value| Box::new(value) as Box<dyn TemporalClientValue>),
+            rpc_options,
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        ActivityIdentifier,
+        temporalio_common::error::ApplicationFailure,
+        Option<Box<dyn TemporalClientValue>>,
+        crate::RpcOptions,
+    ) {
+        (
+            self.identifier,
+            self.failure,
+            self.last_heartbeat_details,
+            self.rpc_options,
+        )
+    }
+
+    /// Attempt to access the last heartbeat details as a concrete type.
+    pub fn last_heartbeat_details_ref<T: Any>(&self) -> Option<&T> {
+        self.last_heartbeat_details
+            .as_ref()
+            .and_then(|details| details.as_any().downcast_ref())
+    }
+
+    /// Attempt to mutably access the last heartbeat details as a concrete type.
+    pub fn last_heartbeat_details_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.last_heartbeat_details
+            .as_mut()
+            .and_then(|details| details.as_any_mut().downcast_mut())
+    }
+
+    /// Replace or clear the last heartbeat details.
+    pub fn replace_last_heartbeat_details<T>(&mut self, details: Option<T>)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.last_heartbeat_details =
+            details.map(|value| Box::new(value) as Box<dyn TemporalClientValue>);
+    }
+}
+
+/// Input to [`ClientInterceptor::report_async_activity_cancellation`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct ReportAsyncActivityCancellationInput {
+    /// Activity being reported as cancelled.
+    pub identifier: ActivityIdentifier,
+    #[debug(skip)]
+    details: Option<Box<dyn TemporalClientValue>>,
+    /// Controls for the cancellation RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+impl ReportAsyncActivityCancellationInput {
+    pub(crate) fn new<T>(
+        identifier: ActivityIdentifier,
+        details: Option<T>,
+        rpc_options: crate::RpcOptions,
+    ) -> Self
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        Self {
+            identifier,
+            details: details.map(|value| Box::new(value) as Box<dyn TemporalClientValue>),
+            rpc_options,
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        ActivityIdentifier,
+        Option<Box<dyn TemporalClientValue>>,
+        crate::RpcOptions,
+    ) {
+        (self.identifier, self.details, self.rpc_options)
+    }
+
+    /// Attempt to access the cancellation details as a concrete type.
+    pub fn details_ref<T: Any>(&self) -> Option<&T> {
+        self.details
+            .as_ref()
+            .and_then(|details| details.as_any().downcast_ref())
+    }
+
+    /// Attempt to mutably access the cancellation details as a concrete type.
+    pub fn details_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.details
+            .as_mut()
+            .and_then(|details| details.as_any_mut().downcast_mut())
+    }
+
+    /// Replace or clear the cancellation details.
+    pub fn replace_details<T>(&mut self, details: Option<T>)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.details = details.map(|value| Box::new(value) as Box<dyn TemporalClientValue>);
+    }
+}
+
+/// Input to [`ClientInterceptor::heartbeat_async_activity`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct HeartbeatAsyncActivityInput {
+    /// Activity being heartbeated.
+    pub identifier: ActivityIdentifier,
+    #[debug(skip)]
+    details: Option<Box<dyn TemporalClientValue>>,
+    /// Controls for the heartbeat RPC.
+    pub rpc_options: crate::RpcOptions,
+}
+
+impl HeartbeatAsyncActivityInput {
+    pub(crate) fn new<T>(
+        identifier: ActivityIdentifier,
+        details: Option<T>,
+        rpc_options: crate::RpcOptions,
+    ) -> Self
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        Self {
+            identifier,
+            details: details.map(|value| Box::new(value) as Box<dyn TemporalClientValue>),
+            rpc_options,
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        ActivityIdentifier,
+        Option<Box<dyn TemporalClientValue>>,
+        crate::RpcOptions,
+    ) {
+        (self.identifier, self.details, self.rpc_options)
+    }
+
+    /// Attempt to access the heartbeat details as a concrete type.
+    pub fn details_ref<T: Any>(&self) -> Option<&T> {
+        self.details
+            .as_ref()
+            .and_then(|details| details.as_any().downcast_ref())
+    }
+
+    /// Attempt to mutably access the heartbeat details as a concrete type.
+    pub fn details_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.details
+            .as_mut()
+            .and_then(|details| details.as_any_mut().downcast_mut())
+    }
+
+    /// Replace or clear the heartbeat details.
+    pub fn replace_details<T>(&mut self, details: Option<T>)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.details = details.map(|value| Box::new(value) as Box<dyn TemporalClientValue>);
+    }
+}
+
+/// Intercepts high-level client operations.
+///
+/// The first interceptor configured on a client is the outermost interceptor. An interceptor can
+/// do asynchronous work before and after calling `next`, mutate or replace typed input, or return
+/// without calling `next` to short-circuit the operation.
+///
+/// ```
+/// use futures_util::future::BoxFuture;
+/// use std::{sync::Arc, time::Duration};
+/// use temporalio_client::{
+///     ClientInterceptor, ClientOptions, Next, StartWorkflowInput, StartWorkflowOutput,
+///     errors::WorkflowStartError,
+/// };
+///
+/// struct StartTimeout;
+///
+/// impl ClientInterceptor for StartTimeout {
+///     fn start_workflow<'a>(
+///         &'a self,
+///         mut input: StartWorkflowInput,
+///         next: Next<
+///             'a,
+///             StartWorkflowInput,
+///             BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+///         >,
+///     ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+///         Box::pin(async move {
+///             input.rpc_options.timeout = Some(Duration::from_secs(10));
+///             let output = next.run(input).await?;
+///             Ok(output)
+///         })
+///     }
+/// }
+///
+/// let _options = ClientOptions::new("my-namespace")
+///     .client_interceptors(vec![Arc::new(StartTimeout) as Arc<dyn ClientInterceptor>])
+///     .build();
+/// ```
+pub trait ClientInterceptor: Send + Sync + 'static {
+    /// Intercept a `start_workflow` operation.
+    fn start_workflow<'a>(
+        &'a self,
+        input: StartWorkflowInput,
+        next: Next<
+            'a,
+            StartWorkflowInput,
+            BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+        >,
+    ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `list_workflows_page` operation.
+    fn list_workflows_page<'a>(
+        &'a self,
+        input: ListWorkflowsPageInput,
+        next: Next<
+            'a,
+            ListWorkflowsPageInput,
+            BoxFuture<'a, Result<ListWorkflowsPageOutput, ClientError>>,
+        >,
+    ) -> BoxFuture<'a, Result<ListWorkflowsPageOutput, ClientError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `count_workflows` operation.
+    fn count_workflows<'a>(
+        &'a self,
+        input: CountWorkflowsInput,
+        next: Next<
+            'a,
+            CountWorkflowsInput,
+            BoxFuture<'a, Result<CountWorkflowsOutput, ClientError>>,
+        >,
+    ) -> BoxFuture<'a, Result<CountWorkflowsOutput, ClientError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `describe_workflow` operation.
+    fn describe_workflow<'a>(
+        &'a self,
+        input: DescribeWorkflowInput,
+        next: Next<
+            'a,
+            DescribeWorkflowInput,
+            BoxFuture<'a, Result<DescribeWorkflowOutput, WorkflowInteractionError>>,
+        >,
+    ) -> BoxFuture<'a, Result<DescribeWorkflowOutput, WorkflowInteractionError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `fetch_workflow_history_page` operation.
+    fn fetch_workflow_history_page<'a>(
+        &'a self,
+        input: FetchWorkflowHistoryPageInput,
+        next: Next<
+            'a,
+            FetchWorkflowHistoryPageInput,
+            BoxFuture<'a, Result<FetchWorkflowHistoryPageOutput, WorkflowInteractionError>>,
+        >,
+    ) -> BoxFuture<'a, Result<FetchWorkflowHistoryPageOutput, WorkflowInteractionError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `signal_workflow` operation.
+    fn signal_workflow<'a>(
+        &'a self,
+        input: SignalWorkflowInput,
+        next: Next<'a, SignalWorkflowInput, BoxFuture<'a, Result<(), WorkflowInteractionError>>>,
+    ) -> BoxFuture<'a, Result<(), WorkflowInteractionError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `query_workflow` operation.
+    fn query_workflow<'a>(
+        &'a self,
+        input: QueryWorkflowInput,
+        next: Next<
+            'a,
+            QueryWorkflowInput,
+            BoxFuture<'a, Result<QueryWorkflowOutput, WorkflowQueryError>>,
+        >,
+    ) -> BoxFuture<'a, Result<QueryWorkflowOutput, WorkflowQueryError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `start_workflow_update` operation.
+    fn start_workflow_update<'a>(
+        &'a self,
+        input: StartWorkflowUpdateInput,
+        next: Next<
+            'a,
+            StartWorkflowUpdateInput,
+            BoxFuture<'a, Result<StartWorkflowUpdateOutput, WorkflowUpdateError>>,
+        >,
+    ) -> BoxFuture<'a, Result<StartWorkflowUpdateOutput, WorkflowUpdateError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `poll_workflow_update` operation.
+    fn poll_workflow_update<'a>(
+        &'a self,
+        input: PollWorkflowUpdateInput,
+        next: Next<
+            'a,
+            PollWorkflowUpdateInput,
+            BoxFuture<'a, Result<PollWorkflowUpdateOutput, WorkflowUpdateError>>,
+        >,
+    ) -> BoxFuture<'a, Result<PollWorkflowUpdateOutput, WorkflowUpdateError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `cancel_workflow` operation.
+    fn cancel_workflow<'a>(
+        &'a self,
+        input: CancelWorkflowInput,
+        next: Next<'a, CancelWorkflowInput, BoxFuture<'a, Result<(), WorkflowInteractionError>>>,
+    ) -> BoxFuture<'a, Result<(), WorkflowInteractionError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `terminate_workflow` operation.
+    fn terminate_workflow<'a>(
+        &'a self,
+        input: TerminateWorkflowInput,
+        next: Next<'a, TerminateWorkflowInput, BoxFuture<'a, Result<(), WorkflowInteractionError>>>,
+    ) -> BoxFuture<'a, Result<(), WorkflowInteractionError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `create_schedule` operation.
+    fn create_schedule<'a>(
+        &'a self,
+        input: CreateScheduleInput,
+        next: Next<
+            'a,
+            CreateScheduleInput,
+            BoxFuture<'a, Result<CreateScheduleOutput, ScheduleError>>,
+        >,
+    ) -> BoxFuture<'a, Result<CreateScheduleOutput, ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `list_schedules_page` operation.
+    fn list_schedules_page<'a>(
+        &'a self,
+        input: ListSchedulesPageInput,
+        next: Next<
+            'a,
+            ListSchedulesPageInput,
+            BoxFuture<'a, Result<ListSchedulesPageOutput, ScheduleError>>,
+        >,
+    ) -> BoxFuture<'a, Result<ListSchedulesPageOutput, ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `describe_schedule` operation.
+    fn describe_schedule<'a>(
+        &'a self,
+        input: DescribeScheduleInput,
+        next: Next<
+            'a,
+            DescribeScheduleInput,
+            BoxFuture<'a, Result<DescribeScheduleOutput, ScheduleError>>,
+        >,
+    ) -> BoxFuture<'a, Result<DescribeScheduleOutput, ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept an `update_schedule` operation.
+    fn update_schedule<'a>(
+        &'a self,
+        input: UpdateScheduleInput,
+        next: Next<'a, UpdateScheduleInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+    ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `send_schedule_update` operation.
+    fn send_schedule_update<'a>(
+        &'a self,
+        input: SendScheduleUpdateInput,
+        next: Next<'a, SendScheduleUpdateInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+    ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `delete_schedule` operation.
+    fn delete_schedule<'a>(
+        &'a self,
+        input: DeleteScheduleInput,
+        next: Next<'a, DeleteScheduleInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+    ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `pause_schedule` operation.
+    fn pause_schedule<'a>(
+        &'a self,
+        input: PauseScheduleInput,
+        next: Next<'a, PauseScheduleInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+    ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept an `unpause_schedule` operation.
+    fn unpause_schedule<'a>(
+        &'a self,
+        input: UnpauseScheduleInput,
+        next: Next<'a, UnpauseScheduleInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+    ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `trigger_schedule` operation.
+    fn trigger_schedule<'a>(
+        &'a self,
+        input: TriggerScheduleInput,
+        next: Next<'a, TriggerScheduleInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+    ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `backfill_schedule` operation.
+    fn backfill_schedule<'a>(
+        &'a self,
+        input: BackfillScheduleInput,
+        next: Next<'a, BackfillScheduleInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+    ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `complete_async_activity` operation.
+    fn complete_async_activity<'a>(
+        &'a self,
+        input: CompleteAsyncActivityInput,
+        next: Next<'a, CompleteAsyncActivityInput, BoxFuture<'a, Result<(), AsyncActivityError>>>,
+    ) -> BoxFuture<'a, Result<(), AsyncActivityError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `fail_async_activity` operation.
+    fn fail_async_activity<'a>(
+        &'a self,
+        input: FailAsyncActivityInput,
+        next: Next<'a, FailAsyncActivityInput, BoxFuture<'a, Result<(), AsyncActivityError>>>,
+    ) -> BoxFuture<'a, Result<(), AsyncActivityError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `report_async_activity_cancellation` operation.
+    fn report_async_activity_cancellation<'a>(
+        &'a self,
+        input: ReportAsyncActivityCancellationInput,
+        next: Next<
+            'a,
+            ReportAsyncActivityCancellationInput,
+            BoxFuture<'a, Result<(), AsyncActivityError>>,
+        >,
+    ) -> BoxFuture<'a, Result<(), AsyncActivityError>> {
+        next.run(input)
+    }
+
+    /// Intercept a `heartbeat_async_activity` operation.
+    fn heartbeat_async_activity<'a>(
+        &'a self,
+        input: HeartbeatAsyncActivityInput,
+        next: Next<
+            'a,
+            HeartbeatAsyncActivityInput,
+            BoxFuture<'a, Result<ActivityHeartbeatResponse, AsyncActivityError>>,
+        >,
+    ) -> BoxFuture<'a, Result<ActivityHeartbeatResponse, AsyncActivityError>> {
+        next.run(input)
+    }
+}
+
+macro_rules! interceptor_chain {
+    ($fn_name:ident, $method:ident, $input:ty, $output:ty) => {
+        pub(crate) fn $fn_name<'a>(
+            interceptors: &'a [Arc<dyn ClientInterceptor>],
+            input: $input,
+            terminal: Next<'a, $input, $output>,
+        ) -> $output {
+            if let Some((interceptor, remaining)) = interceptors.split_first() {
+                let next = Next::new(move |input| $fn_name(remaining, input, terminal));
+                interceptor.$method(input, next)
+            } else {
+                terminal.run(input)
+            }
+        }
+    };
+}
+
+interceptor_chain!(
+    call_start_workflow,
+    start_workflow,
+    StartWorkflowInput,
+    BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>
+);
+
+interceptor_chain!(
+    call_list_workflows_page,
+    list_workflows_page,
+    ListWorkflowsPageInput,
+    BoxFuture<'a, Result<ListWorkflowsPageOutput, ClientError>>
+);
+
+interceptor_chain!(
+    call_count_workflows,
+    count_workflows,
+    CountWorkflowsInput,
+    BoxFuture<'a, Result<CountWorkflowsOutput, ClientError>>
+);
+
+interceptor_chain!(
+    call_describe_workflow,
+    describe_workflow,
+    DescribeWorkflowInput,
+    BoxFuture<'a, Result<DescribeWorkflowOutput, WorkflowInteractionError>>
+);
+
+interceptor_chain!(
+    call_fetch_workflow_history_page,
+    fetch_workflow_history_page,
+    FetchWorkflowHistoryPageInput,
+    BoxFuture<'a, Result<FetchWorkflowHistoryPageOutput, WorkflowInteractionError>>
+);
+
+interceptor_chain!(
+    call_signal_workflow,
+    signal_workflow,
+    SignalWorkflowInput,
+    BoxFuture<'a, Result<(), WorkflowInteractionError>>
+);
+
+interceptor_chain!(
+    call_query_workflow,
+    query_workflow,
+    QueryWorkflowInput,
+    BoxFuture<'a, Result<QueryWorkflowOutput, WorkflowQueryError>>
+);
+
+interceptor_chain!(
+    call_start_workflow_update,
+    start_workflow_update,
+    StartWorkflowUpdateInput,
+    BoxFuture<'a, Result<StartWorkflowUpdateOutput, WorkflowUpdateError>>
+);
+
+interceptor_chain!(
+    call_poll_workflow_update,
+    poll_workflow_update,
+    PollWorkflowUpdateInput,
+    BoxFuture<'a, Result<PollWorkflowUpdateOutput, WorkflowUpdateError>>
+);
+
+interceptor_chain!(
+    call_cancel_workflow,
+    cancel_workflow,
+    CancelWorkflowInput,
+    BoxFuture<'a, Result<(), WorkflowInteractionError>>
+);
+
+interceptor_chain!(
+    call_terminate_workflow,
+    terminate_workflow,
+    TerminateWorkflowInput,
+    BoxFuture<'a, Result<(), WorkflowInteractionError>>
+);
+
+interceptor_chain!(
+    call_create_schedule,
+    create_schedule,
+    CreateScheduleInput,
+    BoxFuture<'a, Result<CreateScheduleOutput, ScheduleError>>
+);
+
+interceptor_chain!(
+    call_list_schedules_page,
+    list_schedules_page,
+    ListSchedulesPageInput,
+    BoxFuture<'a, Result<ListSchedulesPageOutput, ScheduleError>>
+);
+
+interceptor_chain!(
+    call_describe_schedule,
+    describe_schedule,
+    DescribeScheduleInput,
+    BoxFuture<'a, Result<DescribeScheduleOutput, ScheduleError>>
+);
+
+interceptor_chain!(
+    call_update_schedule,
+    update_schedule,
+    UpdateScheduleInput,
+    BoxFuture<'a, Result<(), ScheduleError>>
+);
+
+interceptor_chain!(
+    call_send_schedule_update,
+    send_schedule_update,
+    SendScheduleUpdateInput,
+    BoxFuture<'a, Result<(), ScheduleError>>
+);
+
+interceptor_chain!(
+    call_delete_schedule,
+    delete_schedule,
+    DeleteScheduleInput,
+    BoxFuture<'a, Result<(), ScheduleError>>
+);
+
+interceptor_chain!(
+    call_pause_schedule,
+    pause_schedule,
+    PauseScheduleInput,
+    BoxFuture<'a, Result<(), ScheduleError>>
+);
+
+interceptor_chain!(
+    call_unpause_schedule,
+    unpause_schedule,
+    UnpauseScheduleInput,
+    BoxFuture<'a, Result<(), ScheduleError>>
+);
+
+interceptor_chain!(
+    call_trigger_schedule,
+    trigger_schedule,
+    TriggerScheduleInput,
+    BoxFuture<'a, Result<(), ScheduleError>>
+);
+
+interceptor_chain!(
+    call_backfill_schedule,
+    backfill_schedule,
+    BackfillScheduleInput,
+    BoxFuture<'a, Result<(), ScheduleError>>
+);
+
+interceptor_chain!(
+    call_complete_async_activity,
+    complete_async_activity,
+    CompleteAsyncActivityInput,
+    BoxFuture<'a, Result<(), AsyncActivityError>>
+);
+
+interceptor_chain!(
+    call_fail_async_activity,
+    fail_async_activity,
+    FailAsyncActivityInput,
+    BoxFuture<'a, Result<(), AsyncActivityError>>
+);
+
+interceptor_chain!(
+    call_report_async_activity_cancellation,
+    report_async_activity_cancellation,
+    ReportAsyncActivityCancellationInput,
+    BoxFuture<'a, Result<(), AsyncActivityError>>
+);
+
+interceptor_chain!(
+    call_heartbeat_async_activity,
+    heartbeat_async_activity,
+    HeartbeatAsyncActivityInput,
+    BoxFuture<'a, Result<ActivityHeartbeatResponse, AsyncActivityError>>
+);

--- a/crates/client/src/interceptors.rs
+++ b/crates/client/src/interceptors.rs
@@ -87,6 +87,41 @@ impl dyn TemporalClientValue {
     }
 }
 
+/// Provides access to the arguments carried by a client interceptor input.
+pub trait HasArgs {
+    /// Attempt to access the arguments as a concrete type.
+    fn args_ref<T: Any>(&self) -> Option<&T>;
+
+    /// Attempt to mutably access the arguments as a concrete type.
+    fn args_mut<T: Any>(&mut self) -> Option<&mut T>;
+
+    /// Replace the arguments with another serializable value.
+    fn replace_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static;
+}
+
+macro_rules! impl_with_args {
+    ($input:ty) => {
+        impl HasArgs for $input {
+            fn args_ref<T: Any>(&self) -> Option<&T> {
+                self.args.as_any().downcast_ref()
+            }
+
+            fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
+                self.args.as_any_mut().downcast_mut()
+            }
+
+            fn replace_args<T>(&mut self, args: T)
+            where
+                T: TemporalSerializable + Send + 'static,
+            {
+                self.args = Box::new(args);
+            }
+        }
+    };
+}
+
 /// Continuation for an intercepted client operation.
 ///
 /// A continuation can be invoked at most once because [`run`](Self::run) consumes it.
@@ -148,25 +183,9 @@ impl StartWorkflowInput {
             self.rpc_options,
         )
     }
-
-    /// Attempt to access the workflow arguments as a concrete type.
-    pub fn args_ref<T: Any>(&self) -> Option<&T> {
-        self.args.as_any().downcast_ref()
-    }
-
-    /// Attempt to mutably access the workflow arguments as a concrete type.
-    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
-        self.args.as_any_mut().downcast_mut()
-    }
-
-    /// Replace the workflow arguments with another serializable value.
-    pub fn replace_args<T>(&mut self, args: T)
-    where
-        T: TemporalSerializable + Send + 'static,
-    {
-        self.args = Box::new(args);
-    }
 }
+
+impl_with_args!(StartWorkflowInput);
 
 /// Result of a successful intercepted workflow start.
 #[non_exhaustive]
@@ -354,25 +373,9 @@ impl SignalWorkflowInput {
             self.options,
         )
     }
-
-    /// Attempt to access the signal arguments as a concrete type.
-    pub fn args_ref<T: Any>(&self) -> Option<&T> {
-        self.args.as_any().downcast_ref()
-    }
-
-    /// Attempt to mutably access the signal arguments as a concrete type.
-    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
-        self.args.as_any_mut().downcast_mut()
-    }
-
-    /// Replace the signal arguments with another serializable value.
-    pub fn replace_args<T>(&mut self, args: T)
-    where
-        T: TemporalSerializable + Send + 'static,
-    {
-        self.args = Box::new(args);
-    }
 }
+
+impl_with_args!(SignalWorkflowInput);
 
 /// Input to [`ClientInterceptor::query_workflow`].
 #[non_exhaustive]
@@ -427,25 +430,9 @@ impl QueryWorkflowInput {
             self.options,
         )
     }
-
-    /// Attempt to access the query arguments as a concrete type.
-    pub fn args_ref<T: Any>(&self) -> Option<&T> {
-        self.args.as_any().downcast_ref()
-    }
-
-    /// Attempt to mutably access the query arguments as a concrete type.
-    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
-        self.args.as_any_mut().downcast_mut()
-    }
-
-    /// Replace the query arguments with another serializable value.
-    pub fn replace_args<T>(&mut self, args: T)
-    where
-        T: TemporalSerializable + Send + 'static,
-    {
-        self.args = Box::new(args);
-    }
 }
+
+impl_with_args!(QueryWorkflowInput);
 
 /// Result of an intercepted workflow query before typed result conversion.
 #[non_exhaustive]
@@ -514,25 +501,9 @@ impl StartWorkflowUpdateInput {
             self.options,
         )
     }
-
-    /// Attempt to access the update arguments as a concrete type.
-    pub fn args_ref<T: Any>(&self) -> Option<&T> {
-        self.args.as_any().downcast_ref()
-    }
-
-    /// Attempt to mutably access the update arguments as a concrete type.
-    pub fn args_mut<T: Any>(&mut self) -> Option<&mut T> {
-        self.args.as_any_mut().downcast_mut()
-    }
-
-    /// Replace the update arguments with another serializable value.
-    pub fn replace_args<T>(&mut self, args: T)
-    where
-        T: TemporalSerializable + Send + 'static,
-    {
-        self.args = Box::new(args);
-    }
 }
+
+impl_with_args!(StartWorkflowUpdateInput);
 
 /// Result of an intercepted workflow-update start.
 #[non_exhaustive]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -15,6 +15,8 @@ mod dns;
 pub mod envconfig;
 pub mod errors;
 pub mod grpc;
+/// Interceptors for high-level client operations.
+pub mod interceptors;
 mod metrics;
 mod options_structs;
 /// Visible only for tests
@@ -23,6 +25,7 @@ pub mod proxy;
 mod replaceable;
 pub mod request_extensions;
 mod retry;
+mod rpc_options;
 /// Schedule operations: create, describe, update, pause, trigger, backfill, list, and delete.
 pub mod schedules;
 #[cfg(test)]
@@ -42,10 +45,24 @@ pub use async_activity_handle::{
 #[doc(hidden)]
 pub use retry::jittered;
 
+pub use interceptors::{
+    BackfillScheduleInput, CancelWorkflowInput, ClientInterceptor, CompleteAsyncActivityInput,
+    CountWorkflowsInput, CountWorkflowsOutput, CreateScheduleInput, CreateScheduleOutput,
+    DeleteScheduleInput, DescribeScheduleInput, DescribeScheduleOutput, DescribeWorkflowInput,
+    DescribeWorkflowOutput, FailAsyncActivityInput, FetchWorkflowHistoryPageInput,
+    FetchWorkflowHistoryPageOutput, HeartbeatAsyncActivityInput, ListSchedulesPageInput,
+    ListSchedulesPageOutput, ListWorkflowsPageInput, ListWorkflowsPageOutput, Next,
+    PauseScheduleInput, PollWorkflowUpdateInput, PollWorkflowUpdateOutput, QueryWorkflowInput,
+    QueryWorkflowOutput, ReportAsyncActivityCancellationInput, SendScheduleUpdateInput,
+    SignalWorkflowInput, StartWorkflowInput, StartWorkflowOutput, StartWorkflowUpdateInput,
+    StartWorkflowUpdateOutput, TemporalClientValue, TerminateWorkflowInput, TriggerScheduleInput,
+    UnpauseScheduleInput, UpdateScheduleInput,
+};
 pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use options_structs::*;
 pub use replaceable::SharedReplaceableClient;
 pub use retry::RetryOptions;
+pub use rpc_options::{RpcMetadata, RpcMetadataError, RpcOptions};
 pub use temporalio_common::{Memo, RetryPolicy};
 /// Potentially dangerous TLS related functionality.
 pub mod danger {
@@ -72,7 +89,7 @@ use crate::{
     worker::ClientWorkerSet,
 };
 use errors::*;
-use futures_util::{stream, stream::Stream};
+use futures_util::{future::BoxFuture, stream, stream::Stream};
 use http::Uri;
 use parking_lot::RwLock;
 use std::{
@@ -856,6 +873,10 @@ impl NamespacedClient for Client {
     fn data_converter(&self) -> &DataConverter {
         &self.options.data_converter
     }
+
+    fn client_interceptors(&self) -> &[Arc<dyn ClientInterceptor>] {
+        &self.options.client_interceptors
+    }
 }
 
 /// Enum to help reference a namespace by either the namespace name or the namespace id
@@ -933,6 +954,16 @@ pub trait NamespacedClient {
     fn data_converter(&self) -> &DataConverter {
         static DEFAULT: OnceLock<DataConverter> = OnceLock::new();
         DEFAULT.get_or_init(DataConverter::default)
+    }
+    /// Returns the interceptors used for high-level client operations.
+    ///
+    /// # Warning
+    ///
+    /// This provider exists so SDK-owned client handles can carry interceptor configuration
+    /// through the high-level client blanket implementation. Custom client implementations should
+    /// normally retain the default empty chain unless they deliberately provide the same plumbing.
+    fn client_interceptors(&self) -> &[Arc<dyn ClientInterceptor>] {
+        &[]
     }
 }
 
@@ -1176,133 +1207,181 @@ where
         W: HasWorkflowDefinition,
         W::Input: Send,
     {
-        let payloads = self
-            .data_converter()
-            .to_payloads(&SerializationContextData::Workflow, &input)
-            .await?;
         let namespace = self.namespace();
-        let workflow_id = options.workflow_id.clone();
-        let task_queue_name = options.task_queue.clone();
+        let interceptor_output = interceptors::call_start_workflow(
+            self.client_interceptors(),
+            StartWorkflowInput::new(workflow.name().to_owned(), input, options),
+            Next::new({
+                let client = (*self).clone();
+                move |input: StartWorkflowInput| -> BoxFuture<
+                    '_,
+                    Result<StartWorkflowOutput, WorkflowStartError>,
+                > {
+                    let mut client = client;
+                    Box::pin(async move {
+                        let (workflow_type, args, options, rpc_options) = input.into_parts();
+                        let data_converter = client.data_converter().clone();
+                        let unencoded_payloads = {
+                            let payload_converter = data_converter.payload_converter();
+                            let context = SerializationContext {
+                                data: &SerializationContextData::Workflow,
+                                converter: payload_converter,
+                            };
+                            args.serialize_payloads(&context)
+                        };
+                        drop(args);
 
-        let user_metadata = if options.static_summary.is_some() || options.static_details.is_some()
-        {
-            let payload_converter = PayloadConverter::default();
-            let context = SerializationContext {
-                data: &SerializationContextData::Workflow,
-                converter: &payload_converter,
-            };
-            Some(UserMetadata {
-                summary: options.static_summary.map(|s| {
-                    payload_converter
-                        .to_payload(&context, &s)
-                        .expect("String-to-JSON payload serialization is infallible")
-                }),
-                details: options.static_details.map(|s| {
-                    payload_converter
-                        .to_payload(&context, &s)
-                        .expect("String-to-JSON payload serialization is infallible")
-                }),
-            })
-        } else {
-            None
-        };
+                        let payloads = data_converter
+                            .codec()
+                            .encode(&SerializationContextData::Workflow, unencoded_payloads?)
+                            .await;
+                        let namespace = client.namespace();
+                        let workflow_id = options.workflow_id.clone();
+                        let task_queue_name = options.task_queue.clone();
 
-        let run_id = if let Some(start_signal) = options.start_signal {
-            // Use signal-with-start when a start_signal is provided
-            let res = WorkflowService::signal_with_start_workflow_execution(
-                &mut self.clone(),
-                SignalWithStartWorkflowExecutionRequest {
-                    namespace: namespace.clone(),
-                    workflow_id: workflow_id.clone(),
-                    workflow_type: Some(WorkflowType {
-                        name: workflow.name().to_string(),
-                    }),
-                    task_queue: Some(TaskQueue {
-                        name: task_queue_name,
-                        kind: TaskQueueKind::Normal as i32,
-                        normal_name: "".to_string(),
-                    }),
-                    input: payloads.into_payloads(),
-                    signal_name: start_signal.signal_name,
-                    signal_input: start_signal.input,
-                    identity: self.identity(),
-                    request_id: Uuid::new_v4().to_string(),
-                    workflow_id_reuse_policy: options.id_reuse_policy as i32,
-                    workflow_id_conflict_policy: options.id_conflict_policy as i32,
-                    workflow_execution_timeout: options
-                        .execution_timeout
-                        .and_then(|d| d.try_into().ok()),
-                    workflow_run_timeout: options.run_timeout.and_then(|d| d.try_into().ok()),
-                    workflow_task_timeout: options.task_timeout.and_then(|d| d.try_into().ok()),
-                    search_attributes: options.search_attributes.map(|t| t.into_proto()),
-                    cron_schedule: options.cron_schedule.unwrap_or_default(),
-                    retry_policy: options.retry_policy.map(Into::into),
-                    header: options.header.or(start_signal.header),
-                    user_metadata,
-                    ..Default::default()
-                }
-                .into_request(),
-            )
-            .await?
-            .into_inner();
-            res.run_id
-        } else {
-            // Normal start workflow
-            let res = self
-                .clone()
-                .start_workflow_execution(
-                    StartWorkflowExecutionRequest {
-                        namespace: namespace.clone(),
-                        input: payloads.into_payloads(),
-                        workflow_id: workflow_id.clone(),
-                        workflow_type: Some(WorkflowType {
-                            name: workflow.name().to_string(),
-                        }),
-                        task_queue: Some(TaskQueue {
-                            name: task_queue_name,
-                            kind: TaskQueueKind::Unspecified as i32,
-                            normal_name: "".to_string(),
-                        }),
-                        request_id: Uuid::new_v4().to_string(),
-                        workflow_id_reuse_policy: options.id_reuse_policy as i32,
-                        workflow_id_conflict_policy: options.id_conflict_policy as i32,
-                        workflow_execution_timeout: options
-                            .execution_timeout
-                            .and_then(|d| d.try_into().ok()),
-                        workflow_run_timeout: options.run_timeout.and_then(|d| d.try_into().ok()),
-                        workflow_task_timeout: options.task_timeout.and_then(|d| d.try_into().ok()),
-                        search_attributes: options.search_attributes.map(|t| t.into_proto()),
-                        cron_schedule: options.cron_schedule.unwrap_or_default(),
-                        request_eager_execution: options.enable_eager_workflow_start,
-                        retry_policy: options.retry_policy.map(Into::into),
-                        links: options.links,
-                        completion_callbacks: options.completion_callbacks,
-                        priority: Some(options.priority.into()),
-                        header: options.header,
-                        user_metadata,
-                        ..Default::default()
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(|status| {
-                    if status.code() == Code::AlreadyExists {
-                        let run_id =
-                            decode_status_detail::<WorkflowExecutionAlreadyStartedFailure>(
-                                status.details(),
+                        let user_metadata = if options.static_summary.is_some()
+                            || options.static_details.is_some()
+                        {
+                            let payload_converter = PayloadConverter::default();
+                            let context = SerializationContext {
+                                data: &SerializationContextData::Workflow,
+                                converter: &payload_converter,
+                            };
+                            Some(UserMetadata {
+                                summary: options.static_summary.map(|summary| {
+                                    payload_converter.to_payload(&context, &summary).expect(
+                                        "String-to-JSON payload serialization is infallible",
+                                    )
+                                }),
+                                details: options.static_details.map(|details| {
+                                    payload_converter.to_payload(&context, &details).expect(
+                                        "String-to-JSON payload serialization is infallible",
+                                    )
+                                }),
+                            })
+                        } else {
+                            None
+                        };
+
+                        let run_id = if let Some(start_signal) = options.start_signal {
+                            let mut request = SignalWithStartWorkflowExecutionRequest {
+                                namespace,
+                                workflow_id: workflow_id.clone(),
+                                workflow_type: Some(WorkflowType {
+                                    name: workflow_type,
+                                }),
+                                task_queue: Some(TaskQueue {
+                                    name: task_queue_name,
+                                    kind: TaskQueueKind::Normal as i32,
+                                    normal_name: String::new(),
+                                }),
+                                input: payloads.into_payloads(),
+                                signal_name: start_signal.signal_name,
+                                signal_input: start_signal.input,
+                                identity: client.identity(),
+                                request_id: Uuid::new_v4().to_string(),
+                                workflow_id_reuse_policy: options.id_reuse_policy as i32,
+                                workflow_id_conflict_policy: options.id_conflict_policy as i32,
+                                workflow_execution_timeout: options
+                                    .execution_timeout
+                                    .and_then(|duration| duration.try_into().ok()),
+                                workflow_run_timeout: options
+                                    .run_timeout
+                                    .and_then(|duration| duration.try_into().ok()),
+                                workflow_task_timeout: options
+                                    .task_timeout
+                                    .and_then(|duration| duration.try_into().ok()),
+                                search_attributes: options
+                                    .search_attributes
+                                    .map(|attributes| attributes.into_proto()),
+                                cron_schedule: options.cron_schedule.unwrap_or_default(),
+                                retry_policy: options.retry_policy.map(Into::into),
+                                header: options.header.or(start_signal.header),
+                                user_metadata,
+                                ..Default::default()
+                            }
+                            .into_request();
+                            rpc_options.apply_to(&mut request);
+                            WorkflowService::signal_with_start_workflow_execution(
+                                &mut client,
+                                request,
                             )
-                            .map(|f| f.run_id);
-                        WorkflowStartError::AlreadyStarted {
-                            run_id,
-                            source: status,
-                        }
-                    } else {
-                        WorkflowStartError::Rpc(status)
-                    }
-                })?
-                .into_inner();
-            res.run_id
-        };
+                            .await?
+                            .into_inner()
+                            .run_id
+                        } else {
+                            let mut request = StartWorkflowExecutionRequest {
+                                namespace,
+                                input: payloads.into_payloads(),
+                                workflow_id: workflow_id.clone(),
+                                workflow_type: Some(WorkflowType {
+                                    name: workflow_type,
+                                }),
+                                task_queue: Some(TaskQueue {
+                                    name: task_queue_name,
+                                    kind: TaskQueueKind::Unspecified as i32,
+                                    normal_name: String::new(),
+                                }),
+                                request_id: Uuid::new_v4().to_string(),
+                                workflow_id_reuse_policy: options.id_reuse_policy as i32,
+                                workflow_id_conflict_policy: options.id_conflict_policy as i32,
+                                workflow_execution_timeout: options
+                                    .execution_timeout
+                                    .and_then(|duration| duration.try_into().ok()),
+                                workflow_run_timeout: options
+                                    .run_timeout
+                                    .and_then(|duration| duration.try_into().ok()),
+                                workflow_task_timeout: options
+                                    .task_timeout
+                                    .and_then(|duration| duration.try_into().ok()),
+                                search_attributes: options
+                                    .search_attributes
+                                    .map(|attributes| attributes.into_proto()),
+                                cron_schedule: options.cron_schedule.unwrap_or_default(),
+                                request_eager_execution: options.enable_eager_workflow_start,
+                                retry_policy: options.retry_policy.map(Into::into),
+                                links: options.links,
+                                completion_callbacks: options.completion_callbacks,
+                                priority: Some(options.priority.into()),
+                                header: options.header,
+                                user_metadata,
+                                ..Default::default()
+                            }
+                            .into_request();
+                            rpc_options.apply_to(&mut request);
+                            client
+                                .start_workflow_execution(request)
+                                .await
+                                .map_err(|status| {
+                                    if status.code() == Code::AlreadyExists {
+                                        let run_id = decode_status_detail::<
+                                            WorkflowExecutionAlreadyStartedFailure,
+                                        >(
+                                            status.details()
+                                        )
+                                        .map(|failure| failure.run_id);
+                                        WorkflowStartError::AlreadyStarted {
+                                            run_id,
+                                            source: status,
+                                        }
+                                    } else {
+                                        WorkflowStartError::Rpc(status)
+                                    }
+                                })?
+                                .into_inner()
+                                .run_id
+                        };
+
+                        Ok(StartWorkflowOutput::new(workflow_id, run_id))
+                    })
+                }
+            }),
+        )
+        .await?;
+        let StartWorkflowOutput {
+            workflow_id,
+            run_id,
+        } = interceptor_output;
 
         Ok(WorkflowHandle::new(
             self.clone(),
@@ -1342,6 +1421,7 @@ where
         let namespace = self.namespace();
         let query = query.into();
         let limit = opts.limit;
+        let rpc_options = opts.rpc_options;
 
         // State: (next_page_token, buffer, yielded_count, exhausted)
         let initial_state = (Vec::new(), VecDeque::new(), 0, false);
@@ -1349,9 +1429,10 @@ where
         let stream = stream::unfold(
             initial_state,
             move |(next_page_token, mut buffer, mut yielded, exhausted)| {
-                let mut client = client.clone();
+                let client = client.clone();
                 let namespace = namespace.clone();
                 let query = query.clone();
+                let rpc_options = rpc_options.clone();
 
                 async move {
                     if let Some(l) = limit
@@ -1369,26 +1450,51 @@ where
                         return None;
                     }
 
-                    let response = WorkflowService::list_workflow_executions(
-                        &mut client,
-                        ListWorkflowExecutionsRequest {
-                            namespace,
-                            page_size: 0, // Use server default
-                            next_page_token: next_page_token.clone(),
+                    let response = interceptors::call_list_workflows_page(
+                        client.client_interceptors(),
+                        ListWorkflowsPageInput {
                             query,
-                        }
-                        .into_request(),
+                            next_page_token: next_page_token.clone(),
+                            rpc_options,
+                        },
+                        Next::new({
+                            let mut rpc_client = client.clone();
+                            move |input: ListWorkflowsPageInput| -> BoxFuture<
+                                '_,
+                                Result<ListWorkflowsPageOutput, ClientError>,
+                            > {
+                                Box::pin(async move {
+                                    let mut request = ListWorkflowExecutionsRequest {
+                                        namespace,
+                                        page_size: 0,
+                                        next_page_token: input.next_page_token,
+                                        query: input.query,
+                                    }
+                                    .into_request();
+                                    input.rpc_options.apply_to(&mut request);
+                                    let response = WorkflowService::list_workflow_executions(
+                                        &mut rpc_client,
+                                        request,
+                                    )
+                                    .await?
+                                    .into_inner();
+                                    Ok(ListWorkflowsPageOutput::new(
+                                        response.executions,
+                                        response.next_page_token,
+                                    ))
+                                })
+                            }
+                        }),
                     )
                     .await;
 
                     match response {
-                        Ok(resp) => {
-                            let mut resp = resp.into_inner();
-                            let new_exhausted = resp.next_page_token.is_empty();
-                            let new_token = resp.next_page_token;
+                        Ok(mut output) => {
+                            let new_exhausted = output.next_page_token.is_empty();
+                            let new_token = output.next_page_token;
 
                             let data_converter = client.data_converter().clone();
-                            for execution in &mut resp.executions {
+                            for execution in &mut output.executions {
                                 if let Some(memo) = execution.memo.as_mut() {
                                     decode_payloads(
                                         memo,
@@ -1398,7 +1504,7 @@ where
                                     .await;
                                 }
                             }
-                            buffer = resp
+                            buffer = output
                                 .executions
                                 .into_iter()
                                 .map(|raw| {
@@ -1416,7 +1522,7 @@ where
                                 None
                             }
                         }
-                        Err(e) => Some((Err(e.into()), (next_page_token, buffer, yielded, true))),
+                        Err(e) => Some((Err(e), (next_page_token, buffer, yielded, true))),
                     }
                 }
             },
@@ -1428,20 +1534,41 @@ where
     async fn count_workflows(
         &self,
         query: impl Into<String>,
-        _opts: WorkflowCountOptions,
+        opts: WorkflowCountOptions,
     ) -> Result<WorkflowExecutionCount, ClientError> {
-        let resp = WorkflowService::count_workflow_executions(
-            &mut self.clone(),
-            CountWorkflowExecutionsRequest {
-                namespace: self.namespace(),
+        let output = interceptors::call_count_workflows(
+            self.client_interceptors(),
+            CountWorkflowsInput {
                 query: query.into(),
-            }
-            .into_request(),
+                options: opts,
+            },
+            Next::new({
+                let mut client = (*self).clone();
+                move |input: CountWorkflowsInput| -> BoxFuture<
+                    '_,
+                    Result<CountWorkflowsOutput, ClientError>,
+                > {
+                    Box::pin(async move {
+                        let mut request = CountWorkflowExecutionsRequest {
+                            namespace: client.namespace(),
+                            query: input.query,
+                        }
+                        .into_request();
+                        input.options.rpc_options.apply_to(&mut request);
+                        let response = WorkflowService::count_workflow_executions(
+                            &mut client,
+                            request,
+                        )
+                        .await?
+                        .into_inner();
+                        Ok(CountWorkflowsOutput::new(response))
+                    })
+                }
+            }),
         )
-        .await?
-        .into_inner();
+        .await?;
 
-        Ok(WorkflowExecutionCount::from_response(resp))
+        Ok(WorkflowExecutionCount::from_response(output.response))
     }
 
     fn get_async_activity_handle(&self, identifier: ActivityIdentifier) -> AsyncActivityHandle<Self>
@@ -1832,6 +1959,593 @@ mod tests {
         }
     }
 
+    mod start_workflow_interceptor_tests {
+        use super::*;
+        use crate::request_extensions::RetryConfigForCall;
+        use parking_lot::Mutex;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use temporalio_common::{
+            HasWorkflowDefinition, WorkflowDefinition,
+            data_converters::{
+                DefaultFailureConverter, PayloadCodec, PayloadConversionError,
+                SerializationContext, SerializationContextData, TemporalSerializable,
+            },
+            protos::temporal::api::common::v1::Payload,
+        };
+        use tonic::{Request, Response};
+
+        struct TestWorkflow;
+
+        impl WorkflowDefinition for TestWorkflow {
+            type Input = Vec<String>;
+            type Output = ();
+
+            fn name(&self) -> &str {
+                "test-workflow"
+            }
+        }
+
+        impl HasWorkflowDefinition for TestWorkflow {
+            type Run = Self;
+        }
+
+        #[derive(Default)]
+        struct RecordedStart {
+            calls: usize,
+            workflow_type: String,
+            payloads: Vec<Payload>,
+            ascii_metadata: Option<String>,
+            binary_metadata: Option<Vec<u8>>,
+            grpc_timeout: Option<String>,
+            retry_options: Option<RetryOptions>,
+        }
+
+        struct CountingCodec {
+            encode_calls: Arc<AtomicUsize>,
+        }
+
+        impl PayloadCodec for CountingCodec {
+            fn encode(
+                &self,
+                _context: &SerializationContextData,
+                payloads: Vec<Payload>,
+            ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
+                self.encode_calls.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move { payloads })
+            }
+
+            fn decode(
+                &self,
+                _context: &SerializationContextData,
+                payloads: Vec<Payload>,
+            ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
+                Box::pin(async move { payloads })
+            }
+        }
+
+        #[derive(Clone)]
+        struct MockStartWorkflowClient {
+            recorded: Arc<Mutex<RecordedStart>>,
+            data_converter: DataConverter,
+        }
+
+        impl NamespacedClient for MockStartWorkflowClient {
+            fn namespace(&self) -> String {
+                "test-namespace".to_owned()
+            }
+
+            fn identity(&self) -> String {
+                "test-identity".to_owned()
+            }
+
+            fn data_converter(&self) -> &DataConverter {
+                &self.data_converter
+            }
+        }
+
+        impl WorkflowService for MockStartWorkflowClient {
+            fn start_workflow_execution(
+                &mut self,
+                request: Request<StartWorkflowExecutionRequest>,
+            ) -> futures_util::future::BoxFuture<
+                '_,
+                Result<Response<StartWorkflowExecutionResponse>, tonic::Status>,
+            > {
+                let ascii_metadata = request
+                    .metadata()
+                    .get("call-meta")
+                    .map(|value| value.to_str().unwrap().to_owned());
+                let binary_metadata = request
+                    .metadata()
+                    .get_bin("call-meta-bin")
+                    .map(|value| value.to_bytes().unwrap().to_vec());
+                let grpc_timeout = request
+                    .metadata()
+                    .get("grpc-timeout")
+                    .map(|value| value.to_str().unwrap().to_owned());
+                let retry_options = request
+                    .extensions()
+                    .get::<RetryConfigForCall>()
+                    .map(|config| config.0.clone());
+                let request = request.into_inner();
+                let mut recorded = self.recorded.lock();
+                recorded.calls += 1;
+                recorded.workflow_type = request.workflow_type.unwrap().name;
+                recorded.payloads = request.input.unwrap_or_default().payloads;
+                recorded.ascii_metadata = ascii_metadata;
+                recorded.binary_metadata = binary_metadata;
+                recorded.grpc_timeout = grpc_timeout;
+                recorded.retry_options = retry_options;
+
+                Box::pin(async {
+                    Ok(Response::new(StartWorkflowExecutionResponse {
+                        run_id: "server-run-id".to_owned(),
+                        ..Default::default()
+                    }))
+                })
+            }
+
+            fn signal_with_start_workflow_execution(
+                &mut self,
+                request: Request<SignalWithStartWorkflowExecutionRequest>,
+            ) -> futures_util::future::BoxFuture<
+                '_,
+                Result<Response<SignalWithStartWorkflowExecutionResponse>, tonic::Status>,
+            > {
+                let ascii_metadata = request
+                    .metadata()
+                    .get("call-meta")
+                    .map(|value| value.to_str().unwrap().to_owned());
+                let binary_metadata = request
+                    .metadata()
+                    .get_bin("call-meta-bin")
+                    .map(|value| value.to_bytes().unwrap().to_vec());
+                let grpc_timeout = request
+                    .metadata()
+                    .get("grpc-timeout")
+                    .map(|value| value.to_str().unwrap().to_owned());
+                let retry_options = request
+                    .extensions()
+                    .get::<RetryConfigForCall>()
+                    .map(|config| config.0.clone());
+                let request = request.into_inner();
+                let mut recorded = self.recorded.lock();
+                recorded.calls += 1;
+                recorded.workflow_type = request.workflow_type.unwrap().name;
+                recorded.payloads = request.input.unwrap_or_default().payloads;
+                recorded.ascii_metadata = ascii_metadata;
+                recorded.binary_metadata = binary_metadata;
+                recorded.grpc_timeout = grpc_timeout;
+                recorded.retry_options = retry_options;
+
+                Box::pin(async {
+                    Ok(Response::new(SignalWithStartWorkflowExecutionResponse {
+                        run_id: "signal-server-run-id".to_owned(),
+                        ..Default::default()
+                    }))
+                })
+            }
+        }
+
+        #[derive(Clone)]
+        struct InterceptedClient {
+            inner: MockStartWorkflowClient,
+            interceptors: Vec<Arc<dyn ClientInterceptor>>,
+        }
+
+        impl NamespacedClient for InterceptedClient {
+            fn namespace(&self) -> String {
+                self.inner.namespace()
+            }
+
+            fn identity(&self) -> String {
+                self.inner.identity()
+            }
+
+            fn data_converter(&self) -> &DataConverter {
+                self.inner.data_converter()
+            }
+
+            fn client_interceptors(&self) -> &[Arc<dyn ClientInterceptor>] {
+                &self.interceptors
+            }
+        }
+
+        impl WorkflowService for InterceptedClient {
+            fn start_workflow_execution(
+                &mut self,
+                request: Request<StartWorkflowExecutionRequest>,
+            ) -> futures_util::future::BoxFuture<
+                '_,
+                Result<Response<StartWorkflowExecutionResponse>, tonic::Status>,
+            > {
+                self.inner.start_workflow_execution(request)
+            }
+
+            fn signal_with_start_workflow_execution(
+                &mut self,
+                request: Request<SignalWithStartWorkflowExecutionRequest>,
+            ) -> futures_util::future::BoxFuture<
+                '_,
+                Result<Response<SignalWithStartWorkflowExecutionResponse>, tonic::Status>,
+            > {
+                self.inner.signal_with_start_workflow_execution(request)
+            }
+        }
+
+        struct OrderedInterceptor {
+            name: &'static str,
+            events: Arc<Mutex<Vec<String>>>,
+            encode_calls: Arc<AtomicUsize>,
+        }
+
+        impl ClientInterceptor for OrderedInterceptor {
+            fn start_workflow<'a>(
+                &'a self,
+                mut input: StartWorkflowInput,
+                next: Next<
+                    'a,
+                    StartWorkflowInput,
+                    BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+                >,
+            ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+                Box::pin(async move {
+                    assert_eq!(self.encode_calls.load(Ordering::SeqCst), 0);
+                    self.events.lock().push(format!("{}-pre", self.name));
+                    tokio::task::yield_now().await;
+                    if self.name == "outer" {
+                        input
+                            .args_mut::<Vec<String>>()
+                            .unwrap()
+                            .push("mutated".to_owned());
+                    } else {
+                        assert_eq!(
+                            input.args_ref::<Vec<String>>().unwrap(),
+                            &["initial".to_owned(), "mutated".to_owned()]
+                        );
+                        input.replace_args("replacement".to_owned());
+                        input.workflow_type = "replacement-workflow".to_owned();
+                    }
+                    let result = next.run(input).await;
+                    tokio::task::yield_now().await;
+                    self.events.lock().push(format!("{}-post", self.name));
+                    result
+                })
+            }
+        }
+
+        struct ShortCircuitInterceptor;
+
+        impl ClientInterceptor for ShortCircuitInterceptor {
+            fn start_workflow<'a>(
+                &'a self,
+                input: StartWorkflowInput,
+                _next: Next<
+                    'a,
+                    StartWorkflowInput,
+                    BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+                >,
+            ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+                assert_eq!(
+                    input.args_ref::<Vec<String>>().unwrap(),
+                    &["initial".to_owned()]
+                );
+                Box::pin(async {
+                    Ok(StartWorkflowOutput::new(
+                        "short-circuit-workflow-id",
+                        "short-circuit-run-id",
+                    ))
+                })
+            }
+        }
+
+        struct CountingInput {
+            conversion_calls: Arc<AtomicUsize>,
+        }
+
+        impl TemporalSerializable for CountingInput {
+            fn to_payloads(
+                &self,
+                _context: &SerializationContext<'_>,
+            ) -> Result<Vec<Payload>, PayloadConversionError> {
+                self.conversion_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(vec![Payload::default()])
+            }
+        }
+
+        struct ConversionTimingInterceptor {
+            conversion_calls: Arc<AtomicUsize>,
+        }
+
+        impl ClientInterceptor for ConversionTimingInterceptor {
+            fn start_workflow<'a>(
+                &'a self,
+                mut input: StartWorkflowInput,
+                next: Next<
+                    'a,
+                    StartWorkflowInput,
+                    BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+                >,
+            ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+                input.replace_args(CountingInput {
+                    conversion_calls: self.conversion_calls.clone(),
+                });
+                let future = next.run(input);
+                assert_eq!(self.conversion_calls.load(Ordering::SeqCst), 0);
+                future
+            }
+        }
+
+        fn mock_client(
+            interceptors: Vec<Arc<dyn ClientInterceptor>>,
+            encode_calls: Arc<AtomicUsize>,
+        ) -> (InterceptedClient, Arc<Mutex<RecordedStart>>) {
+            let recorded = Arc::new(Mutex::new(RecordedStart::default()));
+            let data_converter = DataConverter::new(
+                PayloadConverter::default(),
+                DefaultFailureConverter,
+                CountingCodec {
+                    encode_calls: encode_calls.clone(),
+                },
+            );
+            (
+                InterceptedClient {
+                    inner: MockStartWorkflowClient {
+                        recorded: recorded.clone(),
+                        data_converter,
+                    },
+                    interceptors,
+                },
+                recorded,
+            )
+        }
+
+        #[tokio::test]
+        async fn interceptors_order_mutate_replace_and_defer_conversion() {
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let encode_calls = Arc::new(AtomicUsize::new(0));
+            let interceptors: Vec<Arc<dyn ClientInterceptor>> = vec![
+                Arc::new(OrderedInterceptor {
+                    name: "outer",
+                    events: events.clone(),
+                    encode_calls: encode_calls.clone(),
+                }),
+                Arc::new(OrderedInterceptor {
+                    name: "inner",
+                    events: events.clone(),
+                    encode_calls: encode_calls.clone(),
+                }),
+            ];
+            let (client, recorded) = mock_client(interceptors, encode_calls.clone());
+
+            let handle = client
+                .start_workflow(
+                    TestWorkflow,
+                    vec!["initial".to_owned()],
+                    WorkflowStartOptions::new("task-queue", "workflow-id").build(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                events.lock().as_slice(),
+                ["outer-pre", "inner-pre", "inner-post", "outer-post"]
+            );
+            assert_eq!(encode_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(handle.run_id(), Some("server-run-id"));
+            let payloads = {
+                let recorded = recorded.lock();
+                assert_eq!(recorded.calls, 1);
+                assert_eq!(recorded.workflow_type, "replacement-workflow");
+                recorded.payloads.clone()
+            };
+            let replacement: String = client
+                .data_converter()
+                .from_payloads(&SerializationContextData::Workflow, payloads)
+                .await
+                .unwrap();
+            assert_eq!(replacement, "replacement");
+        }
+
+        #[tokio::test]
+        async fn interceptor_can_short_circuit() {
+            let encode_calls = Arc::new(AtomicUsize::new(0));
+            let (client, recorded) = mock_client(
+                vec![Arc::new(ShortCircuitInterceptor)],
+                encode_calls.clone(),
+            );
+            let handle = client
+                .start_workflow(
+                    TestWorkflow,
+                    vec!["initial".to_owned()],
+                    WorkflowStartOptions::new("task-queue", "ignored-workflow-id").build(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(handle.info().workflow_id, "short-circuit-workflow-id");
+            assert_eq!(handle.run_id(), Some("short-circuit-run-id"));
+            assert_eq!(recorded.lock().calls, 0);
+            assert_eq!(encode_calls.load(Ordering::SeqCst), 0);
+        }
+
+        #[tokio::test]
+        async fn payload_conversion_waits_for_next_future_poll() {
+            let conversion_calls = Arc::new(AtomicUsize::new(0));
+            let encode_calls = Arc::new(AtomicUsize::new(0));
+            let recorded = Arc::new(Mutex::new(RecordedStart::default()));
+            let data_converter = DataConverter::new(
+                PayloadConverter::UseWrappers,
+                DefaultFailureConverter,
+                CountingCodec {
+                    encode_calls: encode_calls.clone(),
+                },
+            );
+            let client = InterceptedClient {
+                inner: MockStartWorkflowClient {
+                    recorded: recorded.clone(),
+                    data_converter,
+                },
+                interceptors: vec![Arc::new(ConversionTimingInterceptor {
+                    conversion_calls: conversion_calls.clone(),
+                })],
+            };
+
+            client
+                .start_workflow(
+                    TestWorkflow,
+                    vec!["initial".to_owned()],
+                    WorkflowStartOptions::new("task-queue", "workflow-id").build(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(conversion_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(encode_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(recorded.lock().calls, 1);
+        }
+
+        #[tokio::test]
+        async fn custom_client_defaults_to_empty_chain() {
+            let recorded = Arc::new(Mutex::new(RecordedStart::default()));
+            let client = MockStartWorkflowClient {
+                recorded: recorded.clone(),
+                data_converter: DataConverter::default(),
+            };
+            assert!(client.client_interceptors().is_empty());
+
+            client
+                .start_workflow(
+                    TestWorkflow,
+                    vec!["initial".to_owned()],
+                    WorkflowStartOptions::new("task-queue", "workflow-id").build(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(recorded.lock().calls, 1);
+        }
+
+        #[tokio::test]
+        async fn rpc_options_reach_the_request() {
+            let (client, recorded) = mock_client(Vec::new(), Arc::new(AtomicUsize::new(0)));
+            let mut rpc_options = RpcOptions {
+                timeout: Some(Duration::from_millis(250)),
+                retry_options: Some(RetryOptions::no_retries()),
+                ..Default::default()
+            };
+            rpc_options
+                .metadata
+                .insert("call-meta", "call-value")
+                .unwrap();
+            rpc_options
+                .metadata
+                .insert_binary("call-meta-bin", vec![0, 255])
+                .unwrap();
+            let mut options = WorkflowStartOptions::new("task-queue", "workflow-id").build();
+            options.rpc_options = rpc_options.clone();
+
+            client
+                .start_workflow(TestWorkflow, vec!["initial".to_owned()], options)
+                .await
+                .unwrap();
+
+            {
+                let recorded = recorded.lock();
+                assert_eq!(recorded.ascii_metadata.as_deref(), Some("call-value"));
+                assert_eq!(recorded.binary_metadata.as_deref(), Some(&[0, 255][..]));
+                assert_eq!(recorded.grpc_timeout.as_deref(), Some("250000u"));
+                assert_eq!(recorded.retry_options, Some(RetryOptions::no_retries()));
+            }
+
+            let mut options = WorkflowStartOptions::new("task-queue", "signal-workflow-id").build();
+            options.start_signal = Some(WorkflowStartSignal::new("signal-name").build());
+            options.rpc_options = rpc_options;
+            let handle = client
+                .start_workflow(TestWorkflow, vec!["initial".to_owned()], options)
+                .await
+                .unwrap();
+
+            let recorded = recorded.lock();
+            assert_eq!(recorded.calls, 2);
+            assert_eq!(recorded.ascii_metadata.as_deref(), Some("call-value"));
+            assert_eq!(recorded.binary_metadata.as_deref(), Some(&[0, 255][..]));
+            assert_eq!(recorded.grpc_timeout.as_deref(), Some("250000u"));
+            assert_eq!(recorded.retry_options, Some(RetryOptions::no_retries()));
+            assert_eq!(handle.run_id(), Some("signal-server-run-id"));
+        }
+
+        #[test]
+        fn rpc_metadata_combines_with_and_overrides_connection_defaults() {
+            let headers = Arc::new(RwLock::new(ClientHeaders {
+                user_headers: HashMap::from([
+                    (
+                        "shared-meta".parse().unwrap(),
+                        "connection-value".parse().unwrap(),
+                    ),
+                    (
+                        "connection-meta".parse().unwrap(),
+                        "connection-only".parse().unwrap(),
+                    ),
+                ]),
+                user_binary_headers: HashMap::from([
+                    (
+                        "shared-meta-bin".parse().unwrap(),
+                        BinaryMetadataValue::from_bytes(&[1]),
+                    ),
+                    (
+                        "connection-meta-bin".parse().unwrap(),
+                        BinaryMetadataValue::from_bytes(&[2]),
+                    ),
+                ]),
+                api_key: None,
+            }));
+            let mut service_interceptor = ServiceCallInterceptor {
+                client_name: "test-client".to_owned(),
+                client_version: "test-version".to_owned(),
+                headers,
+            };
+            let mut rpc_options = RpcOptions::default();
+            rpc_options
+                .metadata
+                .insert("shared-meta", "call-value")
+                .unwrap();
+            rpc_options
+                .metadata
+                .insert("call-meta", "call-only")
+                .unwrap();
+            rpc_options
+                .metadata
+                .insert_binary("shared-meta-bin", vec![3])
+                .unwrap();
+            rpc_options
+                .metadata
+                .insert_binary("call-meta-bin", vec![4])
+                .unwrap();
+            let mut request = Request::new(());
+            rpc_options.apply_to(&mut request);
+
+            let request = service_interceptor.call(request).unwrap();
+            assert_eq!(request.metadata().get("shared-meta").unwrap(), "call-value");
+            assert_eq!(request.metadata().get("call-meta").unwrap(), "call-only");
+            assert_eq!(
+                request.metadata().get("connection-meta").unwrap(),
+                "connection-only"
+            );
+            assert_eq!(
+                request.metadata().get_bin("shared-meta-bin").unwrap(),
+                &[3][..]
+            );
+            assert_eq!(
+                request.metadata().get_bin("call-meta-bin").unwrap(),
+                &[4][..]
+            );
+            assert_eq!(
+                request.metadata().get_bin("connection-meta-bin").unwrap(),
+                &[2][..]
+            );
+        }
+    }
+
     mod list_workflows_tests {
         use super::*;
         use crate::test_helpers::XorCodec;
@@ -1854,6 +2568,7 @@ mod tests {
             total_workflows: usize,
             data_converter: DataConverter,
             memo_payload: Option<Payload>,
+            interceptors: Vec<Arc<dyn ClientInterceptor>>,
         }
 
         impl NamespacedClient for MockListWorkflowsClient {
@@ -1865,6 +2580,28 @@ mod tests {
             }
             fn data_converter(&self) -> &DataConverter {
                 &self.data_converter
+            }
+            fn client_interceptors(&self) -> &[Arc<dyn ClientInterceptor>] {
+                &self.interceptors
+            }
+        }
+
+        struct CountingListInterceptor {
+            calls: Arc<AtomicUsize>,
+        }
+
+        impl ClientInterceptor for CountingListInterceptor {
+            fn list_workflows_page<'a>(
+                &'a self,
+                input: ListWorkflowsPageInput,
+                next: Next<
+                    'a,
+                    ListWorkflowsPageInput,
+                    BoxFuture<'a, Result<ListWorkflowsPageOutput, ClientError>>,
+                >,
+            ) -> BoxFuture<'a, Result<ListWorkflowsPageOutput, ClientError>> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                next.run(input)
             }
         }
 
@@ -1929,12 +2666,16 @@ mod tests {
         #[tokio::test]
         async fn list_workflows_paginates_through_all_results() {
             let call_count = Arc::new(AtomicUsize::new(0));
+            let interceptor_calls = Arc::new(AtomicUsize::new(0));
             let client = MockListWorkflowsClient {
                 call_count: call_count.clone(),
                 page_size: 3,
                 total_workflows: 10,
                 data_converter: DataConverter::default(),
                 memo_payload: None,
+                interceptors: vec![Arc::new(CountingListInterceptor {
+                    calls: interceptor_calls.clone(),
+                })],
             };
 
             let stream = client.list_workflows("", WorkflowListOptions::default());
@@ -1948,6 +2689,7 @@ mod tests {
             }
             // Should have made 4 calls: pages of 3, 3, 3, 1
             assert_eq!(call_count.load(Ordering::SeqCst), 4);
+            assert_eq!(interceptor_calls.load(Ordering::SeqCst), 4);
         }
 
         #[tokio::test]
@@ -1959,6 +2701,7 @@ mod tests {
                 total_workflows: 10,
                 data_converter: DataConverter::default(),
                 memo_payload: None,
+                interceptors: Vec::new(),
             };
 
             let opts = WorkflowListOptions::builder().limit(5).build();
@@ -1983,6 +2726,7 @@ mod tests {
                 total_workflows: 100,
                 data_converter: DataConverter::default(),
                 memo_payload: None,
+                interceptors: Vec::new(),
             };
 
             let opts = WorkflowListOptions::builder().limit(3).build();
@@ -2003,6 +2747,7 @@ mod tests {
                 total_workflows: 0,
                 data_converter: DataConverter::default(),
                 memo_payload: None,
+                interceptors: Vec::new(),
             };
 
             let stream = client.list_workflows("", WorkflowListOptions::default());
@@ -2032,6 +2777,7 @@ mod tests {
                 total_workflows: 1,
                 data_converter,
                 memo_payload: Some(memo_payload),
+                interceptors: Vec::new(),
             };
 
             let workflow = client

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -50,7 +50,7 @@ pub use interceptors::{
     CountWorkflowsInput, CountWorkflowsOutput, CreateScheduleInput, CreateScheduleOutput,
     DeleteScheduleInput, DescribeScheduleInput, DescribeScheduleOutput, DescribeWorkflowInput,
     DescribeWorkflowOutput, FailAsyncActivityInput, FetchWorkflowHistoryPageInput,
-    FetchWorkflowHistoryPageOutput, HeartbeatAsyncActivityInput, ListSchedulesPageInput,
+    FetchWorkflowHistoryPageOutput, HasArgs, HeartbeatAsyncActivityInput, ListSchedulesPageInput,
     ListSchedulesPageOutput, ListWorkflowsPageInput, ListWorkflowsPageOutput, Next,
     PauseScheduleInput, PollWorkflowUpdateInput, PollWorkflowUpdateOutput, QueryWorkflowInput,
     QueryWorkflowOutput, ReportAsyncActivityCancellationInput, SendScheduleUpdateInput,

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -1,4 +1,6 @@
-use crate::{HttpConnectProxyOptions, RetryOptions, VERSION, callback_based};
+use crate::{
+    ClientInterceptor, HttpConnectProxyOptions, RetryOptions, RpcOptions, VERSION, callback_based,
+};
 use http::Uri;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use temporalio_common::{
@@ -138,7 +140,7 @@ impl ConnectionOptions {
 }
 
 /// Options for [crate::Client::new].
-#[derive(Clone, Debug, bon::Builder)]
+#[derive(Clone, derive_more::Debug, bon::Builder)]
 #[non_exhaustive]
 #[builder(start_fn = new, on(String, into), state_mod(vis = "pub"))]
 pub struct ClientOptions {
@@ -148,6 +150,10 @@ pub struct ClientOptions {
     /// The data converter used for serializing/deserializing payloads.
     #[builder(default)]
     pub data_converter: DataConverter,
+    /// Interceptors for high-level client operations, ordered outermost to innermost.
+    #[builder(default)]
+    #[debug(skip)]
+    pub client_interceptors: Vec<Arc<dyn ClientInterceptor>>,
 }
 
 /// Selects the transport-level compression used for gRPC calls. See
@@ -356,6 +362,10 @@ pub struct WorkflowStartOptions {
 
     /// Multi-line static details for the workflow, shown in the Temporal UI.
     pub static_details: Option<String>,
+
+    /// Controls for the RPC used to start the workflow.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// A signal to send atomically when starting a workflow.
@@ -376,17 +386,23 @@ pub struct WorkflowStartSignal {
 pub use temporalio_common::Priority;
 
 /// Options for fetching workflow results
-#[derive(Debug, Clone, Copy, bon::Builder)]
+#[derive(Debug, Clone, bon::Builder)]
 #[non_exhaustive]
 pub struct WorkflowGetResultOptions {
     /// If true (the default), follows to the next workflow run in the execution chain while
     /// retrieving results.
     #[builder(default = true)]
     pub follow_runs: bool,
+    /// Controls for each history RPC used to retrieve the result.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 impl Default for WorkflowGetResultOptions {
     fn default() -> Self {
-        Self { follow_runs: true }
+        Self {
+            follow_runs: true,
+            rpc_options: RpcOptions::default(),
+        }
     }
 }
 
@@ -398,6 +414,9 @@ pub struct WorkflowExecuteUpdateOptions {
     pub update_id: Option<String>,
     /// Headers to include.
     pub header: Option<Header>,
+    /// Controls for the start-update and poll-update RPCs.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// Options for sending a signal to a workflow.
@@ -408,6 +427,9 @@ pub struct WorkflowSignalOptions {
     pub request_id: Option<String>,
     /// Headers to include with the signal.
     pub header: Option<Header>,
+    /// Controls for the signal RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// Options for querying a workflow.
@@ -419,6 +441,9 @@ pub struct WorkflowQueryOptions {
     pub reject_condition: Option<QueryRejectCondition>,
     /// Headers to include with the query.
     pub header: Option<Header>,
+    /// Controls for the query RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// Options for cancelling a workflow.
@@ -431,6 +456,9 @@ pub struct WorkflowCancelOptions {
     pub reason: String,
     /// Request ID for idempotency. If not provided, a UUID will be generated.
     pub request_id: Option<String>,
+    /// Controls for the cancellation RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// Options for terminating a workflow.
@@ -443,12 +471,19 @@ pub struct WorkflowTerminateOptions {
     pub reason: String,
     /// Additional details to include with the termination.
     pub details: Option<Payloads>,
+    /// Controls for the termination RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// Options for describing a workflow.
 #[derive(Debug, Clone, Default, bon::Builder)]
 #[non_exhaustive]
-pub struct WorkflowDescribeOptions {}
+pub struct WorkflowDescribeOptions {
+    /// Controls for the describe RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
+}
 
 /// Default workflow execution retention for a Namespace is 3 days
 const DEFAULT_WORKFLOW_EXECUTION_RETENTION_PERIOD: Duration = Duration::from_secs(60 * 60 * 24 * 3);
@@ -532,6 +567,9 @@ pub struct WorkflowFetchHistoryOptions {
     /// Specifies which kind of events will be retrieved. Defaults to all events.
     #[builder(default = HistoryEventFilterType::AllEvent)]
     pub event_filter_type: HistoryEventFilterType,
+    /// Controls for each history page RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// Which lifecycle stage to wait for when starting an update.
@@ -558,6 +596,9 @@ pub struct WorkflowStartUpdateOptions {
     /// The lifecycle stage to wait for before returning the handle.
     #[builder(default)]
     pub wait_for_stage: WorkflowUpdateWaitStage,
+    /// Controls for the start-update RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// Options for listing workflows.
@@ -567,9 +608,16 @@ pub struct WorkflowListOptions {
     /// Maximum number of workflows to return.
     /// If not specified, returns all matching workflows.
     pub limit: Option<usize>,
+    /// Controls for each list page RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// Options for counting workflows.
 #[derive(Debug, Clone, Default, bon::Builder)]
 #[non_exhaustive]
-pub struct WorkflowCountOptions {}
+pub struct WorkflowCountOptions {
+    /// Controls for the count RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
+}

--- a/crates/client/src/rpc_options.rs
+++ b/crates/client/src/rpc_options.rs
@@ -1,0 +1,239 @@
+use crate::{RetryOptions, request_extensions::RetryConfigForCall};
+use std::time::Duration;
+use tonic::metadata::{
+    AsciiMetadataKey, AsciiMetadataValue, BinaryMetadataKey, BinaryMetadataValue, KeyAndValueRef,
+    MetadataMap,
+};
+
+/// Metadata attached to a single high-level client RPC.
+///
+/// Per-call values take precedence over metadata configured on the connection.
+#[derive(Clone, Debug, Default)]
+pub struct RpcMetadata {
+    inner: MetadataMap,
+}
+
+impl RpcMetadata {
+    /// Create empty RPC metadata.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert an ASCII metadata value, returning the previous value for the key.
+    pub fn insert(
+        &mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Option<String>, RpcMetadataError> {
+        let key = key.into();
+        let value = value.into();
+        let parsed_key = key
+            .parse::<AsciiMetadataKey>()
+            .map_err(|_| RpcMetadataError::InvalidAsciiKey { key: key.clone() })?;
+        let parsed_value = value.parse::<AsciiMetadataValue>().map_err(|_| {
+            RpcMetadataError::InvalidAsciiValue {
+                key,
+                value: value.clone(),
+            }
+        })?;
+        Ok(self.inner.insert(parsed_key, parsed_value).map(|previous| {
+            previous
+                .to_str()
+                .expect("ASCII RPC metadata remains valid while stored")
+                .to_owned()
+        }))
+    }
+
+    /// Insert a binary metadata value, returning the previous value for the key.
+    pub fn insert_binary(
+        &mut self,
+        key: impl Into<String>,
+        value: impl Into<Vec<u8>>,
+    ) -> Result<Option<Vec<u8>>, RpcMetadataError> {
+        let key = key.into();
+        let parsed_key = key
+            .parse::<BinaryMetadataKey>()
+            .map_err(|_| RpcMetadataError::InvalidBinaryKey { key })?;
+        Ok(self
+            .inner
+            .insert_bin(parsed_key, BinaryMetadataValue::from_bytes(&value.into()))
+            .map(|previous| {
+                previous
+                    .to_bytes()
+                    .expect("binary RPC metadata remains valid while stored")
+                    .to_vec()
+            }))
+    }
+
+    /// Get an ASCII metadata value.
+    pub fn get_ascii(&self, key: &str) -> Option<&str> {
+        self.inner.get(key).and_then(|value| value.to_str().ok())
+    }
+
+    /// Get a binary metadata value.
+    pub fn get_binary(&self, key: &str) -> Option<Vec<u8>> {
+        self.inner
+            .get_bin(key)
+            .and_then(|value| value.to_bytes().ok())
+            .map(|value| value.to_vec())
+    }
+
+    /// Remove an ASCII metadata value.
+    pub fn remove_ascii(&mut self, key: &str) -> Option<String> {
+        self.inner.remove(key).map(|value| {
+            value
+                .to_str()
+                .expect("ASCII RPC metadata remains valid while stored")
+                .to_owned()
+        })
+    }
+
+    /// Remove a binary metadata value.
+    pub fn remove_binary(&mut self, key: &str) -> Option<Vec<u8>> {
+        self.inner.remove_bin(key).map(|value| {
+            value
+                .to_bytes()
+                .expect("binary RPC metadata remains valid while stored")
+                .to_vec()
+        })
+    }
+
+    /// Iterate over ASCII metadata values.
+    pub fn ascii(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.inner.iter().filter_map(|entry| match entry {
+            KeyAndValueRef::Ascii(key, value) => Some((
+                key.as_str(),
+                value
+                    .to_str()
+                    .expect("ASCII RPC metadata remains valid while stored"),
+            )),
+            KeyAndValueRef::Binary(_, _) => None,
+        })
+    }
+
+    /// Iterate over binary metadata values.
+    pub fn binary(&self) -> impl Iterator<Item = (&str, Vec<u8>)> {
+        self.inner.iter().filter_map(|entry| match entry {
+            KeyAndValueRef::Ascii(_, _) => None,
+            KeyAndValueRef::Binary(key, value) => Some((
+                key.as_str(),
+                value
+                    .to_bytes()
+                    .expect("binary RPC metadata remains valid while stored")
+                    .to_vec(),
+            )),
+        })
+    }
+
+    fn apply_to<T>(&self, request: &mut tonic::Request<T>) {
+        for entry in self.inner.iter() {
+            match entry {
+                KeyAndValueRef::Ascii(key, value) => {
+                    request.metadata_mut().insert(key.clone(), value.clone());
+                }
+                KeyAndValueRef::Binary(key, value) => {
+                    request
+                        .metadata_mut()
+                        .insert_bin(key.clone(), value.clone());
+                }
+            }
+        }
+    }
+}
+
+impl PartialEq for RpcMetadata {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.as_ref() == other.inner.as_ref()
+    }
+}
+
+impl Eq for RpcMetadata {}
+
+/// An invalid key or value supplied to [`RpcMetadata`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RpcMetadataError {
+    /// The key is not valid ASCII gRPC metadata.
+    #[error("invalid ASCII RPC metadata key: {key}")]
+    InvalidAsciiKey {
+        /// The invalid key.
+        key: String,
+    },
+    /// The value is not valid ASCII gRPC metadata.
+    #[error("invalid ASCII RPC metadata value for key {key}: {value:?}")]
+    InvalidAsciiValue {
+        /// The associated key.
+        key: String,
+        /// The invalid value.
+        value: String,
+    },
+    /// The key is not valid binary gRPC metadata.
+    #[error("invalid binary RPC metadata key: {key}")]
+    InvalidBinaryKey {
+        /// The invalid key.
+        key: String,
+    },
+}
+
+/// Controls applied to a single high-level client RPC.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct RpcOptions {
+    /// Metadata attached to the RPC.
+    pub metadata: RpcMetadata,
+    /// Timeout for the RPC, overriding the connection's default deadline.
+    pub timeout: Option<Duration>,
+    /// Retry behavior for the RPC, overriding the connection's retry configuration.
+    pub retry_options: Option<RetryOptions>,
+}
+
+impl RpcOptions {
+    pub(crate) fn apply_to<T>(&self, request: &mut tonic::Request<T>) {
+        self.metadata.apply_to(request);
+        if let Some(timeout) = self.timeout {
+            request.set_timeout(timeout);
+        }
+        if let Some(retry_options) = &self.retry_options {
+            request
+                .extensions_mut()
+                .insert(RetryConfigForCall(retry_options.clone()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_validates_and_exposes_values() {
+        let mut metadata = RpcMetadata::new();
+        assert_eq!(metadata.insert("trace-id", "first").unwrap(), None);
+        assert_eq!(
+            metadata.insert("trace-id", "second").unwrap(),
+            Some("first".to_owned())
+        );
+        assert_eq!(
+            metadata
+                .insert_binary("trace-data-bin", vec![0, 255])
+                .unwrap(),
+            None
+        );
+        assert_eq!(metadata.get_ascii("trace-id"), Some("second"));
+        assert_eq!(metadata.get_binary("trace-data-bin"), Some(vec![0, 255]));
+        assert!(matches!(
+            metadata.insert("bad key", "value"),
+            Err(RpcMetadataError::InvalidAsciiKey { .. })
+        ));
+        assert!(matches!(
+            metadata.insert("valid-key", "bad\nvalue"),
+            Err(RpcMetadataError::InvalidAsciiValue { .. })
+        ));
+        assert!(matches!(
+            metadata.insert_binary("missing-suffix", vec![]),
+            Err(RpcMetadataError::InvalidBinaryKey { .. })
+        ));
+        assert_eq!(metadata.remove_ascii("trace-id"), Some("second".to_owned()));
+        assert_eq!(metadata.remove_binary("trace-data-bin"), Some(vec![0, 255]));
+    }
+}

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -1,4 +1,10 @@
-use crate::{Client, NamespacedClient, grpc::WorkflowService};
+use crate::{
+    BackfillScheduleInput, Client, CreateScheduleInput, CreateScheduleOutput, DeleteScheduleInput,
+    DescribeScheduleInput, DescribeScheduleOutput, ListSchedulesPageInput, ListSchedulesPageOutput,
+    NamespacedClient, Next, PauseScheduleInput, RpcOptions, SendScheduleUpdateInput,
+    TriggerScheduleInput, UnpauseScheduleInput, UpdateScheduleInput, grpc::WorkflowService,
+    interceptors,
+};
 use futures_util::{FutureExt, future::BoxFuture, stream};
 use std::{
     collections::VecDeque,
@@ -122,6 +128,9 @@ pub struct CreateScheduleOptions {
     /// A note to attach to the schedule state (e.g., reason for pausing).
     #[builder(default)]
     pub note: String,
+    /// Controls for the create RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// The action a schedule should perform on each trigger.
@@ -355,6 +364,54 @@ pub struct ListSchedulesOptions {
     /// Query filter string.
     #[builder(default)]
     pub query: String,
+    /// Controls for each list page RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
+}
+
+/// Options for deleting a schedule.
+#[derive(Debug, Clone, Default, bon::Builder)]
+#[non_exhaustive]
+pub struct DeleteScheduleOptions {
+    /// Controls for the delete RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
+}
+
+/// Options for pausing a schedule.
+#[derive(Debug, Clone, Default, bon::Builder)]
+#[non_exhaustive]
+pub struct PauseScheduleOptions {
+    /// Controls for the pause RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
+}
+
+/// Options for unpausing a schedule.
+#[derive(Debug, Clone, Default, bon::Builder)]
+#[non_exhaustive]
+pub struct UnpauseScheduleOptions {
+    /// Controls for the unpause RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
+}
+
+/// Options for triggering a schedule.
+#[derive(Debug, Clone, Default, bon::Builder)]
+#[non_exhaustive]
+pub struct TriggerScheduleOptions {
+    /// Controls for the trigger RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
+}
+
+/// Options for backfilling a schedule.
+#[derive(Debug, Clone, Default, bon::Builder)]
+#[non_exhaustive]
+pub struct BackfillScheduleOptions {
+    /// Controls for the backfill RPC.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
 }
 
 /// A stream of schedule summaries from a list operation.
@@ -997,18 +1054,34 @@ where
     }
 
     /// Describe this schedule, returning its full definition, info, and conflict token.
-    pub async fn describe(&self) -> Result<ScheduleDescription, ScheduleError> {
-        let mut resp = WorkflowService::describe_schedule(
-            &mut self.client.clone(),
-            DescribeScheduleRequest {
-                namespace: self.namespace.clone(),
+    pub async fn describe(
+        &self,
+        rpc_options: RpcOptions,
+    ) -> Result<ScheduleDescription, ScheduleError> {
+        let output = interceptors::call_describe_schedule(
+            self.client.client_interceptors(),
+            DescribeScheduleInput {
                 schedule_id: self.schedule_id.clone(),
-            }
-            .into_request(),
+                rpc_options,
+            },
+            Next::new({
+                let handle = self.clone();
+                move |input: DescribeScheduleInput| -> BoxFuture<
+                    '_,
+                    Result<DescribeScheduleOutput, ScheduleError>,
+                > {
+                    Box::pin(async move {
+                        let response = handle
+                            .describe_raw(input.schedule_id, input.rpc_options)
+                            .await?;
+                        Ok(DescribeScheduleOutput::new(response))
+                    })
+                }
+            }),
         )
-        .await?
-        .into_inner();
+        .await?;
 
+        let mut resp = output.response;
         if let Some(memo) = resp.memo.as_mut() {
             decode_payloads(
                 memo,
@@ -1035,9 +1108,12 @@ where
     /// #     handle: &temporalio_client::schedules::ScheduleHandle<temporalio_client::Client>,
     /// # ) -> Result<(), temporalio_client::schedules::ScheduleError> {
     /// handle
-    ///     .update(|u| {
-    ///         u.set_note("updated").set_paused(true);
-    ///     })
+    ///     .update(
+    ///         |u| {
+    ///             u.set_note("updated").set_paused(true);
+    ///         },
+    ///         Default::default(),
+    ///     )
     ///     .await?;
     /// # Ok(())
     /// # }
@@ -1046,12 +1122,43 @@ where
     // returns FailedPrecondition with "mismatched conflict token".
     pub async fn update(
         &self,
-        updater: impl FnOnce(&mut ScheduleUpdate),
+        updater: impl FnOnce(&mut ScheduleUpdate) + Send + 'static,
+        rpc_options: RpcOptions,
     ) -> Result<(), ScheduleError> {
-        let desc = self.describe().await?;
-        let mut update = desc.into_update();
-        updater(&mut update);
-        self.send_update(update).await
+        interceptors::call_update_schedule(
+            self.client.client_interceptors(),
+            UpdateScheduleInput {
+                schedule_id: self.schedule_id.clone(),
+                rpc_options,
+            },
+            Next::new({
+                let handle = self.clone();
+                move |input: UpdateScheduleInput| -> BoxFuture<'_, Result<(), ScheduleError>> {
+                    Box::pin(async move {
+                        let mut response = handle
+                            .describe_raw(input.schedule_id.clone(), input.rpc_options.clone())
+                            .await?;
+                        decode_payloads(
+                            &mut response,
+                            handle.client.data_converter().codec(),
+                            &SerializationContextData::Workflow,
+                        )
+                        .await;
+                        let description = ScheduleDescription::new(
+                            response,
+                            handle.client.data_converter().clone(),
+                            &input.schedule_id,
+                        )?;
+                        let mut update = description.into_update();
+                        updater(&mut update);
+                        handle
+                            .send_update_raw(input.schedule_id, update, input.rpc_options)
+                            .await
+                    })
+                }
+            }),
+        )
+        .await
     }
 
     /// Send a pre-built [`ScheduleUpdate`] to the server.
@@ -1059,142 +1166,281 @@ where
     /// Prefer [`update()`](Self::update) for most use cases. Use this when you
     /// need to inspect the [`ScheduleDescription`] before deciding what to
     /// change.
-    pub async fn send_update(&self, mut update: ScheduleUpdate) -> Result<(), ScheduleError> {
+    pub async fn send_update(
+        &self,
+        update: ScheduleUpdate,
+        rpc_options: RpcOptions,
+    ) -> Result<(), ScheduleError> {
+        interceptors::call_send_schedule_update(
+            self.client.client_interceptors(),
+            SendScheduleUpdateInput {
+                schedule_id: self.schedule_id.clone(),
+                update,
+                rpc_options,
+            },
+            Next::new({
+                let handle = self.clone();
+                move |input: SendScheduleUpdateInput| -> BoxFuture<'_, Result<(), ScheduleError>> {
+                    Box::pin(async move {
+                        handle
+                            .send_update_raw(input.schedule_id, input.update, input.rpc_options)
+                            .await
+                    })
+                }
+            }),
+        )
+        .await
+    }
+
+    async fn describe_raw(
+        &self,
+        schedule_id: String,
+        rpc_options: RpcOptions,
+    ) -> Result<DescribeScheduleResponse, ScheduleError> {
+        let mut request = DescribeScheduleRequest {
+            namespace: self.namespace.clone(),
+            schedule_id,
+        }
+        .into_request();
+        rpc_options.apply_to(&mut request);
+        Ok(
+            WorkflowService::describe_schedule(&mut self.client.clone(), request)
+                .await?
+                .into_inner(),
+        )
+    }
+
+    async fn send_update_raw(
+        &self,
+        schedule_id: String,
+        mut update: ScheduleUpdate,
+        rpc_options: RpcOptions,
+    ) -> Result<(), ScheduleError> {
         if let Some(action) = update.pending_action.take() {
             update.schedule.action = Some(action.into_proto(self.client.data_converter()).await?);
         }
-        WorkflowService::update_schedule(
-            &mut self.client.clone(),
-            UpdateScheduleRequest {
-                namespace: self.namespace.clone(),
-                schedule_id: self.schedule_id.clone(),
-                schedule: Some(update.schedule),
-                identity: self.client.identity(),
-                request_id: Uuid::new_v4().to_string(),
-                ..Default::default()
-            }
-            .into_request(),
-        )
-        .await?;
+        let mut request = UpdateScheduleRequest {
+            namespace: self.namespace.clone(),
+            schedule_id,
+            schedule: Some(update.schedule),
+            identity: self.client.identity(),
+            request_id: Uuid::new_v4().to_string(),
+            ..Default::default()
+        }
+        .into_request();
+        rpc_options.apply_to(&mut request);
+        WorkflowService::update_schedule(&mut self.client.clone(), request).await?;
         Ok(())
     }
 
     /// Delete this schedule.
-    pub async fn delete(&self) -> Result<(), ScheduleError> {
-        WorkflowService::delete_schedule(
-            &mut self.client.clone(),
-            DeleteScheduleRequest {
-                namespace: self.namespace.clone(),
+    pub async fn delete(&self, options: DeleteScheduleOptions) -> Result<(), ScheduleError> {
+        let rpc_options = options.rpc_options;
+        interceptors::call_delete_schedule(
+            self.client.client_interceptors(),
+            DeleteScheduleInput {
                 schedule_id: self.schedule_id.clone(),
-                identity: self.client.identity(),
-            }
-            .into_request(),
+                rpc_options,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                let namespace = self.namespace.clone();
+                move |input: DeleteScheduleInput| -> BoxFuture<'_, Result<(), ScheduleError>> {
+                    Box::pin(async move {
+                        let mut request = DeleteScheduleRequest {
+                            namespace,
+                            schedule_id: input.schedule_id,
+                            identity: client.identity(),
+                        }
+                        .into_request();
+                        input.rpc_options.apply_to(&mut request);
+                        WorkflowService::delete_schedule(&mut client, request).await?;
+                        Ok(())
+                    })
+                }
+            }),
         )
-        .await?;
-        Ok(())
+        .await
     }
 
     /// Pause the schedule with an optional note.
     ///
     /// If `note` is `None`, a default note is used.
-    pub async fn pause(&self, note: Option<impl Into<String>>) -> Result<(), ScheduleError> {
+    pub async fn pause(
+        &self,
+        note: Option<impl Into<String>>,
+        options: PauseScheduleOptions,
+    ) -> Result<(), ScheduleError> {
         let note = note.map_or_else(|| "Paused via Rust SDK".to_string(), |s| s.into());
-        WorkflowService::patch_schedule(
-            &mut self.client.clone(),
-            PatchScheduleRequest {
-                namespace: self.namespace.clone(),
+        let rpc_options = options.rpc_options;
+        interceptors::call_pause_schedule(
+            self.client.client_interceptors(),
+            PauseScheduleInput {
                 schedule_id: self.schedule_id.clone(),
-                patch: Some(schedule_proto::SchedulePatch {
-                    pause: note,
-                    ..Default::default()
-                }),
-                identity: self.client.identity(),
-                request_id: Uuid::new_v4().to_string(),
-            }
-            .into_request(),
+                note,
+                rpc_options,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                let namespace = self.namespace.clone();
+                move |input: PauseScheduleInput| -> BoxFuture<'_, Result<(), ScheduleError>> {
+                    Box::pin(async move {
+                        let mut request = PatchScheduleRequest {
+                            namespace,
+                            schedule_id: input.schedule_id,
+                            patch: Some(schedule_proto::SchedulePatch {
+                                pause: input.note,
+                                ..Default::default()
+                            }),
+                            identity: client.identity(),
+                            request_id: Uuid::new_v4().to_string(),
+                        }
+                        .into_request();
+                        input.rpc_options.apply_to(&mut request);
+                        WorkflowService::patch_schedule(&mut client, request).await?;
+                        Ok(())
+                    })
+                }
+            }),
         )
-        .await?;
-        Ok(())
+        .await
     }
 
     /// Unpause the schedule with an optional note.
     ///
     /// If `note` is `None`, a default note is used.
-    pub async fn unpause(&self, note: Option<impl Into<String>>) -> Result<(), ScheduleError> {
+    pub async fn unpause(
+        &self,
+        note: Option<impl Into<String>>,
+        options: UnpauseScheduleOptions,
+    ) -> Result<(), ScheduleError> {
         let note = note.map_or_else(|| "Unpaused via Rust SDK".to_string(), |s| s.into());
-        WorkflowService::patch_schedule(
-            &mut self.client.clone(),
-            PatchScheduleRequest {
-                namespace: self.namespace.clone(),
+        let rpc_options = options.rpc_options;
+        interceptors::call_unpause_schedule(
+            self.client.client_interceptors(),
+            UnpauseScheduleInput {
                 schedule_id: self.schedule_id.clone(),
-                patch: Some(schedule_proto::SchedulePatch {
-                    unpause: note,
-                    ..Default::default()
-                }),
-                identity: self.client.identity(),
-                request_id: Uuid::new_v4().to_string(),
-            }
-            .into_request(),
+                note,
+                rpc_options,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                let namespace = self.namespace.clone();
+                move |input: UnpauseScheduleInput| -> BoxFuture<'_, Result<(), ScheduleError>> {
+                    Box::pin(async move {
+                        let mut request = PatchScheduleRequest {
+                            namespace,
+                            schedule_id: input.schedule_id,
+                            patch: Some(schedule_proto::SchedulePatch {
+                                unpause: input.note,
+                                ..Default::default()
+                            }),
+                            identity: client.identity(),
+                            request_id: Uuid::new_v4().to_string(),
+                        }
+                        .into_request();
+                        input.rpc_options.apply_to(&mut request);
+                        WorkflowService::patch_schedule(&mut client, request).await?;
+                        Ok(())
+                    })
+                }
+            }),
         )
-        .await?;
-        Ok(())
+        .await
     }
 
     /// Trigger the schedule to run immediately with the given overlap policy.
     pub async fn trigger(
         &self,
         overlap_policy: ScheduleOverlapPolicy,
+        options: TriggerScheduleOptions,
     ) -> Result<(), ScheduleError> {
-        WorkflowService::patch_schedule(
-            &mut self.client.clone(),
-            PatchScheduleRequest {
-                namespace: self.namespace.clone(),
+        let rpc_options = options.rpc_options;
+        interceptors::call_trigger_schedule(
+            self.client.client_interceptors(),
+            TriggerScheduleInput {
                 schedule_id: self.schedule_id.clone(),
-                patch: Some(schedule_proto::SchedulePatch {
-                    trigger_immediately: Some(schedule_proto::TriggerImmediatelyRequest {
-                        overlap_policy: overlap_policy.to_proto(),
-                        scheduled_time: None,
-                    }),
-                    ..Default::default()
-                }),
-                identity: self.client.identity(),
-                request_id: Uuid::new_v4().to_string(),
-            }
-            .into_request(),
+                overlap_policy,
+                rpc_options,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                let namespace = self.namespace.clone();
+                move |input: TriggerScheduleInput| -> BoxFuture<'_, Result<(), ScheduleError>> {
+                    Box::pin(async move {
+                        let mut request = PatchScheduleRequest {
+                            namespace,
+                            schedule_id: input.schedule_id,
+                            patch: Some(schedule_proto::SchedulePatch {
+                                trigger_immediately: Some(
+                                    schedule_proto::TriggerImmediatelyRequest {
+                                        overlap_policy: input.overlap_policy.to_proto(),
+                                        scheduled_time: None,
+                                    },
+                                ),
+                                ..Default::default()
+                            }),
+                            identity: client.identity(),
+                            request_id: Uuid::new_v4().to_string(),
+                        }
+                        .into_request();
+                        input.rpc_options.apply_to(&mut request);
+                        WorkflowService::patch_schedule(&mut client, request).await?;
+                        Ok(())
+                    })
+                }
+            }),
         )
-        .await?;
-        Ok(())
+        .await
     }
 
     /// Request backfill of missed runs.
     pub async fn backfill(
         &self,
         backfills: impl IntoIterator<Item = ScheduleBackfill>,
+        options: BackfillScheduleOptions,
     ) -> Result<(), ScheduleError> {
-        let backfill_requests: Vec<schedule_proto::BackfillRequest> = backfills
-            .into_iter()
-            .map(|b| schedule_proto::BackfillRequest {
-                start_time: Some(b.start_time.into()),
-                end_time: Some(b.end_time.into()),
-                overlap_policy: b.overlap_policy.to_proto(),
-            })
-            .collect();
-        WorkflowService::patch_schedule(
-            &mut self.client.clone(),
-            PatchScheduleRequest {
-                namespace: self.namespace.clone(),
+        let rpc_options = options.rpc_options;
+        interceptors::call_backfill_schedule(
+            self.client.client_interceptors(),
+            BackfillScheduleInput {
                 schedule_id: self.schedule_id.clone(),
-                patch: Some(schedule_proto::SchedulePatch {
-                    backfill_request: backfill_requests,
-                    ..Default::default()
-                }),
-                identity: self.client.identity(),
-                request_id: Uuid::new_v4().to_string(),
-            }
-            .into_request(),
+                backfills: backfills.into_iter().collect(),
+                rpc_options,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                let namespace = self.namespace.clone();
+                move |input: BackfillScheduleInput| -> BoxFuture<'_, Result<(), ScheduleError>> {
+                    Box::pin(async move {
+                        let backfill_requests = input
+                            .backfills
+                            .into_iter()
+                            .map(|backfill| schedule_proto::BackfillRequest {
+                                start_time: Some(backfill.start_time.into()),
+                                end_time: Some(backfill.end_time.into()),
+                                overlap_policy: backfill.overlap_policy.to_proto(),
+                            })
+                            .collect();
+                        let mut request = PatchScheduleRequest {
+                            namespace,
+                            schedule_id: input.schedule_id,
+                            patch: Some(schedule_proto::SchedulePatch {
+                                backfill_request: backfill_requests,
+                                ..Default::default()
+                            }),
+                            identity: client.identity(),
+                            request_id: Uuid::new_v4().to_string(),
+                        }
+                        .into_request();
+                        input.rpc_options.apply_to(&mut request);
+                        WorkflowService::patch_schedule(&mut client, request).await?;
+                        Ok(())
+                    })
+                }
+            }),
         )
-        .await?;
-        Ok(())
+        .await
     }
 }
 
@@ -1208,53 +1454,72 @@ impl Client {
     ) -> Result<ScheduleHandle<Self>, ScheduleError> {
         let schedule_id = schedule_id.into();
         let namespace = self.namespace();
-
-        let initial_patch = if opts.trigger_immediately {
-            Some(schedule_proto::SchedulePatch {
-                trigger_immediately: Some(schedule_proto::TriggerImmediatelyRequest {
-                    // Always use AllowAll for the initial trigger so the
-                    // schedule fires immediately regardless of overlap state.
-                    overlap_policy: ScheduleOverlapPolicy::AllowAll.to_proto(),
-                    scheduled_time: None,
-                }),
-                ..Default::default()
-            })
-        } else {
-            None
-        };
-        // Only send explicit policies when the user set a non-default overlap
-        // policy, so the server uses its own defaults otherwise.
-        let policies = (opts.overlap_policy != ScheduleOverlapPolicy::Unspecified).then(|| {
-            schedule_proto::SchedulePolicies {
-                overlap_policy: opts.overlap_policy.to_proto(),
-                ..Default::default()
-            }
-        });
-        let schedule = schedule_proto::Schedule {
-            spec: Some(opts.spec.into_proto()),
-            action: Some(opts.action.into_proto(self.data_converter()).await?),
-            policies,
-            state: Some(schedule_proto::ScheduleState {
-                paused: opts.paused,
-                notes: opts.note,
-                ..Default::default()
+        let output = interceptors::call_create_schedule(
+            self.client_interceptors(),
+            CreateScheduleInput {
+                schedule_id,
+                options: opts,
+            },
+            Next::new({
+                let mut client = self.clone();
+                move |input: CreateScheduleInput| -> BoxFuture<
+                    '_,
+                    Result<CreateScheduleOutput, ScheduleError>,
+                > {
+                    Box::pin(async move {
+                        let options = input.options;
+                        let initial_patch = options.trigger_immediately.then(|| {
+                            schedule_proto::SchedulePatch {
+                                trigger_immediately: Some(
+                                    schedule_proto::TriggerImmediatelyRequest {
+                                        overlap_policy: ScheduleOverlapPolicy::AllowAll.to_proto(),
+                                        scheduled_time: None,
+                                    },
+                                ),
+                                ..Default::default()
+                            }
+                        });
+                        let policies = (options.overlap_policy
+                            != ScheduleOverlapPolicy::Unspecified)
+                            .then(|| schedule_proto::SchedulePolicies {
+                                overlap_policy: options.overlap_policy.to_proto(),
+                                ..Default::default()
+                            });
+                        let schedule = schedule_proto::Schedule {
+                            spec: Some(options.spec.into_proto()),
+                            action: Some(
+                                options.action.into_proto(client.data_converter()).await?,
+                            ),
+                            policies,
+                            state: Some(schedule_proto::ScheduleState {
+                                paused: options.paused,
+                                notes: options.note,
+                                ..Default::default()
+                            }),
+                        };
+                        let mut request = CreateScheduleRequest {
+                            namespace: client.namespace(),
+                            schedule_id: input.schedule_id.clone(),
+                            schedule: Some(schedule),
+                            initial_patch,
+                            identity: client.identity(),
+                            request_id: Uuid::new_v4().to_string(),
+                            ..Default::default()
+                        }
+                        .into_request();
+                        options.rpc_options.apply_to(&mut request);
+                        WorkflowService::create_schedule(&mut client, request).await?;
+                        Ok(CreateScheduleOutput::new(input.schedule_id))
+                    })
+                }
             }),
-        };
-        WorkflowService::create_schedule(
-            &mut self.clone(),
-            CreateScheduleRequest {
-                namespace: namespace.clone(),
-                schedule_id: schedule_id.clone(),
-                schedule: Some(schedule),
-                initial_patch,
-                identity: self.identity(),
-                request_id: Uuid::new_v4().to_string(),
-                ..Default::default()
-            }
-            .into_request(),
         )
         .await?;
-        Ok(ScheduleHandle::new(self.clone(), namespace, schedule_id))
+        Ok(ScheduleHandle::new(
+            self.clone(),
+            namespace,
+            output.schedule_id,
+        ))
     }
 
     /// Get a handle to an existing schedule by ID.
@@ -1269,13 +1534,15 @@ impl Client {
         let namespace = self.namespace();
         let query = opts.query;
         let page_size = opts.maximum_page_size;
+        let rpc_options = opts.rpc_options;
 
         let stream = stream::unfold(
             (Vec::new(), VecDeque::new(), false),
             move |(next_page_token, mut buffer, exhausted)| {
-                let mut client = client.clone();
+                let client = client.clone();
                 let namespace = namespace.clone();
                 let query = query.clone();
+                let rpc_options = rpc_options.clone();
 
                 async move {
                     if let Some(item) = buffer.pop_front() {
@@ -1284,26 +1551,50 @@ impl Client {
                         return None;
                     }
 
-                    let response = WorkflowService::list_schedules(
-                        &mut client,
-                        ListSchedulesRequest {
-                            namespace,
+                    let response = interceptors::call_list_schedules_page(
+                        client.client_interceptors(),
+                        ListSchedulesPageInput {
                             maximum_page_size: page_size,
-                            next_page_token: next_page_token.clone(),
                             query,
-                        }
-                        .into_request(),
+                            next_page_token: next_page_token.clone(),
+                            rpc_options,
+                        },
+                        Next::new({
+                            let mut rpc_client = client.clone();
+                            move |input: ListSchedulesPageInput| -> BoxFuture<
+                                '_,
+                                Result<ListSchedulesPageOutput, ScheduleError>,
+                            > {
+                                Box::pin(async move {
+                                    let mut request = ListSchedulesRequest {
+                                        namespace,
+                                        maximum_page_size: input.maximum_page_size,
+                                        next_page_token: input.next_page_token,
+                                        query: input.query,
+                                    }
+                                    .into_request();
+                                    input.rpc_options.apply_to(&mut request);
+                                    let response =
+                                        WorkflowService::list_schedules(&mut rpc_client, request)
+                                            .await?
+                                            .into_inner();
+                                    Ok(ListSchedulesPageOutput::new(
+                                        response.schedules,
+                                        response.next_page_token,
+                                    ))
+                                })
+                            }
+                        }),
                     )
                     .await;
 
                     match response {
-                        Ok(resp) => {
-                            let mut resp = resp.into_inner();
-                            let new_exhausted = resp.next_page_token.is_empty();
-                            let new_token = resp.next_page_token;
+                        Ok(mut output) => {
+                            let new_exhausted = output.next_page_token.is_empty();
+                            let new_token = output.next_page_token;
 
                             let data_converter = client.data_converter().clone();
-                            for schedule in &mut resp.schedules {
+                            for schedule in &mut output.schedules {
                                 if let Some(memo) = schedule.memo.as_mut() {
                                     decode_payloads(
                                         memo,
@@ -1313,7 +1604,7 @@ impl Client {
                                     .await;
                                 }
                             }
-                            buffer = resp
+                            buffer = output
                                 .schedules
                                 .into_iter()
                                 .map(|raw| ScheduleSummary::new(raw, data_converter.clone()))
@@ -1323,7 +1614,7 @@ impl Client {
                                 .pop_front()
                                 .map(|item| (Ok(item), (new_token, buffer, new_exhausted)))
                         }
-                        Err(e) => Some((Err(e.into()), (next_page_token, buffer, true))),
+                        Err(e) => Some((Err(e), (next_page_token, buffer, true))),
                     }
                 }
             },
@@ -1336,7 +1627,11 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{NamespacedClient, grpc::WorkflowService, test_helpers::XorCodec};
+    use crate::{
+        ClientInterceptor, DescribeScheduleInput, DescribeScheduleOutput, NamespacedClient, Next,
+        SendScheduleUpdateInput, UpdateScheduleInput, grpc::WorkflowService,
+        test_helpers::XorCodec,
+    };
     use futures_util::FutureExt;
     use std::{
         collections::HashMap,
@@ -1392,6 +1687,7 @@ mod tests {
         describe_response: DescribeScheduleResponse,
         data_converter: DataConverter,
         should_error: bool,
+        interceptors: Vec<Arc<dyn ClientInterceptor>>,
     }
 
     impl Default for MockScheduleClient {
@@ -1401,6 +1697,7 @@ mod tests {
                 describe_response: describe_response_with_start_workflow(None),
                 data_converter: DataConverter::default(),
                 should_error: false,
+                interceptors: Vec::new(),
             }
         }
     }
@@ -1414,6 +1711,53 @@ mod tests {
         }
         fn data_converter(&self) -> &DataConverter {
             &self.data_converter
+        }
+        fn client_interceptors(&self) -> &[Arc<dyn ClientInterceptor>] {
+            &self.interceptors
+        }
+    }
+
+    #[derive(Default)]
+    struct ScheduleHookCounts {
+        describe: AtomicUsize,
+        update: AtomicUsize,
+        send_update: AtomicUsize,
+    }
+
+    struct RecordingScheduleInterceptor {
+        counts: Arc<ScheduleHookCounts>,
+    }
+
+    impl ClientInterceptor for RecordingScheduleInterceptor {
+        fn describe_schedule<'a>(
+            &'a self,
+            input: DescribeScheduleInput,
+            next: Next<
+                'a,
+                DescribeScheduleInput,
+                BoxFuture<'a, Result<DescribeScheduleOutput, ScheduleError>>,
+            >,
+        ) -> BoxFuture<'a, Result<DescribeScheduleOutput, ScheduleError>> {
+            self.counts.describe.fetch_add(1, Ordering::SeqCst);
+            next.run(input)
+        }
+
+        fn update_schedule<'a>(
+            &'a self,
+            input: UpdateScheduleInput,
+            next: Next<'a, UpdateScheduleInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+        ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+            self.counts.update.fetch_add(1, Ordering::SeqCst);
+            next.run(input)
+        }
+
+        fn send_schedule_update<'a>(
+            &'a self,
+            input: SendScheduleUpdateInput,
+            next: Next<'a, SendScheduleUpdateInput, BoxFuture<'a, Result<(), ScheduleError>>>,
+        ) -> BoxFuture<'a, Result<(), ScheduleError>> {
+            self.counts.send_update.fetch_add(1, Ordering::SeqCst);
+            next.run(input)
         }
     }
 
@@ -1580,7 +1924,7 @@ mod tests {
         };
 
         let handle = make_schedule_handle(client.clone());
-        let desc = handle.describe().await.unwrap();
+        let desc = handle.describe(RpcOptions::default()).await.unwrap();
 
         assert_eq!(client.captured.describe.load(Ordering::SeqCst), 1);
         assert!(desc.raw().schedule.is_some());
@@ -1611,7 +1955,10 @@ mod tests {
             ..Default::default()
         };
 
-        let description = make_schedule_handle(client).describe().await.unwrap();
+        let description = make_schedule_handle(client)
+            .describe(RpcOptions::default())
+            .await
+            .unwrap();
 
         assert_eq!(
             description.memo().get::<String>("memo-key").unwrap(),
@@ -1652,12 +1999,43 @@ mod tests {
         let handle = make_schedule_handle(client.clone());
 
         handle
-            .update(|u| {
-                u.set_note("hi");
-            })
+            .update(
+                |u| {
+                    u.set_note("hi");
+                },
+                RpcOptions::default(),
+            )
             .await
             .unwrap();
 
+        assert_eq!(client.captured.describe.load(Ordering::SeqCst), 1);
+        assert_eq!(client.captured.update.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn schedule_update_does_not_nest_describe_or_send_update_hooks() {
+        let counts = Arc::new(ScheduleHookCounts::default());
+        let client = MockScheduleClient {
+            interceptors: vec![Arc::new(RecordingScheduleInterceptor {
+                counts: counts.clone(),
+            })],
+            ..Default::default()
+        };
+        let handle = make_schedule_handle(client.clone());
+
+        handle
+            .update(
+                |update| {
+                    update.set_note("updated");
+                },
+                RpcOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(counts.update.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.describe.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.send_update.load(Ordering::SeqCst), 0);
         assert_eq!(client.captured.describe.load(Ordering::SeqCst), 1);
         assert_eq!(client.captured.update.load(Ordering::SeqCst), 1);
     }
@@ -1667,8 +2045,8 @@ mod tests {
         let client = MockScheduleClient::default();
         let handle = make_schedule_handle(client.clone());
 
-        handle.update(|_| {}).await.unwrap();
-        handle.update(|_| {}).await.unwrap();
+        handle.update(|_| {}, RpcOptions::default()).await.unwrap();
+        handle.update(|_| {}, RpcOptions::default()).await.unwrap();
 
         assert_eq!(client.captured.update.load(Ordering::SeqCst), 2);
     }
@@ -1678,7 +2056,10 @@ mod tests {
         let client = MockScheduleClient::default();
         let handle = make_schedule_handle(client.clone());
 
-        handle.delete().await.unwrap();
+        handle
+            .delete(DeleteScheduleOptions::default())
+            .await
+            .unwrap();
 
         assert_eq!(client.captured.delete.load(Ordering::SeqCst), 1);
     }
@@ -1688,7 +2069,10 @@ mod tests {
         let client = MockScheduleClient::default();
         let handle = make_schedule_handle(client.clone());
 
-        handle.pause(Some("taking a break")).await.unwrap();
+        handle
+            .pause(Some("taking a break"), PauseScheduleOptions::default())
+            .await
+            .unwrap();
 
         assert_eq!(client.captured.patch.load(Ordering::SeqCst), 1);
     }
@@ -1698,7 +2082,10 @@ mod tests {
         let client = MockScheduleClient::default();
         let handle = make_schedule_handle(client.clone());
 
-        handle.pause(None::<&str>).await.unwrap();
+        handle
+            .pause(None::<&str>, PauseScheduleOptions::default())
+            .await
+            .unwrap();
 
         assert_eq!(client.captured.patch.load(Ordering::SeqCst), 1);
     }
@@ -1708,7 +2095,10 @@ mod tests {
         let client = MockScheduleClient::default();
         let handle = make_schedule_handle(client.clone());
 
-        handle.unpause(Some("resuming work")).await.unwrap();
+        handle
+            .unpause(Some("resuming work"), UnpauseScheduleOptions::default())
+            .await
+            .unwrap();
 
         assert_eq!(client.captured.patch.load(Ordering::SeqCst), 1);
     }
@@ -1719,7 +2109,10 @@ mod tests {
         let handle = make_schedule_handle(client.clone());
 
         handle
-            .trigger(ScheduleOverlapPolicy::Unspecified)
+            .trigger(
+                ScheduleOverlapPolicy::Unspecified,
+                TriggerScheduleOptions::default(),
+            )
             .await
             .unwrap();
 
@@ -1733,14 +2126,17 @@ mod tests {
 
         let now = SystemTime::now();
         handle
-            .backfill(vec![
-                ScheduleBackfill::new(now, now)
-                    .overlap_policy(ScheduleOverlapPolicy::Skip)
-                    .build(),
-                ScheduleBackfill::new(now, now)
-                    .overlap_policy(ScheduleOverlapPolicy::BufferOne)
-                    .build(),
-            ])
+            .backfill(
+                vec![
+                    ScheduleBackfill::new(now, now)
+                        .overlap_policy(ScheduleOverlapPolicy::Skip)
+                        .build(),
+                    ScheduleBackfill::new(now, now)
+                        .overlap_policy(ScheduleOverlapPolicy::BufferOne)
+                        .build(),
+                ],
+                BackfillScheduleOptions::default(),
+            )
             .await
             .unwrap();
 
@@ -1755,7 +2151,7 @@ mod tests {
         };
         let handle = make_schedule_handle(client);
 
-        let err = handle.describe().await.unwrap_err();
+        let err = handle.describe(RpcOptions::default()).await.unwrap_err();
         assert!(
             matches!(err, ScheduleError::Rpc(_)),
             "expected Rpc variant, got: {err:?}"
@@ -1771,7 +2167,10 @@ mod tests {
         };
         let handle = make_schedule_handle(client);
 
-        let err = handle.update(|_| {}).await.unwrap_err();
+        let err = handle
+            .update(|_| {}, RpcOptions::default())
+            .await
+            .unwrap_err();
         assert!(matches!(err, ScheduleError::Rpc(_)));
     }
 
@@ -1783,7 +2182,10 @@ mod tests {
         };
         let handle = make_schedule_handle(client);
 
-        let err = handle.delete().await.unwrap_err();
+        let err = handle
+            .delete(DeleteScheduleOptions::default())
+            .await
+            .unwrap_err();
         assert!(matches!(err, ScheduleError::Rpc(_)));
     }
 
@@ -1795,10 +2197,30 @@ mod tests {
         };
         let handle = make_schedule_handle(client);
 
-        assert!(handle.pause(Some("")).await.is_err());
-        assert!(handle.unpause(Some("")).await.is_err());
-        assert!(handle.trigger(Default::default()).await.is_err());
-        assert!(handle.backfill(vec![]).await.is_err());
+        assert!(
+            handle
+                .pause(Some(""), PauseScheduleOptions::default())
+                .await
+                .is_err()
+        );
+        assert!(
+            handle
+                .unpause(Some(""), UnpauseScheduleOptions::default())
+                .await
+                .is_err()
+        );
+        assert!(
+            handle
+                .trigger(Default::default(), TriggerScheduleOptions::default())
+                .await
+                .is_err()
+        );
+        assert!(
+            handle
+                .backfill(vec![], BackfillScheduleOptions::default())
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -1806,10 +2228,22 @@ mod tests {
         let client = MockScheduleClient::default();
         let handle = make_schedule_handle(client.clone());
 
-        handle.pause(Some("p")).await.unwrap();
-        handle.unpause(Some("u")).await.unwrap();
-        handle.trigger(Default::default()).await.unwrap();
-        handle.backfill(vec![]).await.unwrap();
+        handle
+            .pause(Some("p"), PauseScheduleOptions::default())
+            .await
+            .unwrap();
+        handle
+            .unpause(Some("u"), UnpauseScheduleOptions::default())
+            .await
+            .unwrap();
+        handle
+            .trigger(Default::default(), TriggerScheduleOptions::default())
+            .await
+            .unwrap();
+        handle
+            .backfill(vec![], BackfillScheduleOptions::default())
+            .await
+            .unwrap();
 
         assert_eq!(client.captured.patch.load(Ordering::SeqCst), 4);
     }
@@ -1864,7 +2298,7 @@ mod tests {
         };
 
         let handle = make_schedule_handle(client);
-        let desc = handle.describe().await.unwrap();
+        let desc = handle.describe(RpcOptions::default()).await.unwrap();
 
         assert!(desc.paused());
         assert_eq!(desc.note(), Some("maintenance window"));
@@ -1891,7 +2325,7 @@ mod tests {
         let client = MockScheduleClient::default();
 
         let handle = make_schedule_handle(client);
-        let desc = handle.describe().await.unwrap();
+        let desc = handle.describe(RpcOptions::default()).await.unwrap();
 
         assert!(!desc.paused());
         assert_eq!(desc.note(), None);
@@ -1920,7 +2354,7 @@ mod tests {
         };
 
         let handle = make_schedule_handle(client);
-        let desc = handle.describe().await.unwrap();
+        let desc = handle.describe(RpcOptions::default()).await.unwrap();
         assert_eq!(desc.note(), None);
     }
 
@@ -2081,7 +2515,7 @@ mod tests {
         };
         let handle = make_schedule_handle(client);
 
-        let err = handle.describe().await.unwrap_err();
+        let err = handle.describe(RpcOptions::default()).await.unwrap_err();
         assert_eq!(
             err.to_string(),
             format!("Malformed schedule description for schedule ID 'test-schedule-id': {reason}")

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -1,13 +1,19 @@
 use crate::{
-    NamespacedClient, WorkflowCancelOptions, WorkflowDescribeOptions, WorkflowExecuteUpdateOptions,
-    WorkflowExecutionStatus, WorkflowFetchHistoryOptions, WorkflowGetResultOptions,
-    WorkflowQueryOptions, WorkflowSignalOptions, WorkflowStartUpdateOptions,
-    WorkflowTerminateOptions, WorkflowUpdateWaitStage,
+    CancelWorkflowInput, DescribeWorkflowInput, DescribeWorkflowOutput,
+    FetchWorkflowHistoryPageInput, FetchWorkflowHistoryPageOutput, NamespacedClient, Next,
+    PollWorkflowUpdateInput, PollWorkflowUpdateOutput, QueryWorkflowInput, QueryWorkflowOutput,
+    RpcOptions, SignalWorkflowInput, StartWorkflowUpdateInput, StartWorkflowUpdateOutput,
+    TerminateWorkflowInput, WorkflowCancelOptions, WorkflowDescribeOptions,
+    WorkflowExecuteUpdateOptions, WorkflowExecutionStatus, WorkflowFetchHistoryOptions,
+    WorkflowGetResultOptions, WorkflowQueryOptions, WorkflowSignalOptions,
+    WorkflowStartUpdateOptions, WorkflowTerminateOptions, WorkflowUpdateWaitStage,
     errors::{
         WorkflowGetResultError, WorkflowInteractionError, WorkflowQueryError, WorkflowUpdateError,
     },
     grpc::WorkflowService,
+    interceptors,
 };
+use futures_util::future::BoxFuture;
 use std::{fmt::Debug, marker::PhantomData};
 pub use temporalio_common::UntypedWorkflow;
 use temporalio_common::{
@@ -541,6 +547,7 @@ where
             .skip_archival(true)
             .wait_new_event(true)
             .event_filter_type(HistoryEventFilterType::CloseEvent)
+            .rpc_options(opts.rpc_options.clone())
             .build();
 
         loop {
@@ -646,33 +653,64 @@ where
         S: SignalDefinition<Workflow = W::Run>,
         S::Input: Send,
     {
-        let payloads = self
-            .client
-            .data_converter()
-            .to_payloads(&SerializationContextData::Workflow, &input)
-            .await?;
-        WorkflowService::signal_workflow_execution(
-            &mut self.client.clone(),
-            SignalWorkflowExecutionRequest {
-                namespace: self.client.namespace(),
-                workflow_execution: Some(ProtoWorkflowExecution {
-                    workflow_id: self.info.workflow_id.clone(),
-                    run_id: self.info.run_id.clone().unwrap_or_default(),
-                }),
-                signal_name: signal.name().to_string(),
-                input: Some(Payloads { payloads }),
-                identity: self.client.identity(),
-                request_id: opts
-                    .request_id
-                    .unwrap_or_else(|| Uuid::new_v4().to_string()),
-                header: opts.header,
-                ..Default::default()
-            }
-            .into_request(),
+        interceptors::call_signal_workflow(
+            self.client.client_interceptors(),
+            SignalWorkflowInput::new(
+                self.info.workflow_id.clone(),
+                self.info.run_id.clone().unwrap_or_default(),
+                signal.name().to_string(),
+                input,
+                opts,
+            ),
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: SignalWorkflowInput| -> BoxFuture<
+                    '_,
+                    Result<(), WorkflowInteractionError>,
+                > {
+                    Box::pin(async move {
+                        let (workflow_id, run_id, signal_name, args, options) =
+                            input.into_parts();
+                        let data_converter = client.data_converter().clone();
+                        let unencoded_payloads = {
+                            let payload_converter = data_converter.payload_converter();
+                            let context = SerializationContext {
+                                data: &SerializationContextData::Workflow,
+                                converter: payload_converter,
+                            };
+                            args.serialize_payloads(&context)
+                        };
+                        drop(args);
+                        let payloads = data_converter
+                            .codec()
+                            .encode(&SerializationContextData::Workflow, unencoded_payloads?)
+                            .await;
+                        let mut request = SignalWorkflowExecutionRequest {
+                            namespace: client.namespace(),
+                            workflow_execution: Some(ProtoWorkflowExecution {
+                                workflow_id,
+                                run_id,
+                            }),
+                            signal_name,
+                            input: Some(Payloads { payloads }),
+                            identity: client.identity(),
+                            request_id: options
+                                .request_id
+                                .unwrap_or_else(|| Uuid::new_v4().to_string()),
+                            header: options.header,
+                            ..Default::default()
+                        }
+                        .into_request();
+                        options.rpc_options.apply_to(&mut request);
+                        WorkflowService::signal_workflow_execution(&mut client, request)
+                            .await
+                            .map_err(WorkflowInteractionError::from_status)?;
+                        Ok(())
+                    })
+                }
+            }),
         )
         .await
-        .map_err(WorkflowInteractionError::from_status)?;
-        Ok(())
     }
 
     /// Query the workflow
@@ -687,33 +725,67 @@ where
         Q: QueryDefinition<Workflow = W::Run>,
         Q::Input: Send,
     {
-        let dc = self.client.data_converter();
-        let payloads = dc
-            .to_payloads(&SerializationContextData::Workflow, &input)
-            .await?;
-        let response = self
-            .client
-            .clone()
-            .query_workflow(
-                QueryWorkflowRequest {
-                    namespace: self.client.namespace(),
-                    execution: Some(ProtoWorkflowExecution {
-                        workflow_id: self.info.workflow_id.clone(),
-                        run_id: self.info.run_id.clone().unwrap_or_default(),
-                    }),
-                    query: Some(WorkflowQuery {
-                        query_type: query.name().to_string(),
-                        query_args: Some(Payloads { payloads }),
-                        header: opts.header,
-                    }),
-                    // Default to None (1) which means don't reject
-                    query_reject_condition: opts.reject_condition.map(|c| c as i32).unwrap_or(1),
+        let output = interceptors::call_query_workflow(
+            self.client.client_interceptors(),
+            QueryWorkflowInput::new(
+                self.info.workflow_id.clone(),
+                self.info.run_id.clone().unwrap_or_default(),
+                query.name().to_string(),
+                input,
+                opts,
+            ),
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: QueryWorkflowInput| -> BoxFuture<
+                    '_,
+                    Result<QueryWorkflowOutput, WorkflowQueryError>,
+                > {
+                    Box::pin(async move {
+                        let (workflow_id, run_id, query_name, args, options) = input.into_parts();
+                        let data_converter = client.data_converter().clone();
+                        let unencoded_payloads = {
+                            let payload_converter = data_converter.payload_converter();
+                            let context = SerializationContext {
+                                data: &SerializationContextData::Workflow,
+                                converter: payload_converter,
+                            };
+                            args.serialize_payloads(&context)
+                        };
+                        drop(args);
+                        let payloads = data_converter
+                            .codec()
+                            .encode(&SerializationContextData::Workflow, unencoded_payloads?)
+                            .await;
+                        let mut request = QueryWorkflowRequest {
+                            namespace: client.namespace(),
+                            execution: Some(ProtoWorkflowExecution {
+                                workflow_id,
+                                run_id,
+                            }),
+                            query: Some(WorkflowQuery {
+                                query_type: query_name,
+                                query_args: Some(Payloads { payloads }),
+                                header: options.header,
+                            }),
+                            query_reject_condition: options
+                                .reject_condition
+                                .map(|condition| condition as i32)
+                                .unwrap_or(1),
+                        }
+                        .into_request();
+                        options.rpc_options.apply_to(&mut request);
+                        let response = client
+                            .query_workflow(request)
+                            .await
+                            .map_err(WorkflowQueryError::from_status)?
+                            .into_inner();
+                        Ok(QueryWorkflowOutput::new(response))
+                    })
                 }
-                .into_request(),
-            )
-            .await
-            .map_err(WorkflowQueryError::from_status)?
-            .into_inner();
+            }),
+        )
+        .await?;
+        let response = output.response;
 
         if let Some(rejected) = response.query_rejected {
             return Err(WorkflowQueryError::Rejected {
@@ -727,7 +799,9 @@ where
             .map(|p| p.payloads)
             .unwrap_or_default();
 
-        dc.from_payloads(&SerializationContextData::Workflow, result_payloads)
+        self.client
+            .data_converter()
+            .from_payloads(&SerializationContextData::Workflow, result_payloads)
             .await
             .map_err(WorkflowQueryError::from)
     }
@@ -745,6 +819,7 @@ where
         U::Input: Send,
         U::Output: 'static,
     {
+        let rpc_options = options.rpc_options.clone();
         let handle = self
             .start_update(
                 update,
@@ -753,10 +828,11 @@ where
                     .maybe_update_id(options.update_id)
                     .maybe_header(options.header)
                     .wait_for_stage(WorkflowUpdateWaitStage::Completed)
+                    .rpc_options(rpc_options.clone())
                     .build(),
             )
             .await?;
-        handle.get_result().await
+        handle.get_result(rpc_options).await
     }
 
     /// Start an update and return a handle without waiting for completion.
@@ -772,68 +848,107 @@ where
         U: UpdateDefinition<Workflow = W::Run>,
         U::Input: Send,
     {
-        let dc = self.client.data_converter();
-        let payloads = dc
-            .to_payloads(&SerializationContextData::Workflow, &input)
-            .await?;
-
-        let lifecycle_stage = match options.wait_for_stage {
-            WorkflowUpdateWaitStage::Admitted => UpdateWorkflowExecutionLifecycleStage::Admitted,
-            WorkflowUpdateWaitStage::Accepted => UpdateWorkflowExecutionLifecycleStage::Accepted,
-            WorkflowUpdateWaitStage::Completed => UpdateWorkflowExecutionLifecycleStage::Completed,
-        };
-
-        let update_id = options
-            .update_id
-            .unwrap_or_else(|| Uuid::new_v4().to_string());
-
-        let response = WorkflowService::update_workflow_execution(
-            &mut self.client.clone(),
-            UpdateWorkflowExecutionRequest {
-                namespace: self.client.namespace(),
-                workflow_execution: Some(ProtoWorkflowExecution {
-                    workflow_id: self.info().workflow_id.clone(),
-                    run_id: self.info().run_id.clone().unwrap_or_default(),
-                }),
-                wait_policy: Some(WaitPolicy {
-                    lifecycle_stage: lifecycle_stage.into(),
-                }),
-                request: Some(update::v1::Request {
-                    meta: Some(update::v1::Meta {
-                        update_id: update_id.clone(),
-                        identity: self.client.identity(),
-                    }),
-                    input: Some(update::v1::Input {
-                        header: options.header,
-                        name: update.name().to_string(),
-                        args: Some(Payloads { payloads }),
-                    }),
-
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }
-            .into_request(),
+        let output = interceptors::call_start_workflow_update(
+            self.client.client_interceptors(),
+            StartWorkflowUpdateInput::new(
+                self.info().workflow_id.clone(),
+                self.info().run_id.clone().unwrap_or_default(),
+                update.name().to_string(),
+                input,
+                options,
+            ),
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: StartWorkflowUpdateInput| -> BoxFuture<
+                    '_,
+                    Result<StartWorkflowUpdateOutput, WorkflowUpdateError>,
+                > {
+                    Box::pin(async move {
+                        let (workflow_id, run_id, update_name, args, options) = input.into_parts();
+                        let data_converter = client.data_converter().clone();
+                        let unencoded_payloads = {
+                            let payload_converter = data_converter.payload_converter();
+                            let context = SerializationContext {
+                                data: &SerializationContextData::Workflow,
+                                converter: payload_converter,
+                            };
+                            args.serialize_payloads(&context)
+                        };
+                        drop(args);
+                        let payloads = data_converter
+                            .codec()
+                            .encode(&SerializationContextData::Workflow, unencoded_payloads?)
+                            .await;
+                        let lifecycle_stage = match options.wait_for_stage {
+                            WorkflowUpdateWaitStage::Admitted => {
+                                UpdateWorkflowExecutionLifecycleStage::Admitted
+                            }
+                            WorkflowUpdateWaitStage::Accepted => {
+                                UpdateWorkflowExecutionLifecycleStage::Accepted
+                            }
+                            WorkflowUpdateWaitStage::Completed => {
+                                UpdateWorkflowExecutionLifecycleStage::Completed
+                            }
+                        };
+                        let update_id = options
+                            .update_id
+                            .unwrap_or_else(|| Uuid::new_v4().to_string());
+                        let mut request = UpdateWorkflowExecutionRequest {
+                            namespace: client.namespace(),
+                            workflow_execution: Some(ProtoWorkflowExecution {
+                                workflow_id: workflow_id.clone(),
+                                run_id,
+                            }),
+                            wait_policy: Some(WaitPolicy {
+                                lifecycle_stage: lifecycle_stage.into(),
+                            }),
+                            request: Some(update::v1::Request {
+                                meta: Some(update::v1::Meta {
+                                    update_id: update_id.clone(),
+                                    identity: client.identity(),
+                                }),
+                                input: Some(update::v1::Input {
+                                    header: options.header,
+                                    name: update_name,
+                                    args: Some(Payloads { payloads }),
+                                }),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }
+                        .into_request();
+                        options.rpc_options.apply_to(&mut request);
+                        let response = WorkflowService::update_workflow_execution(
+                            &mut client,
+                            request,
+                        )
+                        .await
+                        .map_err(WorkflowUpdateError::from_status)?
+                        .into_inner();
+                        let run_id = response
+                            .update_ref
+                            .as_ref()
+                            .and_then(|reference| reference.workflow_execution.as_ref())
+                            .map(|execution| execution.run_id.clone())
+                            .filter(|run_id| !run_id.is_empty());
+                        Ok(StartWorkflowUpdateOutput::new(
+                            update_id,
+                            workflow_id,
+                            run_id,
+                            response.outcome,
+                        ))
+                    })
+                }
+            }),
         )
-        .await
-        .map_err(WorkflowUpdateError::from_status)?
-        .into_inner();
-
-        // Extract run_id from response if available
-        let run_id = response
-            .update_ref
-            .as_ref()
-            .and_then(|r| r.workflow_execution.as_ref())
-            .map(|e| e.run_id.clone())
-            .filter(|s| !s.is_empty())
-            .or_else(|| self.info().run_id.clone());
+        .await?;
 
         Ok(WorkflowUpdateHandle {
             client: self.client.clone(),
-            update_id,
-            workflow_id: self.info().workflow_id.clone(),
-            run_id,
-            known_outcome: response.outcome,
+            update_id: output.update_id,
+            workflow_id: output.workflow_id,
+            run_id: output.run_id.or_else(|| self.info().run_id.clone()),
+            known_outcome: output.known_outcome,
             _output: PhantomData,
         })
     }
@@ -843,31 +958,52 @@ where
     where
         CT: NamespacedClient,
     {
-        WorkflowService::request_cancel_workflow_execution(
-            &mut self.client.clone(),
-            RequestCancelWorkflowExecutionRequest {
-                namespace: self.client.namespace(),
-                workflow_execution: Some(ProtoWorkflowExecution {
-                    workflow_id: self.info.workflow_id.clone(),
-                    run_id: self.info.run_id.clone().unwrap_or_default(),
-                }),
-                identity: self.client.identity(),
-                request_id: opts
-                    .request_id
-                    .unwrap_or_else(|| Uuid::new_v4().to_string()),
+        interceptors::call_cancel_workflow(
+            self.client.client_interceptors(),
+            CancelWorkflowInput {
+                workflow_id: self.info.workflow_id.clone(),
+                run_id: self.info.run_id.clone().unwrap_or_default(),
                 first_execution_run_id: self
                     .info
                     .first_execution_run_id
                     .clone()
                     .unwrap_or_default(),
-                reason: opts.reason,
-                links: vec![],
-            }
-            .into_request(),
+                options: opts,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: CancelWorkflowInput| -> BoxFuture<
+                    '_,
+                    Result<(), WorkflowInteractionError>,
+                > {
+                    Box::pin(async move {
+                        let mut request = RequestCancelWorkflowExecutionRequest {
+                            namespace: client.namespace(),
+                            workflow_execution: Some(ProtoWorkflowExecution {
+                                workflow_id: input.workflow_id,
+                                run_id: input.run_id,
+                            }),
+                            identity: client.identity(),
+                            request_id: input
+                                .options
+                                .request_id
+                                .clone()
+                                .unwrap_or_else(|| Uuid::new_v4().to_string()),
+                            first_execution_run_id: input.first_execution_run_id,
+                            reason: input.options.reason.clone(),
+                            links: vec![],
+                        }
+                        .into_request();
+                        input.options.rpc_options.apply_to(&mut request);
+                        WorkflowService::request_cancel_workflow_execution(&mut client, request)
+                            .await
+                            .map_err(WorkflowInteractionError::from_status)?;
+                        Ok(())
+                    })
+                }
+            }),
         )
         .await
-        .map_err(WorkflowInteractionError::from_status)?;
-        Ok(())
     }
 
     /// Terminate this workflow.
@@ -878,54 +1014,93 @@ where
     where
         CT: NamespacedClient,
     {
-        WorkflowService::terminate_workflow_execution(
-            &mut self.client.clone(),
-            TerminateWorkflowExecutionRequest {
-                namespace: self.client.namespace(),
-                workflow_execution: Some(ProtoWorkflowExecution {
-                    workflow_id: self.info.workflow_id.clone(),
-                    run_id: self.info.run_id.clone().unwrap_or_default(),
-                }),
-                reason: opts.reason,
-                details: opts.details,
-                identity: self.client.identity(),
+        interceptors::call_terminate_workflow(
+            self.client.client_interceptors(),
+            TerminateWorkflowInput {
+                workflow_id: self.info.workflow_id.clone(),
+                run_id: self.info.run_id.clone().unwrap_or_default(),
                 first_execution_run_id: self
                     .info
                     .first_execution_run_id
                     .clone()
                     .unwrap_or_default(),
-                links: vec![],
-            }
-            .into_request(),
+                options: opts,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: TerminateWorkflowInput| -> BoxFuture<
+                    '_,
+                    Result<(), WorkflowInteractionError>,
+                > {
+                    Box::pin(async move {
+                        let mut request = TerminateWorkflowExecutionRequest {
+                            namespace: client.namespace(),
+                            workflow_execution: Some(ProtoWorkflowExecution {
+                                workflow_id: input.workflow_id,
+                                run_id: input.run_id,
+                            }),
+                            reason: input.options.reason.clone(),
+                            details: input.options.details.clone(),
+                            identity: client.identity(),
+                            first_execution_run_id: input.first_execution_run_id,
+                            links: vec![],
+                        }
+                        .into_request();
+                        input.options.rpc_options.apply_to(&mut request);
+                        WorkflowService::terminate_workflow_execution(&mut client, request)
+                            .await
+                            .map_err(WorkflowInteractionError::from_status)?;
+                        Ok(())
+                    })
+                }
+            }),
         )
         .await
-        .map_err(WorkflowInteractionError::from_status)?;
-        Ok(())
     }
 
     /// Get workflow execution description/metadata.
     pub async fn describe(
         &self,
-        _opts: WorkflowDescribeOptions,
+        opts: WorkflowDescribeOptions,
     ) -> Result<WorkflowExecutionDescription, WorkflowInteractionError>
     where
         CT: NamespacedClient,
     {
-        let response = WorkflowService::describe_workflow_execution(
-            &mut self.client.clone(),
-            DescribeWorkflowExecutionRequest {
-                namespace: self.client.namespace(),
-                execution: Some(ProtoWorkflowExecution {
-                    workflow_id: self.info.workflow_id.clone(),
-                    run_id: self.info.run_id.clone().unwrap_or_default(),
-                }),
-            }
-            .into_request(),
+        let output = interceptors::call_describe_workflow(
+            self.client.client_interceptors(),
+            DescribeWorkflowInput {
+                workflow_id: self.info.workflow_id.clone(),
+                run_id: self.info.run_id.clone().unwrap_or_default(),
+                options: opts,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                move |input: DescribeWorkflowInput| -> BoxFuture<
+                        '_,
+                        Result<DescribeWorkflowOutput, WorkflowInteractionError>,
+                    > {
+                        Box::pin(async move {
+                            let mut request = DescribeWorkflowExecutionRequest {
+                                namespace: client.namespace(),
+                                execution: Some(ProtoWorkflowExecution {
+                                    workflow_id: input.workflow_id,
+                                    run_id: input.run_id,
+                                }),
+                            }
+                            .into_request();
+                            input.options.rpc_options.apply_to(&mut request);
+                            let response =
+                                WorkflowService::describe_workflow_execution(&mut client, request)
+                                    .await
+                                    .map_err(WorkflowInteractionError::from_status)?
+                                    .into_inner();
+                            Ok(DescribeWorkflowOutput::new(response))
+                        })
+                    }
+            }),
         )
-        .await
-        .map_err(WorkflowInteractionError::from_status)?
-        .into_inner();
-        WorkflowExecutionDescription::new(response, self.client.data_converter())
+        .await?;
+        WorkflowExecutionDescription::new(output.response, self.client.data_converter())
             .await
             .map_err(WorkflowInteractionError::from)
     }
@@ -954,34 +1129,60 @@ where
         let mut next_page_token = vec![];
 
         loop {
-            let response = WorkflowService::get_workflow_execution_history(
-                &mut self.client.clone(),
-                GetWorkflowExecutionHistoryRequest {
-                    namespace: self.client.namespace(),
-                    execution: Some(ProtoWorkflowExecution {
-                        workflow_id: self.info.workflow_id.clone(),
-                        run_id: run_id.to_string(),
-                    }),
-                    next_page_token: next_page_token.clone(),
-                    skip_archival: opts.skip_archival,
-                    wait_new_event: opts.wait_new_event,
-                    history_event_filter_type: opts.event_filter_type as i32,
-                    ..Default::default()
-                }
-                .into_request(),
+            let output = interceptors::call_fetch_workflow_history_page(
+                self.client.client_interceptors(),
+                FetchWorkflowHistoryPageInput {
+                    workflow_id: self.info.workflow_id.clone(),
+                    run_id: run_id.to_string(),
+                    next_page_token,
+                    options: opts.clone(),
+                },
+                Next::new({
+                    let mut client = self.client.clone();
+                    move |input: FetchWorkflowHistoryPageInput| -> BoxFuture<
+                        '_,
+                        Result<FetchWorkflowHistoryPageOutput, WorkflowInteractionError>,
+                    > {
+                        Box::pin(async move {
+                            let mut request = GetWorkflowExecutionHistoryRequest {
+                                namespace: client.namespace(),
+                                execution: Some(ProtoWorkflowExecution {
+                                    workflow_id: input.workflow_id,
+                                    run_id: input.run_id,
+                                }),
+                                next_page_token: input.next_page_token,
+                                skip_archival: input.options.skip_archival,
+                                wait_new_event: input.options.wait_new_event,
+                                history_event_filter_type: input.options.event_filter_type as i32,
+                                ..Default::default()
+                            }
+                            .into_request();
+                            input.options.rpc_options.apply_to(&mut request);
+                            let response = WorkflowService::get_workflow_execution_history(
+                                &mut client,
+                                request,
+                            )
+                            .await
+                            .map_err(WorkflowInteractionError::from_status)?
+                            .into_inner();
+                            Ok(FetchWorkflowHistoryPageOutput::new(
+                                response
+                                    .history
+                                    .map(|history| history.events)
+                                    .unwrap_or_default(),
+                                response.next_page_token,
+                            ))
+                        })
+                    }
+                }),
             )
-            .await
-            .map_err(WorkflowInteractionError::from_status)?
-            .into_inner();
+            .await?;
 
-            if let Some(history) = response.history {
-                all_events.extend(history.events);
-            }
-
-            if response.next_page_token.is_empty() {
+            all_events.extend(output.events);
+            if output.next_page_token.is_empty() {
                 break;
             }
-            next_page_token = response.next_page_token;
+            next_page_token = output.next_page_token;
         }
 
         Ok(WorkflowHistory::new(all_events))
@@ -990,7 +1191,7 @@ where
 
 /// Handle to a workflow update that has been started but may not be complete.
 ///
-/// Use `get_result()` to wait for the update to complete and retrieve its result.
+/// Use [`get_result`](Self::get_result) to wait for the update to complete and retrieve its result.
 pub struct WorkflowUpdateHandle<CT, T> {
     client: CT,
     update_id: String,
@@ -1022,46 +1223,65 @@ impl<CT, T: 'static> WorkflowUpdateHandle<CT, T>
 where
     CT: WorkflowService + NamespacedClient + Clone,
 {
-    /// Wait for the update to complete and return the result.
-    pub async fn get_result(&self) -> Result<T, WorkflowUpdateError>
+    /// Wait for the update to complete and return the result using the provided RPC controls.
+    pub async fn get_result(&self, rpc_options: RpcOptions) -> Result<T, WorkflowUpdateError>
     where
         T: temporalio_common::data_converters::TemporalDeserializable,
     {
-        let outcome = if let Some(known) = &self.known_outcome {
-            known.clone()
-        } else {
-            // The server's internal long-poll timeout (~60s) may expire before the update
-            // completes, returning a response with outcome: None. Keep polling until we
-            // get an actual outcome.
-            loop {
-                let response = WorkflowService::poll_workflow_execution_update(
-                    &mut self.client.clone(),
-                    PollWorkflowExecutionUpdateRequest {
-                        namespace: self.client.namespace(),
-                        update_ref: Some(update::v1::UpdateRef {
-                            workflow_execution: Some(ProtoWorkflowExecution {
-                                workflow_id: self.workflow_id.clone(),
-                                run_id: self.run_id.clone().unwrap_or_default(),
-                            }),
-                            update_id: self.update_id.clone(),
-                        }),
-                        identity: self.client.identity(),
-                        wait_policy: Some(WaitPolicy {
-                            lifecycle_stage: UpdateWorkflowExecutionLifecycleStage::Completed
-                                .into(),
-                        }),
-                    }
-                    .into_request(),
-                )
-                .await
-                .map_err(WorkflowUpdateError::from_status)?
-                .into_inner();
-
-                if let Some(outcome) = response.outcome {
-                    break outcome;
+        let output = interceptors::call_poll_workflow_update(
+            self.client.client_interceptors(),
+            PollWorkflowUpdateInput {
+                update_id: self.update_id.clone(),
+                workflow_id: self.workflow_id.clone(),
+                run_id: self.run_id.clone().unwrap_or_default(),
+                rpc_options,
+            },
+            Next::new({
+                let mut client = self.client.clone();
+                let known_outcome = self.known_outcome.clone();
+                move |input: PollWorkflowUpdateInput| -> BoxFuture<
+                    '_,
+                    Result<PollWorkflowUpdateOutput, WorkflowUpdateError>,
+                > {
+                    Box::pin(async move {
+                        if let Some(outcome) = known_outcome {
+                            return Ok(PollWorkflowUpdateOutput::new(outcome));
+                        }
+                        loop {
+                            let mut request = PollWorkflowExecutionUpdateRequest {
+                                namespace: client.namespace(),
+                                update_ref: Some(update::v1::UpdateRef {
+                                    workflow_execution: Some(ProtoWorkflowExecution {
+                                        workflow_id: input.workflow_id.clone(),
+                                        run_id: input.run_id.clone(),
+                                    }),
+                                    update_id: input.update_id.clone(),
+                                }),
+                                identity: client.identity(),
+                                wait_policy: Some(WaitPolicy {
+                                    lifecycle_stage:
+                                        UpdateWorkflowExecutionLifecycleStage::Completed.into(),
+                                }),
+                            }
+                            .into_request();
+                            input.rpc_options.apply_to(&mut request);
+                            let response = WorkflowService::poll_workflow_execution_update(
+                                &mut client,
+                                request,
+                            )
+                            .await
+                            .map_err(WorkflowUpdateError::from_status)?
+                            .into_inner();
+                            if let Some(outcome) = response.outcome {
+                                return Ok(PollWorkflowUpdateOutput::new(outcome));
+                            }
+                        }
+                    })
                 }
-            }
-        };
+            }),
+        )
+        .await?;
+        let outcome = output.outcome;
 
         match outcome.value {
             Some(update::v1::outcome::Value::Success(success)) => self

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -1247,6 +1247,9 @@ where
                         if let Some(outcome) = known_outcome {
                             return Ok(PollWorkflowUpdateOutput::new(outcome));
                         }
+                        // The server's internal long-poll timeout (~60s) may expire before the update
+                        // completes, returning a response with outcome: None. Keep polling until we
+                        // get an actual outcome.
                         loop {
                             let mut request = PollWorkflowExecutionUpdateRequest {
                                 namespace: client.namespace(),

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -183,7 +183,11 @@ async fn async_activity_completions(
         eprintln!("DEBUG: Calling {:?} on handle", outcome);
 
         let result = match outcome {
-            Outcome::Success => handle.complete(Some(async_response.to_owned())).await,
+            Outcome::Success => {
+                handle
+                    .complete(Some(async_response.to_owned()), Default::default())
+                    .await
+            }
             Outcome::Failure => {
                 handle
                     .fail(
@@ -191,10 +195,15 @@ async fn async_activity_completions(
                             .type_name("TestFailure".to_owned())
                             .build(),
                         None::<()>,
+                        Default::default(),
                     )
                     .await
             }
-            Outcome::Cancellation => handle.report_cancelation(None::<()>).await,
+            Outcome::Cancellation => {
+                handle
+                    .report_cancelation(None::<()>, Default::default())
+                    .await
+            }
         };
         if let Err(e) = &result {
             eprintln!(

--- a/crates/sdk-core/tests/integ_tests/schedule_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/schedule_tests.rs
@@ -53,12 +53,12 @@ async fn create_and_describe_schedule() {
 
     assert_eq!(handle.schedule_id(), schedule_id);
 
-    let desc = handle.describe().await.unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     assert!(desc.paused());
     assert_eq!(desc.note(), Some("created paused for testing"));
     assert!(!desc.conflict_token().is_empty());
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -85,11 +85,11 @@ async fn create_schedule_with_calendar_spec() {
         .await
         .unwrap();
 
-    let desc = handle.describe().await.unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     let raw_spec = desc.raw().schedule.as_ref().unwrap().spec.as_ref().unwrap();
     assert_eq!(raw_spec.structured_calendar.len(), 1);
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -118,7 +118,10 @@ async fn create_schedule_with_trigger_immediately() {
         || {
             let handle = client.get_schedule_handle(&schedule_id);
             async move {
-                let desc = handle.describe().await.map_err(|e| e.to_string())?;
+                let desc = handle
+                    .describe(Default::default())
+                    .await
+                    .map_err(|e| e.to_string())?;
                 if desc.action_count() > 0 {
                     Ok(desc)
                 } else {
@@ -133,7 +136,7 @@ async fn create_schedule_with_trigger_immediately() {
 
     assert!(desc.action_count() >= 1);
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -157,26 +160,35 @@ async fn pause_and_unpause_schedule() {
         .await
         .unwrap();
 
-    let desc = handle.describe().await.unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     assert!(!desc.paused());
 
-    handle.pause(Some("pausing for maintenance")).await.unwrap();
-    let desc = handle.describe().await.unwrap();
+    handle
+        .pause(Some("pausing for maintenance"), Default::default())
+        .await
+        .unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     assert!(desc.paused());
     assert_eq!(desc.note(), Some("pausing for maintenance"));
 
-    handle.unpause(Some("maintenance complete")).await.unwrap();
-    let desc = handle.describe().await.unwrap();
+    handle
+        .unpause(Some("maintenance complete"), Default::default())
+        .await
+        .unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     assert!(!desc.paused());
     assert_eq!(desc.note(), Some("maintenance complete"));
 
     // Verify None uses default note
-    handle.pause(None::<&str>).await.unwrap();
-    let desc = handle.describe().await.unwrap();
+    handle
+        .pause(None::<&str>, Default::default())
+        .await
+        .unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     assert!(desc.paused());
     assert!(desc.note().is_some());
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -203,16 +215,19 @@ async fn update_schedule() {
         .unwrap();
 
     handle
-        .update(|u| {
-            u.set_note("updated notes");
-        })
+        .update(
+            |u| {
+                u.set_note("updated notes");
+            },
+            Default::default(),
+        )
         .await
         .unwrap();
 
-    let desc = handle.describe().await.unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     assert_eq!(desc.note(), Some("updated notes"));
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -237,7 +252,7 @@ async fn trigger_schedule() {
         .unwrap();
 
     handle
-        .trigger(ScheduleOverlapPolicy::AllowAll)
+        .trigger(ScheduleOverlapPolicy::AllowAll, Default::default())
         .await
         .unwrap();
 
@@ -245,7 +260,10 @@ async fn trigger_schedule() {
         || {
             let handle = client.get_schedule_handle(&schedule_id);
             async move {
-                let desc = handle.describe().await.map_err(|e| e.to_string())?;
+                let desc = handle
+                    .describe(Default::default())
+                    .await
+                    .map_err(|e| e.to_string())?;
                 if desc.action_count() > 0 {
                     Ok(desc)
                 } else {
@@ -260,7 +278,7 @@ async fn trigger_schedule() {
 
     assert!(desc.action_count() >= 1);
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -288,13 +306,16 @@ async fn backfill_schedule() {
     let now = SystemTime::now();
     let two_hours_ago = now - Duration::from_secs(7200);
     handle
-        .backfill([ScheduleBackfill::new(two_hours_ago, now)
-            .overlap_policy(ScheduleOverlapPolicy::AllowAll)
-            .build()])
+        .backfill(
+            [ScheduleBackfill::new(two_hours_ago, now)
+                .overlap_policy(ScheduleOverlapPolicy::AllowAll)
+                .build()],
+            Default::default(),
+        )
         .await
         .unwrap();
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -320,9 +341,9 @@ async fn delete_schedule() {
         .unwrap();
 
     let handle = client.get_schedule_handle(&schedule_id);
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 
-    let err = handle.describe().await.unwrap_err();
+    let err = handle.describe(Default::default()).await.unwrap_err();
     assert!(err.to_string().contains("not found") || err.to_string().contains("NotFound"));
 }
 
@@ -349,10 +370,10 @@ async fn get_schedule_handle_for_existing_schedule() {
         .unwrap();
 
     let handle = client.get_schedule_handle(&schedule_id);
-    let desc = handle.describe().await.unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     assert!(desc.paused());
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -417,7 +438,11 @@ async fn list_schedules() {
     assert_eq!(found_ids.len(), num_schedules);
 
     for id in &schedule_ids {
-        client.get_schedule_handle(id).delete().await.unwrap();
+        client
+            .get_schedule_handle(id)
+            .delete(Default::default())
+            .await
+            .unwrap();
     }
 }
 
@@ -444,7 +469,7 @@ async fn describe_accessors_match_created_values() {
         .await
         .unwrap();
 
-    let desc = handle.describe().await.unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
 
     assert!(desc.paused());
     assert_eq!(desc.note(), Some("accessors test"));
@@ -455,7 +480,7 @@ async fn describe_accessors_match_created_values() {
     assert!(desc.running_actions().is_empty());
     assert!(desc.create_time().is_some());
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -489,7 +514,7 @@ async fn create_schedule_with_workflow_input() {
         .await
         .unwrap();
 
-    let desc = handle.describe().await.unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     assert!(desc.paused());
 
     let ScheduleDescriptionAction::StartWorkflow(action) = desc.action() else {
@@ -510,7 +535,7 @@ async fn create_schedule_with_workflow_input() {
         .expect("input should be present");
     assert_eq!(stored.payloads, vec![expected_payload]);
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -536,7 +561,7 @@ async fn schedule_action_start_workflow_encodes_typed_input() {
         .await
         .unwrap();
 
-    let desc = handle.describe().await.unwrap();
+    let desc = handle.describe(Default::default()).await.unwrap();
     let ScheduleDescriptionAction::StartWorkflow(action) = desc.action() else {
         panic!("expected start workflow action")
     };
@@ -551,5 +576,5 @@ async fn schedule_action_start_workflow_encodes_typed_input() {
         .expect("input should be present");
     assert_eq!(stored, "hello");
 
-    handle.delete().await.unwrap();
+    handle.delete(Default::default()).await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_client_tests.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    ClientInterceptor, Next, StartWorkflowInput, StartWorkflowOutput, UntypedWorkflow,
+    ClientInterceptor, HasArgs, Next, StartWorkflowInput, StartWorkflowOutput, UntypedWorkflow,
     WorkflowCountOptions, WorkflowListOptions, WorkflowStartOptions, WorkflowTerminateOptions,
     errors::WorkflowStartError,
 };

--- a/crates/sdk-core/tests/integ_tests/workflow_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_client_tests.rs
@@ -1,9 +1,17 @@
 use crate::common::{CoreWfStarter, eventually, rand_6_chars};
-use futures::TryStreamExt;
-use std::{collections::HashSet, time::Duration};
+use futures::{TryStreamExt, future::BoxFuture};
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 use temporalio_client::{
-    UntypedWorkflow, WorkflowCountOptions, WorkflowListOptions, WorkflowStartOptions,
-    WorkflowTerminateOptions, errors::WorkflowStartError,
+    ClientInterceptor, Next, StartWorkflowInput, StartWorkflowOutput, UntypedWorkflow,
+    WorkflowCountOptions, WorkflowListOptions, WorkflowStartOptions, WorkflowTerminateOptions,
+    errors::WorkflowStartError,
 };
 use temporalio_common::{data_converters::RawValue, worker::WorkerTaskTypes};
 use temporalio_macros::{workflow, workflow_methods};
@@ -19,6 +27,68 @@ impl EmptyWorkflow {
     async fn run(_ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         Ok(())
     }
+}
+
+struct StartWorkflowInterceptor {
+    calls: Arc<AtomicUsize>,
+}
+
+impl ClientInterceptor for StartWorkflowInterceptor {
+    fn start_workflow<'a>(
+        &'a self,
+        mut input: StartWorkflowInput,
+        next: Next<
+            'a,
+            StartWorkflowInput,
+            BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+        >,
+    ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+        Box::pin(async move {
+            assert_eq!(input.args_ref::<()>(), Some(&()));
+            input.replace_args(());
+            input
+                .rpc_options
+                .metadata
+                .insert("integration-interceptor", "present")
+                .unwrap();
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            let output = next.run(input).await?;
+            tokio::task::yield_now().await;
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(output)
+        })
+    }
+}
+
+#[tokio::test]
+async fn client_interceptor_start_workflow() {
+    let test_name = "client_interceptor_start_workflow";
+    let mut starter = CoreWfStarter::new(test_name);
+    let mut client = starter.get_client().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    client
+        .options_mut()
+        .client_interceptors
+        .push(Arc::new(StartWorkflowInterceptor {
+            calls: calls.clone(),
+        }));
+    let workflow_id = format!("{test_name}_{}", rand_6_chars());
+
+    let handle = client
+        .start_workflow(
+            EmptyWorkflow::run,
+            (),
+            WorkflowStartOptions::new(starter.get_task_queue(), workflow_id).build(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    handle
+        .terminate(WorkflowTerminateOptions::default())
+        .await
+        .unwrap();
 }
 
 #[rstest::rstest]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1537,7 +1537,10 @@ async fn async_activity_completion_workflow() {
         .get_client()
         .await
         .get_async_activity_handle(ActivityIdentifier::TaskToken(task.task_token.into()))
-        .complete(Some(RawValue::new(vec![response_payload.clone()])))
+        .complete(
+            Some(RawValue::new(vec![response_payload.clone()])),
+            Default::default(),
+        )
         .await
         .unwrap();
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/client_interactions.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/client_interactions.rs
@@ -1,8 +1,11 @@
-use crate::common::CoreWfStarter;
+use crate::common::{CoreWfStarter, rand_6_chars};
+use futures::future::BoxFuture;
+use parking_lot::Mutex;
+use std::sync::Arc;
 use temporalio_client::{
-    UntypedQuery, UntypedSignal, UntypedUpdate, WorkflowDescribeOptions,
-    WorkflowExecuteUpdateOptions, WorkflowQueryOptions, WorkflowSignalOptions,
-    WorkflowStartOptions,
+    Client, ClientInterceptor, Next, StartWorkflowInput, StartWorkflowOutput, UntypedQuery,
+    UntypedSignal, UntypedUpdate, WorkflowDescribeOptions, WorkflowExecuteUpdateOptions,
+    WorkflowQueryOptions, WorkflowSignalOptions, WorkflowStartOptions, errors::WorkflowStartError,
 };
 use temporalio_common::{
     data_converters::{PayloadConverter, RawValue},
@@ -671,4 +674,91 @@ async fn static_summary_and_details_visible_after_start() {
 
     let details = description.static_details().expect("details present");
     assert_eq!(details, "my static details",);
+}
+
+struct RecordingClientInterceptor {
+    name: &'static str,
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl ClientInterceptor for RecordingClientInterceptor {
+    fn start_workflow<'a>(
+        &'a self,
+        input: StartWorkflowInput,
+        next: Next<
+            'a,
+            StartWorkflowInput,
+            BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+        >,
+    ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+        self.events
+            .lock()
+            .push(format!("{}:start_workflow", self.name));
+        next.run(input)
+    }
+}
+
+fn client_with_interceptors(
+    client: &Client,
+    names: [&'static str; 2],
+    events: Arc<Mutex<Vec<String>>>,
+) -> Client {
+    let mut client = client.clone();
+    client.options_mut().client_interceptors = names
+        .into_iter()
+        .map(|name| {
+            Arc::new(RecordingClientInterceptor {
+                name,
+                events: events.clone(),
+            }) as Arc<dyn ClientInterceptor>
+        })
+        .collect();
+    client
+}
+
+#[tokio::test]
+async fn client_interceptors_respect_registration_order() {
+    let test_name = "client_interceptors_respect_registration_order";
+    let mut starter = CoreWfStarter::new(test_name);
+    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    let client = starter.get_client().await;
+    let mut worker = starter.worker().await;
+    worker
+        .register_workflow::<ImmediatelyCompletingWf>()
+        .unwrap();
+    let task_queue = starter.get_task_queue().to_owned();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let workflow_id = format!("{test_name}_ab_{}", rand_6_chars());
+    let handle = client_with_interceptors(&client, ["A", "B"], events.clone())
+        .start_workflow(
+            ImmediatelyCompletingWf::run,
+            (),
+            WorkflowStartOptions::new(task_queue.clone(), workflow_id.clone()).build(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        events.lock().as_slice(),
+        ["A:start_workflow", "B:start_workflow"]
+    );
+    events.lock().clear();
+    worker.expect_workflow_completion(workflow_id, handle.run_id().map(str::to_owned));
+
+    let workflow_id = format!("{test_name}_ba_{}", rand_6_chars());
+    let handle = client_with_interceptors(&client, ["B", "A"], events.clone())
+        .start_workflow(
+            ImmediatelyCompletingWf::run,
+            (),
+            WorkflowStartOptions::new(task_queue, workflow_id.clone()).build(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        events.lock().as_slice(),
+        ["B:start_workflow", "A:start_workflow"]
+    );
+    worker.expect_workflow_completion(workflow_id, handle.run_id().map(str::to_owned));
+
+    worker.run_until_done().await.unwrap();
 }

--- a/crates/sdk/examples/schedules/starter.rs
+++ b/crates/sdk/examples/schedules/starter.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     println!("Created schedule: {schedule_id}");
 
-    let desc = handle.describe().await?;
+    let desc = handle.describe(Default::default()).await?;
     println!("Schedule is paused: {}", desc.paused());
 
     let mut stream = client.list_schedules(ListSchedulesOptions::default());
@@ -46,12 +46,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Found schedule: {:?}", entry);
     }
 
-    handle.trigger(ScheduleOverlapPolicy::Unspecified).await?;
+    handle
+        .trigger(ScheduleOverlapPolicy::Unspecified, Default::default())
+        .await?;
     println!("Triggered schedule");
 
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-    handle.delete().await?;
+    handle.delete(Default::default()).await?;
     println!("Deleted schedule");
 
     Ok(())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adding `ClientInterceptor` along with methods on client interceptors vec on client options to register the interceptors.

Adding `RpcOptions` to various client calls options.

Add options structs to some client calls that were missing them.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes #1138 

2. How was this tested:
Added some unit tests to ensure connection level rpc options get overridden by call specific ones. Very basic integration test making sure interceptor order is respected on calls.

3. Any docs updates needed?
N/A
