### PR TITLE
fix(sdk): make payload codec failable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ to docs, or any other relevant information.
   when omitted, the parent workflow generates a UUID child workflow ID.
 * `ChildWorkflowOptions` is now tagged with `#[non_exhaustive]` so additional fields will not be breaking
   changes. Users should switch to `ChildWorkflowOptions::builder()` for constructing these options.
+* `PayloadCodec::{encode, decode}` now return `Result<_, PayloadConversionError>`, allowing codecs to fail.
 
 ### Fixed
 * Workflow tasks no longer livelock when a burst of ready async operations exhausts Tokio's

--- a/crates/client/src/async_activity_handle.rs
+++ b/crates/client/src/async_activity_handle.rs
@@ -45,7 +45,7 @@ async fn encode_optional_value(
     let payloads = data_converter
         .codec()
         .encode(&SerializationContextData::Activity, unencoded_payloads)
-        .await;
+        .await?;
     Ok(Some(Payloads { payloads }))
 }
 
@@ -221,7 +221,7 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
                             data_converter.codec(),
                             &SerializationContextData::Activity,
                         )
-                        .await;
+                        .await?;
                         let last_heartbeat_details =
                             encode_optional_value(details, &data_converter).await?;
                         match identifier {

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -243,6 +243,9 @@ impl WorkflowGetResultError {
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum ClientError {
+    /// Error decoding payloads returned by the server.
+    #[error("Payload conversion error: {0}")]
+    PayloadConversion(#[from] PayloadConversionError),
     /// An uncategorized rpc error from the server.
     #[error("Server error: {0}")]
     Rpc(#[from] tonic::Status),

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1234,7 +1234,7 @@ where
                         let payloads = data_converter
                             .codec()
                             .encode(&SerializationContextData::Workflow, unencoded_payloads?)
-                            .await;
+                            .await?;
                         let namespace = client.namespace();
                         let workflow_id = options.workflow_id.clone();
                         let task_queue_name = options.task_queue.clone();
@@ -1495,13 +1495,18 @@ where
 
                             let data_converter = client.data_converter().clone();
                             for execution in &mut output.executions {
-                                if let Some(memo) = execution.memo.as_mut() {
-                                    decode_payloads(
+                                if let Some(memo) = execution.memo.as_mut()
+                                    && let Err(err) = decode_payloads(
                                         memo,
                                         data_converter.codec(),
                                         &SerializationContextData::Workflow,
                                     )
-                                    .await;
+                                    .await
+                                {
+                                    return Some((
+                                        Err(ClientError::from(err)),
+                                        (new_token, buffer, yielded, true),
+                                    ));
                                 }
                             }
                             buffer = output
@@ -2009,17 +2014,23 @@ mod tests {
                 &self,
                 _context: &SerializationContextData,
                 payloads: Vec<Payload>,
-            ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
+            ) -> futures_util::future::BoxFuture<
+                'static,
+                Result<Vec<Payload>, PayloadConversionError>,
+            > {
                 self.encode_calls.fetch_add(1, Ordering::SeqCst);
-                Box::pin(async move { payloads })
+                Box::pin(async move { Ok(payloads) })
             }
 
             fn decode(
                 &self,
                 _context: &SerializationContextData,
                 payloads: Vec<Payload>,
-            ) -> futures_util::future::BoxFuture<'static, Vec<Payload>> {
-                Box::pin(async move { payloads })
+            ) -> futures_util::future::BoxFuture<
+                'static,
+                Result<Vec<Payload>, PayloadConversionError>,
+            > {
+                Box::pin(async move { Ok(payloads) })
             }
         }
 
@@ -2548,7 +2559,7 @@ mod tests {
 
     mod list_workflows_tests {
         use super::*;
-        use crate::test_helpers::XorCodec;
+        use crate::test_helpers::{FailingCodec, XorCodec};
         use futures_util::{FutureExt, StreamExt};
         use std::sync::atomic::{AtomicUsize, Ordering};
         use temporalio_common::{
@@ -2791,6 +2802,28 @@ mod tests {
                 workflow.memo().get::<String>("memo-key").unwrap(),
                 Some("memo-value".to_owned())
             );
+        }
+
+        #[tokio::test]
+        async fn list_workflows_yields_codec_error_then_ends() {
+            let client = MockListWorkflowsClient {
+                call_count: Arc::new(AtomicUsize::new(0)),
+                page_size: 1,
+                total_workflows: 1,
+                data_converter: DataConverter::new(
+                    PayloadConverter::default(),
+                    DefaultFailureConverter,
+                    FailingCodec,
+                ),
+                memo_payload: Some(Payload::default()),
+                interceptors: Vec::new(),
+            };
+            let mut stream = client.list_workflows("", WorkflowListOptions::default());
+
+            let err = stream.next().await.unwrap().unwrap_err();
+
+            assert!(matches!(err, ClientError::PayloadConversion(_)));
+            assert!(stream.next().await.is_none());
         }
     }
 }

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -1088,7 +1088,7 @@ where
                 self.client.data_converter().codec(),
                 &SerializationContextData::Workflow,
             )
-            .await;
+            .await?;
         }
 
         ScheduleDescription::new(
@@ -1143,7 +1143,7 @@ where
                             handle.client.data_converter().codec(),
                             &SerializationContextData::Workflow,
                         )
-                        .await;
+                        .await?;
                         let description = ScheduleDescription::new(
                             response,
                             handle.client.data_converter().clone(),
@@ -1595,13 +1595,18 @@ impl Client {
 
                             let data_converter = client.data_converter().clone();
                             for schedule in &mut output.schedules {
-                                if let Some(memo) = schedule.memo.as_mut() {
-                                    decode_payloads(
+                                if let Some(memo) = schedule.memo.as_mut()
+                                    && let Err(err) = decode_payloads(
                                         memo,
                                         data_converter.codec(),
                                         &SerializationContextData::Workflow,
                                     )
-                                    .await;
+                                    .await
+                                {
+                                    return Some((
+                                        Err(ScheduleError::from(err)),
+                                        (new_token, buffer, true),
+                                    ));
                                 }
                             }
                             buffer = output
@@ -1629,8 +1634,9 @@ mod tests {
     use super::*;
     use crate::{
         ClientInterceptor, DescribeScheduleInput, DescribeScheduleOutput, NamespacedClient, Next,
-        SendScheduleUpdateInput, UpdateScheduleInput, grpc::WorkflowService,
-        test_helpers::XorCodec,
+        SendScheduleUpdateInput, UpdateScheduleInput,
+        grpc::WorkflowService,
+        test_helpers::{FailingCodec, XorCodec},
     };
     use futures_util::FutureExt;
     use std::{
@@ -1964,6 +1970,30 @@ mod tests {
             description.memo().get::<String>("memo-key").unwrap(),
             Some("memo-value".to_owned())
         );
+    }
+
+    #[tokio::test]
+    async fn schedule_describe_propagates_codec_errors() {
+        let mut describe_response = describe_response_with_start_workflow(None);
+        describe_response.memo = Some(Memo {
+            fields: HashMap::from([("memo-key".to_owned(), Payload::default())]),
+        });
+        let client = MockScheduleClient {
+            describe_response,
+            data_converter: DataConverter::new(
+                PayloadConverter::default(),
+                DefaultFailureConverter,
+                FailingCodec,
+            ),
+            ..Default::default()
+        };
+
+        let err = make_schedule_handle(client)
+            .describe(Default::default())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ScheduleError::PayloadConversion(_)));
     }
 
     #[tokio::test]

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -1530,38 +1530,45 @@ impl Client {
     /// List schedules matching the query, returning a stream that lazily
     /// paginates through results.
     pub fn list_schedules(&self, opts: ListSchedulesOptions) -> ListSchedulesStream {
-        let client = self.clone();
-        let namespace = self.namespace();
-        let query = opts.query;
-        let page_size = opts.maximum_page_size;
-        let rpc_options = opts.rpc_options;
+        list_schedules_stream(self.clone(), opts)
+    }
+}
 
-        let stream = stream::unfold(
-            (Vec::new(), VecDeque::new(), false),
-            move |(next_page_token, mut buffer, exhausted)| {
-                let client = client.clone();
-                let namespace = namespace.clone();
-                let query = query.clone();
-                let rpc_options = rpc_options.clone();
+fn list_schedules_stream<CT>(client: CT, opts: ListSchedulesOptions) -> ListSchedulesStream
+where
+    CT: WorkflowService + NamespacedClient + Clone + Send + Sync + 'static,
+{
+    let namespace = client.namespace();
+    let query = opts.query;
+    let page_size = opts.maximum_page_size;
+    let rpc_options = opts.rpc_options;
 
-                async move {
-                    if let Some(item) = buffer.pop_front() {
-                        return Some((Ok(item), (next_page_token, buffer, exhausted)));
-                    } else if exhausted {
-                        return None;
-                    }
+    let stream = stream::unfold(
+        (Vec::new(), VecDeque::new(), false),
+        move |(next_page_token, mut buffer, exhausted)| {
+            let client = client.clone();
+            let namespace = namespace.clone();
+            let query = query.clone();
+            let rpc_options = rpc_options.clone();
 
-                    let response = interceptors::call_list_schedules_page(
-                        client.client_interceptors(),
-                        ListSchedulesPageInput {
-                            maximum_page_size: page_size,
-                            query,
-                            next_page_token: next_page_token.clone(),
-                            rpc_options,
-                        },
-                        Next::new({
-                            let mut rpc_client = client.clone();
-                            move |input: ListSchedulesPageInput| -> BoxFuture<
+            async move {
+                if let Some(item) = buffer.pop_front() {
+                    return Some((Ok(item), (next_page_token, buffer, exhausted)));
+                } else if exhausted {
+                    return None;
+                }
+
+                let response = interceptors::call_list_schedules_page(
+                    client.client_interceptors(),
+                    ListSchedulesPageInput {
+                        maximum_page_size: page_size,
+                        query,
+                        next_page_token: next_page_token.clone(),
+                        rpc_options,
+                    },
+                    Next::new({
+                        let mut rpc_client = client.clone();
+                        move |input: ListSchedulesPageInput| -> BoxFuture<
                                 '_,
                                 Result<ListSchedulesPageOutput, ScheduleError>,
                             > {
@@ -1584,49 +1591,48 @@ impl Client {
                                     ))
                                 })
                             }
-                        }),
-                    )
-                    .await;
+                    }),
+                )
+                .await;
 
-                    match response {
-                        Ok(mut output) => {
-                            let new_exhausted = output.next_page_token.is_empty();
-                            let new_token = output.next_page_token;
+                match response {
+                    Ok(mut output) => {
+                        let new_exhausted = output.next_page_token.is_empty();
+                        let new_token = output.next_page_token;
 
-                            let data_converter = client.data_converter().clone();
-                            for schedule in &mut output.schedules {
-                                if let Some(memo) = schedule.memo.as_mut()
-                                    && let Err(err) = decode_payloads(
-                                        memo,
-                                        data_converter.codec(),
-                                        &SerializationContextData::Workflow,
-                                    )
-                                    .await
-                                {
-                                    return Some((
-                                        Err(ScheduleError::from(err)),
-                                        (new_token, buffer, true),
-                                    ));
-                                }
+                        let data_converter = client.data_converter().clone();
+                        for schedule in &mut output.schedules {
+                            if let Some(memo) = schedule.memo.as_mut()
+                                && let Err(err) = decode_payloads(
+                                    memo,
+                                    data_converter.codec(),
+                                    &SerializationContextData::Workflow,
+                                )
+                                .await
+                            {
+                                return Some((
+                                    Err(ScheduleError::from(err)),
+                                    (new_token, buffer, true),
+                                ));
                             }
-                            buffer = output
-                                .schedules
-                                .into_iter()
-                                .map(|raw| ScheduleSummary::new(raw, data_converter.clone()))
-                                .collect();
-
-                            buffer
-                                .pop_front()
-                                .map(|item| (Ok(item), (new_token, buffer, new_exhausted)))
                         }
-                        Err(e) => Some((Err(e), (next_page_token, buffer, true))),
-                    }
-                }
-            },
-        );
+                        buffer = output
+                            .schedules
+                            .into_iter()
+                            .map(|raw| ScheduleSummary::new(raw, data_converter.clone()))
+                            .collect();
 
-        ListSchedulesStream::new(Box::pin(stream))
-    }
+                        buffer
+                            .pop_front()
+                            .map(|item| (Ok(item), (new_token, buffer, new_exhausted)))
+                    }
+                    Err(e) => Some((Err(e), (next_page_token, buffer, true))),
+                }
+            }
+        },
+    );
+
+    ListSchedulesStream::new(Box::pin(stream))
 }
 
 #[cfg(test)]
@@ -1638,7 +1644,7 @@ mod tests {
         grpc::WorkflowService,
         test_helpers::{FailingCodec, XorCodec},
     };
-    use futures_util::FutureExt;
+    use futures_util::{FutureExt, StreamExt};
     use std::{
         collections::HashMap,
         sync::{
@@ -1664,8 +1670,8 @@ mod tests {
             taskqueue::v1::TaskQueue,
             workflow::v1::NewWorkflowExecutionInfo,
             workflowservice::v1::{
-                DeleteScheduleResponse, DescribeScheduleResponse, PatchScheduleResponse,
-                UpdateScheduleResponse,
+                DeleteScheduleResponse, DescribeScheduleResponse, ListSchedulesResponse,
+                PatchScheduleResponse, UpdateScheduleResponse,
             },
         },
     };
@@ -1685,12 +1691,14 @@ mod tests {
         update: AtomicUsize,
         delete: AtomicUsize,
         patch: AtomicUsize,
+        list: AtomicUsize,
     }
 
     #[derive(Clone)]
     struct MockScheduleClient {
         captured: Arc<CapturedRequests>,
         describe_response: DescribeScheduleResponse,
+        list_response: ListSchedulesResponse,
         data_converter: DataConverter,
         should_error: bool,
         interceptors: Vec<Arc<dyn ClientInterceptor>>,
@@ -1701,6 +1709,7 @@ mod tests {
             Self {
                 captured: Arc::new(CapturedRequests::default()),
                 describe_response: describe_response_with_start_workflow(None),
+                list_response: ListSchedulesResponse::default(),
                 data_converter: DataConverter::default(),
                 should_error: false,
                 interceptors: Vec::new(),
@@ -1844,6 +1853,18 @@ mod tests {
             }
             .boxed()
         }
+
+        fn list_schedules(
+            &mut self,
+            _request: Request<ListSchedulesRequest>,
+        ) -> futures_util::future::BoxFuture<
+            '_,
+            Result<Response<ListSchedulesResponse>, tonic::Status>,
+        > {
+            self.captured.list.fetch_add(1, Ordering::SeqCst);
+            let response = self.list_response.clone();
+            async move { Ok(Response::new(response)) }.boxed()
+        }
     }
 
     fn make_schedule_handle(client: MockScheduleClient) -> ScheduleHandle<MockScheduleClient> {
@@ -1973,30 +1994,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn schedule_describe_propagates_codec_errors() {
-        let mut describe_response = describe_response_with_start_workflow(None);
-        describe_response.memo = Some(Memo {
-            fields: HashMap::from([("memo-key".to_owned(), Payload::default())]),
-        });
-        let client = MockScheduleClient {
-            describe_response,
-            data_converter: DataConverter::new(
-                PayloadConverter::default(),
-                DefaultFailureConverter,
-                FailingCodec,
-            ),
-            ..Default::default()
-        };
-
-        let err = make_schedule_handle(client)
-            .describe(Default::default())
-            .await
-            .unwrap_err();
-
-        assert!(matches!(err, ScheduleError::PayloadConversion(_)));
-    }
-
-    #[tokio::test]
     async fn schedule_summary_exposes_typed_memo() {
         let data_converter = DataConverter::default();
         let memo_payload = data_converter
@@ -2021,6 +2018,34 @@ mod tests {
             summary.memo().get::<String>("memo-key").unwrap(),
             Some("memo-value".to_owned())
         );
+    }
+
+    #[tokio::test]
+    async fn list_schedules_yields_codec_error_then_ends() {
+        let client = MockScheduleClient {
+            list_response: ListSchedulesResponse {
+                schedules: vec![ScheduleListEntry {
+                    memo: Some(Memo {
+                        fields: HashMap::from([("memo-key".to_owned(), Payload::default())]),
+                    }),
+                    ..Default::default()
+                }],
+                next_page_token: b"next-page".to_vec(),
+            },
+            data_converter: DataConverter::new(
+                PayloadConverter::default(),
+                DefaultFailureConverter,
+                FailingCodec,
+            ),
+            ..Default::default()
+        };
+        let mut stream = list_schedules_stream(client.clone(), ListSchedulesOptions::default());
+
+        let err = stream.next().await.unwrap().unwrap_err();
+
+        assert!(matches!(err, ScheduleError::PayloadConversion(_)));
+        assert!(stream.next().await.is_none());
+        assert_eq!(client.captured.list.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/client/src/test_helpers.rs
+++ b/crates/client/src/test_helpers.rs
@@ -1,25 +1,27 @@
 use futures_util::{FutureExt, future::BoxFuture};
 use temporalio_common::{
-    data_converters::{PayloadCodec, SerializationContextData},
+    data_converters::{PayloadCodec, PayloadConversionError, SerializationContextData},
     protos::temporal::api::common::v1::Payload,
 };
 
 pub(crate) struct XorCodec;
+
+pub(crate) struct FailingCodec;
 
 impl PayloadCodec for XorCodec {
     fn encode(
         &self,
         _context: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>> {
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
         async move {
-            payloads
+            Ok(payloads
                 .into_iter()
                 .map(|mut payload| {
                     payload.data.iter_mut().for_each(|byte| *byte ^= 0x42);
                     payload
                 })
-                .collect()
+                .collect())
         }
         .boxed()
     }
@@ -28,7 +30,35 @@ impl PayloadCodec for XorCodec {
         &self,
         context: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>> {
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
         self.encode(context, payloads)
+    }
+}
+
+impl PayloadCodec for FailingCodec {
+    fn encode(
+        &self,
+        _: &SerializationContextData,
+        _: Vec<Payload>,
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+        async move {
+            Err(PayloadConversionError::EncodingError(
+                "codec encode failed".into(),
+            ))
+        }
+        .boxed()
+    }
+
+    fn decode(
+        &self,
+        _: &SerializationContextData,
+        _: Vec<Payload>,
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+        async move {
+            Err(PayloadConversionError::EncodingError(
+                "codec decode failed".into(),
+            ))
+        }
+        .boxed()
     }
 }

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -1309,7 +1309,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{FailingCodec, XorCodec};
+    use crate::test_helpers::XorCodec;
     use std::collections::HashMap;
     use temporalio_common::{
         data_converters::DefaultFailureConverter,

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -1360,47 +1360,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn workflow_result_details_propagate_codec_errors() {
-        let converter = DataConverter::new(
-            PayloadConverter::default(),
-            DefaultFailureConverter,
-            FailingCodec,
-        );
-
-        let err = WorkflowResultDetails::new(vec![Payload::default()], &converter)
-            .await
-            .unwrap_err();
-
-        assert_eq!(err.to_string(), "Encoding error: codec decode failed");
-    }
-
-    #[tokio::test]
-    async fn workflow_description_propagates_codec_errors() {
-        let converter = DataConverter::new(
-            PayloadConverter::default(),
-            DefaultFailureConverter,
-            FailingCodec,
-        );
-
-        let err = WorkflowExecutionDescription::new(
-            DescribeWorkflowExecutionResponse {
-                workflow_execution_info: Some(workflow::WorkflowExecutionInfo {
-                    memo: Some(Memo {
-                        fields: HashMap::from([("memo-key".to_owned(), Payload::default())]),
-                    }),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            &converter,
-        )
-        .await
-        .unwrap_err();
-
-        assert_eq!(err.to_string(), "Encoding error: codec decode failed");
-    }
-
-    #[tokio::test]
     async fn workflow_description_memo_uses_saved_converter() {
         let converter = DataConverter::new(
             PayloadConverter::default(),

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -90,18 +90,21 @@ pub struct WorkflowResultDetails {
 }
 
 impl WorkflowResultDetails {
-    async fn new(payloads: Vec<Payload>, data_converter: &DataConverter) -> Self {
+    async fn new(
+        payloads: Vec<Payload>,
+        data_converter: &DataConverter,
+    ) -> Result<Self, PayloadConversionError> {
         let payloads = data_converter
             .codec()
             .decode(&SerializationContextData::Workflow, payloads)
-            .await;
-        Self {
+            .await?;
+        Ok(Self {
             payloads: DecodablePayloads::new(
                 payloads,
                 data_converter.payload_converter().clone(),
                 SerializationContextData::Workflow,
             ),
-        }
+        })
     }
 
     /// Deserialize the details into a typed value using the client's payload converter.
@@ -173,7 +176,7 @@ impl WorkflowExecutionDescription {
             data_converter.codec(),
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await?;
         let decoded_metadata =
             decode_user_metadata(&SerializationContextData::Workflow, raw_user_metadata)?;
         let history_length_raw = raw_description
@@ -591,7 +594,7 @@ where
                         dc.codec(),
                         &SerializationContextData::Workflow,
                     )
-                    .await;
+                    .await?;
                     let error = dc.failure_converter().to_error(
                         failure,
                         dc.payload_converter(),
@@ -602,7 +605,7 @@ where
                 Some(Attributes::WorkflowExecutionCanceledEventAttributes(attrs)) => {
                     Ok(WorkflowExecutionResult::Cancelled {
                         details: WorkflowResultDetails::new(Vec::from_payloads(attrs.details), dc)
-                            .await,
+                            .await?,
                     })
                 }
                 Some(Attributes::WorkflowExecutionTimedOutEventAttributes(attrs)) => {
@@ -612,7 +615,7 @@ where
                 Some(Attributes::WorkflowExecutionTerminatedEventAttributes(attrs)) => {
                     Ok(WorkflowExecutionResult::Terminated {
                         details: WorkflowResultDetails::new(Vec::from_payloads(attrs.details), dc)
-                            .await,
+                            .await?,
                     })
                 }
                 Some(Attributes::WorkflowExecutionContinuedAsNewEventAttributes(attrs)) => {
@@ -684,7 +687,7 @@ where
                         let payloads = data_converter
                             .codec()
                             .encode(&SerializationContextData::Workflow, unencoded_payloads?)
-                            .await;
+                            .await?;
                         let mut request = SignalWorkflowExecutionRequest {
                             namespace: client.namespace(),
                             workflow_execution: Some(ProtoWorkflowExecution {
@@ -755,7 +758,7 @@ where
                         let payloads = data_converter
                             .codec()
                             .encode(&SerializationContextData::Workflow, unencoded_payloads?)
-                            .await;
+                            .await?;
                         let mut request = QueryWorkflowRequest {
                             namespace: client.namespace(),
                             execution: Some(ProtoWorkflowExecution {
@@ -878,7 +881,7 @@ where
                         let payloads = data_converter
                             .codec()
                             .encode(&SerializationContextData::Workflow, unencoded_payloads?)
-                            .await;
+                            .await?;
                         let lifecycle_stage = match options.wait_for_stage {
                             WorkflowUpdateWaitStage::Admitted => {
                                 UpdateWorkflowExecutionLifecycleStage::Admitted
@@ -1306,7 +1309,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::XorCodec;
+    use crate::test_helpers::{FailingCodec, XorCodec};
     use std::collections::HashMap;
     use temporalio_common::{
         data_converters::DefaultFailureConverter,
@@ -1332,7 +1335,9 @@ mod tests {
             )
             .await
             .unwrap();
-        let details = WorkflowResultDetails::new(payloads.clone(), &converter).await;
+        let details = WorkflowResultDetails::new(payloads.clone(), &converter)
+            .await
+            .unwrap();
 
         assert_ne!(details.raw(), payloads);
         let decoded_payloads = details.raw().to_vec();
@@ -1346,10 +1351,53 @@ mod tests {
     #[tokio::test]
     async fn workflow_result_detail_conversion_errors_are_reported() {
         let details =
-            WorkflowResultDetails::new(vec![Payload::default()], &DataConverter::default()).await;
+            WorkflowResultDetails::new(vec![Payload::default()], &DataConverter::default())
+                .await
+                .unwrap();
 
         assert_eq!(details.raw(), &[Payload::default()]);
         assert!(details.deserialize::<String>().is_err());
+    }
+
+    #[tokio::test]
+    async fn workflow_result_details_propagate_codec_errors() {
+        let converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            FailingCodec,
+        );
+
+        let err = WorkflowResultDetails::new(vec![Payload::default()], &converter)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Encoding error: codec decode failed");
+    }
+
+    #[tokio::test]
+    async fn workflow_description_propagates_codec_errors() {
+        let converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            FailingCodec,
+        );
+
+        let err = WorkflowExecutionDescription::new(
+            DescribeWorkflowExecutionResponse {
+                workflow_execution_info: Some(workflow::WorkflowExecutionInfo {
+                    memo: Some(Memo {
+                        fields: HashMap::from([("memo-key".to_owned(), Payload::default())]),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &converter,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "Encoding error: codec decode failed");
     }
 
     #[tokio::test]

--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -55,7 +55,7 @@ impl DataConverter {
             converter: &self.payload_converter,
         };
         let payload = self.payload_converter.to_payload(&context, val)?;
-        let encoded = self.codec.encode(data, vec![payload]).await;
+        let encoded = self.codec.encode(data, vec![payload]).await?;
         encoded
             .into_iter()
             .next()
@@ -72,7 +72,7 @@ impl DataConverter {
             data,
             converter: &self.payload_converter,
         };
-        let decoded = self.codec.decode(data, vec![payload]).await;
+        let decoded = self.codec.decode(data, vec![payload]).await?;
         let payload = decoded
             .into_iter()
             .next()
@@ -91,7 +91,7 @@ impl DataConverter {
             converter: &self.payload_converter,
         };
         let payloads = self.payload_converter.to_payloads(&context, val)?;
-        Ok(self.codec.encode(data, payloads).await)
+        self.codec.encode(data, payloads).await
     }
 
     /// Deserialize a value from multiple payloads (e.g. for multi-arg support), applying the codec.
@@ -104,7 +104,7 @@ impl DataConverter {
             data,
             converter: &self.payload_converter,
         };
-        let decoded = self.codec.decode(data, payloads).await;
+        let decoded = self.codec.decode(data, payloads).await?;
         self.payload_converter.from_payloads(&context, decoded)
     }
 
@@ -233,19 +233,22 @@ impl std::error::Error for PayloadConversionError {
 }
 
 /// Encodes and decodes payloads, enabling encryption or compression.
+///
+/// Operational codec failures should be returned as
+/// [`PayloadConversionError::EncodingError`].
 pub trait PayloadCodec {
     /// Encode payloads before they are sent to the server.
     fn encode(
         &self,
         context: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>>;
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>>;
     /// Decode payloads after they are received from the server.
     fn decode(
         &self,
         context: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>>;
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>>;
 }
 
 impl<T: PayloadCodec> PayloadCodec for Arc<T> {
@@ -253,14 +256,14 @@ impl<T: PayloadCodec> PayloadCodec for Arc<T> {
         &self,
         context: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>> {
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
         (**self).encode(context, payloads)
     }
     fn decode(
         &self,
         context: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>> {
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
         (**self).decode(context, payloads)
     }
 }
@@ -740,15 +743,15 @@ impl PayloadCodec for DefaultPayloadCodec {
         &self,
         _: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>> {
-        async move { payloads }.boxed()
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+        async move { Ok(payloads) }.boxed()
     }
     fn decode(
         &self,
         _: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>> {
-        async move { payloads }.boxed()
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+        async move { Ok(payloads) }.boxed()
     }
 }
 
@@ -814,6 +817,43 @@ impl_multi_args!(MultiArgs6; 6; 0: A, 1: B, 2: C, 3: D, 4: E, 5: F);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct FailingCodec;
+
+    impl PayloadCodec for FailingCodec {
+        fn encode(
+            &self,
+            _: &SerializationContextData,
+            _: Vec<Payload>,
+        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+            async move {
+                Err(PayloadConversionError::EncodingError(
+                    "codec encode failed".into(),
+                ))
+            }
+            .boxed()
+        }
+
+        fn decode(
+            &self,
+            _: &SerializationContextData,
+            _: Vec<Payload>,
+        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+            async move {
+                Err(PayloadConversionError::EncodingError(
+                    "codec decode failed".into(),
+                ))
+            }
+            .boxed()
+        }
+    }
+
+    fn assert_encoding_error(err: PayloadConversionError, message: &str) {
+        let PayloadConversionError::EncodingError(source) = err else {
+            panic!("expected encoding error, got {err}")
+        };
+        assert_eq!(source.to_string(), message);
+    }
 
     #[test]
     fn test_empty_payloads_as_unit_type() {
@@ -959,5 +999,57 @@ mod tests {
         let result: Vec<String> = payloads.deserialize().unwrap();
 
         assert_eq!(result, vec!["hello".to_string(), "world".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn data_converter_propagates_codec_encode_errors() {
+        let converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            FailingCodec,
+        );
+
+        assert_encoding_error(
+            converter
+                .to_payload(&SerializationContextData::Workflow, &"value")
+                .await
+                .unwrap_err(),
+            "codec encode failed",
+        );
+        assert_encoding_error(
+            converter
+                .to_payloads(&SerializationContextData::Workflow, &"value")
+                .await
+                .unwrap_err(),
+            "codec encode failed",
+        );
+    }
+
+    #[tokio::test]
+    async fn data_converter_propagates_codec_decode_errors() {
+        let payload = DataConverter::default()
+            .to_payload(&SerializationContextData::Workflow, &"value")
+            .await
+            .unwrap();
+        let converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            FailingCodec,
+        );
+
+        assert_encoding_error(
+            converter
+                .from_payload::<String>(&SerializationContextData::Workflow, payload.clone())
+                .await
+                .unwrap_err(),
+            "codec decode failed",
+        );
+        assert_encoding_error(
+            converter
+                .from_payloads::<String>(&SerializationContextData::Workflow, vec![payload])
+                .await
+                .unwrap_err(),
+            "codec decode failed",
+        );
     }
 }

--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -818,43 +818,6 @@ impl_multi_args!(MultiArgs6; 6; 0: A, 1: B, 2: C, 3: D, 4: E, 5: F);
 mod tests {
     use super::*;
 
-    struct FailingCodec;
-
-    impl PayloadCodec for FailingCodec {
-        fn encode(
-            &self,
-            _: &SerializationContextData,
-            _: Vec<Payload>,
-        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
-            async move {
-                Err(PayloadConversionError::EncodingError(
-                    "codec encode failed".into(),
-                ))
-            }
-            .boxed()
-        }
-
-        fn decode(
-            &self,
-            _: &SerializationContextData,
-            _: Vec<Payload>,
-        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
-            async move {
-                Err(PayloadConversionError::EncodingError(
-                    "codec decode failed".into(),
-                ))
-            }
-            .boxed()
-        }
-    }
-
-    fn assert_encoding_error(err: PayloadConversionError, message: &str) {
-        let PayloadConversionError::EncodingError(source) = err else {
-            panic!("expected encoding error, got {err}")
-        };
-        assert_eq!(source.to_string(), message);
-    }
-
     #[test]
     fn test_empty_payloads_as_unit_type() {
         let converter = PayloadConverter::default();
@@ -999,57 +962,5 @@ mod tests {
         let result: Vec<String> = payloads.deserialize().unwrap();
 
         assert_eq!(result, vec!["hello".to_string(), "world".to_string()]);
-    }
-
-    #[tokio::test]
-    async fn data_converter_propagates_codec_encode_errors() {
-        let converter = DataConverter::new(
-            PayloadConverter::default(),
-            DefaultFailureConverter,
-            FailingCodec,
-        );
-
-        assert_encoding_error(
-            converter
-                .to_payload(&SerializationContextData::Workflow, &"value")
-                .await
-                .unwrap_err(),
-            "codec encode failed",
-        );
-        assert_encoding_error(
-            converter
-                .to_payloads(&SerializationContextData::Workflow, &"value")
-                .await
-                .unwrap_err(),
-            "codec encode failed",
-        );
-    }
-
-    #[tokio::test]
-    async fn data_converter_propagates_codec_decode_errors() {
-        let payload = DataConverter::default()
-            .to_payload(&SerializationContextData::Workflow, &"value")
-            .await
-            .unwrap();
-        let converter = DataConverter::new(
-            PayloadConverter::default(),
-            DefaultFailureConverter,
-            FailingCodec,
-        );
-
-        assert_encoding_error(
-            converter
-                .from_payload::<String>(&SerializationContextData::Workflow, payload.clone())
-                .await
-                .unwrap_err(),
-            "codec decode failed",
-        );
-        assert_encoding_error(
-            converter
-                .from_payloads::<String>(&SerializationContextData::Workflow, vec![payload])
-                .await
-                .unwrap_err(),
-            "codec decode failed",
-        );
     }
 }

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -372,9 +372,10 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
     fn visit_payloads_mut<'a>(
         &'a mut self,
         visitor: &'a mut (dyn crate::payload_visitor::AsyncPayloadVisitor + Send),
-    ) -> futures::future::BoxFuture<'a, ()> {{
+    ) -> futures::future::BoxFuture<'a, Result<(), crate::data_converters::PayloadConversionError>> {{
         Box::pin(async move {{
-{impl_body}        }})
+{impl_body}            Ok(())
+        }})
     }}
 }}
 "#,
@@ -398,7 +399,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
             visitor.visit(crate::payload_visitor::PayloadField {{
                 path: "{path}",
                 data: crate::payload_visitor::PayloadFieldData::Single(payload),
-            }}).await;
+            }}).await?;
         }}
 "#,
                     field = rust_field,
@@ -410,7 +411,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
                     r#"        visitor.visit(crate::payload_visitor::PayloadField {{
             path: "{path}",
             data: crate::payload_visitor::PayloadFieldData::Repeated(&mut self.{field}),
-        }}).await;
+        }}).await?;
 "#,
                     field = rust_field,
                     path = proto_path
@@ -422,7 +423,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
             visitor.visit(crate::payload_visitor::PayloadField {{
                 path: "{path}",
                 data: crate::payload_visitor::PayloadFieldData::Payloads(payloads),
-            }}).await;
+            }}).await?;
         }}
 "#,
                     field = rust_field,
@@ -435,7 +436,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
             visitor.visit(crate::payload_visitor::PayloadField {{
                 path: "{path}",
                 data: crate::payload_visitor::PayloadFieldData::Single(payload),
-            }}).await;
+            }}).await?;
         }}
 "#,
                     field = rust_field,
@@ -445,7 +446,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
             PayloadFieldKind::MapNestedMessage => {
                 format!(
                     r#"        for item in self.{field}.values_mut() {{
-            item.visit_payloads_mut(visitor).await;
+            item.visit_payloads_mut(visitor).await?;
         }}
 "#,
                     field = rust_field
@@ -465,7 +466,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
                 if is_field_repeated {
                     format!(
                         r#"        for item in &mut self.{field} {{
-            item.visit_payloads_mut(visitor).await;
+            item.visit_payloads_mut(visitor).await?;
         }}
 "#,
                         field = rust_field
@@ -473,7 +474,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
                 } else {
                     format!(
                         r#"        if let Some(msg) = &mut self.{field} {{
-            msg.visit_payloads_mut(visitor).await;
+            msg.visit_payloads_mut(visitor).await?;
         }}
 "#,
                         field = rust_field
@@ -497,7 +498,7 @@ impl crate::payload_visitor::PayloadVisitable for {rust_path} {{
                 for variant in variants {
                     let variant_name = to_pascal_case(&variant.name);
                     arms.push_str(&format!(
-                        "                {enum_path}::{variant}(msg) => msg.visit_payloads_mut(visitor).await,\n",
+                        "                {enum_path}::{variant}(msg) => msg.visit_payloads_mut(visitor).await?,\n",
                         enum_path = enum_path,
                         variant = variant_name
                     ));

--- a/crates/common/src/payload_visitor.rs
+++ b/crates/common/src/payload_visitor.rs
@@ -5,7 +5,7 @@
 //! boundary between the SDK and Core.
 
 use crate::{
-    data_converters::{PayloadCodec, SerializationContextData},
+    data_converters::{PayloadCodec, PayloadConversionError, SerializationContextData},
     protos::temporal::api::common::v1::{Payload, Payloads},
 };
 use futures::future::BoxFuture;
@@ -62,12 +62,13 @@ fn should_encode(path: &str) -> bool {
 pub struct EncodeVisitor<'a> {
     codec: &'a (dyn PayloadCodec + Send + Sync),
     context: &'a SerializationContextData,
+    error: Option<PayloadConversionError>,
 }
 
 impl AsyncPayloadVisitor for EncodeVisitor<'_> {
     fn visit<'a>(&'a mut self, field: PayloadField<'a>) -> BoxFuture<'a, ()> {
         Box::pin(async move {
-            if !should_encode(field.path) {
+            if self.error.is_some() || !should_encode(field.path) {
                 return;
             }
             match field.data {
@@ -76,21 +77,34 @@ impl AsyncPayloadVisitor for EncodeVisitor<'_> {
                         .codec
                         .encode(self.context, vec![std::mem::take(payload)])
                         .await;
-                    if let Some(p) = encoded.into_iter().next() {
-                        *payload = p;
+                    match encoded {
+                        Ok(encoded) => {
+                            if let Some(p) = encoded.into_iter().next() {
+                                *payload = p;
+                            }
+                        }
+                        Err(err) => self.error = Some(err),
                     }
                 }
                 PayloadFieldData::Repeated(payloads) => {
-                    *payloads = self
+                    match self
                         .codec
                         .encode(self.context, std::mem::take(payloads))
-                        .await;
+                        .await
+                    {
+                        Ok(encoded) => *payloads = encoded,
+                        Err(err) => self.error = Some(err),
+                    }
                 }
                 PayloadFieldData::Payloads(payloads_msg) => {
-                    payloads_msg.payloads = self
+                    match self
                         .codec
                         .encode(self.context, std::mem::take(&mut payloads_msg.payloads))
-                        .await;
+                        .await
+                    {
+                        Ok(encoded) => payloads_msg.payloads = encoded,
+                        Err(err) => self.error = Some(err),
+                    }
                 }
             }
         })
@@ -101,12 +115,13 @@ impl AsyncPayloadVisitor for EncodeVisitor<'_> {
 pub struct DecodeVisitor<'a> {
     codec: &'a (dyn PayloadCodec + Send + Sync),
     context: &'a SerializationContextData,
+    error: Option<PayloadConversionError>,
 }
 
 impl AsyncPayloadVisitor for DecodeVisitor<'_> {
     fn visit<'a>(&'a mut self, field: PayloadField<'a>) -> BoxFuture<'a, ()> {
         Box::pin(async move {
-            if !should_encode(field.path) {
+            if self.error.is_some() || !should_encode(field.path) {
                 return;
             }
             match field.data {
@@ -115,21 +130,34 @@ impl AsyncPayloadVisitor for DecodeVisitor<'_> {
                         .codec
                         .decode(self.context, vec![std::mem::take(payload)])
                         .await;
-                    if let Some(p) = decoded.into_iter().next() {
-                        *payload = p;
+                    match decoded {
+                        Ok(decoded) => {
+                            if let Some(p) = decoded.into_iter().next() {
+                                *payload = p;
+                            }
+                        }
+                        Err(err) => self.error = Some(err),
                     }
                 }
                 PayloadFieldData::Repeated(payloads) => {
-                    *payloads = self
+                    match self
                         .codec
                         .decode(self.context, std::mem::take(payloads))
-                        .await;
+                        .await
+                    {
+                        Ok(decoded) => *payloads = decoded,
+                        Err(err) => self.error = Some(err),
+                    }
                 }
                 PayloadFieldData::Payloads(payloads_msg) => {
-                    payloads_msg.payloads = self
+                    match self
                         .codec
                         .decode(self.context, std::mem::take(&mut payloads_msg.payloads))
-                        .await;
+                        .await
+                    {
+                        Ok(decoded) => payloads_msg.payloads = decoded,
+                        Err(err) => self.error = Some(err),
+                    }
                 }
             }
         })
@@ -141,9 +169,14 @@ pub async fn encode_payloads<M: PayloadVisitable + Send>(
     msg: &mut M,
     codec: &(dyn PayloadCodec + Send + Sync),
     context: &SerializationContextData,
-) {
-    let mut visitor = EncodeVisitor { codec, context };
+) -> Result<(), PayloadConversionError> {
+    let mut visitor = EncodeVisitor {
+        codec,
+        context,
+        error: None,
+    };
     msg.visit_payloads_mut(&mut visitor).await;
+    visitor.error.map_or(Ok(()), Err)
 }
 
 /// Decode all payloads in a message using the given codec.
@@ -151,9 +184,14 @@ pub async fn decode_payloads<M: PayloadVisitable + Send>(
     msg: &mut M,
     codec: &(dyn PayloadCodec + Send + Sync),
     context: &SerializationContextData,
-) {
-    let mut visitor = DecodeVisitor { codec, context };
+) -> Result<(), PayloadConversionError> {
+    let mut visitor = DecodeVisitor {
+        codec,
+        context,
+        error: None,
+    };
     msg.visit_payloads_mut(&mut visitor).await;
+    visitor.error.map_or(Ok(()), Err)
 }
 
 // Manual impl for Payload - visits itself as a single payload
@@ -196,37 +234,39 @@ include!(concat!(env!("OUT_DIR"), "/payload_visitor_impl.rs"));
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        data_converters::{DefaultFailureConverter, FailureConverter, PayloadConverter},
-        error::{ApplicationFailure, OutgoingError, OutgoingWorkflowError},
-        protos::{
-            coresdk::{
-                activity_result::{
-                    ActivityResolution, Success, activity_resolution::Status as ActivityStatus,
-                },
-                workflow_activation::{
-                    InitializeWorkflow, ResolveActivity, WorkflowActivation, WorkflowActivationJob,
-                    workflow_activation_job::Variant,
-                },
-                workflow_commands::{
-                    ContinueAsNewWorkflowExecution, ScheduleActivity, StartChildWorkflowExecution,
-                    UpsertWorkflowSearchAttributes, WorkflowCommand,
-                    workflow_command::Variant as CmdVariant,
-                },
-                workflow_completion::{
-                    WorkflowActivationCompletion, workflow_activation_completion::Status,
-                },
+    use crate::protos::{
+        coresdk::{
+            activity_result::{
+                ActivityResolution, Success, activity_resolution::Status as ActivityStatus,
             },
-            temporal::api::{
-                common::v1::{Memo, SearchAttributes},
-                failure::v1::failure::FailureInfo,
-                workflow::v1::WorkflowExecutionInfo,
-                workflowservice::v1::DescribeWorkflowExecutionResponse,
+            workflow_activation::{
+                InitializeWorkflow, ResolveActivity, WorkflowActivation, WorkflowActivationJob,
+                workflow_activation_job::Variant,
             },
+            workflow_commands::{
+                ContinueAsNewWorkflowExecution, ScheduleActivity, StartChildWorkflowExecution,
+                UpsertWorkflowSearchAttributes, WorkflowCommand,
+                workflow_command::Variant as CmdVariant,
+            },
+            workflow_completion::{
+                WorkflowActivationCompletion, workflow_activation_completion::Status,
+            },
+        },
+        temporal::api::{
+            common::v1::{Memo, SearchAttributes},
+            failure::v1::{
+                ApplicationFailureInfo, CanceledFailureInfo, Failure, ResetWorkflowFailureInfo,
+                TimeoutFailureInfo, failure::FailureInfo,
+            },
+            workflow::v1::WorkflowExecutionInfo,
+            workflowservice::v1::DescribeWorkflowExecutionResponse,
         },
     };
     use futures::FutureExt;
-    use std::collections::HashMap;
+    use std::{
+        collections::HashMap,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     struct MarkingCodec;
     impl PayloadCodec for MarkingCodec {
@@ -234,15 +274,15 @@ mod tests {
             &self,
             _: &SerializationContextData,
             payloads: Vec<Payload>,
-        ) -> BoxFuture<'static, Vec<Payload>> {
+        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
             async move {
-                payloads
+                Ok(payloads
                     .into_iter()
                     .map(|mut p| {
                         p.metadata.insert("encoded".to_string(), b"true".to_vec());
                         p
                     })
-                    .collect()
+                    .collect())
             }
             .boxed()
         }
@@ -251,15 +291,51 @@ mod tests {
             &self,
             _: &SerializationContextData,
             payloads: Vec<Payload>,
-        ) -> BoxFuture<'static, Vec<Payload>> {
+        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
             async move {
-                payloads
+                Ok(payloads
                     .into_iter()
                     .map(|mut p| {
                         p.metadata.insert("decoded".to_string(), b"true".to_vec());
                         p
                     })
-                    .collect()
+                    .collect())
+            }
+            .boxed()
+        }
+    }
+
+    #[derive(Default)]
+    struct FailingCodec {
+        encode_calls: AtomicUsize,
+        decode_calls: AtomicUsize,
+    }
+
+    impl PayloadCodec for FailingCodec {
+        fn encode(
+            &self,
+            _: &SerializationContextData,
+            _: Vec<Payload>,
+        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+            self.encode_calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                Err(PayloadConversionError::EncodingError(
+                    "visitor encode failed".into(),
+                ))
+            }
+            .boxed()
+        }
+
+        fn decode(
+            &self,
+            _: &SerializationContextData,
+            _: Vec<Payload>,
+        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+            self.decode_calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                Err(PayloadConversionError::EncodingError(
+                    "visitor decode failed".into(),
+                ))
             }
             .boxed()
         }
@@ -302,6 +378,29 @@ mod tests {
 
     fn is_decoded(p: &Payload) -> bool {
         p.metadata.contains_key("decoded")
+    }
+
+    fn assert_failure_payloads_marked(failure: &Failure, marker: &str) {
+        if let Some(payload) = failure.encoded_attributes.as_ref() {
+            assert!(payload.metadata.contains_key(marker));
+        }
+        let payloads = match failure.failure_info.as_ref() {
+            Some(FailureInfo::ApplicationFailureInfo(info)) => info.details.as_ref(),
+            Some(FailureInfo::TimeoutFailureInfo(info)) => info.last_heartbeat_details.as_ref(),
+            Some(FailureInfo::CanceledFailureInfo(info)) => info.details.as_ref(),
+            Some(FailureInfo::ResetWorkflowFailureInfo(info)) => {
+                info.last_heartbeat_details.as_ref()
+            }
+            _ => None,
+        };
+        if let Some(payloads) = payloads {
+            for payload in &payloads.payloads {
+                assert!(payload.metadata.contains_key(marker));
+            }
+        }
+        if let Some(cause) = failure.cause.as_deref() {
+            assert_failure_payloads_marked(cause, marker);
+        }
     }
 
     #[tokio::test]
@@ -385,7 +484,8 @@ mod tests {
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
 
         let status = completion.status.as_ref().unwrap();
         let Status::Successful(success) = status else {
@@ -428,7 +528,8 @@ mod tests {
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
 
         let job = &activation.jobs[0];
         let Variant::InitializeWorkflow(init) = job.variant.as_ref().unwrap() else {
@@ -466,7 +567,8 @@ mod tests {
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
 
         let job = &activation.jobs[0];
         let Variant::ResolveActivity(resolve) = job.variant.as_ref().unwrap() else {
@@ -563,7 +665,8 @@ mod tests {
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
 
         let status = completion.status.as_ref().unwrap();
         let Status::Successful(success) = status else {
@@ -640,7 +743,8 @@ mod tests {
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
 
         let info = response.workflow_execution_info.as_ref().unwrap();
         assert!(
@@ -669,7 +773,8 @@ mod tests {
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(is_encoded(&payload), "single payload should be encoded");
     }
@@ -683,7 +788,8 @@ mod tests {
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(is_decoded(&payload), "single payload should be decoded");
     }
@@ -699,7 +805,8 @@ mod tests {
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
 
         for (i, p) in payloads.payloads.iter().enumerate() {
             assert!(is_encoded(p), "payload {} should be encoded", i);
@@ -707,29 +814,89 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_encode_failure_encodes_application_failure_details() {
-        let mut failure = DefaultFailureConverter.to_failure(
-            OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
-                ApplicationFailure::builder(anyhow::anyhow!("app boom"))
-                    .details(crate::data_converters::RawValue::new(vec![make_payload(
-                        "detail",
-                    )]))
-                    .build(),
-            ))),
-            &PayloadConverter::default(),
-            &SerializationContextData::Workflow,
-        );
+    async fn test_codec_errors_stop_subsequent_codec_invocations() {
+        let codec = FailingCodec::default();
+        let mut activation = WorkflowActivation {
+            jobs: vec![WorkflowActivationJob {
+                variant: Some(Variant::InitializeWorkflow(InitializeWorkflow {
+                    arguments: vec![make_payload("input")],
+                    headers: HashMap::from([("header".to_string(), make_payload("value"))]),
+                    memo: Some(Memo {
+                        fields: HashMap::from([("memo".to_string(), make_payload("memo-value"))]),
+                    }),
+                    ..Default::default()
+                })),
+            }],
+            ..Default::default()
+        };
+
+        let err = decode_payloads(&mut activation, &codec, &SerializationContextData::Workflow)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Encoding error: visitor decode failed");
+        assert_eq!(codec.decode_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_failure_payload_tree_is_encoded_and_decoded() {
+        let mut failure = Failure {
+            encoded_attributes: Some(make_payload("root-attributes")),
+            failure_info: Some(FailureInfo::ApplicationFailureInfo(
+                ApplicationFailureInfo {
+                    details: Some(Payloads {
+                        payloads: vec![make_payload("application-detail")],
+                    }),
+                    ..Default::default()
+                },
+            )),
+            cause: Some(Box::new(Failure {
+                failure_info: Some(FailureInfo::TimeoutFailureInfo(TimeoutFailureInfo {
+                    last_heartbeat_details: Some(Payloads {
+                        payloads: vec![make_payload("heartbeat-detail")],
+                    }),
+                    ..Default::default()
+                })),
+                cause: Some(Box::new(Failure {
+                    failure_info: Some(FailureInfo::CanceledFailureInfo(CanceledFailureInfo {
+                        details: Some(Payloads {
+                            payloads: vec![make_payload("cancellation-detail")],
+                        }),
+                        ..Default::default()
+                    })),
+                    cause: Some(Box::new(Failure {
+                        failure_info: Some(FailureInfo::ResetWorkflowFailureInfo(
+                            ResetWorkflowFailureInfo {
+                                last_heartbeat_details: Some(Payloads {
+                                    payloads: vec![make_payload("reset-detail")],
+                                }),
+                            },
+                        )),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
 
         encode_payloads(
             &mut failure,
             &MarkingCodec,
             &SerializationContextData::Workflow,
         )
-        .await;
+        .await
+        .unwrap();
+        assert_failure_payloads_marked(&failure, "encoded");
 
-        let Some(FailureInfo::ApplicationFailureInfo(info)) = failure.failure_info else {
-            panic!("expected application failure info")
-        };
-        assert!(is_encoded(&info.details.unwrap().payloads[0]));
+        decode_payloads(
+            &mut failure,
+            &MarkingCodec,
+            &SerializationContextData::Workflow,
+        )
+        .await
+        .unwrap();
+        assert_failure_payloads_marked(&failure, "decoded");
     }
 }

--- a/crates/common/src/payload_visitor.rs
+++ b/crates/common/src/payload_visitor.rs
@@ -228,10 +228,7 @@ mod tests {
         },
         temporal::api::{
             common::v1::{Memo, SearchAttributes},
-            failure::v1::{
-                ApplicationFailureInfo, CanceledFailureInfo, Failure, ResetWorkflowFailureInfo,
-                TimeoutFailureInfo, failure::FailureInfo,
-            },
+            failure::v1::failure::FailureInfo,
             workflow::v1::WorkflowExecutionInfo,
             workflowservice::v1::DescribeWorkflowExecutionResponse,
         },
@@ -240,6 +237,10 @@ mod tests {
     use std::{
         collections::HashMap,
         sync::atomic::{AtomicUsize, Ordering},
+    };
+    use temporalio_common_wasm::{
+        data_converters::{DefaultFailureConverter, FailureConverter, PayloadConverter},
+        error::{ApplicationFailure, OutgoingError, OutgoingWorkflowError},
     };
 
     struct MarkingCodec;
@@ -355,29 +356,6 @@ mod tests {
 
     fn is_decoded(p: &Payload) -> bool {
         p.metadata.contains_key("decoded")
-    }
-
-    fn assert_failure_payloads_marked(failure: &Failure, marker: &str) {
-        if let Some(payload) = failure.encoded_attributes.as_ref() {
-            assert!(payload.metadata.contains_key(marker));
-        }
-        let payloads = match failure.failure_info.as_ref() {
-            Some(FailureInfo::ApplicationFailureInfo(info)) => info.details.as_ref(),
-            Some(FailureInfo::TimeoutFailureInfo(info)) => info.last_heartbeat_details.as_ref(),
-            Some(FailureInfo::CanceledFailureInfo(info)) => info.details.as_ref(),
-            Some(FailureInfo::ResetWorkflowFailureInfo(info)) => {
-                info.last_heartbeat_details.as_ref()
-            }
-            _ => None,
-        };
-        if let Some(payloads) = payloads {
-            for payload in &payloads.payloads {
-                assert!(payload.metadata.contains_key(marker));
-            }
-        }
-        if let Some(cause) = failure.cause.as_deref() {
-            assert_failure_payloads_marked(cause, marker);
-        }
     }
 
     #[tokio::test]
@@ -816,47 +794,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_failure_payload_tree_is_encoded_and_decoded() {
-        let mut failure = Failure {
-            encoded_attributes: Some(make_payload("root-attributes")),
-            failure_info: Some(FailureInfo::ApplicationFailureInfo(
-                ApplicationFailureInfo {
-                    details: Some(Payloads {
-                        payloads: vec![make_payload("application-detail")],
-                    }),
-                    ..Default::default()
-                },
-            )),
-            cause: Some(Box::new(Failure {
-                failure_info: Some(FailureInfo::TimeoutFailureInfo(TimeoutFailureInfo {
-                    last_heartbeat_details: Some(Payloads {
-                        payloads: vec![make_payload("heartbeat-detail")],
-                    }),
-                    ..Default::default()
-                })),
-                cause: Some(Box::new(Failure {
-                    failure_info: Some(FailureInfo::CanceledFailureInfo(CanceledFailureInfo {
-                        details: Some(Payloads {
-                            payloads: vec![make_payload("cancellation-detail")],
-                        }),
-                        ..Default::default()
-                    })),
-                    cause: Some(Box::new(Failure {
-                        failure_info: Some(FailureInfo::ResetWorkflowFailureInfo(
-                            ResetWorkflowFailureInfo {
-                                last_heartbeat_details: Some(Payloads {
-                                    payloads: vec![make_payload("reset-detail")],
-                                }),
-                            },
-                        )),
-                        ..Default::default()
-                    })),
-                    ..Default::default()
-                })),
-                ..Default::default()
-            })),
-            ..Default::default()
-        };
+    async fn test_encode_failure_encodes_application_failure_details() {
+        let mut failure = DefaultFailureConverter.to_failure(
+            OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
+                ApplicationFailure::builder(anyhow::anyhow!("app boom"))
+                    .details(crate::data_converters::RawValue::new(vec![make_payload(
+                        "detail",
+                    )]))
+                    .build(),
+            ))),
+            &PayloadConverter::default(),
+            &SerializationContextData::Workflow,
+        );
 
         encode_payloads(
             &mut failure,
@@ -865,15 +814,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_failure_payloads_marked(&failure, "encoded");
 
-        decode_payloads(
-            &mut failure,
-            &MarkingCodec,
-            &SerializationContextData::Workflow,
-        )
-        .await
-        .unwrap();
-        assert_failure_payloads_marked(&failure, "decoded");
+        let Some(FailureInfo::ApplicationFailureInfo(info)) = failure.failure_info else {
+            panic!("expected application failure info")
+        };
+        assert!(is_encoded(&info.details.unwrap().payloads[0]));
     }
 }

--- a/crates/common/src/payload_visitor.rs
+++ b/crates/common/src/payload_visitor.rs
@@ -32,8 +32,11 @@ pub enum PayloadFieldData<'a> {
 
 /// Async visitor for transforming payload fields.
 pub trait AsyncPayloadVisitor {
-    /// Visit a payload field, potentially transforming it.
-    fn visit<'a>(&'a mut self, field: PayloadField<'a>) -> BoxFuture<'a, ()>;
+    /// Visit a payload field, potentially transforming it. Returning an error stops traversal.
+    fn visit<'a>(
+        &'a mut self,
+        field: PayloadField<'a>,
+    ) -> BoxFuture<'a, Result<(), PayloadConversionError>>;
 }
 
 /// Trait for messages that contain Payload fields (directly or transitively).
@@ -41,10 +44,11 @@ pub trait AsyncPayloadVisitor {
 pub trait PayloadVisitable: Send {
     /// Visit all payload fields in this message.
     /// The visitor is called once per field, receiving the field's payload(s).
+    /// Traversal stops and returns the first visitor error.
     fn visit_payloads_mut<'a>(
         &'a mut self,
         visitor: &'a mut (dyn AsyncPayloadVisitor + Send),
-    ) -> BoxFuture<'a, ()>;
+    ) -> BoxFuture<'a, Result<(), PayloadConversionError>>;
 }
 
 /// Check if a field path represents search attributes that should not be encoded.
@@ -62,51 +66,41 @@ fn should_encode(path: &str) -> bool {
 pub struct EncodeVisitor<'a> {
     codec: &'a (dyn PayloadCodec + Send + Sync),
     context: &'a SerializationContextData,
-    error: Option<PayloadConversionError>,
 }
 
 impl AsyncPayloadVisitor for EncodeVisitor<'_> {
-    fn visit<'a>(&'a mut self, field: PayloadField<'a>) -> BoxFuture<'a, ()> {
+    fn visit<'a>(
+        &'a mut self,
+        field: PayloadField<'a>,
+    ) -> BoxFuture<'a, Result<(), PayloadConversionError>> {
         Box::pin(async move {
-            if self.error.is_some() || !should_encode(field.path) {
-                return;
+            if !should_encode(field.path) {
+                return Ok(());
             }
             match field.data {
                 PayloadFieldData::Single(payload) => {
                     let encoded = self
                         .codec
                         .encode(self.context, vec![std::mem::take(payload)])
-                        .await;
-                    match encoded {
-                        Ok(encoded) => {
-                            if let Some(p) = encoded.into_iter().next() {
-                                *payload = p;
-                            }
-                        }
-                        Err(err) => self.error = Some(err),
+                        .await?;
+                    if let Some(p) = encoded.into_iter().next() {
+                        *payload = p;
                     }
                 }
                 PayloadFieldData::Repeated(payloads) => {
-                    match self
+                    *payloads = self
                         .codec
                         .encode(self.context, std::mem::take(payloads))
-                        .await
-                    {
-                        Ok(encoded) => *payloads = encoded,
-                        Err(err) => self.error = Some(err),
-                    }
+                        .await?;
                 }
                 PayloadFieldData::Payloads(payloads_msg) => {
-                    match self
+                    payloads_msg.payloads = self
                         .codec
                         .encode(self.context, std::mem::take(&mut payloads_msg.payloads))
-                        .await
-                    {
-                        Ok(encoded) => payloads_msg.payloads = encoded,
-                        Err(err) => self.error = Some(err),
-                    }
+                        .await?;
                 }
             }
+            Ok(())
         })
     }
 }
@@ -115,51 +109,41 @@ impl AsyncPayloadVisitor for EncodeVisitor<'_> {
 pub struct DecodeVisitor<'a> {
     codec: &'a (dyn PayloadCodec + Send + Sync),
     context: &'a SerializationContextData,
-    error: Option<PayloadConversionError>,
 }
 
 impl AsyncPayloadVisitor for DecodeVisitor<'_> {
-    fn visit<'a>(&'a mut self, field: PayloadField<'a>) -> BoxFuture<'a, ()> {
+    fn visit<'a>(
+        &'a mut self,
+        field: PayloadField<'a>,
+    ) -> BoxFuture<'a, Result<(), PayloadConversionError>> {
         Box::pin(async move {
-            if self.error.is_some() || !should_encode(field.path) {
-                return;
+            if !should_encode(field.path) {
+                return Ok(());
             }
             match field.data {
                 PayloadFieldData::Single(payload) => {
                     let decoded = self
                         .codec
                         .decode(self.context, vec![std::mem::take(payload)])
-                        .await;
-                    match decoded {
-                        Ok(decoded) => {
-                            if let Some(p) = decoded.into_iter().next() {
-                                *payload = p;
-                            }
-                        }
-                        Err(err) => self.error = Some(err),
+                        .await?;
+                    if let Some(p) = decoded.into_iter().next() {
+                        *payload = p;
                     }
                 }
                 PayloadFieldData::Repeated(payloads) => {
-                    match self
+                    *payloads = self
                         .codec
                         .decode(self.context, std::mem::take(payloads))
-                        .await
-                    {
-                        Ok(decoded) => *payloads = decoded,
-                        Err(err) => self.error = Some(err),
-                    }
+                        .await?;
                 }
                 PayloadFieldData::Payloads(payloads_msg) => {
-                    match self
+                    payloads_msg.payloads = self
                         .codec
                         .decode(self.context, std::mem::take(&mut payloads_msg.payloads))
-                        .await
-                    {
-                        Ok(decoded) => payloads_msg.payloads = decoded,
-                        Err(err) => self.error = Some(err),
-                    }
+                        .await?;
                 }
             }
+            Ok(())
         })
     }
 }
@@ -170,13 +154,8 @@ pub async fn encode_payloads<M: PayloadVisitable + Send>(
     codec: &(dyn PayloadCodec + Send + Sync),
     context: &SerializationContextData,
 ) -> Result<(), PayloadConversionError> {
-    let mut visitor = EncodeVisitor {
-        codec,
-        context,
-        error: None,
-    };
-    msg.visit_payloads_mut(&mut visitor).await;
-    visitor.error.map_or(Ok(()), Err)
+    let mut visitor = EncodeVisitor { codec, context };
+    msg.visit_payloads_mut(&mut visitor).await
 }
 
 /// Decode all payloads in a message using the given codec.
@@ -185,13 +164,8 @@ pub async fn decode_payloads<M: PayloadVisitable + Send>(
     codec: &(dyn PayloadCodec + Send + Sync),
     context: &SerializationContextData,
 ) -> Result<(), PayloadConversionError> {
-    let mut visitor = DecodeVisitor {
-        codec,
-        context,
-        error: None,
-    };
-    msg.visit_payloads_mut(&mut visitor).await;
-    visitor.error.map_or(Ok(()), Err)
+    let mut visitor = DecodeVisitor { codec, context };
+    msg.visit_payloads_mut(&mut visitor).await
 }
 
 // Manual impl for Payload - visits itself as a single payload
@@ -199,14 +173,14 @@ impl PayloadVisitable for Payload {
     fn visit_payloads_mut<'a>(
         &'a mut self,
         visitor: &'a mut (dyn AsyncPayloadVisitor + Send),
-    ) -> BoxFuture<'a, ()> {
+    ) -> BoxFuture<'a, Result<(), PayloadConversionError>> {
         Box::pin(async move {
             visitor
                 .visit(PayloadField {
                     path: "temporal.api.common.v1.Payload",
                     data: PayloadFieldData::Single(self),
                 })
-                .await;
+                .await
         })
     }
 }
@@ -216,14 +190,14 @@ impl PayloadVisitable for Payloads {
     fn visit_payloads_mut<'a>(
         &'a mut self,
         visitor: &'a mut (dyn AsyncPayloadVisitor + Send),
-    ) -> BoxFuture<'a, ()> {
+    ) -> BoxFuture<'a, Result<(), PayloadConversionError>> {
         Box::pin(async move {
             visitor
                 .visit(PayloadField {
                     path: "temporal.api.common.v1.Payloads",
                     data: PayloadFieldData::Payloads(self),
                 })
-                .await;
+                .await
         })
     }
 }
@@ -357,10 +331,13 @@ mod tests {
     }
 
     impl AsyncPayloadVisitor for PathRecordingVisitor {
-        fn visit<'a>(&'a mut self, field: PayloadField<'a>) -> BoxFuture<'a, ()> {
+        fn visit<'a>(
+            &'a mut self,
+            field: PayloadField<'a>,
+        ) -> BoxFuture<'a, Result<(), PayloadConversionError>> {
             let path = field.path.to_string();
             self.visited_paths.push(path);
-            async move {}.boxed()
+            async move { Ok(()) }.boxed()
         }
     }
 
@@ -430,7 +407,7 @@ mod tests {
         };
 
         let mut visitor = PathRecordingVisitor::new();
-        activation.visit_payloads_mut(&mut visitor).await;
+        activation.visit_payloads_mut(&mut visitor).await.unwrap();
 
         let paths = visitor.paths();
         assert!(

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -3,7 +3,7 @@ use futures::{FutureExt, future::BoxFuture};
 use std::{
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -133,6 +133,7 @@ const ACTIVITY_PANIC_MESSAGE: &str = "activity converter fallback panic";
 const QUERY_FAILURE_MESSAGE: &str = "query converter fallback failure";
 const UPDATE_VALIDATOR_FAILURE_MESSAGE: &str = "update validator converter fallback failure";
 const UPDATE_HANDLER_FAILURE_MESSAGE: &str = "update handler converter fallback failure";
+const CODEC_RETRY_MARKER: &str = "codec-retry-test";
 
 #[derive(Debug)]
 struct FailingFailureConverter;
@@ -802,14 +803,14 @@ impl PayloadCodec for XorCodec {
         &self,
         _context: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>> {
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
         let count = payloads.len();
         eprintln!("XorCodec::encode called with {} payloads", count);
         self.encode_count.fetch_add(count, Ordering::SeqCst);
         let key = self.key;
         let gate_on_metadata = self.gate_on_metadata;
         async move {
-            payloads
+            Ok(payloads
                 .into_iter()
                 .map(|mut p| {
                     p.data = p.data.iter().map(|b| b ^ key).collect();
@@ -818,7 +819,7 @@ impl PayloadCodec for XorCodec {
                     }
                     p
                 })
-                .collect()
+                .collect())
         }
         .boxed()
     }
@@ -827,14 +828,14 @@ impl PayloadCodec for XorCodec {
         &self,
         _context: &SerializationContextData,
         payloads: Vec<Payload>,
-    ) -> BoxFuture<'static, Vec<Payload>> {
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
         let count = payloads.len();
         eprintln!("XorCodec::decode called with {} payloads", count);
         self.decode_count.fetch_add(count, Ordering::SeqCst);
         let key = self.key;
         let gate_on_metadata = self.gate_on_metadata;
         async move {
-            payloads
+            Ok(payloads
                 .into_iter()
                 .map(|mut p| {
                     if !gate_on_metadata || p.metadata.remove("xor_encoded").is_some() {
@@ -842,10 +843,168 @@ impl PayloadCodec for XorCodec {
                     }
                     p
                 })
-                .collect()
+                .collect())
         }
         .boxed()
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CodecFailurePoint {
+    WorkflowEncode,
+    WorkflowDecode,
+    ActivityEncode,
+    ActivityDecode,
+}
+
+struct FailOnceCodec {
+    failure_point: CodecFailurePoint,
+    failed: AtomicBool,
+    matching_calls: AtomicUsize,
+}
+
+impl FailOnceCodec {
+    fn new(failure_point: CodecFailurePoint) -> Self {
+        Self {
+            failure_point,
+            failed: AtomicBool::new(false),
+            matching_calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl PayloadCodec for FailOnceCodec {
+    fn encode(
+        &self,
+        context: &SerializationContextData,
+        payloads: Vec<Payload>,
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+        let matches_context = matches!(
+            (self.failure_point, context),
+            (
+                CodecFailurePoint::WorkflowEncode,
+                SerializationContextData::Workflow
+            ) | (
+                CodecFailurePoint::ActivityEncode,
+                SerializationContextData::Activity
+            )
+        );
+        let marker = if matches!(self.failure_point, CodecFailurePoint::WorkflowEncode) {
+            b"activity-processed:codec-retry-test".as_slice()
+        } else {
+            CODEC_RETRY_MARKER.as_bytes()
+        };
+        let matches_payload = payloads.iter().any(|payload| {
+            payload
+                .data
+                .windows(marker.len())
+                .any(|data| data == marker)
+        });
+        let should_fail = matches_context && matches_payload;
+        if should_fail {
+            self.matching_calls.fetch_add(1, Ordering::SeqCst);
+        }
+        let should_fail = should_fail && !self.failed.swap(true, Ordering::SeqCst);
+        async move {
+            if should_fail {
+                Err(PayloadConversionError::EncodingError(
+                    "intentional codec encode failure".into(),
+                ))
+            } else {
+                Ok(payloads)
+            }
+        }
+        .boxed()
+    }
+
+    fn decode(
+        &self,
+        context: &SerializationContextData,
+        payloads: Vec<Payload>,
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+        let matches_context = matches!(
+            (self.failure_point, context),
+            (
+                CodecFailurePoint::WorkflowDecode,
+                SerializationContextData::Workflow
+            ) | (
+                CodecFailurePoint::ActivityDecode,
+                SerializationContextData::Activity
+            )
+        );
+        let matches_payload = payloads.iter().any(|payload| {
+            payload
+                .data
+                .windows(CODEC_RETRY_MARKER.len())
+                .any(|data| data == CODEC_RETRY_MARKER.as_bytes())
+        });
+        let should_fail = matches_context && matches_payload;
+        if should_fail {
+            self.matching_calls.fetch_add(1, Ordering::SeqCst);
+        }
+        let should_fail = should_fail && !self.failed.swap(true, Ordering::SeqCst);
+        async move {
+            if should_fail {
+                Err(PayloadConversionError::EncodingError(
+                    "intentional codec decode failure".into(),
+                ))
+            } else {
+                Ok(payloads)
+            }
+        }
+        .boxed()
+    }
+}
+
+#[rstest::rstest]
+#[case::workflow_encode(CodecFailurePoint::WorkflowEncode)]
+#[case::workflow_decode(CodecFailurePoint::WorkflowDecode)]
+#[case::activity_encode(CodecFailurePoint::ActivityEncode)]
+#[case::activity_decode(CodecFailurePoint::ActivityDecode)]
+#[tokio::test]
+async fn codec_errors_fail_tasks_and_retry(#[case] failure_point: CodecFailurePoint) {
+    let codec = Arc::new(FailOnceCodec::new(failure_point));
+    let connection = get_integ_connection(None).await;
+    let data_converter = DataConverter::new(
+        PayloadConverter::default(),
+        DefaultFailureConverter,
+        codec.clone(),
+    );
+    let client_opts = ClientOptions::new(integ_namespace())
+        .data_converter(data_converter)
+        .build();
+    let client = Client::new(connection, client_opts).unwrap();
+    let mut starter = CoreWfStarter::new_with_overrides(
+        &format!("codec_errors_fail_and_retry_{failure_point:?}"),
+        None,
+        Some(client),
+    );
+    starter.sdk_config.register_activities(TestActivities);
+    starter.sdk_config.task_types = WorkerTaskTypes::all();
+    starter
+        .sdk_config
+        .register_workflow::<DataConverterTestWorkflow>()
+        .unwrap();
+    let workflow_id = starter.get_task_queue().to_owned();
+    let mut worker = starter.worker().await;
+    let handle = worker
+        .submit_workflow(
+            DataConverterTestWorkflow::run,
+            TrackedWrapper(TrackedValue::new(CODEC_RETRY_MARKER.to_owned())),
+            WorkflowStartOptions::new(starter.get_task_queue(), workflow_id).build(),
+        )
+        .await
+        .unwrap();
+
+    worker.run_until_done().await.unwrap();
+
+    let output = handle.get_result(Default::default()).await.unwrap().0;
+    assert_eq!(
+        output.data,
+        format!("activity-processed:{CODEC_RETRY_MARKER}")
+    );
+    assert!(codec.failed.load(Ordering::SeqCst));
+    assert!(codec.matching_calls.load(Ordering::SeqCst) >= 2);
 }
 
 #[tokio::test]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -136,7 +136,9 @@ use temporalio_common::{
             workflow_activation::{WorkflowActivation, workflow_activation_job::Variant},
             workflow_completion::WorkflowActivationCompletion,
         },
-        temporal::api::{common::v1::Payload, enums::v1::WorkflowTaskFailedCause},
+        temporal::api::{
+            common::v1::Payload, enums::v1::WorkflowTaskFailedCause, failure::v1::Failure,
+        },
     },
     worker::{WorkerDeploymentOptions, WorkerTaskTypes, build_id_from_current_exe},
 };
@@ -543,6 +545,49 @@ impl ActivityNotRegisteredError {
     }
 }
 
+async fn encode_workflow_completion(
+    completion: &mut WorkflowActivationCompletion,
+    data_converter: &DataConverter,
+) {
+    let run_id = completion.run_id.clone();
+    if let Err(err) = encode_payloads(
+        completion,
+        data_converter.codec(),
+        &SerializationContextData::Workflow,
+    )
+    .await
+    {
+        error!(run_id, error = %err, "Failed encoding workflow activation completion");
+        *completion = WorkflowActivationCompletion::fail(
+            run_id,
+            Failure {
+                message: format!("Failed encoding completion: {err}"),
+                ..Default::default()
+            },
+            Some(WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure),
+        );
+    }
+}
+
+async fn encode_activity_completion(
+    completion: &mut ActivityTaskCompletion,
+    data_converter: &DataConverter,
+) {
+    if let Err(err) = encode_payloads(
+        completion,
+        data_converter.codec(),
+        &SerializationContextData::Activity,
+    )
+    .await
+    {
+        error!(error = %err, "Failed encoding activity task completion");
+        completion.result = Some(ActivityExecutionResult::fail(Failure::application_failure(
+            format!("Failed encoding activity completion: {err}"),
+            false,
+        )));
+    }
+}
+
 impl Worker {
     /// Create a new worker from an existing client, and options.
     pub fn new(
@@ -743,12 +788,7 @@ impl Worker {
             UnboundedReceiverStream::new(completions_rx)
                 .map(Ok)
                 .try_for_each_concurrent(None, |mut completion| async {
-                    encode_payloads(
-                        &mut completion,
-                        common.data_converter.codec(),
-                        &SerializationContextData::Workflow,
-                    )
-                    .await;
+                    encode_workflow_completion(&mut completion, &common.data_converter).await;
                     if let Some(ref i) = common.worker_interceptor {
                         i.on_workflow_activation_completion(&completion).await;
                     }
@@ -773,12 +813,29 @@ impl Worker {
                                     }
                                     o => o?,
                                 };
-                            decode_payloads(
+                            if let Err(err) = decode_payloads(
                                 &mut activation,
                                 common.data_converter.codec(),
                                 &SerializationContextData::Workflow,
                             )
-                            .await;
+                            .await
+                            {
+                                let run_id = activation.run_id;
+                                error!(run_id, error = %err, "Failed decoding workflow activation");
+                                completions_tx
+                                    .send(WorkflowActivationCompletion::fail(
+                                        run_id,
+                                        Failure {
+                                            message: format!("Failed decoding activation: {err}"),
+                                            ..Default::default()
+                                        },
+                                        Some(
+                                            WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure,
+                                        ),
+                                    ))
+                                    .expect("Completion channel intact");
+                                continue;
+                            }
                             if let Some(ref i) = common.worker_interceptor {
                                 i.on_workflow_activation(&activation).await?;
                             }
@@ -824,12 +881,28 @@ impl Worker {
                             break;
                         }
                         let mut activity = activity?;
-                        decode_payloads(
+                        if let Err(err) = decode_payloads(
                             &mut activity,
                             common.data_converter.codec(),
                             &SerializationContextData::Activity,
                         )
-                        .await;
+                        .await
+                        {
+                            error!(error = %err, "Failed decoding activity task");
+                            let mut completion = ActivityTaskCompletion {
+                                task_token: activity.task_token,
+                                result: Some(ActivityExecutionResult::fail(
+                                    Failure::application_failure(
+                                        format!("Failed decoding activity task: {err}"),
+                                        false,
+                                    ),
+                                )),
+                            };
+                            encode_activity_completion(&mut completion, &common.data_converter)
+                                .await;
+                            common.worker.complete_activity_task(completion).await?;
+                            continue;
+                        }
                         match act_half.activity_task_handler(
                             common.worker.clone(),
                             common.client_options.clone(),
@@ -856,12 +929,8 @@ impl Worker {
                                     task_token,
                                     result: Some(ActivityExecutionResult::fail(failure)),
                                 };
-                                encode_payloads(
-                                    &mut completion,
-                                    common.data_converter.codec(),
-                                    &SerializationContextData::Activity,
-                                )
-                                .await;
+                                encode_activity_completion(&mut completion, &common.data_converter)
+                                    .await;
                                 common.worker.complete_activity_task(completion).await?;
                             }
                             Err(ActivityTaskHandlerError::Fatal(err)) => return Err(err),
@@ -1135,12 +1204,7 @@ impl ActivityHalf {
                         task_token,
                         result: Some(result),
                     };
-                    encode_payloads(
-                        &mut completion,
-                        codec_data_converter.codec(),
-                        &SerializationContextData::Activity,
-                    )
-                    .await;
+                    encode_activity_completion(&mut completion, &codec_data_converter).await;
                     worker.complete_activity_task(completion).await?;
                     Ok::<_, anyhow::Error>(())
                 });
@@ -1217,7 +1281,48 @@ impl PrintablePanicType for EndPrintingAttempts {
 mod tests {
     use super::*;
     use crate::activities::ActivityError;
+    use futures_util::future::BoxFuture;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use temporalio_common::{
+        data_converters::{
+            DefaultFailureConverter, PayloadCodec, PayloadConversionError, PayloadConverter,
+        },
+        protos::coresdk::{
+            activity_result::activity_execution_result,
+            workflow_commands::{CompleteWorkflowExecution, workflow_command},
+            workflow_completion::workflow_activation_completion,
+        },
+    };
     use temporalio_macros::{activities, activity_definitions, workflow, workflow_methods};
+
+    #[derive(Default)]
+    struct FailingEncodeCodec {
+        calls: AtomicUsize,
+    }
+
+    impl PayloadCodec for FailingEncodeCodec {
+        fn encode(
+            &self,
+            _: &SerializationContextData,
+            _: Vec<Payload>,
+        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                Err(PayloadConversionError::EncodingError(
+                    "codec encode failed".into(),
+                ))
+            }
+            .boxed()
+        }
+
+        fn decode(
+            &self,
+            _: &SerializationContextData,
+            payloads: Vec<Payload>,
+        ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+            async move { Ok(payloads) }.boxed()
+        }
+    }
 
     struct MyActivities {}
 
@@ -1256,6 +1361,71 @@ mod tests {
     fn test_activity_registration() {
         let act_instance = MyActivities {};
         let _ = WorkerOptions::new("task_q").register_activities(act_instance);
+    }
+
+    #[tokio::test]
+    async fn workflow_completion_codec_error_uses_unencoded_failure() {
+        let codec = Arc::new(FailingEncodeCodec::default());
+        let data_converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            codec.clone(),
+        );
+        let mut completion = WorkflowActivationCompletion::from_cmd(
+            "run-id",
+            workflow_command::Variant::CompleteWorkflowExecution(CompleteWorkflowExecution {
+                result: Some(Payload::default()),
+            }),
+        );
+
+        encode_workflow_completion(&mut completion, &data_converter).await;
+
+        let Some(workflow_activation_completion::Status::Failed(failed)) = completion.status else {
+            panic!("expected failed workflow completion")
+        };
+        assert_eq!(
+            failed.failure.unwrap().message,
+            "Failed encoding completion: Encoding error: codec encode failed"
+        );
+        assert_eq!(
+            failed.force_cause,
+            WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure as i32
+        );
+        assert_eq!(codec.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn activity_completion_codec_error_uses_unencoded_failure() {
+        let codec = Arc::new(FailingEncodeCodec::default());
+        let data_converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter,
+            codec.clone(),
+        );
+        let mut completion = ActivityTaskCompletion {
+            task_token: vec![],
+            result: Some(ActivityExecutionResult::ok(Payload::default())),
+        };
+
+        encode_activity_completion(&mut completion, &data_converter).await;
+
+        let Some(activity_execution_result::Status::Failed(failed)) =
+            completion.result.unwrap().status
+        else {
+            panic!("expected failed activity completion")
+        };
+        let failure = failed.failure.unwrap();
+        assert_eq!(
+            failure.message,
+            "Failed encoding activity completion: Encoding error: codec encode failed"
+        );
+        assert!(matches!(
+            failure.failure_info,
+            Some(
+                temporalio_common::protos::temporal::api::failure::v1::failure::FailureInfo::ApplicationFailureInfo(info)
+            ) if !info.non_retryable
+        ));
+        assert_eq!(codec.calls.load(Ordering::SeqCst), 1);
     }
 
     // Compile-only test for workflow context invocation


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Update `PayloadCodec` trait methods to now return `Result<_, PayloadConversionError>`
- Update `AsyncPayloadVisitor::visit` to be faillable, `PayloadVisitable::visit_payloads_mut` is now responsible for failing when a visitor fails. Generated `PayloadVisitable` impls now have `?` after their `visit` calls.
- activity/workflow completions will fall back to non-encoded failure if encoding fails. From what I can tell this is behavior of the other SDKs
- Adding `?`

## Why?
Discovered this while working on client interceptors, codecs certainly can fail.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added integration tests to verify codec failures result in failed tasks that are retried. Small unit tests to ensure we fallback to un-encoded failures if a codec operation fails along with ensuring codec failures abort streaming responses.

3. Any docs updates needed?
N/A
