### PR TITLE
Bump auto-enroll autoscaling minimum to the fixed poller default

### DIFF
--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -539,7 +539,7 @@ pub(crate) fn resolve_effective_behavior(
     match configured {
         Some(b) => b,
         None if capabilities.poller_autoscaling_auto_enroll() => PollerBehavior::Autoscaling {
-            minimum: 1,
+            minimum: 5,
             maximum: 100,
             initial: 5,
         },
@@ -2741,7 +2741,7 @@ mod tests {
         assert_eq!(
             resolve_effective_behavior(None, &caps),
             PollerBehavior::Autoscaling {
-                minimum: 1,
+                minimum: 5,
                 maximum: 100,
                 initial: 5,
             },


### PR DESCRIPTION
## Why

When a worker auto-enrolls into poller autoscaling (via the `poller_autoscaling_auto_enroll` namespace capability), it previously started with a minimum of **1** poller. That's fewer than the fixed default (**5**, i.e. `SimpleMaximum(5)`) a worker would otherwise run, so auto-enrolling could cause a throughput regression from too few pollers.

This sets the autoscaling **minimum equal to the fixed default poller count**, so auto-enrolling never starts below what a non-autoscaling worker would use.

## What

`resolve_effective_behavior` now returns explicit values:

| min | max | initial |
|-----|-----|---------|
| **5** (fixed default) | 100 | 5 |

Applies to workflow, activity, and nexus pollers.

**Tested:** `cargo test -p temporalio-sdk-core resolve_effective_behavior` passes (3/3). Updated the unit test to expect `minimum: 5`.