### PR TITLE
feat(sdk): Add plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ to docs, or any other relevant information.
   runtime and worker configuration types under `temporalio_sdk::runtime`, so workers no
   longer need a direct `temporalio-sdk-core` dependency. `Url` is also re-exported from
   `temporalio_client`.
+* Experimental plugin APIs for packaging reusable client and worker configuration, including data
+  converters, interceptors, activities, workflows, and automatic propagation from clients to
+  workers.
 * Workers can configure the maximum number of activity slots reserved for eager execution per
   workflow task with `WorkerOptions::max_eager_activity_reservations_per_workflow_task`.
 * `WorkflowInterceptor` for observing, transforming, or short-circuiting inbound workflow calls

--- a/crates/client/src/dns.rs
+++ b/crates/client/src/dns.rs
@@ -164,6 +164,7 @@ pub(crate) async fn create_balanced_channel(
 }
 
 /// Handle that aborts the DNS re-resolution task when dropped.
+#[derive(Debug)]
 pub(crate) struct DnsReresolutionHandle {
     abort_handle: tokio::task::AbortHandle,
 }

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -1,6 +1,6 @@
 //! Contains errors that can be returned by clients.
 
-use crate::{WorkflowExecutionStatus, workflow_handle::WorkflowResultDetails};
+use crate::{PluginApplyError, WorkflowExecutionStatus, workflow_handle::WorkflowResultDetails};
 use http::uri::InvalidUri;
 use temporalio_common::{
     data_converters::PayloadConversionError, error::IncomingError,
@@ -12,6 +12,9 @@ use tonic::Code;
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum ClientConnectError {
+    /// A plugin failed while configuring connection options.
+    #[error(transparent)]
+    Plugin(#[from] PluginApplyError),
     /// Invalid URI. Configuration error, fatal.
     #[error("Invalid URI: {0:?}")]
     InvalidUri(#[from] InvalidUri),
@@ -309,8 +312,10 @@ impl AsyncActivityError {
 }
 
 /// Errors that can occur when constructing a [`crate::Client`].
-///
-/// Currently has no variants, but may be extended in the future.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum ClientNewError {}
+pub enum ClientNewError {
+    /// A plugin failed while configuring client options.
+    #[error(transparent)]
+    Plugin(#[from] PluginApplyError),
+}

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -42,6 +42,14 @@ pub enum ClientConnectError {
     InvalidConfig(String),
 }
 
+impl From<ClientNewError> for ClientConnectError {
+    fn from(value: ClientNewError) -> Self {
+        match value {
+            ClientNewError::Plugin(err) => Self::Plugin(err),
+        }
+    }
+}
+
 /// Errors thrown when a gRPC metadata header is invalid.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -63,8 +63,7 @@ pub use interceptors::{
 pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use options_structs::*;
 pub use plugins::{
-    ClientPlugin, ClientPluginRegistration, PluginApplyError, PluginError, PluginResult,
-    PluginTarget,
+    ClientPlugin, ErasedClientPlugin, PluginApplyError, PluginError, PluginTarget, WorkerPluginData,
 };
 pub use replaceable::SharedReplaceableClient;
 pub use retry::RetryOptions;
@@ -780,9 +779,7 @@ impl Client {
     ) -> Result<Self, ClientConnectError> {
         plugins::apply_connection_plugins(&client_options, &mut connection_options)?;
         let connection = Connection::connect(connection_options).await?;
-        Self::new(connection, client_options).map_err(|err| match err {
-            ClientNewError::Plugin(err) => ClientConnectError::Plugin(err),
-        })
+        Ok(Self::new(connection, client_options)?)
     }
 
     /// Create a new client from a connection and options.

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -19,6 +19,8 @@ pub mod grpc;
 pub mod interceptors;
 mod metrics;
 mod options_structs;
+/// Experimental APIs for configuring clients with reusable plugins.
+pub mod plugins;
 /// Visible only for tests
 #[doc(hidden)]
 pub mod proxy;
@@ -60,6 +62,10 @@ pub use interceptors::{
 };
 pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use options_structs::*;
+pub use plugins::{
+    ClientPlugin, ClientPluginRegistration, PluginApplyError, PluginError, PluginResult,
+    PluginTarget,
+};
 pub use replaceable::SharedReplaceableClient;
 pub use retry::RetryOptions;
 pub use rpc_options::{RpcMetadata, RpcMetadataError, RpcOptions};
@@ -764,11 +770,27 @@ pub struct Client {
 }
 
 impl Client {
+    /// Connect to a Temporal service and create a namespace-bound client, applying registered
+    /// plugins to connection and client options in registration order.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub async fn connect(
+        mut connection_options: ConnectionOptions,
+        client_options: ClientOptions,
+    ) -> Result<Self, ClientConnectError> {
+        plugins::apply_connection_plugins(&client_options, &mut connection_options)?;
+        let connection = Connection::connect(connection_options).await?;
+        Self::new(connection, client_options).map_err(|err| match err {
+            ClientNewError::Plugin(err) => ClientConnectError::Plugin(err),
+        })
+    }
+
     /// Create a new client from a connection and options.
     ///
-    /// Currently infallible, but returns a `Result` for future extensibility
-    /// (e.g., interceptor or plugin validation).
-    pub fn new(connection: Connection, options: ClientOptions) -> Result<Self, ClientNewError> {
+    /// Registered client plugins are applied here. Connection plugin hooks only run when using
+    /// [`Client::connect`].
+    pub fn new(connection: Connection, mut options: ClientOptions) -> Result<Self, ClientNewError> {
+        plugins::apply_client_plugins(&mut options)?;
         Ok(Client {
             connection,
             options: Arc::new(options),

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -181,13 +181,14 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 ///
 /// Cloning a connection is cheap (single Arc increment). The underlying connection is shared
 /// between clones.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Connection {
     inner: Arc<ConnectionInner>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, derive_more::Debug)]
 struct ConnectionInner {
+    #[debug(skip)]
     service: TemporalServiceClient,
     retry_options: RetryOptions,
     identity: String,
@@ -762,7 +763,7 @@ impl TemporalServiceClient {
 
 /// Contains an instance of a namespace-bound client for interacting with the Temporal server.
 /// Cheap to clone.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     connection: Connection,
     options: Arc<ClientOptions>,
@@ -771,8 +772,6 @@ pub struct Client {
 impl Client {
     /// Connect to a Temporal service and create a namespace-bound client, applying registered
     /// plugins to connection and client options in registration order.
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub async fn connect(
         mut connection_options: ConnectionOptions,
         client_options: ClientOptions,

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ClientInterceptor, ClientPlugin, ClientPluginRegistration, HttpConnectProxyOptions,
-    RetryOptions, RpcOptions, VERSION, callback_based,
+    ClientInterceptor, ClientPlugin, ErasedClientPlugin, HttpConnectProxyOptions, RetryOptions,
+    RpcOptions, VERSION, callback_based,
 };
 use http::Uri;
 use std::{collections::HashMap, sync::Arc, time::Duration};
@@ -151,7 +151,7 @@ pub struct ClientOptions {
 
     #[builder(field)]
     #[debug(skip)]
-    plugins: Vec<ClientPluginRegistration>,
+    plugins: Vec<ErasedClientPlugin>,
 
     #[builder(field)]
     plugins_applied: bool,
@@ -169,7 +169,7 @@ impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     /// Register a type-erased client plugin.
     ///
     /// **Experimental:** This API may change or be removed.
-    pub fn plugin<P: Into<ClientPluginRegistration>>(mut self, plugin: P) -> Self {
+    pub fn plugin<P: Into<ErasedClientPlugin>>(mut self, plugin: P) -> Self {
         self.plugins.push(plugin.into());
         self
     }
@@ -180,7 +180,7 @@ impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     pub fn plugins<I, P>(mut self, plugins: I) -> Self
     where
         I: IntoIterator<Item = P>,
-        P: Into<ClientPluginRegistration>,
+        P: Into<ErasedClientPlugin>,
     {
         self.plugins.extend(plugins.into_iter().map(Into::into));
         self
@@ -190,7 +190,7 @@ impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     ///
     /// **Experimental:** This API may change or be removed.
     pub fn client_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
-        self.plugins.push(ClientPluginRegistration::new(plugin));
+        self.plugins.push(ErasedClientPlugin::new(plugin));
         self
     }
 }
@@ -201,7 +201,7 @@ impl ClientOptions {
     /// This is intended for SDK integrations that propagate worker plugin registrations.
     ///
     /// **Experimental:** This API may change or be removed.
-    pub fn plugins(&self) -> &[ClientPluginRegistration] {
+    pub fn plugins(&self) -> &[ErasedClientPlugin] {
         &self.plugins
     }
 

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -154,7 +154,8 @@ pub struct ClientOptions {
     plugins: Vec<ErasedClientPlugin>,
 
     #[builder(field)]
-    plugins_applied: bool,
+    #[debug(skip)]
+    client_plugins_applied: bool,
 
     /// The data converter used for serializing/deserializing payloads.
     #[builder(default)]
@@ -205,12 +206,12 @@ impl ClientOptions {
         &self.plugins
     }
 
-    pub(crate) fn plugins_applied(&self) -> bool {
-        self.plugins_applied
+    pub(crate) fn client_plugins_applied(&self) -> bool {
+        self.client_plugins_applied
     }
 
-    pub(crate) fn mark_plugins_applied(&mut self) {
-        self.plugins_applied = true;
+    pub(crate) fn mark_client_plugins_applied(&mut self) {
+        self.client_plugins_applied = true;
     }
 }
 

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -1,5 +1,6 @@
 use crate::{
-    ClientInterceptor, HttpConnectProxyOptions, RetryOptions, RpcOptions, VERSION, callback_based,
+    ClientInterceptor, ClientPlugin, ClientPluginRegistration, HttpConnectProxyOptions,
+    RetryOptions, RpcOptions, VERSION, callback_based,
 };
 use http::Uri;
 use std::{collections::HashMap, sync::Arc, time::Duration};
@@ -147,6 +148,14 @@ pub struct ClientOptions {
     /// The namespace this client will be bound to.
     #[builder(start_fn)]
     pub namespace: String,
+
+    #[builder(field)]
+    #[debug(skip)]
+    plugins: Vec<ClientPluginRegistration>,
+
+    #[builder(field)]
+    plugins_applied: bool,
+
     /// The data converter used for serializing/deserializing payloads.
     #[builder(default)]
     pub data_converter: DataConverter,
@@ -154,6 +163,55 @@ pub struct ClientOptions {
     #[builder(default)]
     #[debug(skip)]
     pub client_interceptors: Vec<Arc<dyn ClientInterceptor>>,
+}
+
+impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
+    /// Register a type-erased client plugin.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn plugin<P: Into<ClientPluginRegistration>>(mut self, plugin: P) -> Self {
+        self.plugins.push(plugin.into());
+        self
+    }
+
+    /// Register type-erased client plugins in iteration order.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn plugins<I, P>(mut self, plugins: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<ClientPluginRegistration>,
+    {
+        self.plugins.extend(plugins.into_iter().map(Into::into));
+        self
+    }
+
+    /// Register a client-only plugin.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn client_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
+        self.plugins.push(ClientPluginRegistration::new(plugin));
+        self
+    }
+}
+
+impl ClientOptions {
+    /// Return the registered plugins.
+    ///
+    /// This is intended for SDK integrations that propagate worker plugin registrations.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn plugins(&self) -> &[ClientPluginRegistration] {
+        &self.plugins
+    }
+
+    pub(crate) fn plugins_applied(&self) -> bool {
+        self.plugins_applied
+    }
+
+    pub(crate) fn mark_plugins_applied(&mut self) {
+        self.plugins_applied = true;
+    }
 }
 
 /// Selects the transport-level compression used for gRPC calls. See

--- a/crates/client/src/plugins.rs
+++ b/crates/client/src/plugins.rs
@@ -139,9 +139,6 @@ pub(crate) fn apply_connection_plugins(
     client_options: &ClientOptions,
     connection_options: &mut ConnectionOptions,
 ) -> Result<(), PluginApplyError> {
-    if client_options.plugins_applied() {
-        return Ok(());
-    }
     for registration in client_options.plugins() {
         registration
             .plugin()
@@ -158,7 +155,7 @@ pub(crate) fn apply_connection_plugins(
 }
 
 pub(crate) fn apply_client_plugins(options: &mut ClientOptions) -> Result<(), PluginApplyError> {
-    if options.plugins_applied() {
+    if options.client_plugins_applied() {
         return Ok(());
     }
     let plugins = options.plugins().to_vec();
@@ -170,7 +167,7 @@ pub(crate) fn apply_client_plugins(options: &mut ClientOptions) -> Result<(), Pl
                 PluginApplyError::new(registration.plugin().name(), PluginTarget::Client, source)
             })?;
     }
-    options.mark_plugins_applied();
+    options.mark_client_plugins_applied();
     Ok(())
 }
 
@@ -207,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn plugins_apply_once() {
+    fn plugins_follow_target_lifecycles() {
         let connection_calls = Arc::new(AtomicUsize::new(0));
         let client_calls = Arc::new(AtomicUsize::new(0));
         let mut client_options = ClientOptions::new("namespace")
@@ -216,19 +213,24 @@ mod tests {
                 client_calls: client_calls.clone(),
             })
             .build();
-        let mut connection_options =
+        let mut first_connection_options =
             ConnectionOptions::new(Url::parse("http://localhost:7233").unwrap())
-                .identity("identity")
+                .identity("first")
+                .build();
+        let mut second_connection_options =
+            ConnectionOptions::new(Url::parse("http://localhost:7233").unwrap())
+                .identity("second")
                 .build();
 
-        apply_connection_plugins(&client_options, &mut connection_options).unwrap();
+        apply_connection_plugins(&client_options, &mut first_connection_options).unwrap();
         apply_client_plugins(&mut client_options).unwrap();
-        apply_connection_plugins(&client_options, &mut connection_options).unwrap();
+        apply_connection_plugins(&client_options, &mut second_connection_options).unwrap();
         apply_client_plugins(&mut client_options).unwrap();
 
-        assert_eq!(connection_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(connection_calls.load(Ordering::Relaxed), 2);
         assert_eq!(client_calls.load(Ordering::Relaxed), 1);
-        assert_eq!(connection_options.identity, "identity-configured");
+        assert_eq!(first_connection_options.identity, "first-configured");
+        assert_eq!(second_connection_options.identity, "second-configured");
         assert_eq!(client_options.namespace, "namespace-configured");
     }
 }

--- a/crates/client/src/plugins.rs
+++ b/crates/client/src/plugins.rs
@@ -1,0 +1,303 @@
+//! Experimental client plugin APIs.
+
+use crate::{ClientOptions, ConnectionOptions};
+use std::{any::Any, error::Error, fmt, sync::Arc};
+
+/// The result type returned by plugin configuration hooks.
+///
+/// **Experimental:** This API may change or be removed.
+pub type PluginResult<T = ()> = Result<T, PluginError>;
+
+/// An error returned by a plugin configuration hook.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct PluginError(Box<dyn Error + Send + Sync + 'static>);
+
+impl PluginError {
+    /// Wrap an error returned by a plugin.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn new(error: impl Error + Send + Sync + 'static) -> Self {
+        Self(Box::new(error))
+    }
+
+    /// Create a plugin error from a message.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn message(message: impl Into<String>) -> Self {
+        Self(Box::new(PluginMessageError(message.into())))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct PluginMessageError(String);
+
+/// The configuration target being modified when a plugin failed.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum PluginTarget {
+    /// Connection options.
+    Connection,
+    /// Namespace-bound client options.
+    Client,
+    /// Worker options.
+    Worker,
+}
+
+impl fmt::Display for PluginTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Connection => f.write_str("connection options"),
+            Self::Client => f.write_str("client options"),
+            Self::Worker => f.write_str("worker options"),
+        }
+    }
+}
+
+/// An error applying a named plugin to a configuration target.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Debug, thiserror::Error)]
+#[error("plugin '{plugin_name}' failed to configure {target}: {source}")]
+pub struct PluginApplyError {
+    /// The plugin name reported by [`ClientPlugin::name`] or its worker equivalent.
+    pub plugin_name: String,
+    /// The configuration target being modified.
+    pub target: PluginTarget,
+    /// The error returned by the plugin.
+    #[source]
+    pub source: PluginError,
+}
+
+impl PluginApplyError {
+    pub(crate) fn new(
+        plugin_name: impl Into<String>,
+        target: PluginTarget,
+        source: PluginError,
+    ) -> Self {
+        Self {
+            plugin_name: plugin_name.into(),
+            target,
+            source,
+        }
+    }
+}
+
+/// Configures connection and namespace-bound client options.
+///
+/// **Experimental:** This API may change or be removed.
+pub trait ClientPlugin: Send + Sync + 'static {
+    /// Return the stable name used to identify this plugin in diagnostics and worker heartbeats.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    fn name(&self) -> &str;
+
+    /// Configure options before the connection is established.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    fn configure_connection_options(&self, _options: &mut ConnectionOptions) -> PluginResult {
+        Ok(())
+    }
+
+    /// Configure options before the namespace-bound client is created.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    fn configure_client_options(&self, _options: &mut ClientOptions) -> PluginResult {
+        Ok(())
+    }
+}
+
+/// A type-erased client plugin and worker-plugin propagation data.
+///
+/// The worker data is intentionally opaque so SDK layers can carry their own registration type
+/// through the client crate without creating a dependency from the client to an SDK.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Clone)]
+pub struct ClientPluginRegistration {
+    pub(crate) client: Arc<dyn ClientPlugin>,
+    worker_plugins: Vec<Arc<dyn Any + Send + Sync>>,
+    pub(crate) instance_id: Arc<()>,
+}
+
+impl ClientPluginRegistration {
+    /// Type-erase a client plugin for registration on [`ClientOptions`].
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn new<P: ClientPlugin>(plugin: P) -> Self {
+        Self {
+            client: Arc::new(plugin),
+            worker_plugins: Vec::new(),
+            instance_id: Arc::new(()),
+        }
+    }
+
+    /// Attach opaque worker-plugin propagation data.
+    ///
+    /// This is intended for SDK integrations that define their own worker plugin trait. Values
+    /// with types unknown to an SDK are ignored.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn with_worker_plugin<T: Any + Send + Sync>(mut self, plugin: T) -> Self {
+        self.worker_plugins.push(Arc::new(plugin));
+        self
+    }
+
+    /// Iterate over opaque worker-plugin propagation data.
+    ///
+    /// This is intended for SDK integrations that recognize their own private registration type.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn worker_plugins(&self) -> impl Iterator<Item = &(dyn Any + Send + Sync)> {
+        self.worker_plugins.iter().map(AsRef::as_ref)
+    }
+
+    /// Return this registration's identity token.
+    ///
+    /// This is intended for SDK integrations that need to recognize duplicate use of a combined
+    /// client and worker plugin registration.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn instance_id(&self) -> Arc<()> {
+        self.instance_id.clone()
+    }
+
+    pub(crate) fn plugin(&self) -> &dyn ClientPlugin {
+        self.client.as_ref()
+    }
+}
+
+pub(crate) fn apply_connection_plugins(
+    client_options: &ClientOptions,
+    connection_options: &mut ConnectionOptions,
+) -> Result<(), PluginApplyError> {
+    if client_options.plugins_applied() {
+        return Ok(());
+    }
+    for registration in client_options.plugins() {
+        registration
+            .plugin()
+            .configure_connection_options(connection_options)
+            .map_err(|source| {
+                PluginApplyError::new(
+                    registration.plugin().name(),
+                    PluginTarget::Connection,
+                    source,
+                )
+            })?;
+    }
+    Ok(())
+}
+
+pub(crate) fn apply_client_plugins(options: &mut ClientOptions) -> Result<(), PluginApplyError> {
+    if options.plugins_applied() {
+        return Ok(());
+    }
+    let plugins = options.plugins().to_vec();
+    for registration in plugins {
+        registration
+            .plugin()
+            .configure_client_options(options)
+            .map_err(|source| {
+                PluginApplyError::new(registration.plugin().name(), PluginTarget::Client, source)
+            })?;
+    }
+    options.mark_plugins_applied();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use url::Url;
+
+    struct CountingPlugin {
+        connection_calls: Arc<AtomicUsize>,
+        client_calls: Arc<AtomicUsize>,
+    }
+
+    impl ClientPlugin for CountingPlugin {
+        fn name(&self) -> &str {
+            "counting"
+        }
+
+        fn configure_connection_options(&self, options: &mut ConnectionOptions) -> PluginResult {
+            self.connection_calls.fetch_add(1, Ordering::Relaxed);
+            options.identity.push_str("-configured");
+            Ok(())
+        }
+
+        fn configure_client_options(&self, options: &mut ClientOptions) -> PluginResult {
+            self.client_calls.fetch_add(1, Ordering::Relaxed);
+            options.namespace.push_str("-configured");
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn plugins_apply_in_each_phase_once() {
+        let connection_calls = Arc::new(AtomicUsize::new(0));
+        let client_calls = Arc::new(AtomicUsize::new(0));
+        let mut client_options = ClientOptions::new("namespace")
+            .client_plugin(CountingPlugin {
+                connection_calls: connection_calls.clone(),
+                client_calls: client_calls.clone(),
+            })
+            .build();
+        let mut connection_options =
+            ConnectionOptions::new(Url::parse("http://localhost:7233").unwrap())
+                .identity("identity")
+                .build();
+
+        apply_connection_plugins(&client_options, &mut connection_options).unwrap();
+        apply_client_plugins(&mut client_options).unwrap();
+        apply_connection_plugins(&client_options, &mut connection_options).unwrap();
+        apply_client_plugins(&mut client_options).unwrap();
+
+        assert_eq!(connection_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(client_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(connection_options.identity, "identity-configured");
+        assert_eq!(client_options.namespace, "namespace-configured");
+    }
+
+    struct FailingPlugin;
+
+    impl ClientPlugin for FailingPlugin {
+        fn name(&self) -> &str {
+            "failing"
+        }
+
+        fn configure_client_options(&self, _options: &mut ClientOptions) -> PluginResult {
+            Err(PluginError::message("expected failure"))
+        }
+    }
+
+    #[test]
+    fn application_errors_include_name_target_and_source() {
+        let mut options = ClientOptions::new("namespace")
+            .client_plugin(FailingPlugin)
+            .build();
+        let error = apply_client_plugins(&mut options).unwrap_err();
+
+        assert_eq!(error.plugin_name, "failing");
+        assert_eq!(error.target, PluginTarget::Client);
+        assert_eq!(error.source.to_string(), "expected failure");
+    }
+
+    #[test]
+    fn worker_plugin_data_is_opaque_and_ordered() {
+        let registration = ClientPluginRegistration::new(FailingPlugin)
+            .with_worker_plugin(1usize)
+            .with_worker_plugin("second");
+        let values = registration.worker_plugins().collect::<Vec<_>>();
+
+        assert_eq!(values[0].downcast_ref::<usize>(), Some(&1));
+        assert_eq!(values[1].downcast_ref::<&str>(), Some(&"second"));
+    }
+}

--- a/crates/client/src/plugins.rs
+++ b/crates/client/src/plugins.rs
@@ -121,6 +121,14 @@ impl ErasedClientPlugin {
         self.worker_plugins.iter().map(AsRef::as_ref)
     }
 
+    /// Return the stable name so SDK integrations can report client-only plugins in worker
+    /// metadata.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn name(&self) -> &str {
+        self.client.name()
+    }
+
     pub(crate) fn plugin(&self) -> &dyn ClientPlugin {
         self.client.as_ref()
     }
@@ -221,32 +229,5 @@ mod tests {
         assert_eq!(client_calls.load(Ordering::Relaxed), 1);
         assert_eq!(connection_options.identity, "identity-configured");
         assert_eq!(client_options.namespace, "namespace-configured");
-    }
-
-    struct FailingPlugin;
-
-    impl ClientPlugin for FailingPlugin {
-        fn name(&self) -> &str {
-            "failing"
-        }
-
-        fn configure_client_options(
-            &self,
-            _options: &mut ClientOptions,
-        ) -> Result<(), PluginError> {
-            Err(PluginError::new("expected failure"))
-        }
-    }
-
-    #[test]
-    fn plugin_errors_propigated() {
-        let mut options = ClientOptions::new("namespace")
-            .client_plugin(FailingPlugin)
-            .build();
-        let error = apply_client_plugins(&mut options).unwrap_err();
-
-        assert_eq!(error.plugin_name, FailingPlugin.name());
-        assert_eq!(error.target, PluginTarget::Client);
-        assert_eq!(error.source.to_string(), "expected failure");
     }
 }

--- a/crates/client/src/plugins.rs
+++ b/crates/client/src/plugins.rs
@@ -62,7 +62,8 @@ impl PluginApplyError {
 ///
 /// **Experimental:** This API may change or be removed.
 pub trait ClientPlugin: Send + Sync + 'static {
-    /// Return the stable name used to identify this plugin in diagnostics and worker heartbeats.
+    /// Return the stable, unique name used to identify this plugin in diagnostics and worker
+    /// heartbeats.
     fn name(&self) -> &str;
 
     /// Configure options before the connection is established.

--- a/crates/client/src/plugins.rs
+++ b/crates/client/src/plugins.rs
@@ -1,69 +1,39 @@
 //! Experimental client plugin APIs.
 
 use crate::{ClientOptions, ConnectionOptions};
-use std::{any::Any, error::Error, fmt, sync::Arc};
-
-/// The result type returned by plugin configuration hooks.
-///
-/// **Experimental:** This API may change or be removed.
-pub type PluginResult<T = ()> = Result<T, PluginError>;
+use std::{any::Any, error::Error, sync::Arc};
 
 /// An error returned by a plugin configuration hook.
-///
-/// **Experimental:** This API may change or be removed.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
-pub struct PluginError(Box<dyn Error + Send + Sync + 'static>);
+pub struct PluginError(Box<dyn Error + Send + Sync>);
 
 impl PluginError {
     /// Wrap an error returned by a plugin.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn new(error: impl Error + Send + Sync + 'static) -> Self {
-        Self(Box::new(error))
-    }
-
-    /// Create a plugin error from a message.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn message(message: impl Into<String>) -> Self {
-        Self(Box::new(PluginMessageError(message.into())))
+    pub fn new(error: impl Into<Box<dyn Error + Send + Sync>>) -> Self {
+        Self(error.into())
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-#[error("{0}")]
-struct PluginMessageError(String);
-
 /// The configuration target being modified when a plugin failed.
-///
-/// **Experimental:** This API may change or be removed.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, derive_more::Display)]
 #[non_exhaustive]
 pub enum PluginTarget {
     /// Connection options.
+    #[display("connection options")]
     Connection,
     /// Namespace-bound client options.
+    #[display("client options")]
     Client,
     /// Worker options.
+    #[display("worker options")]
     Worker,
 }
 
-impl fmt::Display for PluginTarget {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Connection => f.write_str("connection options"),
-            Self::Client => f.write_str("client options"),
-            Self::Worker => f.write_str("worker options"),
-        }
-    }
-}
-
 /// An error applying a named plugin to a configuration target.
-///
-/// **Experimental:** This API may change or be removed.
 #[derive(Debug, thiserror::Error)]
 #[error("plugin '{plugin_name}' failed to configure {target}: {source}")]
+#[non_exhaustive]
 pub struct PluginApplyError {
     /// The plugin name reported by [`ClientPlugin::name`] or its worker equivalent.
     pub plugin_name: String,
@@ -75,11 +45,11 @@ pub struct PluginApplyError {
 }
 
 impl PluginApplyError {
-    pub(crate) fn new(
-        plugin_name: impl Into<String>,
-        target: PluginTarget,
-        source: PluginError,
-    ) -> Self {
+    /// Create an error for a plugin that failed to configure a target.
+    ///
+    /// **Internal:** This method is intended to be used during worker construction. Arguments can
+    /// change or be removed in breaking manners.
+    pub fn new(plugin_name: impl Into<String>, target: PluginTarget, source: PluginError) -> Self {
         Self {
             plugin_name: plugin_name.into(),
             target,
@@ -93,47 +63,45 @@ impl PluginApplyError {
 /// **Experimental:** This API may change or be removed.
 pub trait ClientPlugin: Send + Sync + 'static {
     /// Return the stable name used to identify this plugin in diagnostics and worker heartbeats.
-    ///
-    /// **Experimental:** This API may change or be removed.
     fn name(&self) -> &str;
 
     /// Configure options before the connection is established.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    fn configure_connection_options(&self, _options: &mut ConnectionOptions) -> PluginResult {
+    fn configure_connection_options(
+        &self,
+        _options: &mut ConnectionOptions,
+    ) -> Result<(), PluginError> {
         Ok(())
     }
 
     /// Configure options before the namespace-bound client is created.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    fn configure_client_options(&self, _options: &mut ClientOptions) -> PluginResult {
+    fn configure_client_options(&self, _options: &mut ClientOptions) -> Result<(), PluginError> {
         Ok(())
     }
 }
 
+/// Marks opaque worker-plugin propagation data supplied by an SDK integration.
+///
+/// Implementing this trait will not make a type recognized as plugin. Only SDK known
+/// `WorkerPluginExtension` implementers will be used as plugins.
+pub trait WorkerPluginData: Any + Send + Sync + 'static {}
+
 /// A type-erased client plugin and worker-plugin propagation data.
 ///
-/// The worker data is intentionally opaque so SDK layers can carry their own registration type
-/// through the client crate without creating a dependency from the client to an SDK.
+/// The worker data is intentionally opaque to avoid taking a dependency on `temporalio-sdk`.
 ///
 /// **Experimental:** This API may change or be removed.
 #[derive(Clone)]
-pub struct ClientPluginRegistration {
-    pub(crate) client: Arc<dyn ClientPlugin>,
-    worker_plugins: Vec<Arc<dyn Any + Send + Sync>>,
-    pub(crate) instance_id: Arc<()>,
+pub struct ErasedClientPlugin {
+    client: Arc<dyn ClientPlugin>,
+    worker_plugins: Vec<Arc<dyn WorkerPluginData>>,
 }
 
-impl ClientPluginRegistration {
+impl ErasedClientPlugin {
     /// Type-erase a client plugin for registration on [`ClientOptions`].
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub fn new<P: ClientPlugin>(plugin: P) -> Self {
         Self {
             client: Arc::new(plugin),
             worker_plugins: Vec::new(),
-            instance_id: Arc::new(()),
         }
     }
 
@@ -141,9 +109,7 @@ impl ClientPluginRegistration {
     ///
     /// This is intended for SDK integrations that define their own worker plugin trait. Values
     /// with types unknown to an SDK are ignored.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn with_worker_plugin<T: Any + Send + Sync>(mut self, plugin: T) -> Self {
+    pub fn with_worker_plugin<T: WorkerPluginData>(mut self, plugin: T) -> Self {
         self.worker_plugins.push(Arc::new(plugin));
         self
     }
@@ -151,20 +117,8 @@ impl ClientPluginRegistration {
     /// Iterate over opaque worker-plugin propagation data.
     ///
     /// This is intended for SDK integrations that recognize their own private registration type.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn worker_plugins(&self) -> impl Iterator<Item = &(dyn Any + Send + Sync)> {
+    pub fn worker_plugins(&self) -> impl Iterator<Item = &dyn WorkerPluginData> {
         self.worker_plugins.iter().map(AsRef::as_ref)
-    }
-
-    /// Return this registration's identity token.
-    ///
-    /// This is intended for SDK integrations that need to recognize duplicate use of a combined
-    /// client and worker plugin registration.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn instance_id(&self) -> Arc<()> {
-        self.instance_id.clone()
     }
 
     pub(crate) fn plugin(&self) -> &dyn ClientPlugin {
@@ -227,13 +181,16 @@ mod tests {
             "counting"
         }
 
-        fn configure_connection_options(&self, options: &mut ConnectionOptions) -> PluginResult {
+        fn configure_connection_options(
+            &self,
+            options: &mut ConnectionOptions,
+        ) -> Result<(), PluginError> {
             self.connection_calls.fetch_add(1, Ordering::Relaxed);
             options.identity.push_str("-configured");
             Ok(())
         }
 
-        fn configure_client_options(&self, options: &mut ClientOptions) -> PluginResult {
+        fn configure_client_options(&self, options: &mut ClientOptions) -> Result<(), PluginError> {
             self.client_calls.fetch_add(1, Ordering::Relaxed);
             options.namespace.push_str("-configured");
             Ok(())
@@ -241,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn plugins_apply_in_each_phase_once() {
+    fn plugins_apply_once() {
         let connection_calls = Arc::new(AtomicUsize::new(0));
         let client_calls = Arc::new(AtomicUsize::new(0));
         let mut client_options = ClientOptions::new("namespace")
@@ -273,31 +230,23 @@ mod tests {
             "failing"
         }
 
-        fn configure_client_options(&self, _options: &mut ClientOptions) -> PluginResult {
-            Err(PluginError::message("expected failure"))
+        fn configure_client_options(
+            &self,
+            _options: &mut ClientOptions,
+        ) -> Result<(), PluginError> {
+            Err(PluginError::new("expected failure"))
         }
     }
 
     #[test]
-    fn application_errors_include_name_target_and_source() {
+    fn plugin_errors_propigated() {
         let mut options = ClientOptions::new("namespace")
             .client_plugin(FailingPlugin)
             .build();
         let error = apply_client_plugins(&mut options).unwrap_err();
 
-        assert_eq!(error.plugin_name, "failing");
+        assert_eq!(error.plugin_name, FailingPlugin.name());
         assert_eq!(error.target, PluginTarget::Client);
         assert_eq!(error.source.to_string(), "expected failure");
-    }
-
-    #[test]
-    fn worker_plugin_data_is_opaque_and_ordered() {
-        let registration = ClientPluginRegistration::new(FailingPlugin)
-            .with_worker_plugin(1usize)
-            .with_worker_plugin("second");
-        let values = registration.worker_plugins().collect::<Vec<_>>();
-
-        assert_eq!(values[0].downcast_ref::<usize>(), Some(&1));
-        assert_eq!(values[1].downcast_ref::<&str>(), Some(&"second"));
     }
 }

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -319,24 +319,24 @@ struct InitializedWorker {
 
 #[derive(Clone, Default)]
 struct TestWorkerInterceptorRouter {
-    interceptors: Arc<RwLock<Vec<Arc<dyn WorkerInterceptor>>>>,
+    interceptor: Arc<RwLock<Option<Arc<dyn WorkerInterceptor>>>>,
 }
 
 impl TestWorkerInterceptorRouter {
     fn set(&self, interceptor: impl WorkerInterceptor + 'static) {
-        *self.interceptors.write() = vec![Arc::new(interceptor)];
+        *self.interceptor.write() = Some(Arc::new(interceptor));
     }
 
     fn clear(&self) {
-        self.interceptors.write().clear();
+        *self.interceptor.write() = None;
     }
 }
 
 #[async_trait::async_trait(?Send)]
 impl WorkerInterceptor for TestWorkerInterceptorRouter {
     async fn on_workflow_activation_completion(&self, completion: &WorkflowActivationCompletion) {
-        let interceptors = self.interceptors.read().clone();
-        for interceptor in interceptors {
+        let interceptor = self.interceptor.read().clone();
+        if let Some(interceptor) = interceptor {
             interceptor
                 .on_workflow_activation_completion(completion)
                 .await;
@@ -344,14 +344,15 @@ impl WorkerInterceptor for TestWorkerInterceptorRouter {
     }
 
     fn on_shutdown(&self, sdk_worker: &Worker) {
-        for interceptor in self.interceptors.read().iter() {
+        let interceptor = self.interceptor.read().clone();
+        if let Some(interceptor) = interceptor {
             interceptor.on_shutdown(sdk_worker);
         }
     }
 
     async fn on_workflow_activation(&self, activation: &WorkflowActivation) -> anyhow::Result<()> {
-        let interceptors = self.interceptors.read().clone();
-        for interceptor in interceptors {
+        let interceptor = self.interceptor.read().clone();
+        if let Some(interceptor) = interceptor {
             interceptor.on_workflow_activation(activation).await?;
         }
         Ok(())
@@ -1141,10 +1142,16 @@ pub(crate) fn mock_sdk_cfg(
     let mut mock = build_mock_pollers(poll_cfg);
     mock.worker_cfg(mutator);
     let core = mock_worker(mock);
-    TestWorker::new(temporalio_sdk::Worker::new_from_core(
-        Arc::new(core),
-        DataConverter::default(),
-    ))
+    let interceptor_router = TestWorkerInterceptorRouter::default();
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(interceptor_router.clone())
+        .build();
+    let sdk = Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+        .expect("mock worker options are valid");
+    TestWorker::new_with_interceptor_router(sdk, interceptor_router)
 }
 
 #[derive(Default)]

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -11,7 +11,7 @@ use futures_util::{
     Future, StreamExt, future, stream,
     stream::{Stream, TryStreamExt},
 };
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use prost::Message;
 use rand::RngExt;
 use std::{
@@ -29,8 +29,8 @@ use std::{
     time::{Duration, Instant},
 };
 use temporalio_client::{
-    Client, ClientTlsOptions, Connection, ConnectionOptions, GrpcCompression, NamespacedClient,
-    TlsOptions, UntypedWorkflow, UntypedWorkflowHandle, WorkflowExecutionInfo,
+    Client, ClientOptions, ClientTlsOptions, Connection, ConnectionOptions, GrpcCompression,
+    NamespacedClient, TlsOptions, UntypedWorkflow, UntypedWorkflowHandle, WorkflowExecutionInfo,
     WorkflowGetResultOptions, WorkflowHandle, WorkflowStartOptions,
     errors::{WorkflowGetResultError, WorkflowStartError},
     grpc::WorkflowService,
@@ -72,7 +72,7 @@ use temporalio_sdk_core::{
 };
 use tokio::{sync::OnceCell, task::AbortHandle};
 use tonic::IntoRequest;
-use tracing::{debug, warn};
+use tracing::warn;
 use url::Url;
 use uuid::Uuid;
 /// The env var used to specify where the integ tests should point
@@ -159,15 +159,55 @@ where
 {
     replay_sdk_worker_stream(stream::iter(histories))
 }
+pub(crate) fn replay_sdk_worker_intercepted<I>(
+    histories: I,
+    interceptor: impl WorkerInterceptor + 'static,
+) -> Worker
+where
+    I: IntoIterator<Item = HistoryForReplay> + 'static,
+    <I as IntoIterator>::IntoIter: Send,
+{
+    let core = init_core_replay_stream("replay_worker_test", stream::iter(histories));
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(interceptor)
+        .build();
+    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+        .expect("replay worker options are valid")
+}
+
 pub(crate) fn replay_sdk_worker_stream<I>(histories: I) -> Worker
 where
     I: Stream<Item = HistoryForReplay> + Send + 'static,
 {
     let core = init_core_replay_stream("replay_worker_test", histories);
-    // TODO [rust-sdk-branch]: Needs DC passed in
-    let mut worker = Worker::new_from_core(Arc::new(core), DataConverter::default());
-    worker.set_worker_interceptor(FailOnNondeterminismInterceptor {});
-    worker
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(FailOnNondeterminismInterceptor {})
+        .build();
+    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+        .expect("replay worker options are valid")
+}
+pub(crate) fn replay_sdk_worker_stream_intercepted<I>(
+    histories: I,
+    interceptor: impl WorkerInterceptor + 'static,
+) -> Worker
+where
+    I: Stream<Item = HistoryForReplay> + Send + 'static,
+{
+    let core = init_core_replay_stream("replay_worker_test", histories);
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(interceptor)
+        .build();
+    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+        .expect("replay worker options are valid")
 }
 
 /// Load history from a file containing the protobuf serialization of it.
@@ -277,6 +317,47 @@ struct InitializedWorker {
     client: Client,
 }
 
+#[derive(Clone, Default)]
+struct TestWorkerInterceptorRouter {
+    interceptors: Arc<RwLock<Vec<Arc<dyn WorkerInterceptor>>>>,
+}
+
+impl TestWorkerInterceptorRouter {
+    fn set(&self, interceptor: impl WorkerInterceptor + 'static) {
+        *self.interceptors.write() = vec![Arc::new(interceptor)];
+    }
+
+    fn clear(&self) {
+        self.interceptors.write().clear();
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl WorkerInterceptor for TestWorkerInterceptorRouter {
+    async fn on_workflow_activation_completion(&self, completion: &WorkflowActivationCompletion) {
+        let interceptors = self.interceptors.read().clone();
+        for interceptor in interceptors {
+            interceptor
+                .on_workflow_activation_completion(completion)
+                .await;
+        }
+    }
+
+    fn on_shutdown(&self, sdk_worker: &Worker) {
+        for interceptor in self.interceptors.read().iter() {
+            interceptor.on_shutdown(sdk_worker);
+        }
+    }
+
+    async fn on_workflow_activation(&self, activation: &WorkflowActivation) -> anyhow::Result<()> {
+        let interceptors = self.interceptors.read().clone();
+        for interceptor in interceptors {
+            interceptor.on_workflow_activation(activation).await?;
+        }
+        Ok(())
+    }
+}
+
 impl CoreWfStarter {
     pub(crate) fn new(test_name: &str) -> Self {
         init_integ_telem();
@@ -372,13 +453,12 @@ impl CoreWfStarter {
             .await
             .expect("Worker validation should succeed");
         let client = self.get_client().await;
-        let sdk = Worker::new_from_core_options(
-            worker,
-            client.options().clone(),
-            self.sdk_config.clone(),
-        )
-        .expect("SDK worker should initialize from core worker and options");
-        let mut w = TestWorker::new(sdk);
+        let interceptor_router = TestWorkerInterceptorRouter::default();
+        let mut sdk_config = self.sdk_config.clone();
+        sdk_config.worker_interceptor(interceptor_router.clone());
+        let sdk = Worker::new_from_core_options(worker, client.options().clone(), sdk_config)
+            .expect("SDK worker should initialize from core worker and options");
+        let mut w = TestWorker::new_with_interceptor_router(sdk, interceptor_router);
         w.client = Some(client);
 
         w
@@ -527,6 +607,7 @@ impl CoreWfStarter {
 /// Provides conveniences for running integ tests with the SDK (against real server or mocks)
 pub(crate) struct TestWorker {
     inner: Worker,
+    interceptor_router: Option<TestWorkerInterceptorRouter>,
     client: Option<Client>,
     pub started_workflows: Arc<Mutex<Vec<WorkflowExecutionInfo>>>,
     /// If set true (default), and a client is available, we will fetch workflow results to
@@ -538,14 +619,32 @@ impl TestWorker {
     pub(crate) fn new(sdk: Worker) -> Self {
         Self {
             inner: sdk,
+            interceptor_router: None,
             client: None,
             started_workflows: Arc::new(Mutex::new(vec![])),
             fetch_results: true,
         }
     }
 
+    fn new_with_interceptor_router(
+        sdk: Worker,
+        interceptor_router: TestWorkerInterceptorRouter,
+    ) -> Self {
+        Self {
+            interceptor_router: Some(interceptor_router),
+            ..Self::new(sdk)
+        }
+    }
+
     pub(crate) fn inner_mut(&mut self) -> &mut Worker {
         &mut self.inner
+    }
+
+    pub(crate) fn set_worker_interceptor(&self, interceptor: impl WorkerInterceptor + 'static) {
+        self.interceptor_router
+            .as_ref()
+            .expect("intercepted test workers must be created with an interceptor router")
+            .set(interceptor);
     }
 
     pub(crate) fn worker_instance_key(&self) -> Uuid {
@@ -662,7 +761,7 @@ impl TestWorker {
 
     /// Runs until all expected workflows have completed and then shuts down the worker
     pub(crate) async fn run_until_done(&mut self) -> Result<(), anyhow::Error> {
-        self.run_until_done_intercepted(Option::<TestWorkerCompletionIceptor>::None)
+        self.run_until_done_intercepted(Option::<FailOnNondeterminismInterceptor>::None)
             .await
     }
 
@@ -671,7 +770,7 @@ impl TestWorker {
         &mut self,
         next_interceptor: Option<impl WorkerInterceptor + 'static>,
     ) -> Result<(), anyhow::Error> {
-        let mut iceptor = TestWorkerCompletionIceptor::new(
+        let mut completion_waiter = TestWorkerCompletionIceptor::new(
             TestWorkerShutdownCond::NoAutoShutdown,
             Arc::new(self.inner.shutdown_handle()),
         );
@@ -679,14 +778,20 @@ impl TestWorker {
         if self.fetch_results
             && let Some(c) = self.client.clone()
         {
-            iceptor.condition = TestWorkerShutdownCond::GetResults(
+            completion_waiter.condition = TestWorkerShutdownCond::GetResults(
                 std::mem::take(&mut self.started_workflows.lock()),
                 c,
             );
         }
-        iceptor.next = next_interceptor.map(|i| Box::new(i) as Box<dyn WorkerInterceptor>);
-        let get_results_waiter = iceptor.wait_all_wfs();
-        self.inner.set_worker_interceptor(iceptor);
+        if let Some(interceptor) = next_interceptor {
+            self.interceptor_router
+                .as_ref()
+                .expect("intercepted test workers must be created with an interceptor router")
+                .set(interceptor);
+        } else if let Some(interceptor_router) = &self.interceptor_router {
+            interceptor_router.clear();
+        }
+        let get_results_waiter = completion_waiter.wait_all_wfs();
         tokio::try_join!(self.inner.run(), get_results_waiter)?;
         Ok(())
     }
@@ -740,15 +845,16 @@ pub(crate) enum TestWorkerShutdownCond {
 /// Implements calling the shutdown handle when the expected number of test workflows has completed
 pub(crate) struct TestWorkerCompletionIceptor {
     condition: TestWorkerShutdownCond,
-    shutdown_handle: Arc<dyn Fn()>,
-    next: Option<Box<dyn WorkerInterceptor>>,
+    shutdown_handle: Arc<dyn Fn() + Send + Sync>,
 }
 impl TestWorkerCompletionIceptor {
-    pub(crate) fn new(condition: TestWorkerShutdownCond, shutdown_handle: Arc<dyn Fn()>) -> Self {
+    pub(crate) fn new(
+        condition: TestWorkerShutdownCond,
+        shutdown_handle: Arc<dyn Fn() + Send + Sync>,
+    ) -> Self {
         Self {
             condition,
             shutdown_handle,
-            next: None,
         }
     }
 
@@ -781,30 +887,6 @@ impl TestWorkerCompletionIceptor {
         }
     }
 }
-#[async_trait::async_trait(?Send)]
-impl WorkerInterceptor for TestWorkerCompletionIceptor {
-    async fn on_workflow_activation_completion(&self, completion: &WorkflowActivationCompletion) {
-        if completion.has_execution_ending() {
-            debug!("Workflow {} says it's finishing", &completion.run_id);
-        }
-        if let Some(n) = self.next.as_ref() {
-            n.on_workflow_activation_completion(completion).await;
-        }
-    }
-
-    fn on_shutdown(&self, sdk_worker: &Worker) {
-        if let Some(n) = self.next.as_ref() {
-            n.on_shutdown(sdk_worker);
-        }
-    }
-    async fn on_workflow_activation(&self, a: &WorkflowActivation) -> Result<(), anyhow::Error> {
-        if let Some(n) = self.next.as_ref() {
-            n.on_workflow_activation(a).await?;
-        }
-        Ok(())
-    }
-}
-
 /// Returns the connection options used to connect to the server used for integration tests.
 pub(crate) fn get_integ_server_options() -> ConnectionOptions {
     let temporal_server_address = env::var(INTEG_SERVER_TARGET_ENV_VAR)
@@ -915,7 +997,7 @@ pub(crate) fn get_integ_runtime_options(telemopts: TelemetryOptions) -> RuntimeO
 pub(crate) trait WorkflowHandleExt {
     async fn fetch_history_and_replay(
         &self,
-        worker: &mut Worker,
+        worker: &mut TestWorker,
     ) -> Result<Option<Payload>, anyhow::Error>;
 }
 
@@ -926,19 +1008,23 @@ where
 {
     async fn fetch_history_and_replay(
         &self,
-        worker: &mut Worker,
+        worker: &mut TestWorker,
     ) -> Result<Option<Payload>, anyhow::Error> {
         let wf_id = self.info().workflow_id.clone();
         let events = self.fetch_history(Default::default()).await?.into_events();
         let with_id = HistoryForReplay::new(events, wf_id);
-        let replay_worker = init_core_replay_preloaded(worker.task_queue(), [with_id]);
-        worker.with_new_core_worker(Arc::new(replay_worker));
+        let replay_worker = init_core_replay_preloaded(worker.inner.task_queue(), [with_id]);
+        worker.inner.with_new_core_worker(Arc::new(replay_worker));
         let retval_icept = ReturnWorkflowExitValueInterceptor::default();
         let retval_handle = retval_icept.result_handle();
         let mut top_icept = InterceptorWithNext::new(Box::new(FailOnNondeterminismInterceptor {}));
         top_icept.set_next(Box::new(retval_icept));
-        worker.set_worker_interceptor(top_icept);
-        worker.run().await?;
+        worker
+            .interceptor_router
+            .as_ref()
+            .expect("replay test workers must be created with an interceptor router")
+            .set(top_icept);
+        worker.inner.run().await?;
         Ok(retval_handle.get().cloned())
     }
 }
@@ -1013,10 +1099,34 @@ pub(crate) fn build_fake_sdk(mock_cfg: MockPollCfg) -> temporalio_sdk::Worker {
         c.ignore_evicts_on_shutdown = false;
     });
     let core = mock_worker(mock);
-    let mut worker =
-        temporalio_sdk::Worker::new_from_core(Arc::new(core), DataConverter::default());
-    worker.set_worker_interceptor(FailOnNondeterminismInterceptor {});
-    worker
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(FailOnNondeterminismInterceptor {})
+        .build();
+    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+        .expect("mock worker options are valid")
+}
+
+pub(crate) fn build_fake_sdk_intercepted(
+    mock_cfg: MockPollCfg,
+    interceptor: impl WorkerInterceptor + 'static,
+) -> temporalio_sdk::Worker {
+    let mut mock = build_mock_pollers(mock_cfg);
+    mock.worker_cfg(|c| {
+        c.max_cached_workflows = 1;
+        c.ignore_evicts_on_shutdown = false;
+    });
+    let core = mock_worker(mock);
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(interceptor)
+        .build();
+    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+        .expect("mock worker options are valid")
 }
 
 pub(crate) fn mock_sdk(poll_cfg: MockPollCfg) -> TestWorker {
@@ -1040,7 +1150,7 @@ pub(crate) fn mock_sdk_cfg(
 #[derive(Default)]
 pub(crate) struct ActivationAssertionsInterceptor {
     #[allow(clippy::type_complexity)]
-    assertions: Mutex<VecDeque<Box<dyn FnOnce(&WorkflowActivation)>>>,
+    assertions: Mutex<VecDeque<Box<dyn FnOnce(&WorkflowActivation) + Send>>>,
     used: AtomicBool,
 }
 
@@ -1050,7 +1160,10 @@ impl ActivationAssertionsInterceptor {
         self
     }
 
-    pub(crate) fn then(&mut self, assert: impl FnOnce(&WorkflowActivation) + 'static) -> &mut Self {
+    pub(crate) fn then(
+        &mut self,
+        assert: impl FnOnce(&WorkflowActivation) + Send + 'static,
+    ) -> &mut Self {
         self.assertions.lock().push_back(Box::new(assert));
         self
     }

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -267,13 +267,10 @@ async fn simple_plugin_configures_working_client_and_worker() {
 
 #[tokio::test]
 async fn plugin_errors_surface() {
-    let connection_plugin = SimplePlugin::new("failing-connection")
-        .configure_connection_options(|_| Err(PluginError::new("connection failure")))
-        .build();
     let connection_result = Client::connect(
         get_integ_server_options(),
         ClientOptions::new(integ_namespace())
-            .plugin(connection_plugin)
+            .client_plugin(FailingConnectionPlugin)
             .build(),
     )
     .await;
@@ -282,13 +279,10 @@ async fn plugin_errors_surface() {
         "plugin 'failing-connection' failed to configure connection options: connection failure"
     );
 
-    let client_plugin = SimplePlugin::new("failing-client")
-        .configure_client_options(|_| Err(PluginError::new("client failure")))
-        .build();
     let client_result = Client::connect(
         get_integ_server_options(),
         ClientOptions::new(integ_namespace())
-            .plugin(client_plugin)
+            .client_plugin(FailingClientPlugin)
             .build(),
     )
     .await;
@@ -303,21 +297,57 @@ async fn plugin_errors_surface() {
     )
     .await
     .unwrap();
-    let worker_plugin = SimplePlugin::new("failing-worker")
-        .configure_worker_options(|_| Err(PluginError::new("worker failure")))
-        .build();
     let worker_result = Worker::new(
         &CoreRuntime::new_assume_tokio(get_integ_runtime_options(get_integ_telem_options()))
             .unwrap(),
         client,
         WorkerOptions::new(format!("failing-plugin-{}", Uuid::new_v4()))
-            .plugin(worker_plugin)
+            .worker_plugin(FailingWorkerPlugin)
             .build(),
     );
     assert_eq!(
         worker_result.unwrap_err().to_string(),
         "plugin 'failing-worker' failed to configure worker options: worker failure"
     );
+}
+
+struct FailingConnectionPlugin;
+
+impl ClientPlugin for FailingConnectionPlugin {
+    fn name(&self) -> &str {
+        "failing-connection"
+    }
+
+    fn configure_connection_options(
+        &self,
+        _options: &mut ConnectionOptions,
+    ) -> Result<(), PluginError> {
+        Err(PluginError::new("connection failure"))
+    }
+}
+
+struct FailingClientPlugin;
+
+impl ClientPlugin for FailingClientPlugin {
+    fn name(&self) -> &str {
+        "failing-client"
+    }
+
+    fn configure_client_options(&self, _options: &mut ClientOptions) -> Result<(), PluginError> {
+        Err(PluginError::new("client failure"))
+    }
+}
+
+struct FailingWorkerPlugin;
+
+impl WorkerPlugin for FailingWorkerPlugin {
+    fn name(&self) -> &str {
+        "failing-worker"
+    }
+
+    fn configure_worker_options(&self, _options: &mut WorkerOptions) -> Result<(), PluginError> {
+        Err(PluginError::new("worker failure"))
+    }
 }
 
 struct ClientOnlyMetadataPlugin;

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -31,8 +31,8 @@ use temporalio_common::{
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, ClientAndWorkerPlugin, SimplePlugin, Worker, WorkerOptions, WorkerPlugin,
-    WorkflowContext, WorkflowResult,
-    activities::{ActivityContext, ActivityError},
+    WorkflowContext, WorkflowDefinitions, WorkflowResult,
+    activities::{ActivityContext, ActivityDefinitions, ActivityError},
     interceptors::WorkerInterceptor,
 };
 use temporalio_sdk_core::CoreRuntime;
@@ -217,17 +217,22 @@ async fn simple_plugin_configures_working_client_and_worker() {
             decode_calls: decode_calls.clone(),
         },
     );
+    let mut activities = ActivityDefinitions::default();
+    activities.register_activities(SimplePluginActivities);
+    let mut workflows = WorkflowDefinitions::new();
+    workflows
+        .register_workflow::<SimplePluginWorkflow>()
+        .unwrap();
     let plugin = SimplePlugin::builder("simple-integration-plugin")
         .data_converter(data_converter)
-        .client_interceptor(CountingClientInterceptor {
+        .client_interceptors(vec![Arc::new(CountingClientInterceptor {
             calls: client_interceptor_calls.clone(),
-        })
-        .worker_interceptor(CountingWorkerInterceptor {
+        }) as Arc<dyn ClientInterceptor>])
+        .worker_interceptors(vec![Arc::new(CountingWorkerInterceptor {
             calls: worker_interceptor_calls.clone(),
-        })
-        .register_activities(SimplePluginActivities)
-        .register_workflow::<SimplePluginWorkflow>()
-        .unwrap()
+        }) as Arc<dyn WorkerInterceptor>])
+        .activities(activities)
+        .workflows(workflows)
         .build();
     let client_options = ClientOptions::new(integ_namespace()).plugin(plugin).build();
     let client = Client::connect(get_integ_server_options(), client_options)

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -1,0 +1,370 @@
+use crate::common::{
+    CoreWfStarter, get_integ_runtime_options, get_integ_server_options, get_integ_telem_options,
+    integ_namespace,
+};
+use futures_util::future::BoxFuture;
+use std::{
+    sync::{
+        Arc,
+        atomic::{
+            AtomicU8, AtomicUsize,
+            Ordering::{self, Relaxed},
+        },
+    },
+    time::Duration,
+};
+use temporalio_client::{
+    Client, ClientInterceptor, ClientOptions, ClientPlugin, ConnectionOptions, NamespacedClient,
+    Next, PluginError, StartWorkflowInput, StartWorkflowOutput, WorkflowStartOptions,
+    errors::WorkflowStartError,
+};
+use temporalio_common::{
+    data_converters::{
+        DataConverter, DefaultFailureConverter, PayloadCodec, PayloadConversionError,
+        PayloadConverter, SerializationContextData,
+    },
+    protos::{
+        coresdk::workflow_activation::WorkflowActivation, temporal::api::common::v1::Payload,
+    },
+    worker::WorkerTaskTypes,
+};
+use temporalio_macros::{activities, workflow, workflow_methods};
+use temporalio_sdk::{
+    ActivityOptions, ClientAndWorkerPlugin, SimplePlugin, Worker, WorkerOptions, WorkerPlugin,
+    WorkflowContext, WorkflowResult,
+    activities::{ActivityContext, ActivityError},
+    interceptors::WorkerInterceptor,
+};
+use temporalio_sdk_core::CoreRuntime;
+use url::Url;
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct IntegrationPlugin {
+    connection_calls: Arc<AtomicU8>,
+    client_calls: Arc<AtomicU8>,
+    worker_calls: Arc<AtomicU8>,
+    target: Url,
+}
+
+impl ClientPlugin for IntegrationPlugin {
+    fn name(&self) -> &str {
+        "integration-plugin"
+    }
+
+    fn configure_connection_options(
+        &self,
+        options: &mut ConnectionOptions,
+    ) -> Result<(), PluginError> {
+        self.connection_calls.fetch_add(1, Relaxed);
+        options.target = self.target.clone();
+        options.identity = "integration-plugin-client".to_owned();
+        Ok(())
+    }
+
+    fn configure_client_options(&self, options: &mut ClientOptions) -> Result<(), PluginError> {
+        self.client_calls.fetch_add(1, Relaxed);
+        options.namespace = integ_namespace();
+        Ok(())
+    }
+}
+
+impl WorkerPlugin for IntegrationPlugin {
+    fn name(&self) -> &str {
+        "integration-plugin"
+    }
+
+    fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
+        self.worker_calls.fetch_add(1, Relaxed);
+        options.max_cached_workflows = 0;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn plugins_configure_client_and_worker() {
+    let runtime =
+        CoreRuntime::new_assume_tokio(get_integ_runtime_options(get_integ_telem_options()))
+            .unwrap();
+    let connection_calls = Arc::new(AtomicU8::new(0));
+    let client_calls = Arc::new(AtomicU8::new(0));
+    let worker_calls = Arc::new(AtomicU8::new(0));
+    let server_options = get_integ_server_options();
+    let plugin = ClientAndWorkerPlugin::new(IntegrationPlugin {
+        connection_calls: connection_calls.clone(),
+        client_calls: client_calls.clone(),
+        worker_calls: worker_calls.clone(),
+        target: server_options.target,
+    });
+    let client_options = ClientOptions::new("plugin-replaces-this-namespace")
+        .plugin(plugin)
+        .build();
+    let connection_options =
+        ConnectionOptions::new(Url::parse("http://127.0.0.1:1").unwrap()).build();
+    let client = Client::connect(connection_options, client_options)
+        .await
+        .unwrap();
+    assert_eq!(client.connection().identity(), "integration-plugin-client");
+    assert_eq!(client.namespace(), integ_namespace());
+    let worker_options = WorkerOptions::new(format!("plugins-{}", Uuid::new_v4())).build();
+    let worker = Worker::new(&runtime, client, worker_options).unwrap();
+
+    assert_eq!(connection_calls.load(Relaxed), 1);
+    assert_eq!(client_calls.load(Relaxed), 1);
+    assert_eq!(worker_calls.load(Relaxed), 1);
+    assert_eq!(worker.core_worker().get_config().max_cached_workflows, 0);
+    assert_eq!(worker.core_worker().get_config().plugins.len(), 1);
+}
+
+struct CountingPayloadCodec {
+    encode_calls: Arc<AtomicUsize>,
+    decode_calls: Arc<AtomicUsize>,
+}
+
+impl PayloadCodec for CountingPayloadCodec {
+    fn encode(
+        &self,
+        _context: &SerializationContextData,
+        payloads: Vec<Payload>,
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+        self.encode_calls.fetch_add(1, Ordering::Relaxed);
+        Box::pin(async move { Ok(payloads) })
+    }
+
+    fn decode(
+        &self,
+        _context: &SerializationContextData,
+        payloads: Vec<Payload>,
+    ) -> BoxFuture<'static, Result<Vec<Payload>, PayloadConversionError>> {
+        self.decode_calls.fetch_add(1, Ordering::Relaxed);
+        Box::pin(async move { Ok(payloads) })
+    }
+}
+
+struct CountingClientInterceptor {
+    calls: Arc<AtomicUsize>,
+}
+
+impl ClientInterceptor for CountingClientInterceptor {
+    fn start_workflow<'a>(
+        &'a self,
+        input: StartWorkflowInput,
+        next: Next<
+            'a,
+            StartWorkflowInput,
+            BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+        >,
+    ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        next.run(input)
+    }
+}
+
+struct CountingWorkerInterceptor {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait(?Send)]
+impl WorkerInterceptor for CountingWorkerInterceptor {
+    async fn on_workflow_activation(
+        &self,
+        _activation: &WorkflowActivation,
+    ) -> Result<(), anyhow::Error> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[workflow]
+#[derive(Default)]
+struct SimplePluginWorkflow;
+
+struct SimplePluginActivities;
+
+#[activities]
+impl SimplePluginActivities {
+    #[activity]
+    async fn greet(_ctx: ActivityContext, name: String) -> Result<String, ActivityError> {
+        Ok(format!("Hello, {name}!"))
+    }
+}
+
+#[workflow_methods]
+impl SimplePluginWorkflow {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>, name: String) -> WorkflowResult<String> {
+        Ok(ctx
+            .execute_activity(
+                SimplePluginActivities::greet,
+                name,
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+            )
+            .await?)
+    }
+}
+
+#[tokio::test]
+async fn simple_plugin_configures_working_client_and_worker() {
+    let encode_calls = Arc::new(AtomicUsize::new(0));
+    let decode_calls = Arc::new(AtomicUsize::new(0));
+    let client_interceptor_calls = Arc::new(AtomicUsize::new(0));
+    let worker_interceptor_calls = Arc::new(AtomicUsize::new(0));
+    let data_converter = DataConverter::new(
+        PayloadConverter::default(),
+        DefaultFailureConverter,
+        CountingPayloadCodec {
+            encode_calls: encode_calls.clone(),
+            decode_calls: decode_calls.clone(),
+        },
+    );
+    let plugin = SimplePlugin::new("simple-integration-plugin")
+        .data_converter(data_converter)
+        .client_interceptor(CountingClientInterceptor {
+            calls: client_interceptor_calls.clone(),
+        })
+        .worker_interceptor(CountingWorkerInterceptor {
+            calls: worker_interceptor_calls.clone(),
+        })
+        .register_activities(SimplePluginActivities)
+        .register_workflow::<SimplePluginWorkflow>()
+        .unwrap()
+        .build();
+    let client_options = ClientOptions::new(integ_namespace()).plugin(plugin).build();
+    let client = Client::connect(get_integ_server_options(), client_options)
+        .await
+        .unwrap();
+    let mut starter = CoreWfStarter::new_with_overrides(
+        "simple_plugin_configures_working_client_and_worker",
+        None,
+        Some(client),
+    );
+    starter.sdk_config.task_types = WorkerTaskTypes {
+        enable_workflows: true,
+        enable_local_activities: true,
+        enable_remote_activities: true,
+        enable_nexus: false,
+    };
+    let task_queue = starter.get_task_queue().to_owned();
+    let mut worker = starter.worker().await;
+    let workflow_id = format!("simple-plugin-{}", Uuid::new_v4());
+    let handle = worker
+        .submit_workflow(
+            SimplePluginWorkflow::run,
+            "Temporal".to_owned(),
+            WorkflowStartOptions::new(task_queue, workflow_id).build(),
+        )
+        .await
+        .unwrap();
+
+    worker.run_until_done().await.unwrap();
+    let workflow_result = handle.get_result(Default::default()).await.unwrap();
+    assert_eq!(workflow_result, "Hello, Temporal!");
+    assert_eq!(client_interceptor_calls.load(Ordering::Relaxed), 1);
+    assert!(worker_interceptor_calls.load(Ordering::Relaxed) > 0);
+    assert!(encode_calls.load(Ordering::Relaxed) > 0);
+    assert!(decode_calls.load(Ordering::Relaxed) > 0);
+}
+
+#[tokio::test]
+async fn plugin_errors_surface() {
+    let connection_plugin = SimplePlugin::new("failing-connection")
+        .configure_connection_options(|_| Err(PluginError::new("connection failure")))
+        .build();
+    let connection_result = Client::connect(
+        get_integ_server_options(),
+        ClientOptions::new(integ_namespace())
+            .plugin(connection_plugin)
+            .build(),
+    )
+    .await;
+    assert_eq!(
+        connection_result.unwrap_err().to_string(),
+        "plugin 'failing-connection' failed to configure connection options: connection failure"
+    );
+
+    let client_plugin = SimplePlugin::new("failing-client")
+        .configure_client_options(|_| Err(PluginError::new("client failure")))
+        .build();
+    let client_result = Client::connect(
+        get_integ_server_options(),
+        ClientOptions::new(integ_namespace())
+            .plugin(client_plugin)
+            .build(),
+    )
+    .await;
+    assert_eq!(
+        client_result.unwrap_err().to_string(),
+        "plugin 'failing-client' failed to configure client options: client failure"
+    );
+
+    let client = Client::connect(
+        get_integ_server_options(),
+        ClientOptions::new(integ_namespace()).build(),
+    )
+    .await
+    .unwrap();
+    let worker_plugin = SimplePlugin::new("failing-worker")
+        .configure_worker_options(|_| Err(PluginError::new("worker failure")))
+        .build();
+    let worker_result = Worker::new(
+        &CoreRuntime::new_assume_tokio(get_integ_runtime_options(get_integ_telem_options()))
+            .unwrap(),
+        client,
+        WorkerOptions::new(format!("failing-plugin-{}", Uuid::new_v4()))
+            .plugin(worker_plugin)
+            .build(),
+    );
+    assert_eq!(
+        worker_result.unwrap_err().to_string(),
+        "plugin 'failing-worker' failed to configure worker options: worker failure"
+    );
+}
+
+struct ClientOnlyMetadataPlugin;
+
+impl ClientPlugin for ClientOnlyMetadataPlugin {
+    fn name(&self) -> &str {
+        "client-only-plugin"
+    }
+}
+
+struct WorkerOnlyMetadataPlugin;
+
+impl WorkerPlugin for WorkerOnlyMetadataPlugin {
+    fn name(&self) -> &str {
+        "worker-only-plugin"
+    }
+}
+
+#[tokio::test]
+async fn worker_metadata_includes_client_and_worker_plugin_names() {
+    let runtime =
+        CoreRuntime::new_assume_tokio(get_integ_runtime_options(get_integ_telem_options()))
+            .unwrap();
+    let client = Client::connect(
+        get_integ_server_options(),
+        ClientOptions::new(integ_namespace())
+            .client_plugin(ClientOnlyMetadataPlugin)
+            .build(),
+    )
+    .await
+    .unwrap();
+    let worker = Worker::new(
+        &runtime,
+        client,
+        WorkerOptions::new(format!("plugin-metadata-{}", Uuid::new_v4()))
+            .worker_plugin(WorkerOnlyMetadataPlugin)
+            .build(),
+    )
+    .unwrap();
+    let core_worker = worker.core_worker();
+    let mut names = core_worker
+        .get_config()
+        .plugins
+        .iter()
+        .map(|plugin| plugin.name.clone())
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+
+    assert_eq!(names, ["client-only-plugin", "worker-only-plugin"]);
+}

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -217,7 +217,7 @@ async fn simple_plugin_configures_working_client_and_worker() {
             decode_calls: decode_calls.clone(),
         },
     );
-    let plugin = SimplePlugin::new("simple-integration-plugin")
+    let plugin = SimplePlugin::builder("simple-integration-plugin")
         .data_converter(data_converter)
         .client_interceptor(CountingClientInterceptor {
             calls: client_interceptor_calls.clone(),

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -731,10 +731,7 @@ async fn update_with_local_acts() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, run);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[tokio::test]
@@ -797,10 +794,7 @@ async fn update_rejection_sdk() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, run);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[tokio::test]
@@ -854,10 +848,7 @@ async fn update_fail_sdk() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, run);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[tokio::test]
@@ -991,10 +982,7 @@ async fn update_timer_sequence() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, run);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[tokio::test]
@@ -1064,10 +1052,7 @@ async fn task_failure_during_validation() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, run);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
     // Verify we did not spam task failures. There should only be one.
     let history = starter.get_history().await;
     assert_eq!(
@@ -1138,10 +1123,7 @@ async fn task_failure_after_update() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, run);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 static BARR: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(2));
@@ -1267,10 +1249,7 @@ async fn worker_restarted_in_middle_of_update() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, run, stopper);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[tokio::test]
@@ -1364,10 +1343,7 @@ async fn update_after_empty_wft() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, runner);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[tokio::test]
@@ -1442,8 +1418,5 @@ async fn update_lost_on_activity_mismatch() {
         worker.run_until_done().await.unwrap();
     };
     join!(update, runner);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -9,7 +9,6 @@ use crate::{
 use assert_matches::assert_matches;
 use futures_util::{FutureExt, StreamExt};
 use std::{
-    cell::Cell,
     sync::{
         Arc, Mutex,
         atomic::{
@@ -132,7 +131,7 @@ async fn worker_handles_unknown_workflow_types_gracefully() {
     struct GracefulAsserter {
         notify: Arc<Notify>,
         run_id: String,
-        unregistered_failure_seen: Cell<bool>,
+        unregistered_failure_seen: AtomicBool,
     }
     #[async_trait::async_trait(?Send)]
     impl WorkerInterceptor for GracefulAsserter {
@@ -150,7 +149,8 @@ async fn worker_handles_unknown_workflow_types_gracefully() {
                     run_id,
                 } if message == "Workflow type unregistered not found" && *run_id == self.run_id
             ) {
-                self.unregistered_failure_seen.set(true);
+                self.unregistered_failure_seen
+                    .store(true, Ordering::Relaxed);
             }
             // If we've seen the failure, and the completion is a success for the same run, we're done
             if matches!(
@@ -158,7 +158,7 @@ async fn worker_handles_unknown_workflow_types_gracefully() {
                 WorkflowActivationCompletion {
                     status: Some(Status::Successful(..)),
                     run_id,
-                } if self.unregistered_failure_seen.get() && *run_id == self.run_id
+                } if self.unregistered_failure_seen.load(Ordering::Relaxed) && *run_id == self.run_id
             ) {
                 // Shutdown the worker
                 self.notify.notify_one();
@@ -167,13 +167,13 @@ async fn worker_handles_unknown_workflow_types_gracefully() {
         fn on_shutdown(&self, _: &temporalio_sdk::Worker) {}
     }
 
-    let inner = worker.inner_mut();
     let notify = Arc::new(Notify::new());
-    inner.set_worker_interceptor(GracefulAsserter {
+    worker.set_worker_interceptor(GracefulAsserter {
         notify: notify.clone(),
         run_id,
-        unregistered_failure_seen: Cell::new(false),
+        unregistered_failure_seen: AtomicBool::new(false),
     });
+    let inner = worker.inner_mut();
     tokio::join!(async { inner.run().await.unwrap() }, async move {
         notify.notified().await;
         let worker = starter.get_worker().await.clone();

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -19,8 +19,8 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    Client, ClientOptions, ClientPlugin, Connection, ConnectionOptions, PayloadLimitsOptions,
-    PluginError, WorkflowStartOptions, errors::WorkflowGetResultError,
+    Client, ClientOptions, Connection, PayloadLimitsOptions, WorkflowStartOptions,
+    errors::WorkflowGetResultError,
 };
 use temporalio_common::{
     data_converters::{DataConverter, RawValue},
@@ -58,8 +58,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, ClientAndWorkerPlugin, LocalActivityOptions, Worker, WorkerOptions,
-    WorkerPlugin, WorkflowContext, WorkflowResult, WorkflowTermination,
+    ActivityOptions, LocalActivityOptions, WorkerOptions, WorkflowContext, WorkflowResult,
+    WorkflowTermination,
     activities::{ActivityContext, ActivityError},
     interceptors::WorkerInterceptor,
 };
@@ -79,71 +79,6 @@ use tokio::sync::{Barrier, Notify, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
 use uuid::Uuid;
-
-#[derive(Clone)]
-struct IntegrationPlugin {
-    connection_calls: Arc<AtomicU8>,
-    client_calls: Arc<AtomicU8>,
-    worker_calls: Arc<AtomicU8>,
-}
-
-impl ClientPlugin for IntegrationPlugin {
-    fn name(&self) -> &str {
-        "integration-plugin"
-    }
-
-    fn configure_connection_options(
-        &self,
-        options: &mut ConnectionOptions,
-    ) -> Result<(), PluginError> {
-        self.connection_calls.fetch_add(1, Relaxed);
-        options.identity = "integration-plugin-client".to_owned();
-        Ok(())
-    }
-
-    fn configure_client_options(&self, _options: &mut ClientOptions) -> Result<(), PluginError> {
-        self.client_calls.fetch_add(1, Relaxed);
-        Ok(())
-    }
-}
-
-impl WorkerPlugin for IntegrationPlugin {
-    fn name(&self) -> &str {
-        "integration-plugin"
-    }
-
-    fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
-        self.worker_calls.fetch_add(1, Relaxed);
-        options.max_cached_workflows = 0;
-        Ok(())
-    }
-}
-
-#[tokio::test]
-async fn plugins_configure_client_and_worker() {
-    let runtime =
-        CoreRuntime::new_assume_tokio(get_integ_runtime_options(get_integ_telem_options()))
-            .unwrap();
-    let connection_calls = Arc::new(AtomicU8::new(0));
-    let client_calls = Arc::new(AtomicU8::new(0));
-    let worker_calls = Arc::new(AtomicU8::new(0));
-    let plugin = ClientAndWorkerPlugin::new(IntegrationPlugin {
-        connection_calls: connection_calls.clone(),
-        client_calls: client_calls.clone(),
-        worker_calls: worker_calls.clone(),
-    });
-    let client_options = ClientOptions::new(integ_namespace()).plugin(plugin).build();
-    let client = Client::connect(get_integ_server_options(), client_options)
-        .await
-        .unwrap();
-    let worker_options = WorkerOptions::new(format!("plugins-{}", Uuid::new_v4())).build();
-    let worker = Worker::new(&runtime, client, worker_options).unwrap();
-
-    assert_eq!(connection_calls.load(Relaxed), 1);
-    assert_eq!(client_calls.load(Relaxed), 1);
-    assert_eq!(worker_calls.load(Relaxed), 1);
-    assert_eq!(worker.core_worker().get_config().plugins.len(), 1);
-}
 
 #[tokio::test]
 async fn worker_validation_fails_on_nonexistent_namespace() {

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -20,7 +20,7 @@ use std::{
 };
 use temporalio_client::{
     Client, ClientOptions, ClientPlugin, Connection, ConnectionOptions, PayloadLimitsOptions,
-    PluginResult, WorkflowStartOptions, errors::WorkflowGetResultError,
+    PluginError, WorkflowStartOptions, errors::WorkflowGetResultError,
 };
 use temporalio_common::{
     data_converters::{DataConverter, RawValue},
@@ -92,13 +92,16 @@ impl ClientPlugin for IntegrationPlugin {
         "integration-plugin"
     }
 
-    fn configure_connection_options(&self, options: &mut ConnectionOptions) -> PluginResult {
+    fn configure_connection_options(
+        &self,
+        options: &mut ConnectionOptions,
+    ) -> Result<(), PluginError> {
         self.connection_calls.fetch_add(1, Relaxed);
         options.identity = "integration-plugin-client".to_owned();
         Ok(())
     }
 
-    fn configure_client_options(&self, _options: &mut ClientOptions) -> PluginResult {
+    fn configure_client_options(&self, _options: &mut ClientOptions) -> Result<(), PluginError> {
         self.client_calls.fetch_add(1, Relaxed);
         Ok(())
     }
@@ -109,7 +112,7 @@ impl WorkerPlugin for IntegrationPlugin {
         "integration-plugin"
     }
 
-    fn configure_worker_options(&self, options: &mut WorkerOptions) -> PluginResult {
+    fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
         self.worker_calls.fetch_add(1, Relaxed);
         options.max_cached_workflows = 0;
         Ok(())

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -19,8 +19,8 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    Client, ClientOptions, Connection, PayloadLimitsOptions, WorkflowStartOptions,
-    errors::WorkflowGetResultError,
+    Client, ClientOptions, ClientPlugin, Connection, ConnectionOptions, PayloadLimitsOptions,
+    PluginResult, WorkflowStartOptions, errors::WorkflowGetResultError,
 };
 use temporalio_common::{
     data_converters::{DataConverter, RawValue},
@@ -58,8 +58,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, LocalActivityOptions, WorkerOptions, WorkflowContext, WorkflowResult,
-    WorkflowTermination,
+    ActivityOptions, ClientAndWorkerPlugin, LocalActivityOptions, Worker, WorkerOptions,
+    WorkerPlugin, WorkflowContext, WorkflowResult, WorkflowTermination,
     activities::{ActivityContext, ActivityError},
     interceptors::WorkerInterceptor,
 };
@@ -79,6 +79,68 @@ use tokio::sync::{Barrier, Notify, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
 use uuid::Uuid;
+
+#[derive(Clone)]
+struct IntegrationPlugin {
+    connection_calls: Arc<AtomicU8>,
+    client_calls: Arc<AtomicU8>,
+    worker_calls: Arc<AtomicU8>,
+}
+
+impl ClientPlugin for IntegrationPlugin {
+    fn name(&self) -> &str {
+        "integration-plugin"
+    }
+
+    fn configure_connection_options(&self, options: &mut ConnectionOptions) -> PluginResult {
+        self.connection_calls.fetch_add(1, Relaxed);
+        options.identity = "integration-plugin-client".to_owned();
+        Ok(())
+    }
+
+    fn configure_client_options(&self, _options: &mut ClientOptions) -> PluginResult {
+        self.client_calls.fetch_add(1, Relaxed);
+        Ok(())
+    }
+}
+
+impl WorkerPlugin for IntegrationPlugin {
+    fn name(&self) -> &str {
+        "integration-plugin"
+    }
+
+    fn configure_worker_options(&self, options: &mut WorkerOptions) -> PluginResult {
+        self.worker_calls.fetch_add(1, Relaxed);
+        options.max_cached_workflows = 0;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn plugins_configure_client_and_worker() {
+    let runtime =
+        CoreRuntime::new_assume_tokio(get_integ_runtime_options(get_integ_telem_options()))
+            .unwrap();
+    let connection_calls = Arc::new(AtomicU8::new(0));
+    let client_calls = Arc::new(AtomicU8::new(0));
+    let worker_calls = Arc::new(AtomicU8::new(0));
+    let plugin = ClientAndWorkerPlugin::new(IntegrationPlugin {
+        connection_calls: connection_calls.clone(),
+        client_calls: client_calls.clone(),
+        worker_calls: worker_calls.clone(),
+    });
+    let client_options = ClientOptions::new(integ_namespace()).plugin(plugin).build();
+    let client = Client::connect(get_integ_server_options(), client_options)
+        .await
+        .unwrap();
+    let worker_options = WorkerOptions::new(format!("plugins-{}", Uuid::new_v4())).build();
+    let worker = Worker::new(&runtime, client, worker_options).unwrap();
+
+    assert_eq!(connection_calls.load(Relaxed), 1);
+    assert_eq!(client_calls.load(Relaxed), 1);
+    assert_eq!(worker_calls.load(Relaxed), 1);
+    assert_eq!(worker.core_worker().get_config().plugins.len(), 1);
+}
 
 #[tokio::test]
 async fn worker_validation_fails_on_nonexistent_namespace() {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1,8 +1,8 @@
 use crate::{
     common::{
         ActivationAssertionsInterceptor, CoreWfStarter, INTEG_CLIENT_IDENTITY,
-        activity_functions::StdActivities, build_fake_sdk, eventually, init_core_and_create_wf,
-        mock_sdk, mock_sdk_cfg,
+        activity_functions::StdActivities, build_fake_sdk_intercepted, eventually,
+        init_core_and_create_wf, mock_sdk, mock_sdk_cfg,
     },
     shared_tests,
 };
@@ -316,21 +316,20 @@ async fn activity_interceptor_wraps_activity_execution() {
         .sdk_config
         .register_workflow::<OneActivityWorkflow>()
         .unwrap();
-    let mut worker = starter.worker().await;
-
     let records = Arc::new(ActivityInterceptorRecords::default());
-    worker
-        .inner_mut()
-        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+    starter
+        .sdk_config
+        .activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "outer",
             records: records.clone(),
         });
-    worker
-        .inner_mut()
-        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+    starter
+        .sdk_config
+        .activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "inner",
             records: records.clone(),
         });
+    let mut worker = starter.worker().await;
 
     let input = "hello from input!".to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -402,15 +401,14 @@ async fn activity_interceptor_wraps_local_activity_execution() {
         .sdk_config
         .register_workflow::<OneLocalActivityWorkflow>()
         .unwrap();
-    let mut worker = starter.worker().await;
-
     let records = Arc::new(ActivityInterceptorRecords::default());
-    worker
-        .inner_mut()
-        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+    starter
+        .sdk_config
+        .activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "local",
             records: records.clone(),
         });
+    let mut worker = starter.worker().await;
 
     let input = "hello from local input!".to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -476,11 +474,10 @@ async fn activity_inbound_interceptor_can_mutate_activity_input() {
         .sdk_config
         .register_workflow::<OneActivityWorkflow>()
         .unwrap();
+    starter
+        .sdk_config
+        .activity_inbound_interceptor(MutatingActivityInboundInterceptor);
     let mut worker = starter.worker().await;
-
-    worker
-        .inner_mut()
-        .add_activity_inbound_interceptor(MutatingActivityInboundInterceptor);
 
     let input = "hello from input!".to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -541,15 +538,14 @@ async fn activity_interceptor_observes_activity_error() {
         .sdk_config
         .register_workflow::<ActivityFailureWorkflow>()
         .unwrap();
-    let mut worker = starter.worker().await;
-
     let records = Arc::new(ActivityInterceptorRecords::default());
-    worker
-        .inner_mut()
-        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+    starter
+        .sdk_config
+        .activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "failure",
             records: records.clone(),
         });
+    let mut worker = starter.worker().await;
 
     let input = "bad input".to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -638,15 +634,14 @@ async fn activity_interceptor_observes_activity_panic() {
         .sdk_config
         .register_workflow::<ActivityPanicWorkflow>()
         .unwrap();
-    let mut worker = starter.worker().await;
-
     let records = Arc::new(ActivityInterceptorRecords::default());
-    worker
-        .inner_mut()
-        .add_activity_inbound_interceptor(RecordingActivityInboundInterceptor {
+    starter
+        .sdk_config
+        .activity_inbound_interceptor(RecordingActivityInboundInterceptor {
             interceptor: "panic",
             records: records.clone(),
         });
+    let mut worker = starter.worker().await;
 
     let input = "panic input".to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -2219,11 +2214,6 @@ async fn immediate_activity_cancelation() {
     t.add_by_type(EventType::WorkflowExecutionStarted);
     t.add_full_wf_task();
     t.add_workflow_execution_completed();
-    let mut worker = build_fake_sdk(MockPollCfg::from_resps(t, [ResponseType::AllHistory]));
-    worker
-        .register_workflow::<ImmediateActivityCancelationWorkflow>()
-        .unwrap();
-
     let mut aai = ActivationAssertionsInterceptor::default();
     aai.then(|a| {
         assert_matches!(
@@ -2233,6 +2223,7 @@ async fn immediate_activity_cancelation() {
             }]
         )
     });
+
     aai.then(|a| {
         assert_matches!(
             a.jobs.as_slice(),
@@ -2249,7 +2240,12 @@ async fn immediate_activity_cancelation() {
         )
     });
 
-    worker.set_worker_interceptor(aai);
+    let mut worker =
+        build_fake_sdk_intercepted(MockPollCfg::from_resps(t, [ResponseType::AllHistory]), aai);
+    worker
+        .register_workflow::<ImmediateActivityCancelationWorkflow>()
+        .unwrap();
+
     worker.run().await.unwrap();
 }
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -1,4 +1,4 @@
-use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter, build_fake_sdk};
+use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter, build_fake_sdk_intercepted};
 use std::time::Duration;
 use temporalio_client::{
     UntypedWorkflow, WorkflowCancelOptions, WorkflowDescribeOptions, WorkflowStartOptions,
@@ -142,8 +142,7 @@ async fn wf_completing_with_cancelled() {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
     worker.register_workflow::<WfWithTimer>().unwrap();
-    worker.set_worker_interceptor(aai);
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -104,10 +104,7 @@ async fn child_workflow_happy_path() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[workflow]
@@ -1237,10 +1234,7 @@ async fn cancel_child_wf_before_started_event_real_server() {
     );
 
     // Replay the history to verify determinism
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[workflow]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -145,10 +145,7 @@ async fn task_fail_causes_replay_unset_too_soon() {
         .unwrap();
 
     worker.run_until_done().await.unwrap();
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[workflow]
@@ -184,7 +181,7 @@ async fn random_workflow_replays() {
     worker.run_until_done().await.unwrap();
     let result = handle.get_result(Default::default()).await.unwrap();
     let replay_result = handle
-        .fetch_history_and_replay(worker.inner_mut())
+        .fetch_history_and_replay(&mut worker)
         .await
         .unwrap()
         .expect("replayed workflow should return a result");

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
@@ -224,8 +224,8 @@ impl WorkflowInterceptor for MutatingWorkflowInterceptor {
 async fn workflow_interceptors_mutate_inputs_and_replace_outputs() {
     let mut starter = CoreWfStarter::new("workflow_interceptors_mutate_inputs_and_replace_outputs");
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<InboundInterceptorWorkflow>()
         .unwrap();
 
@@ -233,14 +233,15 @@ async fn workflow_interceptors_mutate_inputs_and_replace_outputs() {
     let saw_query_history_replay = Arc::new(Mutex::new(None));
     let signal_post_handler_done_ref = signal_post_handler_done.clone();
     let saw_query_history_replay_ref = saw_query_history_replay.clone();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             MutatingWorkflowInterceptor {
                 signal_post_handler_done: signal_post_handler_done_ref.clone(),
                 saw_query_history_replay: saw_query_history_replay_ref.clone(),
             }
         })]);
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -389,15 +390,15 @@ impl WorkflowInterceptor for RecordingWorkflowInterceptor {
 async fn workflow_interceptors_wrap_execute_in_order() {
     let mut starter = CoreWfStarter::new("workflow_interceptors_wrap_execute_in_order");
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<InboundInterceptorOrderWorkflow>()
         .unwrap();
 
     let records = Arc::new(Mutex::new(Vec::new()));
     let outer_records = records.clone();
     let inner_records = records.clone();
-    worker.inner_mut().register_workflow_interceptors(vec![
+    starter.sdk_config.register_workflow_interceptors(vec![
         WorkflowInterceptorConstructor::new(move |_| RecordingWorkflowInterceptor {
             name: "outer",
             records: outer_records.clone(),
@@ -407,6 +408,7 @@ async fn workflow_interceptors_wrap_execute_in_order() {
             records: inner_records.clone(),
         }),
     ]);
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -493,20 +495,21 @@ impl WorkflowInterceptor for InitInputMutationInterceptor {
 async fn workflow_initialize_interceptor_mutates_init_input() {
     let mut starter = CoreWfStarter::new("workflow_initialize_interceptor_mutates_init_input");
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<InitInputInterceptorWorkflow>()
         .unwrap();
 
     let received_input = Arc::new(AtomicUsize::new(0));
     let received_input_ref = received_input.clone();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             InitInputMutationInterceptor {
                 received_input: received_input_ref.clone(),
             }
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -770,15 +773,16 @@ impl WorkflowInterceptor for SdkTimerBeforeNextInterceptor {
 async fn sdk_future_before_next_produces_an_activation() {
     let mut starter = CoreWfStarter::new("sdk_future_before_next_produces_an_activation");
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ConstructionWakeWorkflow>()
         .unwrap();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(|_| {
             SdkTimerBeforeNextInterceptor
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -817,20 +821,21 @@ async fn nondeterministic_future_detection_is_respected_for_interceptors(
     ));
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.detect_nondeterministic_futures = detect_nondeterministic_futures;
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ConstructionWakeWorkflow>()
         .unwrap();
     let attempts = Arc::new(AtomicUsize::new(0));
     let interceptor_attempts = attempts.clone();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             ConstructionWakeInterceptor {
                 wake_point: ConstructionWakePoint::Execute,
                 attempts: interceptor_attempts.clone(),
             }
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -872,20 +877,21 @@ async fn nondeterministic_future_detection_is_respected_for_async_signal_interce
     ));
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.detect_nondeterministic_futures = detect_nondeterministic_futures;
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ConstructionWakeHandlerWorkflow>()
         .unwrap();
     let attempts = Arc::new(AtomicUsize::new(0));
     let interceptor_attempts = attempts.clone();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             ConstructionWakeInterceptor {
                 wake_point: ConstructionWakePoint::Signal,
                 attempts: interceptor_attempts.clone(),
             }
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -933,20 +939,21 @@ async fn nondeterministic_future_detection_is_respected_for_async_update_interce
     ));
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.detect_nondeterministic_futures = detect_nondeterministic_futures;
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ConstructionWakeHandlerWorkflow>()
         .unwrap();
     let attempts = Arc::new(AtomicUsize::new(0));
     let interceptor_attempts = attempts.clone();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             ConstructionWakeInterceptor {
                 wake_point: ConstructionWakePoint::Update,
                 attempts: interceptor_attempts.clone(),
             }
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -1017,8 +1024,8 @@ async fn workflow_interceptors_are_polled_once_during_construction() {
     let mut starter =
         CoreWfStarter::new("workflow_interceptors_are_polled_once_during_construction");
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<InterceptorConstructionPollingWorkflow>()
         .unwrap();
 
@@ -1028,8 +1035,8 @@ async fn workflow_interceptors_are_polled_once_during_construction() {
     let sync_polls_ref = sync_polls.clone();
     let deferred_polls_ref = deferred_polls.clone();
     let async_polls_ref = async_polls.clone();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             ConstructionPollingInterceptor {
                 sync_polls: sync_polls_ref.clone(),
@@ -1037,6 +1044,7 @@ async fn workflow_interceptors_are_polled_once_during_construction() {
                 async_polls: async_polls_ref.clone(),
             }
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -1158,14 +1166,14 @@ async fn workflow_interceptor_constructors_create_unified_per_instance_intercept
         "workflow_interceptor_constructors_create_unified_per_instance_interceptors",
     );
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ConstructorOutboundInterceptorWorkflow>()
         .unwrap();
 
     let expected_task_queue = starter.get_task_queue().to_owned();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |ctx| {
             assert_eq!(
                 ctx.workflow_type(),
@@ -1177,6 +1185,7 @@ async fn workflow_interceptor_constructors_create_unified_per_instance_intercept
                 ..Default::default()
             }
         })]);
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let first_workflow_id = format!("{}-1", starter.get_wf_id());
@@ -1284,20 +1293,21 @@ async fn inbound_interceptor_context_operations_use_the_outbound_chain_around_ne
         "inbound_interceptor_context_operations_use_the_outbound_chain_around_next",
     );
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<InboundContextOutboundWorkflow>()
         .unwrap();
 
     let events = Arc::new(Mutex::new(Vec::new()));
     let events_ref = events.clone();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             InboundContextOutboundInterceptor {
                 events: events_ref.clone(),
             }
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -1449,15 +1459,16 @@ async fn workflow_outbound_interceptors_mutate_activity_calls_and_results() {
     let mut starter =
         CoreWfStarter::new("workflow_outbound_interceptors_mutate_activity_calls_and_results");
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<OutboundActivityInterceptorWorkflow>()
         .unwrap();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(|_| {
             OutboundActivityInterceptor
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -1549,18 +1560,20 @@ async fn workflow_outbound_interceptors_wrap_child_start_and_completion() {
     let mut starter =
         CoreWfStarter::new("workflow_outbound_interceptors_wrap_child_start_and_completion");
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<OutboundChildInterceptorParent>()
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<OutboundChildInterceptorChild>()
         .unwrap();
-    worker
-        .inner_mut()
+    starter
+        .sdk_config
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(|_| {
             OutboundChildInterceptor
         })]);
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -3011,10 +3011,7 @@ async fn local_activity_resolutions_are_delivered_incrementally() {
         completed_while_long_was_running,
         "the short LA sequence did not complete while the long LA was still running"
     );
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[workflow]
@@ -3088,8 +3085,7 @@ async fn old_batched_local_activity_history_replays() {
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.set_worker_interceptor(activation_assertions);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, activation_assertions);
     worker
         .register_workflow::<OldBatchedLocalActivityHistoryWf>()
         .unwrap();
@@ -3228,8 +3224,7 @@ async fn mixed_la_completion_times(#[values(true, false)] replay: bool) {
         }
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.set_worker_interceptor(activation_assertions);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, activation_assertions);
     worker
         .register_workflow::<MixedCompletionTimesWf>()
         .unwrap();
@@ -3319,8 +3314,7 @@ async fn two_las_with_heartbeat(
         }
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.set_worker_interceptor(activation_assertions);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, activation_assertions);
     worker.register_workflow::<TwoLaWfParallel>().unwrap();
     worker.register_activities(HeartbeatGatedActivity {
         release: release_activities,
@@ -4025,6 +4019,9 @@ async fn replay_out_of_order_local_activity_markers_is_deterministic() {
     let test_name = "replay_out_of_order_local_activity_markers_is_deterministic";
     let mut starter = CoreWfStarter::new(test_name);
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
+    starter
+        .sdk_config
+        .worker_interceptor(FailOnNondeterminismInterceptor {});
 
     let release_first = Arc::new(Notify::new());
     starter
@@ -4075,8 +4072,8 @@ async fn replay_out_of_order_local_activity_markers_is_deterministic() {
 
     let replay_core =
         init_core_replay_preloaded(&task_queue, [HistoryForReplay::new(events, workflow_id)]);
-    let inner = worker.inner_mut();
-    inner.with_new_core_worker(Arc::new(replay_core));
-    inner.set_worker_interceptor(FailOnNondeterminismInterceptor {});
-    inner.run().await.unwrap();
+    worker
+        .inner_mut()
+        .with_new_core_worker(Arc::new(replay_core));
+    worker.inner_mut().run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -1,8 +1,8 @@
 use crate::common::{
     ActivationAssertionsInterceptor, CoreWfStarter, WorkflowHandleExt,
-    activity_functions::StdActivities, build_fake_sdk, history_from_proto_binary,
-    init_core_replay_preloaded, mock_sdk, mock_sdk_cfg, replay_sdk_worker,
-    workflows::LaProblemWorkflow,
+    activity_functions::StdActivities, build_fake_sdk, build_fake_sdk_intercepted,
+    history_from_proto_binary, init_core_replay_preloaded, mock_sdk, mock_sdk_cfg,
+    replay_sdk_worker, workflows::LaProblemWorkflow,
 };
 use anyhow::anyhow;
 use crossbeam_queue::SegQueue;
@@ -114,10 +114,7 @@ async fn one_local_activity() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[workflow]
@@ -343,10 +340,7 @@ async fn local_act_retry_timer_backoff() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[rstest::rstest]
@@ -936,10 +930,7 @@ async fn repro_nondeterminism_with_timer_bug() {
         first_execution_run_id: None,
     }
     .bind_untyped(client.clone());
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[rstest::rstest]
@@ -1093,10 +1084,7 @@ async fn la_resolve_same_time_as_other_cancel() {
         first_execution_run_id: None,
     }
     .bind_untyped(client.clone());
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[rstest::rstest]
@@ -1185,10 +1173,7 @@ async fn long_local_activity_with_update(
     };
     tokio::select!(_ = update => {}, _ = runner => {});
     let res = handle.get_result(Default::default()).await.unwrap();
-    let replay_res = handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    let replay_res = handle.fetch_history_and_replay(&mut worker).await.unwrap();
     assert_eq!(res, usize::from_json_payload(&replay_res.unwrap()).unwrap());
 
     // Load histories from pre-fix version and ensure compat
@@ -1201,10 +1186,11 @@ async fn long_local_activity_with_update(
             "fake".to_owned(),
         )],
     );
-    let inner_worker = worker.inner_mut();
-    inner_worker.with_new_core_worker(Arc::new(replay_worker));
-    inner_worker.set_worker_interceptor(FailOnNondeterminismInterceptor {});
-    inner_worker.run().await.unwrap();
+    worker
+        .inner_mut()
+        .with_new_core_worker(Arc::new(replay_worker));
+    worker.set_worker_interceptor(FailOnNondeterminismInterceptor {});
+    worker.inner_mut().run().await.unwrap();
 }
 
 #[tokio::test]
@@ -1265,10 +1251,7 @@ async fn local_activity_with_heartbeat_only_causes_one_wakeup() {
     worker.run_until_done().await.unwrap();
     let r = handle.get_result(Default::default()).await.unwrap();
     assert_eq!(r, 2);
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[workflow]
@@ -1303,10 +1286,7 @@ async fn local_activity_with_summary() {
 
     let handle = starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 
     let la_events = starter
         .get_history()
@@ -3453,8 +3433,7 @@ async fn two_sequential_las(
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.set_worker_interceptor(aai);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
     if parallel {
         worker.register_workflow::<TwoLaWfParallel>().unwrap();
     } else {
@@ -3549,8 +3528,7 @@ async fn las_separated_by_timer(#[case] replay: bool) {
         }
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.set_worker_interceptor(aai);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
     worker.register_workflow::<LaTimerLaWf>().unwrap();
     worker.register_activities(ResolvedActivity);
     worker.run().await.unwrap();

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
@@ -225,7 +225,7 @@ async fn nexus_basic(
         _ => unreachable!(),
     }
     wf_handle
-        .fetch_history_and_replay(worker.inner_mut())
+        .fetch_history_and_replay(&mut worker)
         .await
         .unwrap();
 }
@@ -520,7 +520,7 @@ async fn nexus_async(
         }
     }
     wf_handle
-        .fetch_history_and_replay(worker.inner_mut())
+        .fetch_history_and_replay(&mut worker)
         .await
         .unwrap();
 }
@@ -588,10 +588,7 @@ async fn nexus_cancel_before_start() {
 
     worker.run_until_done().await.unwrap();
 
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[workflow]
@@ -707,10 +704,7 @@ async fn nexus_must_complete_task_to_shutdown(#[values(true, false)] use_grace_p
     // The first thing to finish needs to have been the nexus task completion
     assert_eq!(complete_order_rx.recv().await.unwrap(), "t");
 
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
 #[workflow]
@@ -1081,7 +1075,7 @@ async fn nexus_cancellation_types(
     }
 
     wf_handle
-        .fetch_history_and_replay(worker.inner_mut())
+        .fetch_history_and_replay(&mut worker)
         .await
         .unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -1,5 +1,6 @@
 use crate::common::{
     ActivationAssertionsInterceptor, CoreWfStarter, WorkflowHandleExt, build_fake_sdk,
+    build_fake_sdk_intercepted,
 };
 use std::{
     collections::{HashSet, VecDeque, hash_map::RandomState},
@@ -805,8 +806,7 @@ async fn v1_and_v4_changes(
         });
     }
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.set_worker_interceptor(aai);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
     worker
         .register_workflow_with_factory(move || PatchWf {
             version: wf_version,
@@ -914,8 +914,7 @@ async fn v2_and_v3_changes(
         });
     }
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.set_worker_interceptor(aai);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
     worker
         .register_workflow_with_factory(move || PatchWf {
             version: wf_version,
@@ -1197,8 +1196,5 @@ async fn patch_marker_size_overflow_replay_is_deterministic() {
 
     // Replay the workflow from the fetched history. This must succeed: the SDK must produce the
     // same sequence of upsert SA commands during replay as it did during the original execution.
-    handle
-        .fetch_history_and_replay(worker.inner_mut())
-        .await
-        .unwrap();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/replay.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/replay.rs
@@ -1,7 +1,8 @@
 use crate::{
     common::{
-        ActivationAssertionsInterceptor, build_fake_sdk, history_from_proto_binary,
-        init_core_replay_preloaded, replay_sdk_worker, replay_sdk_worker_stream,
+        ActivationAssertionsInterceptor, build_fake_sdk_intercepted, history_from_proto_binary,
+        init_core_replay_preloaded, replay_sdk_worker, replay_sdk_worker_intercepted,
+        replay_sdk_worker_stream_intercepted,
     },
     integ_tests::workflow_tests::patches::ChangesWf,
 };
@@ -62,7 +63,12 @@ impl TimersWf {
 fn fire_happy_hist(num_timers: u32) -> Worker {
     let mut t = canned_histories::long_sequential_timers(num_timers as usize);
     t.set_wf_input(num_timers.as_json_payload().unwrap());
-    let mut worker = build_fake_sdk(MockPollCfg::from_resps(t, [ResponseType::AllHistory]));
+    let mut aai = ActivationAssertionsInterceptor::default();
+    for _ in 1..=num_timers + 1 {
+        aai.then(|activation| assert!(activation.is_replaying));
+    }
+    let mut worker =
+        build_fake_sdk_intercepted(MockPollCfg::from_resps(t, [ResponseType::AllHistory]), aai);
     worker.register_workflow::<TimersWf>().unwrap();
     worker
 }
@@ -71,17 +77,10 @@ fn fire_happy_hist(num_timers: u32) -> Worker {
 #[case::one_timer(fire_happy_hist(1), 1)]
 #[case::five_timers(fire_happy_hist(5), 5)]
 #[tokio::test]
-async fn replay_flag_is_correct(#[case] mut worker: Worker, #[case] num_timers: usize) {
+async fn replay_flag_is_correct(#[case] mut worker: Worker, #[case] _num_timers: usize) {
     // Verify replay flag is correct by constructing a workflow manager that already has a complete
     // history fed into it. It should always be replaying, because history is complete.
 
-    let mut aai = ActivationAssertionsInterceptor::default();
-
-    for _ in 1..=num_timers + 1 {
-        aai.then(|a| assert!(a.is_replaying));
-    }
-
-    worker.set_worker_interceptor(aai);
     worker.run().await.unwrap();
 }
 
@@ -89,13 +88,10 @@ async fn replay_flag_is_correct(#[case] mut worker: Worker, #[case] num_timers: 
 async fn replay_flag_is_correct_partial_history() {
     let mut t = canned_histories::long_sequential_timers(2);
     t.set_wf_input(1u32.as_json_payload().unwrap());
-    let mut worker = build_fake_sdk(MockPollCfg::from_resps(t, [1]));
-    worker.register_workflow::<TimersWf>().unwrap();
-
     let mut aai = ActivationAssertionsInterceptor::default();
     aai.then(|a| assert!(!a.is_replaying));
-
-    worker.set_worker_interceptor(aai);
+    let mut worker = build_fake_sdk_intercepted(MockPollCfg::from_resps(t, [1]), aai);
+    worker.register_workflow::<TimersWf>().unwrap();
     worker.run().await.unwrap();
 }
 
@@ -246,11 +242,10 @@ async fn replay_ok_ending_with_timed_out() {
 async fn replay_shutdown_worker() {
     let mut t = canned_histories::single_timer("1");
     t.set_wf_input(1u32.as_json_payload().unwrap());
-    let mut worker = replay_sdk_worker([test_hist_to_replay(t)]);
-    worker.register_workflow::<TimersWf>().unwrap();
     let shutdown_ctr_i = UniqueShutdownWorker::default();
     let shutdown_ctr = shutdown_ctr_i.runs.clone();
-    worker.set_worker_interceptor(shutdown_ctr_i);
+    let mut worker = replay_sdk_worker_intercepted([test_hist_to_replay(t)], shutdown_ctr_i);
+    worker.register_workflow::<TimersWf>().unwrap();
     worker.run().await.unwrap();
     assert_eq!(shutdown_ctr.lock().len(), 1);
 }
@@ -310,17 +305,19 @@ async fn multiple_histories_replay(#[values(false, true)] use_feeder: bool) {
     seq_timer_hist.set_wf_type("seqtimer");
     seq_timer_hist.set_wf_input(num_timers.as_json_payload().unwrap());
     let (feeder, stream) = HistoryFeeder::new(1);
-    let mut worker = if use_feeder {
-        replay_sdk_worker_stream(stream)
-    } else {
-        replay_sdk_worker([
-            test_hist_to_replay(one_timer_hist.clone()),
-            test_hist_to_replay(seq_timer_hist.clone()),
-        ])
-    };
     let runs_ctr_i = UniqueRunsCounter::default();
     let runs_ctr = runs_ctr_i.runs.clone();
-    worker.set_worker_interceptor(runs_ctr_i);
+    let mut worker = if use_feeder {
+        replay_sdk_worker_stream_intercepted(stream, runs_ctr_i)
+    } else {
+        replay_sdk_worker_intercepted(
+            [
+                test_hist_to_replay(one_timer_hist.clone()),
+                test_hist_to_replay(seq_timer_hist.clone()),
+            ],
+            runs_ctr_i,
+        )
+    };
     worker.register_workflow::<OneTimerWf>().unwrap();
     worker.register_workflow::<SeqTimerWf>().unwrap();
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -1,4 +1,6 @@
-use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter, build_fake_sdk};
+use crate::common::{
+    ActivationAssertionsInterceptor, CoreWfStarter, build_fake_sdk, build_fake_sdk_intercepted,
+};
 use std::collections::HashMap;
 use temporalio_client::{WorkflowStartOptions, WorkflowStartSignal};
 use temporalio_common::protos::{
@@ -356,8 +358,7 @@ async fn cancels_before_sending() {
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.set_worker_interceptor(aai);
+    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
     worker.register_workflow::<CancelsBeforeSending>().unwrap();
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/main.rs
+++ b/crates/sdk-core/tests/main.rs
@@ -19,6 +19,7 @@ mod integ_tests {
     mod heartbeat_tests;
     mod metrics_tests;
     mod pagination_tests;
+    mod plugin_tests;
     mod poll_loop_tests;
     mod polling_tests;
     mod queries_tests;

--- a/crates/sdk/examples/activity_interceptor/worker.rs
+++ b/crates/sdk/examples/activity_interceptor/worker.rs
@@ -59,12 +59,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new(connection, client_opts)?;
 
     let worker_options = WorkerOptions::new("activity-interceptor")
+        .activity_inbound_interceptor(LoggingActivityInterceptor)
         .register_workflow::<ActivityInterceptorWorkflow>()?
         .register_activities(GreetingActivities)
         .build();
 
     let mut worker = Worker::new(&runtime, client, worker_options)?;
-    worker.add_activity_inbound_interceptor(LoggingActivityInterceptor);
     println!("Worker started on task queue: activity-interceptor");
     worker.run().await?;
 

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -443,6 +443,10 @@ pub struct ActivityDefinitions {
 }
 
 impl ActivityDefinitions {
+    pub(crate) fn extend(&mut self, other: &Self) {
+        self.activities.extend(other.activities.clone());
+    }
+
     /// Registers all activities on an activity implementer.
     pub fn register_activities<AI: ActivityImplementer>(&mut self, instance: AI) -> &mut Self {
         let arcd = Arc::new(instance);

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -1,6 +1,21 @@
 //! Shared SDK error re-exports.
 
 pub use crate::workflow_registry::WorkflowRegistrationError;
+use temporalio_client::PluginApplyError;
+
+/// Errors that can occur while creating a worker.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkerCreateError {
+    /// A plugin failed while configuring worker options.
+    #[error(transparent)]
+    Plugin(#[from] PluginApplyError),
+    /// Worker initialization failed after plugin configuration completed.
+    #[error("worker initialization failed: {0}")]
+    Initialization(#[source] anyhow::Error),
+}
 pub use temporalio_common::error::{
     ActivityExecutionError, ApplicationErrorCategory, ApplicationFailure,
     ChildWorkflowExecutionError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,

--- a/crates/sdk/src/interceptors.rs
+++ b/crates/sdk/src/interceptors.rs
@@ -51,7 +51,7 @@ mod activity_execution_value {
 ///
 /// Advanced usage only.
 #[async_trait::async_trait(?Send)]
-pub trait WorkerInterceptor {
+pub trait WorkerInterceptor: Send + Sync {
     /// Called every time a workflow activation completes (just before sending the completion to
     /// core).
     async fn on_workflow_activation_completion(&self, _completion: &WorkflowActivationCompletion) {}

--- a/crates/sdk/src/interceptors.rs
+++ b/crates/sdk/src/interceptors.rs
@@ -50,6 +50,7 @@ mod activity_execution_value {
 /// Implementors can intercept certain actions that happen within the Worker.
 ///
 /// Advanced usage only.
+/// **Experimental:** This API may change or be removed.
 #[async_trait::async_trait(?Send)]
 pub trait WorkerInterceptor: Send + Sync {
     /// Called every time a workflow activation completes (just before sending the completion to

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -101,7 +101,10 @@ pub use crate::{
         ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
         RetryState, TimeoutType, WorkerCreateError, WorkflowRegistrationError, WorkflowSignalError,
     },
-    plugins::{ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, WorkerPlugin},
+    plugins::{
+        ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, SimplePluginOption, WorkerPlugin,
+        WorkflowDefinitions,
+    },
 };
 pub use temporalio_client::Namespace;
 pub use temporalio_sdk_core::CoreRuntime as Runtime;
@@ -128,7 +131,6 @@ use crate::{
     workflow_executor::{TaskHandle, WorkflowExecutor},
     workflow_future::start_workflow,
     workflow_interceptors::WorkflowInterceptorConstructor,
-    workflow_registry::WorkflowDefinitions,
 };
 use anyhow::{Context, anyhow, bail};
 use futures_util::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
@@ -1681,11 +1683,47 @@ mod tests {
         }
     }
 
+    #[workflow]
+    #[derive(Default)]
+    struct OtherWorkflow;
+
+    #[workflow_methods]
+    impl OtherWorkflow {
+        #[run]
+        async fn run(_ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn test_workflow_registration() {
         let _ = WorkerOptions::new("task_q")
             .register_workflow::<MyWorkflow>()
             .unwrap();
+    }
+
+    #[test]
+    fn simple_plugin_workflow_function_merges_definitions() {
+        let plugin = SimplePlugin::builder("simple")
+            .workflows(|existing: Option<WorkflowDefinitions>| {
+                assert!(existing.is_some());
+                let mut workflows = WorkflowDefinitions::new();
+                workflows.register_workflow::<OtherWorkflow>().unwrap();
+                workflows
+            })
+            .build();
+        let client_options = ClientOptions::new("namespace").build();
+        let mut worker_options = WorkerOptions::new("task_q")
+            .register_workflow::<MyWorkflow>()
+            .unwrap()
+            .worker_plugin(plugin)
+            .build();
+
+        crate::plugins::apply_worker_plugins(&client_options, &mut worker_options).unwrap();
+
+        let workflows = format!("{:?}", worker_options.workflows());
+        assert!(workflows.contains("MyWorkflow"));
+        assert!(workflows.contains("OtherWorkflow"));
     }
 
     #[test]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -101,9 +101,7 @@ pub use crate::{
         ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
         RetryState, TimeoutType, WorkerCreateError, WorkflowRegistrationError, WorkflowSignalError,
     },
-    plugins::{
-        ClientAndWorkerPlugin, ErasedWorkerPlugin, SimplePlugin, SimplePluginBuilder, WorkerPlugin,
-    },
+    plugins::{ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, WorkerPlugin},
 };
 pub use temporalio_client::Namespace;
 pub use temporalio_sdk_core::CoreRuntime as Runtime;
@@ -206,7 +204,7 @@ pub struct WorkerOptions {
     workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
 
     #[builder(field)]
-    worker_plugins: Vec<ErasedWorkerPlugin>,
+    worker_plugins: Vec<Arc<dyn WorkerPlugin>>,
 
     #[builder(field)]
     client_plugin_names: HashSet<String>,
@@ -332,19 +330,11 @@ pub struct WorkerOptions {
 }
 
 impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
-    /// Register a type-erased worker plugin.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn plugin<P: Into<ErasedWorkerPlugin>>(mut self, plugin: P) -> Self {
-        self.worker_plugins.push(plugin.into());
-        self
-    }
-
-    /// Register a worker-only plugin.
+    /// Register a worker plugin.
     ///
     /// **Experimental:** This API may change or be removed.
     pub fn worker_plugin<P: WorkerPlugin>(mut self, plugin: P) -> Self {
-        self.worker_plugins.push(ErasedWorkerPlugin::new(plugin));
+        self.worker_plugins.push(Arc::new(plugin));
         self
     }
 
@@ -606,7 +596,7 @@ impl WorkerOptions {
                         version: String::new(),
                     })
                     .chain(self.worker_plugins.iter().map(|registration| PluginInfo {
-                        name: registration.plugin().name().to_owned(),
+                        name: registration.name().to_owned(),
                         version: String::new(),
                     }))
                     .collect(),

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -189,6 +189,12 @@ pub struct WorkerOptions {
     workflows: WorkflowDefinitions,
 
     #[builder(field)]
+    worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
+
+    #[builder(field)]
+    activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
+
+    #[builder(field)]
     workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
 
     #[cfg(feature = "wasm-workflows")]
@@ -309,6 +315,35 @@ pub struct WorkerOptions {
 }
 
 impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
+    /// Append a worker interceptor. Interceptors run in registration order.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
+        self.worker_interceptors.push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append an activity inbound interceptor. Interceptors run outermost-first in registration
+    /// order.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn activity_inbound_interceptor<I: ActivityInboundInterceptor>(
+        mut self,
+        interceptor: I,
+    ) -> Self {
+        self.activity_inbound_interceptors
+            .push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append a workflow interceptor constructor.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn workflow_interceptor(mut self, constructor: WorkflowInterceptorConstructor) -> Self {
+        self.workflow_interceptor_constructors.push(constructor);
+        self
+    }
+
     /// Registers all activities on an activity implementer.
     pub fn register_activities<AI: ActivityImplementer>(mut self, instance: AI) -> Self {
         self.activities.register_activities::<AI>(instance);
@@ -398,6 +433,41 @@ fn def_build_id() -> WorkerDeploymentOptions {
 }
 
 impl WorkerOptions {
+    /// Append a worker interceptor. Interceptors run in registration order.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn worker_interceptor<I: WorkerInterceptor + 'static>(
+        &mut self,
+        interceptor: I,
+    ) -> &mut Self {
+        self.worker_interceptors.push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append an activity inbound interceptor. Interceptors run outermost-first in registration
+    /// order.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn activity_inbound_interceptor<I: ActivityInboundInterceptor>(
+        &mut self,
+        interceptor: I,
+    ) -> &mut Self {
+        self.activity_inbound_interceptors
+            .push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append a workflow interceptor constructor.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn workflow_interceptor(
+        &mut self,
+        constructor: WorkflowInterceptorConstructor,
+    ) -> &mut Self {
+        self.workflow_interceptor_constructors.push(constructor);
+        self
+    }
+
     /// Registers all activities on an activity implementer.
     pub fn register_activities<AI: ActivityImplementer>(&mut self, instance: AI) -> &mut Self {
         self.activities.register_activities::<AI>(instance);
@@ -524,7 +594,7 @@ pub struct Worker {
 struct CommonWorker {
     worker: Arc<CoreWorker>,
     task_queue: String,
-    worker_interceptor: Option<Box<dyn WorkerInterceptor>>,
+    worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
     activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
     workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
     client_options: ClientOptions,
@@ -663,6 +733,8 @@ impl Worker {
             Default::default(),
             Default::default(),
             Default::default(),
+            Default::default(),
+            Default::default(),
         )
     }
 
@@ -675,6 +747,9 @@ impl Worker {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let acts = std::mem::take(&mut options.activities);
         let wfs = std::mem::take(&mut options.workflows);
+        let worker_interceptors = std::mem::take(&mut options.worker_interceptors);
+        let activity_inbound_interceptors =
+            std::mem::take(&mut options.activity_inbound_interceptors);
         let workflow_interceptor_constructors =
             std::mem::take(&mut options.workflow_interceptor_constructors);
         #[cfg(feature = "wasm-workflows")]
@@ -684,6 +759,8 @@ impl Worker {
             client_options,
             acts,
             wfs,
+            worker_interceptors,
+            activity_inbound_interceptors,
             workflow_interceptor_constructors,
         );
         me.set_detect_nondeterministic_futures(options.detect_nondeterministic_futures);
@@ -703,6 +780,8 @@ impl Worker {
         client_options: ClientOptions,
         activities: ActivityDefinitions,
         workflows: WorkflowDefinitions,
+        worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
+        activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
         workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
     ) -> Self {
         let data_converter = client_options.data_converter.clone();
@@ -710,8 +789,8 @@ impl Worker {
             common: CommonWorker {
                 task_queue: worker.get_config().task_queue.clone(),
                 worker,
-                worker_interceptor: None,
-                activity_inbound_interceptors: Vec::new(),
+                worker_interceptors,
+                activity_inbound_interceptors,
                 workflow_interceptor_constructors,
                 client_options,
                 data_converter,
@@ -852,7 +931,7 @@ impl Worker {
                 .map(Ok)
                 .try_for_each_concurrent(None, |mut completion| async {
                     encode_workflow_completion(&mut completion, &common.data_converter).await;
-                    if let Some(ref i) = common.worker_interceptor {
+                    for i in &common.worker_interceptors {
                         i.on_workflow_activation_completion(&completion).await;
                     }
                     common.worker.complete_workflow_activation(completion).await
@@ -899,7 +978,7 @@ impl Worker {
                                     .expect("Completion channel intact");
                                 continue;
                             }
-                            if let Some(ref i) = common.worker_interceptor {
+                            for i in &common.worker_interceptors {
                                 i.on_workflow_activation(&activation).await?;
                             }
                             if let Some(wf_fut) = wf_half
@@ -1009,38 +1088,11 @@ impl Worker {
             wf_completion_processor,
         )?;
 
-        if let Some(i) = self.common.worker_interceptor.as_ref() {
+        for i in &self.common.worker_interceptors {
             i.on_shutdown(self);
         }
         self.common.worker.shutdown().await;
         Ok(())
-    }
-
-    /// Set a [WorkerInterceptor]
-    pub fn set_worker_interceptor(&mut self, interceptor: impl WorkerInterceptor + 'static) {
-        self.common.worker_interceptor = Some(Box::new(interceptor));
-    }
-
-    /// Append an [ActivityInboundInterceptor] to the chain. Interceptors run in the order they
-    /// are added, outer-most first.
-    pub fn add_activity_inbound_interceptor(
-        &mut self,
-        interceptor: impl ActivityInboundInterceptor,
-    ) {
-        self.common
-            .activity_inbound_interceptors
-            .push(Arc::new(interceptor));
-    }
-
-    /// Set the ordered constructors used to create workflow interceptors for each workflow instance.
-    ///
-    /// This replaces any previously configured constructors. Existing workflow instances retain
-    /// their current interceptors; the new constructors apply when later instances are created.
-    pub fn register_workflow_interceptors(
-        &mut self,
-        constructors: Vec<WorkflowInterceptorConstructor>,
-    ) {
-        self.common.workflow_interceptor_constructors = constructors;
     }
 
     /// Turns this rust worker into a new worker with all the same workflows and activities

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -67,6 +67,8 @@ extern crate self as temporalio_sdk;
 pub mod activities;
 pub mod error;
 pub mod interceptors;
+/// Experimental APIs for configuring clients and workers with reusable plugins.
+pub mod plugins;
 /// Runtime configuration and low-level Core worker building blocks.
 ///
 /// These types are grouped here to keep Core-specific configuration separate from the SDK's
@@ -93,10 +95,16 @@ mod workflow_registry;
 mod workflow_wasm;
 pub mod workflows;
 
-pub use crate::error::{
-    ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
-    ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
-    RetryState, TimeoutType, WorkflowRegistrationError, WorkflowSignalError,
+pub use crate::{
+    error::{
+        ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
+        ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
+        RetryState, TimeoutType, WorkerCreateError, WorkflowRegistrationError, WorkflowSignalError,
+    },
+    plugins::{
+        ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, WorkerPlugin,
+        WorkerPluginRegistration,
+    },
 };
 pub use temporalio_client::Namespace;
 pub use temporalio_sdk_core::CoreRuntime as Runtime;
@@ -152,6 +160,7 @@ use temporalio_common::{
         },
         temporal::api::{
             common::v1::Payload, enums::v1::WorkflowTaskFailedCause, failure::v1::Failure,
+            worker::v1::PluginInfo,
         },
     },
     worker::{WorkerDeploymentOptions, WorkerTaskTypes, build_id_from_current_exe},
@@ -196,6 +205,12 @@ pub struct WorkerOptions {
 
     #[builder(field)]
     workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
+
+    #[builder(field)]
+    worker_plugins: Vec<WorkerPluginRegistration>,
+
+    #[builder(field)]
+    plugins_applied: bool,
 
     #[cfg(feature = "wasm-workflows")]
     #[builder(field)]
@@ -315,6 +330,27 @@ pub struct WorkerOptions {
 }
 
 impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
+    /// Register a type-erased worker plugin.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn worker_plugin<P: Into<WorkerPluginRegistration>>(mut self, plugin: P) -> Self {
+        self.worker_plugins.push(plugin.into());
+        self
+    }
+
+    /// Register type-erased worker plugins in iteration order.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn worker_plugins<I, P>(mut self, plugins: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<WorkerPluginRegistration>,
+    {
+        self.worker_plugins
+            .extend(plugins.into_iter().map(Into::into));
+        self
+    }
+
     /// Append a worker interceptor. Interceptors run in registration order.
     ///
     /// **Experimental:** This API may change or be removed.
@@ -577,6 +613,15 @@ impl WorkerOptions {
             ))
             .workflow_failure_errors(self.workflow_failure_errors.clone())
             .workflow_types_to_failure_errors(self.workflow_types_to_failure_errors.clone())
+            .plugins(
+                self.worker_plugins
+                    .iter()
+                    .map(|registration| PluginInfo {
+                        name: registration.plugin().name().to_owned(),
+                        version: String::new(),
+                    })
+                    .collect(),
+            )
             .disable_payload_error_limit(self.disable_payload_error_limit)
             .build()
     }
@@ -712,12 +757,14 @@ impl Worker {
     pub fn new(
         runtime: &Runtime,
         client: Client,
-        options: WorkerOptions,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+        mut options: WorkerOptions,
+    ) -> Result<Self, WorkerCreateError> {
+        plugins::apply_worker_plugins(client.options(), &mut options)?;
         let wc = options
             .to_core_options(client.namespace(), client.identity())
-            .map_err(|s| anyhow::anyhow!("{s}"))?;
-        let core = init_worker(runtime, wc, client.connection().clone())?;
+            .map_err(|error| WorkerCreateError::Initialization(anyhow!(error)))?;
+        let core = init_worker(runtime, wc, client.connection().clone())
+            .map_err(WorkerCreateError::Initialization)?;
         Self::new_from_core_options(Arc::new(core), client.options().clone(), options)
     }
 
@@ -744,7 +791,8 @@ impl Worker {
         worker: Arc<CoreWorker>,
         client_options: ClientOptions,
         mut options: WorkerOptions,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, WorkerCreateError> {
+        plugins::apply_worker_plugins(&client_options, &mut options)?;
         let acts = std::mem::take(&mut options.activities);
         let wfs = std::mem::take(&mut options.workflows);
         let worker_interceptors = std::mem::take(&mut options.worker_interceptors);
@@ -771,7 +819,8 @@ impl Worker {
             .register_wasm_workflows(
                 wasm_components,
                 !me.common.workflow_interceptor_constructors.is_empty(),
-            )?;
+            )
+            .map_err(|error| WorkerCreateError::Initialization(anyhow!(error)))?;
         Ok(me)
     }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -102,8 +102,7 @@ pub use crate::{
         RetryState, TimeoutType, WorkerCreateError, WorkflowRegistrationError, WorkflowSignalError,
     },
     plugins::{
-        ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, WorkerPlugin,
-        WorkerPluginRegistration,
+        ClientAndWorkerPlugin, ErasedWorkerPlugin, SimplePlugin, SimplePluginBuilder, WorkerPlugin,
     },
 };
 pub use temporalio_client::Namespace;
@@ -207,7 +206,7 @@ pub struct WorkerOptions {
     workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
 
     #[builder(field)]
-    worker_plugins: Vec<WorkerPluginRegistration>,
+    worker_plugins: Vec<ErasedWorkerPlugin>,
 
     #[builder(field)]
     plugins_applied: bool,
@@ -333,8 +332,16 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     /// Register a type-erased worker plugin.
     ///
     /// **Experimental:** This API may change or be removed.
-    pub fn worker_plugin<P: Into<WorkerPluginRegistration>>(mut self, plugin: P) -> Self {
+    pub fn plugin<P: Into<ErasedWorkerPlugin>>(mut self, plugin: P) -> Self {
         self.worker_plugins.push(plugin.into());
+        self
+    }
+
+    /// Register a worker-only plugin.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn worker_plugin<P: WorkerPlugin>(mut self, plugin: P) -> Self {
+        self.worker_plugins.push(ErasedWorkerPlugin::new(plugin));
         self
     }
 
@@ -344,7 +351,7 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     pub fn worker_plugins<I, P>(mut self, plugins: I) -> Self
     where
         I: IntoIterator<Item = P>,
-        P: Into<WorkerPluginRegistration>,
+        P: Into<ErasedWorkerPlugin>,
     {
         self.worker_plugins
             .extend(plugins.into_iter().map(Into::into));

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -209,6 +209,9 @@ pub struct WorkerOptions {
     worker_plugins: Vec<ErasedWorkerPlugin>,
 
     #[builder(field)]
+    client_plugin_names: HashSet<String>,
+
+    #[builder(field)]
     plugins_applied: bool,
 
     #[cfg(feature = "wasm-workflows")]
@@ -621,12 +624,16 @@ impl WorkerOptions {
             .workflow_failure_errors(self.workflow_failure_errors.clone())
             .workflow_types_to_failure_errors(self.workflow_types_to_failure_errors.clone())
             .plugins(
-                self.worker_plugins
+                self.client_plugin_names
                     .iter()
-                    .map(|registration| PluginInfo {
-                        name: registration.plugin().name().to_owned(),
+                    .map(|name| PluginInfo {
+                        name: name.clone(),
                         version: String::new(),
                     })
+                    .chain(self.worker_plugins.iter().map(|registration| PluginInfo {
+                        name: registration.plugin().name().to_owned(),
+                        version: String::new(),
+                    }))
                     .collect(),
             )
             .disable_payload_error_limit(self.disable_payload_error_limit)
@@ -637,30 +644,39 @@ impl WorkerOptions {
 /// A worker that can poll for and respond to workflow tasks by using
 /// [temporalio_macros::workflow], and activity tasks by using activities defined with
 /// [temporalio_macros::activities].
+#[derive(Debug)]
 pub struct Worker {
     common: CommonWorker,
     workflow_half: WorkflowHalf,
     activity_half: ActivityHalf,
 }
 
+#[derive(derive_more::Debug)]
 struct CommonWorker {
+    #[debug(skip)]
     worker: Arc<CoreWorker>,
     task_queue: String,
+    #[debug(skip)]
     worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
+    #[debug(skip)]
     activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
+    #[debug(skip)]
     workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
     client_options: ClientOptions,
     data_converter: DataConverter,
 }
 
+#[derive(derive_more::Debug)]
 struct WorkflowHalf {
     /// Maps run id to cached workflow state
     workflows: RefCell<HashMap<String, WorkflowData>>,
     workflow_definitions: WorkflowDefinitions,
     workflow_removed_from_map: Notify,
     detect_nondeterministic_futures: bool,
+    #[debug(skip)]
     patch_activation_callback: Option<PatchActivationCallback>,
 }
+#[derive(Debug)]
 struct WorkflowData {
     /// Channel used to send the workflow activations
     activation_chan: UnboundedSender<WorkflowActivation>,
@@ -671,7 +687,7 @@ struct WorkflowFutureHandle<F: Future> {
     run_id: String,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct ActivityHalf {
     /// Maps activity type to the function for executing activities of that type
     activities: ActivityDefinitions,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -209,9 +209,6 @@ pub struct WorkerOptions {
     #[builder(field)]
     client_plugin_names: HashSet<String>,
 
-    #[builder(field)]
-    plugins_applied: bool,
-
     #[cfg(feature = "wasm-workflows")]
     #[builder(field)]
     wasm_workflow_components: Vec<WasmWorkflowComponent>,
@@ -753,7 +750,7 @@ impl Worker {
             .map_err(|error| WorkerCreateError::Initialization(anyhow!(error)))?;
         let core = init_worker(runtime, wc, client.connection().clone())
             .map_err(WorkerCreateError::Initialization)?;
-        Self::new_from_core_options(Arc::new(core), client.options().clone(), options)
+        Self::new_from_core_options_prepared(Arc::new(core), client.options().clone(), options)
     }
 
     // TODO [rust-sdk-branch]: Eliminate this constructor in favor of passing in fake connection
@@ -781,6 +778,14 @@ impl Worker {
         mut options: WorkerOptions,
     ) -> Result<Self, WorkerCreateError> {
         plugins::apply_worker_plugins(&client_options, &mut options)?;
+        Self::new_from_core_options_prepared(worker, client_options, options)
+    }
+
+    fn new_from_core_options_prepared(
+        worker: Arc<CoreWorker>,
+        client_options: ClientOptions,
+        mut options: WorkerOptions,
+    ) -> Result<Self, WorkerCreateError> {
         let acts = std::mem::take(&mut options.activities);
         let wfs = std::mem::take(&mut options.workflows);
         let worker_interceptors = std::mem::take(&mut options.worker_interceptors);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -348,22 +348,7 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
         self
     }
 
-    /// Register type-erased worker plugins in iteration order.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn worker_plugins<I, P>(mut self, plugins: I) -> Self
-    where
-        I: IntoIterator<Item = P>,
-        P: Into<ErasedWorkerPlugin>,
-    {
-        self.worker_plugins
-            .extend(plugins.into_iter().map(Into::into));
-        self
-    }
-
     /// Append a worker interceptor. Interceptors run in registration order.
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
         self.worker_interceptors.push(Arc::new(interceptor));
         self
@@ -371,8 +356,6 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
 
     /// Append an activity inbound interceptor. Interceptors run outermost-first in registration
     /// order.
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub fn activity_inbound_interceptor<I: ActivityInboundInterceptor>(
         mut self,
         interceptor: I,
@@ -383,8 +366,6 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     }
 
     /// Append a workflow interceptor constructor.
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub fn workflow_interceptor(mut self, constructor: WorkflowInterceptorConstructor) -> Self {
         self.workflow_interceptor_constructors.push(constructor);
         self
@@ -480,8 +461,6 @@ fn def_build_id() -> WorkerDeploymentOptions {
 
 impl WorkerOptions {
     /// Append a worker interceptor. Interceptors run in registration order.
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(
         &mut self,
         interceptor: I,
@@ -492,8 +471,6 @@ impl WorkerOptions {
 
     /// Append an activity inbound interceptor. Interceptors run outermost-first in registration
     /// order.
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub fn activity_inbound_interceptor<I: ActivityInboundInterceptor>(
         &mut self,
         interceptor: I,
@@ -504,8 +481,6 @@ impl WorkerOptions {
     }
 
     /// Append a workflow interceptor constructor.
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub fn workflow_interceptor(
         &mut self,
         constructor: WorkflowInterceptorConstructor,

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -449,6 +449,11 @@ pub(crate) fn apply_worker_plugins(
         return Ok(());
     }
 
+    options.client_plugin_names = client_options
+        .plugins()
+        .iter()
+        .map(|plugin| plugin.name().to_owned())
+        .collect();
     let mut plugins = client_options
         .plugins()
         .iter()
@@ -478,8 +483,9 @@ pub(crate) fn apply_worker_plugins(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::{collections::HashSet, sync::Mutex};
     use temporalio_client::ClientOptions;
+    use temporalio_common::protos::temporal::api::worker::v1::PluginInfo;
 
     struct RecordingCombinedPlugin {
         order: Arc<Mutex<Vec<&'static str>>>,
@@ -576,6 +582,14 @@ mod tests {
         }
     }
 
+    struct SameNameClientPlugin;
+
+    impl ClientPlugin for SameNameClientPlugin {
+        fn name(&self) -> &str {
+            "same-name"
+        }
+    }
+
     struct UnrecognizedWorkerPluginExtension {
         _registration: ErasedWorkerPlugin,
     }
@@ -605,9 +619,12 @@ mod tests {
     }
 
     #[test]
-    fn heartbeat_plugin_names_are_deduplicated() {
+    fn heartbeat_plugin_names_include_client_plugins_and_are_deduplicated() {
         let order = Arc::new(Mutex::new(Vec::new()));
-        let client_options = ClientOptions::new("namespace").build();
+        let client_options = ClientOptions::new("namespace")
+            .client_plugin(ClientOnlyPlugin)
+            .client_plugin(SameNameClientPlugin)
+            .build();
         let mut worker_options = WorkerOptions::new("queue")
             .worker_plugin(RecordingWorkerPlugin {
                 name: "same-name",
@@ -630,10 +647,19 @@ mod tests {
             .to_core_options("namespace".to_owned(), "identity".to_owned())
             .unwrap();
 
-        assert_eq!(core_options.plugins.len(), 1);
-        let plugin = core_options.plugins.iter().next().unwrap();
-        assert_eq!(plugin.name, "same-name");
-        assert!(plugin.version.is_empty());
+        let expected_plugins: HashSet<_> = vec![
+            PluginInfo {
+                name: "client-only".into(),
+                version: "".into(),
+            },
+            PluginInfo {
+                name: "same-name".into(),
+                version: "".into(),
+            },
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(core_options.plugins, expected_plugins);
     }
 
     struct EmptyClientInterceptor;
@@ -675,34 +701,5 @@ mod tests {
 
         assert_eq!(worker_options.max_cached_workflows, 0);
         assert_eq!(worker_options.worker_interceptors.len(), 1);
-    }
-
-    struct FailingWorkerPlugin;
-
-    impl WorkerPlugin for FailingWorkerPlugin {
-        fn name(&self) -> &str {
-            "failing-worker"
-        }
-
-        fn configure_worker_options(
-            &self,
-            _options: &mut WorkerOptions,
-        ) -> Result<(), PluginError> {
-            Err(PluginError::new("worker failure"))
-        }
-    }
-
-    #[test]
-    fn worker_application_errors_include_context() {
-        let client_options = ClientOptions::new("namespace").build();
-        let mut worker_options = WorkerOptions::new("queue")
-            .worker_plugin(FailingWorkerPlugin)
-            .build();
-
-        let error = apply_worker_plugins(&client_options, &mut worker_options).unwrap_err();
-
-        assert_eq!(error.plugin_name, "failing-worker");
-        assert_eq!(error.target, PluginTarget::Worker);
-        assert_eq!(error.source.to_string(), "worker failure");
     }
 }

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -23,7 +23,7 @@ use temporalio_workflow::runtime::entry::WorkflowImplementation;
 ///
 /// **Experimental:** This API may change or be removed.
 pub trait WorkerPlugin: Send + Sync + 'static {
-    /// Name used to identify this plugin.
+    /// Stable, unique name used to identify this plugin.
     fn name(&self) -> &str;
 
     /// Configure worker options.
@@ -35,39 +35,16 @@ pub trait WorkerPlugin: Send + Sync + 'static {
     }
 }
 
-/// A type-erased worker plugin.
-///
-/// **Experimental:** This API may change or be removed.
 #[derive(Clone)]
-pub struct ErasedWorkerPlugin {
-    worker: Arc<dyn WorkerPlugin>,
-}
-
-impl ErasedWorkerPlugin {
-    /// Type-erase a worker plugin for registration on [`WorkerOptions`].
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn new<P: WorkerPlugin>(plugin: P) -> Self {
-        Self {
-            worker: Arc::new(plugin),
-        }
-    }
-
-    pub(crate) fn plugin(&self) -> &dyn WorkerPlugin {
-        self.worker.as_ref()
-    }
-}
-
-#[derive(Clone)]
-struct PropagatedWorkerPlugin(ErasedWorkerPlugin);
+struct PropagatedWorkerPlugin(Arc<dyn WorkerPlugin>);
 
 impl WorkerPluginData for PropagatedWorkerPlugin {}
 
 /// A container for a plugin that implements both [`ClientPlugin`] and
 /// [`WorkerPlugin`].
 ///
-/// This wrapper is only needed when the same plugin configures both a client and workers. Use
-/// [`ErasedClientPlugin`] or [`ErasedWorkerPlugin`] for one-sided plugins.
+/// This wrapper is only needed when the same plugin configures both a client and workers.
+/// One-sided plugins can implement [`ClientPlugin`] or [`WorkerPlugin`] directly.
 ///
 /// When registered on [`ClientOptions`], the resulting client carries the worker plugin and
 /// automatically applies it to workers created from that client. Do not also register the plugin
@@ -92,7 +69,7 @@ impl WorkerPluginData for PropagatedWorkerPlugin {}
 #[derive(Clone)]
 pub struct ClientAndWorkerPlugin {
     client: ErasedClientPlugin,
-    worker: ErasedWorkerPlugin,
+    worker: Arc<dyn WorkerPlugin>,
 }
 
 impl ClientAndWorkerPlugin {
@@ -104,7 +81,7 @@ impl ClientAndWorkerPlugin {
     {
         let plugin = Arc::new(plugin);
         let mut client = ErasedClientPlugin::new(SharedClientPlugin(plugin.clone()));
-        let worker = ErasedWorkerPlugin::new(SharedWorkerPlugin(plugin));
+        let worker: Arc<dyn WorkerPlugin> = Arc::new(SharedWorkerPlugin(plugin));
         client = client.with_worker_plugin(PropagatedWorkerPlugin(worker.clone()));
         Self { client, worker }
     }
@@ -116,9 +93,13 @@ impl From<ClientAndWorkerPlugin> for ErasedClientPlugin {
     }
 }
 
-impl From<ClientAndWorkerPlugin> for ErasedWorkerPlugin {
-    fn from(plugin: ClientAndWorkerPlugin) -> Self {
-        plugin.worker
+impl WorkerPlugin for ClientAndWorkerPlugin {
+    fn name(&self) -> &str {
+        self.worker.name()
+    }
+
+    fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
+        self.worker.configure_worker_options(options)
     }
 }
 
@@ -169,12 +150,6 @@ pub struct SimplePlugin {
 impl From<SimplePlugin> for ErasedClientPlugin {
     fn from(plugin: SimplePlugin) -> Self {
         ClientAndWorkerPlugin::new(plugin).into()
-    }
-}
-
-impl From<SimplePlugin> for ErasedWorkerPlugin {
-    fn from(plugin: SimplePlugin) -> Self {
-        ErasedWorkerPlugin::new(plugin)
     }
 }
 
@@ -341,15 +316,15 @@ struct WorkerPluginWarning<'a> {
 }
 
 fn worker_plugin_warnings(
-    plugins: &[ErasedWorkerPlugin],
+    plugins: &[Arc<dyn WorkerPlugin>],
 ) -> impl Iterator<Item = WorkerPluginWarning<'_>> {
     plugins.iter().enumerate().filter_map(|(index, plugin)| {
         plugins[index + 1..]
             .iter()
-            .any(|other| Arc::ptr_eq(&plugin.worker, &other.worker))
+            .any(|other| plugin.name() == other.name())
             .then_some(WorkerPluginWarning {
-                plugin_name: plugin.plugin().name(),
-                message: "The same combined client and worker plugin was registered both through the client and directly on the worker",
+                plugin_name: plugin.name(),
+                message: "Multiple worker plugins with the same name were registered",
             })
     })
 }
@@ -382,10 +357,9 @@ pub(crate) fn apply_worker_plugins(
 
     for registration in &plugins {
         registration
-            .plugin()
             .configure_worker_options(options)
             .map_err(|source| {
-                PluginApplyError::new(registration.plugin().name(), PluginTarget::Worker, source)
+                PluginApplyError::new(registration.name(), PluginTarget::Worker, source)
             })?;
     }
     options.worker_plugins = plugins;
@@ -479,7 +453,7 @@ mod tests {
         let client_options = ClientOptions::new("namespace")
             .plugin(combined.clone())
             .build();
-        let mut worker_options = WorkerOptions::new("queue").plugin(combined).build();
+        let mut worker_options = WorkerOptions::new("queue").worker_plugin(combined).build();
 
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
@@ -487,7 +461,7 @@ mod tests {
             worker_plugin_warnings(&worker_options.worker_plugins).collect::<Vec<_>>(),
             [WorkerPluginWarning {
                 plugin_name: "combined",
-                message: "The same combined client and worker plugin was registered both through the client and directly on the worker",
+                message: "Multiple worker plugins with the same name were registered",
             }]
         );
         assert_eq!(*order.lock().unwrap(), ["propagated", "propagated"]);
@@ -510,7 +484,7 @@ mod tests {
     }
 
     struct UnrecognizedWorkerPluginExtension {
-        _registration: ErasedWorkerPlugin,
+        _registration: Arc<dyn WorkerPlugin>,
     }
 
     impl WorkerPluginData for UnrecognizedWorkerPluginExtension {}
@@ -520,7 +494,7 @@ mod tests {
         let order = Arc::new(Mutex::new(Vec::new()));
         let client_registration = ErasedClientPlugin::new(ClientOnlyPlugin).with_worker_plugin(
             UnrecognizedWorkerPluginExtension {
-                _registration: ErasedWorkerPlugin::new(RecordingWorkerPlugin {
+                _registration: Arc::new(RecordingWorkerPlugin {
                     name: "unrecognized",
                     value: "should-not-run",
                     order: order.clone(),
@@ -538,7 +512,7 @@ mod tests {
     }
 
     #[test]
-    fn heartbeat_plugin_names_include_client_plugins_and_are_deduplicated() {
+    fn duplicate_worker_plugin_names_warn_and_heartbeat_names_are_deduplicated() {
         let order = Arc::new(Mutex::new(Vec::new()));
         let client_options = ClientOptions::new("namespace")
             .client_plugin(ClientOnlyPlugin)
@@ -559,8 +533,11 @@ mod tests {
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
         assert_eq!(
-            worker_plugin_warnings(&worker_options.worker_plugins).count(),
-            0
+            worker_plugin_warnings(&worker_options.worker_plugins).collect::<Vec<_>>(),
+            [WorkerPluginWarning {
+                plugin_name: "same-name",
+                message: "Multiple worker plugins with the same name were registered",
+            }]
         );
         let core_options = worker_options
             .to_core_options("namespace".to_owned(), "identity".to_owned())
@@ -605,7 +582,7 @@ mod tests {
             .worker_interceptor(EmptyWorkerInterceptor)
             .build();
         let client_options = ClientOptions::new("namespace").build();
-        let mut worker_options = WorkerOptions::new("queue").plugin(plugin).build();
+        let mut worker_options = WorkerOptions::new("queue").worker_plugin(plugin).build();
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
         assert_eq!(worker_options.worker_interceptors.len(), 1);

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -1,0 +1,675 @@
+//! Experimental plugin APIs for configuring workers and clients from reusable values.
+
+#[cfg(feature = "wasm-workflows")]
+use crate::WasmWorkflowComponent;
+use crate::{
+    WorkerOptions, WorkflowRegistrationError,
+    activities::{ActivityDefinitions, ActivityImplementer},
+    interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
+    workflow_interceptors::WorkflowInterceptorConstructor,
+    workflow_registry::WorkflowDefinitions,
+};
+use std::sync::Arc;
+use temporalio_client::{
+    ClientInterceptor, ClientOptions, ClientPlugin, ClientPluginRegistration, ConnectionOptions,
+    PluginApplyError, PluginError, PluginResult, PluginTarget,
+};
+use temporalio_common::{WorkflowDefinition, data_converters::DataConverter};
+use temporalio_workflow::runtime::entry::WorkflowImplementation;
+
+/// Configures worker options before the underlying Core worker is created.
+///
+/// **Experimental:** This API may change or be removed.
+pub trait WorkerPlugin: Send + Sync + 'static {
+    /// Return the stable name used to identify this plugin in diagnostics and worker heartbeats.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    fn name(&self) -> &str;
+
+    /// Configure worker options.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    fn configure_worker_options(&self, _options: &mut WorkerOptions) -> PluginResult {
+        Ok(())
+    }
+}
+
+/// A type-erased worker plugin with an identity used to diagnose duplicate registration.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Clone)]
+pub struct WorkerPluginRegistration {
+    worker: Arc<dyn WorkerPlugin>,
+    instance_id: Arc<()>,
+}
+
+impl WorkerPluginRegistration {
+    /// Type-erase a worker plugin for registration on [`WorkerOptions`].
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn new<P: WorkerPlugin>(plugin: P) -> Self {
+        Self {
+            worker: Arc::new(plugin),
+            instance_id: Arc::new(()),
+        }
+    }
+
+    fn with_instance_id<P: WorkerPlugin>(plugin: P, instance_id: Arc<()>) -> Self {
+        Self {
+            worker: Arc::new(plugin),
+            instance_id,
+        }
+    }
+
+    pub(crate) fn plugin(&self) -> &dyn WorkerPlugin {
+        self.worker.as_ref()
+    }
+}
+
+#[derive(Clone)]
+struct PropagatedWorkerPlugin(WorkerPluginRegistration);
+
+/// A type-erased registration for one value that implements both [`ClientPlugin`] and
+/// [`WorkerPlugin`].
+///
+/// This wrapper is only needed when the same plugin configures both a client and its workers. Use
+/// [`ClientPluginRegistration`] or [`WorkerPluginRegistration`] for one-sided plugins.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Clone)]
+pub struct ClientAndWorkerPlugin {
+    client: ClientPluginRegistration,
+    worker: WorkerPluginRegistration,
+}
+
+impl ClientAndWorkerPlugin {
+    /// Type-erase one plugin value for client registration, automatic worker propagation, and
+    /// optional explicit worker registration.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn new<P>(plugin: P) -> Self
+    where
+        P: ClientPlugin + WorkerPlugin,
+    {
+        let plugin = Arc::new(plugin);
+        let mut client = ClientPluginRegistration::new(SharedClientPlugin(plugin.clone()));
+        let worker = WorkerPluginRegistration::with_instance_id(
+            SharedWorkerPlugin(plugin),
+            client.instance_id(),
+        );
+        client = client.with_worker_plugin(PropagatedWorkerPlugin(worker.clone()));
+        Self { client, worker }
+    }
+}
+
+impl From<ClientAndWorkerPlugin> for ClientPluginRegistration {
+    fn from(plugin: ClientAndWorkerPlugin) -> Self {
+        plugin.client
+    }
+}
+
+impl From<ClientAndWorkerPlugin> for WorkerPluginRegistration {
+    fn from(plugin: ClientAndWorkerPlugin) -> Self {
+        plugin.worker
+    }
+}
+
+/// A plugin assembled from declarative values and optional fallible configuration callbacks.
+///
+/// Scalar values replace the corresponding option, while interceptors and definitions append in
+/// registration order. Declarative values are applied before configuration callbacks.
+///
+/// ```
+/// use temporalio_client::ClientOptions;
+/// use temporalio_sdk::SimplePlugin;
+///
+/// let plugin = SimplePlugin::new("acme.standard-library")
+///     .configure_worker_options(|options| {
+///         options.max_cached_workflows = 0;
+///         Ok(())
+///     })
+///     .build();
+/// let client_options = ClientOptions::new("default").plugin(plugin).build();
+/// # let _ = client_options;
+/// ```
+///
+/// Worker configuration declared by this combined plugin is automatically propagated through the
+/// configured client when a worker is created.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Clone)]
+pub struct SimplePlugin {
+    combined: ClientAndWorkerPlugin,
+}
+
+impl SimplePlugin {
+    /// Begin declaring a simple plugin with the name used in diagnostics and worker heartbeats.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(name: impl Into<String>) -> SimplePluginBuilder {
+        SimplePluginBuilder {
+            definition: SimplePluginDefinition {
+                name: name.into(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl From<SimplePlugin> for ClientPluginRegistration {
+    fn from(plugin: SimplePlugin) -> Self {
+        plugin.combined.into()
+    }
+}
+
+impl From<SimplePlugin> for WorkerPluginRegistration {
+    fn from(plugin: SimplePlugin) -> Self {
+        plugin.combined.into()
+    }
+}
+
+type ConnectionCustomizer =
+    Arc<dyn Fn(&mut ConnectionOptions) -> PluginResult + Send + Sync + 'static>;
+type ClientCustomizer = Arc<dyn Fn(&mut ClientOptions) -> PluginResult + Send + Sync + 'static>;
+type WorkerCustomizer = Arc<dyn Fn(&mut WorkerOptions) -> PluginResult + Send + Sync + 'static>;
+
+#[derive(Default)]
+struct SimplePluginDefinition {
+    name: String,
+    data_converter: Option<DataConverter>,
+    client_interceptors: Vec<Arc<dyn ClientInterceptor>>,
+    worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
+    activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
+    workflow_interceptors: Vec<WorkflowInterceptorConstructor>,
+    activities: ActivityDefinitions,
+    workflows: WorkflowDefinitions,
+    #[cfg(feature = "wasm-workflows")]
+    wasm_workflow_components: Vec<WasmWorkflowComponent>,
+    connection_customizers: Vec<ConnectionCustomizer>,
+    client_customizers: Vec<ClientCustomizer>,
+    worker_customizers: Vec<WorkerCustomizer>,
+}
+
+impl ClientPlugin for SimplePluginDefinition {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn configure_connection_options(&self, options: &mut ConnectionOptions) -> PluginResult {
+        for configure in &self.connection_customizers {
+            configure(options)?;
+        }
+        Ok(())
+    }
+
+    fn configure_client_options(&self, options: &mut ClientOptions) -> PluginResult {
+        if let Some(data_converter) = &self.data_converter {
+            options.data_converter = data_converter.clone();
+        }
+        options
+            .client_interceptors
+            .extend(self.client_interceptors.iter().cloned());
+        for configure in &self.client_customizers {
+            configure(options)?;
+        }
+        Ok(())
+    }
+}
+
+impl WorkerPlugin for SimplePluginDefinition {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn configure_worker_options(&self, options: &mut WorkerOptions) -> PluginResult {
+        options.activities.extend(&self.activities);
+        options
+            .workflows
+            .extend(&self.workflows)
+            .map_err(PluginError::new)?;
+        options
+            .worker_interceptors
+            .extend(self.worker_interceptors.iter().cloned());
+        options
+            .activity_inbound_interceptors
+            .extend(self.activity_inbound_interceptors.iter().cloned());
+        options
+            .workflow_interceptor_constructors
+            .extend(self.workflow_interceptors.iter().cloned());
+        #[cfg(feature = "wasm-workflows")]
+        options
+            .wasm_workflow_components
+            .extend(self.wasm_workflow_components.iter().cloned());
+        for configure in &self.worker_customizers {
+            configure(options)?;
+        }
+        Ok(())
+    }
+}
+
+/// Builds a [`SimplePlugin`] from common SDK configuration values.
+///
+/// **Experimental:** This API may change or be removed.
+pub struct SimplePluginBuilder {
+    definition: SimplePluginDefinition,
+}
+
+impl SimplePluginBuilder {
+    /// Set the data converter installed on configured clients.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn data_converter(mut self, data_converter: DataConverter) -> Self {
+        self.definition.data_converter = Some(data_converter);
+        self
+    }
+
+    /// Append a client interceptor.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn client_interceptor<I: ClientInterceptor>(mut self, interceptor: I) -> Self {
+        self.definition
+            .client_interceptors
+            .push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append a worker interceptor.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
+        self.definition
+            .worker_interceptors
+            .push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append an activity inbound interceptor.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn activity_inbound_interceptor<I: ActivityInboundInterceptor>(
+        mut self,
+        interceptor: I,
+    ) -> Self {
+        self.definition
+            .activity_inbound_interceptors
+            .push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append a workflow interceptor constructor.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn workflow_interceptor(mut self, constructor: WorkflowInterceptorConstructor) -> Self {
+        self.definition.workflow_interceptors.push(constructor);
+        self
+    }
+
+    /// Append every activity defined by an activity implementer.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn register_activities<AI: ActivityImplementer>(mut self, instance: AI) -> Self {
+        self.definition.activities.register_activities(instance);
+        self
+    }
+
+    /// Append a workflow definition.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn register_workflow<W>(mut self) -> Result<Self, WorkflowRegistrationError>
+    where
+        W: WorkflowImplementation,
+        <W::Run as WorkflowDefinition>::Input: Send,
+    {
+        self.definition.workflows.register_workflow::<W>()?;
+        Ok(self)
+    }
+
+    /// Append a prebuilt WASM workflow component.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    #[cfg(feature = "wasm-workflows")]
+    pub fn register_wasm_workflow(mut self, component: WasmWorkflowComponent) -> Self {
+        self.definition.wasm_workflow_components.push(component);
+        self
+    }
+
+    /// Append a fallible connection-options callback.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn configure_connection_options<F>(mut self, configure: F) -> Self
+    where
+        F: Fn(&mut ConnectionOptions) -> PluginResult + Send + Sync + 'static,
+    {
+        self.definition
+            .connection_customizers
+            .push(Arc::new(configure));
+        self
+    }
+
+    /// Append a fallible client-options callback.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn configure_client_options<F>(mut self, configure: F) -> Self
+    where
+        F: Fn(&mut ClientOptions) -> PluginResult + Send + Sync + 'static,
+    {
+        self.definition.client_customizers.push(Arc::new(configure));
+        self
+    }
+
+    /// Append a fallible worker-options callback.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn configure_worker_options<F>(mut self, configure: F) -> Self
+    where
+        F: Fn(&mut WorkerOptions) -> PluginResult + Send + Sync + 'static,
+    {
+        self.definition.worker_customizers.push(Arc::new(configure));
+        self
+    }
+
+    /// Build the reusable plugin registration.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn build(self) -> SimplePlugin {
+        SimplePlugin {
+            combined: ClientAndWorkerPlugin::new(self.definition),
+        }
+    }
+}
+
+struct SharedClientPlugin<P>(Arc<P>);
+
+impl<P> ClientPlugin for SharedClientPlugin<P>
+where
+    P: ClientPlugin,
+{
+    fn name(&self) -> &str {
+        ClientPlugin::name(self.0.as_ref())
+    }
+
+    fn configure_connection_options(&self, options: &mut ConnectionOptions) -> PluginResult {
+        self.0.configure_connection_options(options)
+    }
+
+    fn configure_client_options(&self, options: &mut ClientOptions) -> PluginResult {
+        self.0.configure_client_options(options)
+    }
+}
+
+struct SharedWorkerPlugin<P>(Arc<P>);
+
+impl<P> WorkerPlugin for SharedWorkerPlugin<P>
+where
+    P: ClientPlugin + WorkerPlugin,
+{
+    fn name(&self) -> &str {
+        ClientPlugin::name(self.0.as_ref())
+    }
+
+    fn configure_worker_options(&self, options: &mut WorkerOptions) -> PluginResult {
+        self.0.configure_worker_options(options)
+    }
+}
+
+pub(crate) fn apply_worker_plugins(
+    client_options: &ClientOptions,
+    options: &mut WorkerOptions,
+) -> Result<(), PluginApplyError> {
+    if options.plugins_applied {
+        return Ok(());
+    }
+
+    let mut plugins = client_options
+        .plugins()
+        .iter()
+        .flat_map(ClientPluginRegistration::worker_plugins)
+        .filter_map(|plugin| plugin.downcast_ref::<PropagatedWorkerPlugin>())
+        .map(|plugin| plugin.0.clone())
+        .collect::<Vec<_>>();
+    plugins.append(&mut options.worker_plugins);
+
+    for (index, plugin) in plugins.iter().enumerate() {
+        if plugins[index + 1..]
+            .iter()
+            .any(|other| Arc::ptr_eq(&plugin.instance_id, &other.instance_id))
+        {
+            warn!(
+                plugin = plugin.plugin().name(),
+                "The same combined client and worker plugin was registered both through the client and directly on the worker"
+            );
+        }
+    }
+
+    for registration in &plugins {
+        registration
+            .plugin()
+            .configure_worker_options(options)
+            .map_err(|source| PluginApplyError {
+                plugin_name: registration.plugin().name().to_owned(),
+                target: PluginTarget::Worker,
+                source,
+            })?;
+    }
+    options.worker_plugins = plugins;
+    options.plugins_applied = true;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use temporalio_client::ClientOptions;
+
+    struct RecordingCombinedPlugin {
+        order: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl ClientPlugin for RecordingCombinedPlugin {
+        fn name(&self) -> &str {
+            "combined"
+        }
+    }
+
+    impl WorkerPlugin for RecordingCombinedPlugin {
+        fn name(&self) -> &str {
+            "combined"
+        }
+
+        fn configure_worker_options(&self, _options: &mut WorkerOptions) -> PluginResult {
+            self.order.lock().unwrap().push("propagated");
+            Ok(())
+        }
+    }
+
+    struct RecordingWorkerPlugin {
+        name: &'static str,
+        value: &'static str,
+        order: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl WorkerPlugin for RecordingWorkerPlugin {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn configure_worker_options(&self, _options: &mut WorkerOptions) -> PluginResult {
+            self.order.lock().unwrap().push(self.value);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn propagated_plugins_run_before_local_plugins() {
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let combined = ClientAndWorkerPlugin::new(RecordingCombinedPlugin {
+            order: order.clone(),
+        });
+        let client_options = ClientOptions::new("namespace").plugin(combined).build();
+        let mut worker_options = WorkerOptions::new("queue")
+            .worker_plugin(WorkerPluginRegistration::new(RecordingWorkerPlugin {
+                name: "local",
+                value: "local",
+                order: order.clone(),
+            }))
+            .build();
+
+        apply_worker_plugins(&client_options, &mut worker_options).unwrap();
+
+        assert_eq!(*order.lock().unwrap(), ["propagated", "local"]);
+    }
+
+    #[test]
+    fn explicitly_reusing_a_combined_registration_applies_both_registrations() {
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let combined = ClientAndWorkerPlugin::new(RecordingCombinedPlugin {
+            order: order.clone(),
+        });
+        let client_registration: ClientPluginRegistration = combined.clone().into();
+        let worker_registration: WorkerPluginRegistration = combined.into();
+        let propagated_registration = client_registration
+            .worker_plugins()
+            .find_map(|plugin| plugin.downcast_ref::<PropagatedWorkerPlugin>())
+            .unwrap();
+        assert!(Arc::ptr_eq(
+            &propagated_registration.0.instance_id,
+            &worker_registration.instance_id
+        ));
+        let client_options = ClientOptions::new("namespace")
+            .plugin(client_registration)
+            .build();
+        let mut worker_options = WorkerOptions::new("queue")
+            .worker_plugin(worker_registration)
+            .build();
+
+        apply_worker_plugins(&client_options, &mut worker_options).unwrap();
+
+        assert_eq!(*order.lock().unwrap(), ["propagated", "propagated"]);
+    }
+
+    struct ClientOnlyPlugin;
+
+    impl ClientPlugin for ClientOnlyPlugin {
+        fn name(&self) -> &str {
+            "client-only"
+        }
+    }
+
+    #[test]
+    fn arbitrary_opaque_data_cannot_impersonate_propagated_plugin() {
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let client_registration = ClientPluginRegistration::new(ClientOnlyPlugin)
+            .with_worker_plugin(WorkerPluginRegistration::new(RecordingWorkerPlugin {
+                name: "unrecognized",
+                value: "should-not-run",
+                order: order.clone(),
+            }));
+        let client_options = ClientOptions::new("namespace")
+            .plugin(client_registration)
+            .build();
+        let mut worker_options = WorkerOptions::new("queue").build();
+
+        apply_worker_plugins(&client_options, &mut worker_options).unwrap();
+
+        assert!(order.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn heartbeat_plugin_names_are_deduplicated() {
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let client_options = ClientOptions::new("namespace").build();
+        let mut worker_options = WorkerOptions::new("queue")
+            .worker_plugins([
+                WorkerPluginRegistration::new(RecordingWorkerPlugin {
+                    name: "same-name",
+                    value: "first",
+                    order: order.clone(),
+                }),
+                WorkerPluginRegistration::new(RecordingWorkerPlugin {
+                    name: "same-name",
+                    value: "second",
+                    order,
+                }),
+            ])
+            .build();
+        apply_worker_plugins(&client_options, &mut worker_options).unwrap();
+
+        let core_options = worker_options
+            .to_core_options("namespace".to_owned(), "identity".to_owned())
+            .unwrap();
+
+        assert_eq!(core_options.plugins.len(), 1);
+        let plugin = core_options.plugins.iter().next().unwrap();
+        assert_eq!(plugin.name, "same-name");
+        assert!(plugin.version.is_empty());
+    }
+
+    struct EmptyClientInterceptor;
+
+    impl ClientInterceptor for EmptyClientInterceptor {}
+
+    struct EmptyWorkerInterceptor;
+
+    #[async_trait::async_trait(?Send)]
+    impl WorkerInterceptor for EmptyWorkerInterceptor {}
+
+    #[test]
+    fn simple_plugin_applies_declarative_values_before_customizers() {
+        let client_builder = SimplePlugin::new("simple")
+            .client_interceptor(EmptyClientInterceptor)
+            .configure_client_options(|options| {
+                assert_eq!(options.client_interceptors.len(), 1);
+                options.namespace.push_str("-customized");
+                Ok(())
+            });
+        let mut client_options = ClientOptions::new("namespace").build();
+        client_builder
+            .definition
+            .configure_client_options(&mut client_options)
+            .unwrap();
+        assert_eq!(client_options.namespace, "namespace-customized");
+
+        let plugin = SimplePlugin::new("simple")
+            .worker_interceptor(EmptyWorkerInterceptor)
+            .configure_worker_options(|options| {
+                assert_eq!(options.worker_interceptors.len(), 1);
+                options.max_cached_workflows = 0;
+                Ok(())
+            })
+            .build();
+        let client_options = ClientOptions::new("namespace").build();
+        let mut worker_options = WorkerOptions::new("queue").worker_plugin(plugin).build();
+        apply_worker_plugins(&client_options, &mut worker_options).unwrap();
+
+        assert_eq!(worker_options.max_cached_workflows, 0);
+        assert_eq!(worker_options.worker_interceptors.len(), 1);
+    }
+
+    struct FailingWorkerPlugin;
+
+    impl WorkerPlugin for FailingWorkerPlugin {
+        fn name(&self) -> &str {
+            "failing-worker"
+        }
+
+        fn configure_worker_options(&self, _options: &mut WorkerOptions) -> PluginResult {
+            Err(PluginError::message("worker failure"))
+        }
+    }
+
+    #[test]
+    fn worker_application_errors_include_context() {
+        let client_options = ClientOptions::new("namespace").build();
+        let mut worker_options = WorkerOptions::new("queue")
+            .worker_plugin(WorkerPluginRegistration::new(FailingWorkerPlugin))
+            .build();
+
+        let error = apply_worker_plugins(&client_options, &mut worker_options).unwrap_err();
+
+        assert_eq!(error.plugin_name, "failing-worker");
+        assert_eq!(error.target, PluginTarget::Worker);
+        assert_eq!(error.source.to_string(), "worker failure");
+    }
+}

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -27,6 +27,9 @@ pub trait WorkerPlugin: Send + Sync + 'static {
     fn name(&self) -> &str;
 
     /// Configure worker options.
+    ///
+    /// Worker plugin registrations are captured before this method is called. Altering plugins in
+    /// this method does not change which plugins are applied.
     fn configure_worker_options(&self, _options: &mut WorkerOptions) -> Result<(), PluginError> {
         Ok(())
     }
@@ -393,7 +396,13 @@ pub(crate) fn apply_worker_plugins(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{collections::HashSet, sync::Mutex};
+    use std::{
+        collections::HashSet,
+        sync::{
+            Mutex,
+            atomic::{AtomicU8, Ordering},
+        },
+    };
     use temporalio_client::ClientOptions;
     use temporalio_common::protos::temporal::api::worker::v1::PluginInfo;
 
@@ -600,5 +609,32 @@ mod tests {
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
         assert_eq!(worker_options.worker_interceptors.len(), 1);
+    }
+
+    struct RecursivePlugin(Arc<AtomicU8>);
+
+    impl WorkerPlugin for RecursivePlugin {
+        fn name(&self) -> &str {
+            "recursive"
+        }
+
+        fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            *options = WorkerOptions::new(options.task_queue.clone())
+                .worker_plugin(RecursivePlugin(self.0.clone()))
+                .worker_plugin(RecursivePlugin(self.0.clone()))
+                .build();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_plugins_cannot_recurse() {
+        let count = Arc::new(AtomicU8::new(0));
+        let mut worker_opts = WorkerOptions::new("my-task-queue")
+            .worker_plugin(RecursivePlugin(count.clone()))
+            .build();
+        apply_worker_plugins(&ClientOptions::new("my-ns").build(), &mut worker_opts).unwrap();
+        assert_eq!(count.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -119,20 +119,17 @@ impl From<ClientAndWorkerPlugin> for ErasedWorkerPlugin {
     }
 }
 
-/// A plugin assembled from declarative values and optional fallible configuration callbacks.
+/// A plugin assembled from declarative values.
 ///
-/// Scalar values replace the corresponding option, while interceptors and definitions append in
-/// registration order. Declarative values are applied before configuration callbacks.
+/// Scalar values replace the corresponding option, while array values append.
 ///
 /// ```
 /// use temporalio_client::ClientOptions;
+/// use temporalio_common::data_converters::DataConverter;
 /// use temporalio_sdk::SimplePlugin;
 ///
-/// let plugin = SimplePlugin::new("acme.standard-library")
-///     .configure_worker_options(|options| {
-///         options.max_cached_workflows = 0;
-///         Ok(())
-///     })
+/// let plugin = SimplePlugin::new("my-plugin")
+///     .data_converter(DataConverter::default())
 ///     .build();
 /// let client_options = ClientOptions::new("default").plugin(plugin).build();
 /// # let _ = client_options;
@@ -174,8 +171,6 @@ impl From<SimplePlugin> for ErasedWorkerPlugin {
     }
 }
 
-type Customizer<T> = Arc<dyn Fn(&mut T) -> Result<(), PluginError> + Send + Sync + 'static>;
-
 #[derive(Default)]
 struct SimplePluginDefinition {
     name: String,
@@ -188,24 +183,11 @@ struct SimplePluginDefinition {
     workflows: WorkflowDefinitions,
     #[cfg(feature = "wasm-workflows")]
     wasm_workflow_components: Vec<WasmWorkflowComponent>,
-    connection_customizers: Vec<Customizer<ConnectionOptions>>,
-    client_customizers: Vec<Customizer<ClientOptions>>,
-    worker_customizers: Vec<Customizer<WorkerOptions>>,
 }
 
 impl ClientPlugin for SimplePluginDefinition {
     fn name(&self) -> &str {
         &self.name
-    }
-
-    fn configure_connection_options(
-        &self,
-        options: &mut ConnectionOptions,
-    ) -> Result<(), PluginError> {
-        for configure in &self.connection_customizers {
-            configure(options)?;
-        }
-        Ok(())
     }
 
     fn configure_client_options(&self, options: &mut ClientOptions) -> Result<(), PluginError> {
@@ -215,9 +197,6 @@ impl ClientPlugin for SimplePluginDefinition {
         options
             .client_interceptors
             .extend(self.client_interceptors.iter().cloned());
-        for configure in &self.client_customizers {
-            configure(options)?;
-        }
         Ok(())
     }
 }
@@ -246,9 +225,6 @@ impl WorkerPlugin for SimplePluginDefinition {
         options
             .wasm_workflow_components
             .extend(self.wasm_workflow_components.iter().cloned());
-        for configure in &self.worker_customizers {
-            configure(options)?;
-        }
         Ok(())
     }
 }
@@ -336,41 +312,6 @@ impl SimplePluginBuilder {
     #[cfg(feature = "wasm-workflows")]
     pub fn register_wasm_workflow(mut self, component: WasmWorkflowComponent) -> Self {
         self.definition.wasm_workflow_components.push(component);
-        self
-    }
-
-    /// Append a fallible connection-options callback.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn configure_connection_options<F>(mut self, configure: F) -> Self
-    where
-        F: Fn(&mut ConnectionOptions) -> Result<(), PluginError> + Send + Sync + 'static,
-    {
-        self.definition
-            .connection_customizers
-            .push(Arc::new(configure));
-        self
-    }
-
-    /// Append a fallible client-options callback.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn configure_client_options<F>(mut self, configure: F) -> Self
-    where
-        F: Fn(&mut ClientOptions) -> Result<(), PluginError> + Send + Sync + 'static,
-    {
-        self.definition.client_customizers.push(Arc::new(configure));
-        self
-    }
-
-    /// Append a fallible worker-options callback.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn configure_worker_options<F>(mut self, configure: F) -> Self
-    where
-        F: Fn(&mut WorkerOptions) -> Result<(), PluginError> + Send + Sync + 'static,
-    {
-        self.definition.worker_customizers.push(Arc::new(configure));
         self
     }
 
@@ -672,34 +613,22 @@ mod tests {
     impl WorkerInterceptor for EmptyWorkerInterceptor {}
 
     #[test]
-    fn simple_plugin_applies_declarative_values_before_customizers() {
-        let client_builder = SimplePlugin::new("simple")
-            .client_interceptor(EmptyClientInterceptor)
-            .configure_client_options(|options| {
-                assert_eq!(options.client_interceptors.len(), 1);
-                options.namespace.push_str("-customized");
-                Ok(())
-            });
+    fn simple_plugin_applies_declarative_values() {
+        let client_builder = SimplePlugin::new("simple").client_interceptor(EmptyClientInterceptor);
         let mut client_options = ClientOptions::new("namespace").build();
         client_builder
             .definition
             .configure_client_options(&mut client_options)
             .unwrap();
-        assert_eq!(client_options.namespace, "namespace-customized");
+        assert_eq!(client_options.client_interceptors.len(), 1);
 
         let plugin = SimplePlugin::new("simple")
             .worker_interceptor(EmptyWorkerInterceptor)
-            .configure_worker_options(|options| {
-                assert_eq!(options.worker_interceptors.len(), 1);
-                options.max_cached_workflows = 0;
-                Ok(())
-            })
             .build();
         let client_options = ClientOptions::new("namespace").build();
         let mut worker_options = WorkerOptions::new("queue").plugin(plugin).build();
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
-        assert_eq!(worker_options.max_cached_workflows, 0);
         assert_eq!(worker_options.worker_interceptors.len(), 1);
     }
 }

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -128,7 +128,7 @@ impl From<ClientAndWorkerPlugin> for ErasedWorkerPlugin {
 /// use temporalio_common::data_converters::DataConverter;
 /// use temporalio_sdk::SimplePlugin;
 ///
-/// let plugin = SimplePlugin::new("my-plugin")
+/// let plugin = SimplePlugin::builder("my-plugin")
 ///     .data_converter(DataConverter::default())
 ///     .build();
 /// let client_options = ClientOptions::new("default").plugin(plugin).build();
@@ -139,53 +139,43 @@ impl From<ClientAndWorkerPlugin> for ErasedWorkerPlugin {
 /// configured client when a worker is created.
 ///
 /// **Experimental:** This API may change or be removed.
-#[derive(Clone)]
+#[derive(Clone, bon::Builder)]
+#[builder(state_mod(vis = "pub"))]
 pub struct SimplePlugin {
-    combined: ClientAndWorkerPlugin,
-}
-
-impl SimplePlugin {
-    /// Construct a new `SimplePluginBuilder` with a given name.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(name: impl Into<String>) -> SimplePluginBuilder {
-        SimplePluginBuilder {
-            definition: SimplePluginDefinition {
-                name: name.into(),
-                ..Default::default()
-            },
-        }
-    }
+    #[builder(start_fn, into)]
+    name: String,
+    #[builder(field)]
+    data_converter: Option<DataConverter>,
+    #[builder(field)]
+    client_interceptors: Vec<Arc<dyn ClientInterceptor>>,
+    #[builder(field)]
+    worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
+    #[builder(field)]
+    activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
+    #[builder(field)]
+    workflow_interceptors: Vec<WorkflowInterceptorConstructor>,
+    #[builder(field)]
+    activities: ActivityDefinitions,
+    #[builder(field)]
+    workflows: WorkflowDefinitions,
+    #[cfg(feature = "wasm-workflows")]
+    #[builder(field)]
+    wasm_workflow_components: Vec<WasmWorkflowComponent>,
 }
 
 impl From<SimplePlugin> for ErasedClientPlugin {
     fn from(plugin: SimplePlugin) -> Self {
-        plugin.combined.into()
+        ClientAndWorkerPlugin::new(plugin).into()
     }
 }
 
 impl From<SimplePlugin> for ErasedWorkerPlugin {
     fn from(plugin: SimplePlugin) -> Self {
-        plugin.combined.into()
+        ErasedWorkerPlugin::new(plugin)
     }
 }
 
-#[derive(Default)]
-struct SimplePluginDefinition {
-    name: String,
-    data_converter: Option<DataConverter>,
-    client_interceptors: Vec<Arc<dyn ClientInterceptor>>,
-    worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
-    activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
-    workflow_interceptors: Vec<WorkflowInterceptorConstructor>,
-    activities: ActivityDefinitions,
-    workflows: WorkflowDefinitions,
-    #[cfg(feature = "wasm-workflows")]
-    wasm_workflow_components: Vec<WasmWorkflowComponent>,
-}
-
-impl ClientPlugin for SimplePluginDefinition {
+impl ClientPlugin for SimplePlugin {
     fn name(&self) -> &str {
         &self.name
     }
@@ -201,7 +191,7 @@ impl ClientPlugin for SimplePluginDefinition {
     }
 }
 
-impl WorkerPlugin for SimplePluginDefinition {
+impl WorkerPlugin for SimplePlugin {
     fn name(&self) -> &str {
         &self.name
     }
@@ -229,19 +219,12 @@ impl WorkerPlugin for SimplePluginDefinition {
     }
 }
 
-/// Builds a [`SimplePlugin`] from common SDK configuration values.
-///
-/// **Experimental:** This API may change or be removed.
-pub struct SimplePluginBuilder {
-    definition: SimplePluginDefinition,
-}
-
-impl SimplePluginBuilder {
+impl<S: simple_plugin_builder::State> SimplePluginBuilder<S> {
     /// Set the data converter installed on configured clients.
     ///
     /// **Experimental:** This API may change or be removed.
     pub fn data_converter(mut self, data_converter: DataConverter) -> Self {
-        self.definition.data_converter = Some(data_converter);
+        self.data_converter = Some(data_converter);
         self
     }
 
@@ -249,9 +232,7 @@ impl SimplePluginBuilder {
     ///
     /// **Experimental:** This API may change or be removed.
     pub fn client_interceptor<I: ClientInterceptor>(mut self, interceptor: I) -> Self {
-        self.definition
-            .client_interceptors
-            .push(Arc::new(interceptor));
+        self.client_interceptors.push(Arc::new(interceptor));
         self
     }
 
@@ -259,9 +240,7 @@ impl SimplePluginBuilder {
     ///
     /// **Experimental:** This API may change or be removed.
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
-        self.definition
-            .worker_interceptors
-            .push(Arc::new(interceptor));
+        self.worker_interceptors.push(Arc::new(interceptor));
         self
     }
 
@@ -272,8 +251,7 @@ impl SimplePluginBuilder {
         mut self,
         interceptor: I,
     ) -> Self {
-        self.definition
-            .activity_inbound_interceptors
+        self.activity_inbound_interceptors
             .push(Arc::new(interceptor));
         self
     }
@@ -282,7 +260,7 @@ impl SimplePluginBuilder {
     ///
     /// **Experimental:** This API may change or be removed.
     pub fn workflow_interceptor(mut self, constructor: WorkflowInterceptorConstructor) -> Self {
-        self.definition.workflow_interceptors.push(constructor);
+        self.workflow_interceptors.push(constructor);
         self
     }
 
@@ -290,7 +268,7 @@ impl SimplePluginBuilder {
     ///
     /// **Experimental:** This API may change or be removed.
     pub fn register_activities<AI: ActivityImplementer>(mut self, instance: AI) -> Self {
-        self.definition.activities.register_activities(instance);
+        self.activities.register_activities(instance);
         self
     }
 
@@ -302,7 +280,7 @@ impl SimplePluginBuilder {
         W: WorkflowImplementation,
         <W::Run as WorkflowDefinition>::Input: Send,
     {
-        self.definition.workflows.register_workflow::<W>()?;
+        self.workflows.register_workflow::<W>()?;
         Ok(self)
     }
 
@@ -311,17 +289,8 @@ impl SimplePluginBuilder {
     /// **Experimental:** This API may change or be removed.
     #[cfg(feature = "wasm-workflows")]
     pub fn register_wasm_workflow(mut self, component: WasmWorkflowComponent) -> Self {
-        self.definition.wasm_workflow_components.push(component);
+        self.wasm_workflow_components.push(component);
         self
-    }
-
-    /// Build the reusable plugin registration.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn build(self) -> SimplePlugin {
-        SimplePlugin {
-            combined: ClientAndWorkerPlugin::new(self.definition),
-        }
     }
 }
 
@@ -614,15 +583,16 @@ mod tests {
 
     #[test]
     fn simple_plugin_applies_declarative_values() {
-        let client_builder = SimplePlugin::new("simple").client_interceptor(EmptyClientInterceptor);
+        let plugin = SimplePlugin::builder("simple")
+            .client_interceptor(EmptyClientInterceptor)
+            .build();
         let mut client_options = ClientOptions::new("namespace").build();
-        client_builder
-            .definition
+        plugin
             .configure_client_options(&mut client_options)
             .unwrap();
         assert_eq!(client_options.client_interceptors.len(), 1);
 
-        let plugin = SimplePlugin::new("simple")
+        let plugin = SimplePlugin::builder("simple")
             .worker_interceptor(EmptyWorkerInterceptor)
             .build();
         let client_options = ClientOptions::new("namespace").build();

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -2,20 +2,19 @@
 
 #[cfg(feature = "wasm-workflows")]
 use crate::WasmWorkflowComponent;
+pub use crate::workflow_registry::WorkflowDefinitions;
 use crate::{
-    WorkerOptions, WorkflowRegistrationError,
-    activities::{ActivityDefinitions, ActivityImplementer},
+    WorkerOptions,
+    activities::ActivityDefinitions,
     interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
     workflow_interceptors::WorkflowInterceptorConstructor,
-    workflow_registry::WorkflowDefinitions,
 };
 use std::{any::Any, sync::Arc};
 use temporalio_client::{
     ClientInterceptor, ClientOptions, ClientPlugin, ConnectionOptions, ErasedClientPlugin,
     PluginApplyError, PluginError, PluginTarget, WorkerPluginData,
 };
-use temporalio_common::{WorkflowDefinition, data_converters::DataConverter};
-use temporalio_workflow::runtime::entry::WorkflowImplementation;
+use temporalio_common::data_converters::DataConverter;
 
 /// Configures worker options before the worker is created.
 ///
@@ -103,9 +102,78 @@ impl WorkerPlugin for ClientAndWorkerPlugin {
     }
 }
 
-/// A plugin assembled from declarative values.
+/// A simple plugin field that either supplies a value or customizes the existing value.
 ///
-/// Scalar values replace the corresponding option, while array values append.
+/// Builder methods on [`SimplePluginBuilder`] automatically convert supported values and
+/// functions into this type.
+///
+/// **Experimental:** This API may change or be removed.
+#[derive(Clone)]
+pub enum SimplePluginOption<T> {
+    /// A value that replaces a scalar field or appends to a collection field.
+    Value(T),
+    /// A function that receives the existing field and returns a configured value.
+    Function(Arc<dyn Fn(Option<T>) -> T + Send + Sync>),
+}
+
+macro_rules! impl_simple_plugin_option_conversions {
+    ($type:ty) => {
+        impl From<$type> for SimplePluginOption<$type> {
+            fn from(value: $type) -> Self {
+                Self::Value(value)
+            }
+        }
+
+        impl<F> From<F> for SimplePluginOption<$type>
+        where
+            F: Fn(Option<$type>) -> $type + Send + Sync + 'static,
+        {
+            fn from(function: F) -> Self {
+                Self::Function(Arc::new(function))
+            }
+        }
+    };
+}
+
+impl_simple_plugin_option_conversions!(DataConverter);
+impl_simple_plugin_option_conversions!(Vec<Arc<dyn ClientInterceptor>>);
+impl_simple_plugin_option_conversions!(Vec<Arc<dyn WorkerInterceptor>>);
+impl_simple_plugin_option_conversions!(Vec<Arc<dyn ActivityInboundInterceptor>>);
+impl_simple_plugin_option_conversions!(Vec<WorkflowInterceptorConstructor>);
+impl_simple_plugin_option_conversions!(ActivityDefinitions);
+impl_simple_plugin_option_conversions!(WorkflowDefinitions);
+#[cfg(feature = "wasm-workflows")]
+impl_simple_plugin_option_conversions!(Vec<WasmWorkflowComponent>);
+
+fn apply_replacing<T: Clone>(target: &mut T, option: Option<&SimplePluginOption<T>>) {
+    let Some(option) = option else {
+        return;
+    };
+    *target = match option {
+        SimplePluginOption::Value(value) => value.clone(),
+        SimplePluginOption::Function(function) => function(Some(target.clone())),
+    };
+}
+
+fn apply_appending<T: Clone>(
+    target: &mut T,
+    option: Option<&SimplePluginOption<T>>,
+    append: impl Fn(&mut T, &T),
+) {
+    let Some(option) = option else {
+        return;
+    };
+    match option {
+        SimplePluginOption::Value(value) => append(target, value),
+        SimplePluginOption::Function(function) => *target = function(Some(target.clone())),
+    }
+}
+
+/// A plugin assembled from declarative values or functions of existing values.
+///
+/// Scalar values replace the corresponding option, while collection values append. Functions
+/// receive the existing field and replace it with their return value, except that returned
+/// workflow definitions are merged into the existing definitions.
 ///
 /// ```
 /// use temporalio_client::ClientOptions;
@@ -113,7 +181,7 @@ impl WorkerPlugin for ClientAndWorkerPlugin {
 /// use temporalio_sdk::SimplePlugin;
 ///
 /// let plugin = SimplePlugin::builder("my-plugin")
-///     .data_converter(DataConverter::default())
+///     .data_converter(|existing: Option<DataConverter>| existing.unwrap_or_default())
 ///     .build();
 /// let client_options = ClientOptions::new("default").plugin(plugin).build();
 /// # let _ = client_options;
@@ -128,23 +196,24 @@ impl WorkerPlugin for ClientAndWorkerPlugin {
 pub struct SimplePlugin {
     #[builder(start_fn, into)]
     name: String,
-    #[builder(field)]
-    data_converter: Option<DataConverter>,
-    #[builder(field)]
-    client_interceptors: Vec<Arc<dyn ClientInterceptor>>,
-    #[builder(field)]
-    worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
-    #[builder(field)]
-    activity_inbound_interceptors: Vec<Arc<dyn ActivityInboundInterceptor>>,
-    #[builder(field)]
-    workflow_interceptors: Vec<WorkflowInterceptorConstructor>,
-    #[builder(field)]
-    activities: ActivityDefinitions,
-    #[builder(field)]
-    workflows: WorkflowDefinitions,
+    #[builder(into)]
+    data_converter: Option<SimplePluginOption<DataConverter>>,
+    #[builder(into)]
+    client_interceptors: Option<SimplePluginOption<Vec<Arc<dyn ClientInterceptor>>>>,
+    #[builder(into)]
+    worker_interceptors: Option<SimplePluginOption<Vec<Arc<dyn WorkerInterceptor>>>>,
+    #[builder(into)]
+    activity_inbound_interceptors:
+        Option<SimplePluginOption<Vec<Arc<dyn ActivityInboundInterceptor>>>>,
+    #[builder(into)]
+    workflow_interceptors: Option<SimplePluginOption<Vec<WorkflowInterceptorConstructor>>>,
+    #[builder(into)]
+    activities: Option<SimplePluginOption<ActivityDefinitions>>,
+    #[builder(into)]
+    workflows: Option<SimplePluginOption<WorkflowDefinitions>>,
     #[cfg(feature = "wasm-workflows")]
-    #[builder(field)]
-    wasm_workflow_components: Vec<WasmWorkflowComponent>,
+    #[builder(into)]
+    wasm_workflow_components: Option<SimplePluginOption<Vec<WasmWorkflowComponent>>>,
 }
 
 impl From<SimplePlugin> for ErasedClientPlugin {
@@ -159,12 +228,12 @@ impl ClientPlugin for SimplePlugin {
     }
 
     fn configure_client_options(&self, options: &mut ClientOptions) -> Result<(), PluginError> {
-        if let Some(data_converter) = &self.data_converter {
-            options.data_converter = data_converter.clone();
-        }
-        options
-            .client_interceptors
-            .extend(self.client_interceptors.iter().cloned());
+        apply_replacing(&mut options.data_converter, self.data_converter.as_ref());
+        apply_appending(
+            &mut options.client_interceptors,
+            self.client_interceptors.as_ref(),
+            |existing, value| existing.extend(value.iter().cloned()),
+        );
         Ok(())
     }
 }
@@ -175,100 +244,43 @@ impl WorkerPlugin for SimplePlugin {
     }
 
     fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
-        options.activities.extend(&self.activities);
-        options
-            .workflows
-            .extend(&self.workflows)
+        apply_appending(
+            &mut options.activities,
+            self.activities.as_ref(),
+            |existing, value| existing.extend(value),
+        );
+        if let Some(workflows) = &self.workflows {
+            match workflows {
+                SimplePluginOption::Value(value) => options.workflows.extend(value),
+                SimplePluginOption::Function(function) => {
+                    let workflows = function(Some(options.workflows.clone()));
+                    options.workflows.extend(&workflows)
+                }
+            }
             .map_err(PluginError::new)?;
-        options
-            .worker_interceptors
-            .extend(self.worker_interceptors.iter().cloned());
-        options
-            .activity_inbound_interceptors
-            .extend(self.activity_inbound_interceptors.iter().cloned());
-        options
-            .workflow_interceptor_constructors
-            .extend(self.workflow_interceptors.iter().cloned());
+        }
+        apply_appending(
+            &mut options.worker_interceptors,
+            self.worker_interceptors.as_ref(),
+            |existing, value| existing.extend(value.iter().cloned()),
+        );
+        apply_appending(
+            &mut options.activity_inbound_interceptors,
+            self.activity_inbound_interceptors.as_ref(),
+            |existing, value| existing.extend(value.iter().cloned()),
+        );
+        apply_appending(
+            &mut options.workflow_interceptor_constructors,
+            self.workflow_interceptors.as_ref(),
+            |existing, value| existing.extend(value.iter().cloned()),
+        );
         #[cfg(feature = "wasm-workflows")]
-        options
-            .wasm_workflow_components
-            .extend(self.wasm_workflow_components.iter().cloned());
+        apply_appending(
+            &mut options.wasm_workflow_components,
+            self.wasm_workflow_components.as_ref(),
+            |existing, value| existing.extend(value.iter().cloned()),
+        );
         Ok(())
-    }
-}
-
-impl<S: simple_plugin_builder::State> SimplePluginBuilder<S> {
-    /// Set the data converter installed on configured clients.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn data_converter(mut self, data_converter: DataConverter) -> Self {
-        self.data_converter = Some(data_converter);
-        self
-    }
-
-    /// Append a client interceptor.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn client_interceptor<I: ClientInterceptor>(mut self, interceptor: I) -> Self {
-        self.client_interceptors.push(Arc::new(interceptor));
-        self
-    }
-
-    /// Append a worker interceptor.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
-        self.worker_interceptors.push(Arc::new(interceptor));
-        self
-    }
-
-    /// Append an activity inbound interceptor.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn activity_inbound_interceptor<I: ActivityInboundInterceptor>(
-        mut self,
-        interceptor: I,
-    ) -> Self {
-        self.activity_inbound_interceptors
-            .push(Arc::new(interceptor));
-        self
-    }
-
-    /// Append a workflow interceptor constructor.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn workflow_interceptor(mut self, constructor: WorkflowInterceptorConstructor) -> Self {
-        self.workflow_interceptors.push(constructor);
-        self
-    }
-
-    /// Append every activity defined by an activity implementer.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn register_activities<AI: ActivityImplementer>(mut self, instance: AI) -> Self {
-        self.activities.register_activities(instance);
-        self
-    }
-
-    /// Append a workflow definition.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    pub fn register_workflow<W>(mut self) -> Result<Self, WorkflowRegistrationError>
-    where
-        W: WorkflowImplementation,
-        <W::Run as WorkflowDefinition>::Input: Send,
-    {
-        self.workflows.register_workflow::<W>()?;
-        Ok(self)
-    }
-
-    /// Append a prebuilt WASM workflow component.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    #[cfg(feature = "wasm-workflows")]
-    pub fn register_wasm_workflow(mut self, component: WasmWorkflowComponent) -> Self {
-        self.wasm_workflow_components.push(component);
-        self
     }
 }
 
@@ -565,22 +577,111 @@ mod tests {
     #[test]
     fn simple_plugin_applies_declarative_values() {
         let plugin = SimplePlugin::builder("simple")
-            .client_interceptor(EmptyClientInterceptor)
+            .client_interceptors(vec![
+                Arc::new(EmptyClientInterceptor) as Arc<dyn ClientInterceptor>
+            ])
             .build();
         let mut client_options = ClientOptions::new("namespace").build();
+        client_options
+            .client_interceptors
+            .push(Arc::new(EmptyClientInterceptor));
         plugin
             .configure_client_options(&mut client_options)
             .unwrap();
-        assert_eq!(client_options.client_interceptors.len(), 1);
+        assert_eq!(client_options.client_interceptors.len(), 2);
 
         let plugin = SimplePlugin::builder("simple")
-            .worker_interceptor(EmptyWorkerInterceptor)
+            .worker_interceptors(vec![
+                Arc::new(EmptyWorkerInterceptor) as Arc<dyn WorkerInterceptor>
+            ])
             .build();
         let client_options = ClientOptions::new("namespace").build();
-        let mut worker_options = WorkerOptions::new("queue").worker_plugin(plugin).build();
+        let mut worker_options = WorkerOptions::new("queue")
+            .worker_interceptor(EmptyWorkerInterceptor)
+            .worker_plugin(plugin)
+            .build();
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
-        assert_eq!(worker_options.worker_interceptors.len(), 1);
+        assert_eq!(worker_options.worker_interceptors.len(), 2);
+    }
+
+    #[test]
+    fn simple_plugin_options_accept_values_and_functions() {
+        let calls = Arc::new(AtomicU8::new(0));
+        let plugin = SimplePlugin::builder("simple")
+            .data_converter({
+                let calls = calls.clone();
+                move |existing: Option<DataConverter>| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    existing.unwrap()
+                }
+            })
+            .client_interceptors({
+                let calls = calls.clone();
+                move |existing: Option<Vec<Arc<dyn ClientInterceptor>>>| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(existing.unwrap().len(), 1);
+                    Vec::new()
+                }
+            })
+            .worker_interceptors({
+                let calls = calls.clone();
+                move |existing: Option<Vec<Arc<dyn WorkerInterceptor>>>| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(existing.unwrap().len(), 1);
+                    Vec::new()
+                }
+            })
+            .activity_inbound_interceptors({
+                let calls = calls.clone();
+                move |existing: Option<Vec<Arc<dyn ActivityInboundInterceptor>>>| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    existing.unwrap()
+                }
+            })
+            .workflow_interceptors({
+                let calls = calls.clone();
+                move |existing: Option<Vec<WorkflowInterceptorConstructor>>| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    existing.unwrap()
+                }
+            })
+            .activities({
+                let calls = calls.clone();
+                move |existing: Option<ActivityDefinitions>| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    existing.unwrap()
+                }
+            })
+            .workflows({
+                let calls = calls.clone();
+                move |existing: Option<WorkflowDefinitions>| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    existing.unwrap()
+                }
+            })
+            .build();
+
+        let mut client_options = ClientOptions::new("namespace").build();
+        client_options
+            .client_interceptors
+            .push(Arc::new(EmptyClientInterceptor));
+        plugin
+            .configure_client_options(&mut client_options)
+            .unwrap();
+        assert!(client_options.client_interceptors.is_empty());
+
+        let mut worker_options = WorkerOptions::new("queue")
+            .worker_interceptor(EmptyWorkerInterceptor)
+            .worker_plugin(plugin)
+            .build();
+        apply_worker_plugins(
+            &ClientOptions::new("namespace").build(),
+            &mut worker_options,
+        )
+        .unwrap();
+        assert!(worker_options.worker_interceptors.is_empty());
+        assert_eq!(calls.load(Ordering::SeqCst), 7);
     }
 
     struct RecursivePlugin(Arc<AtomicU8>);

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -9,55 +9,44 @@ use crate::{
     workflow_interceptors::WorkflowInterceptorConstructor,
     workflow_registry::WorkflowDefinitions,
 };
-use std::sync::Arc;
+use std::{any::Any, sync::Arc};
 use temporalio_client::{
-    ClientInterceptor, ClientOptions, ClientPlugin, ClientPluginRegistration, ConnectionOptions,
-    PluginApplyError, PluginError, PluginResult, PluginTarget,
+    ClientInterceptor, ClientOptions, ClientPlugin, ConnectionOptions, ErasedClientPlugin,
+    PluginApplyError, PluginError, PluginTarget, WorkerPluginData,
 };
 use temporalio_common::{WorkflowDefinition, data_converters::DataConverter};
 use temporalio_workflow::runtime::entry::WorkflowImplementation;
 
-/// Configures worker options before the underlying Core worker is created.
+/// Configures worker options before the worker is created.
+///
+/// Use [`ClientAndWorkerPlugin`] for plugins that target both clients and workers.
 ///
 /// **Experimental:** This API may change or be removed.
 pub trait WorkerPlugin: Send + Sync + 'static {
-    /// Return the stable name used to identify this plugin in diagnostics and worker heartbeats.
-    ///
-    /// **Experimental:** This API may change or be removed.
+    /// Name used to identify this plugin.
     fn name(&self) -> &str;
 
     /// Configure worker options.
-    ///
-    /// **Experimental:** This API may change or be removed.
-    fn configure_worker_options(&self, _options: &mut WorkerOptions) -> PluginResult {
+    fn configure_worker_options(&self, _options: &mut WorkerOptions) -> Result<(), PluginError> {
         Ok(())
     }
 }
 
-/// A type-erased worker plugin with an identity used to diagnose duplicate registration.
+/// A type-erased worker plugin.
 ///
 /// **Experimental:** This API may change or be removed.
 #[derive(Clone)]
-pub struct WorkerPluginRegistration {
+pub struct ErasedWorkerPlugin {
     worker: Arc<dyn WorkerPlugin>,
-    instance_id: Arc<()>,
 }
 
-impl WorkerPluginRegistration {
+impl ErasedWorkerPlugin {
     /// Type-erase a worker plugin for registration on [`WorkerOptions`].
     ///
     /// **Experimental:** This API may change or be removed.
     pub fn new<P: WorkerPlugin>(plugin: P) -> Self {
         Self {
             worker: Arc::new(plugin),
-            instance_id: Arc::new(()),
-        }
-    }
-
-    fn with_instance_id<P: WorkerPlugin>(plugin: P, instance_id: Arc<()>) -> Self {
-        Self {
-            worker: Arc::new(plugin),
-            instance_id,
         }
     }
 
@@ -67,48 +56,64 @@ impl WorkerPluginRegistration {
 }
 
 #[derive(Clone)]
-struct PropagatedWorkerPlugin(WorkerPluginRegistration);
+struct PropagatedWorkerPlugin(ErasedWorkerPlugin);
 
-/// A type-erased registration for one value that implements both [`ClientPlugin`] and
+impl WorkerPluginData for PropagatedWorkerPlugin {}
+
+/// A container for a plugin that implements both [`ClientPlugin`] and
 /// [`WorkerPlugin`].
 ///
-/// This wrapper is only needed when the same plugin configures both a client and its workers. Use
-/// [`ClientPluginRegistration`] or [`WorkerPluginRegistration`] for one-sided plugins.
+/// This wrapper is only needed when the same plugin configures both a client and workers. Use
+/// [`ErasedClientPlugin`] or [`ErasedWorkerPlugin`] for one-sided plugins.
+///
+/// When registered on [`ClientOptions`], the resulting client carries the worker plugin and
+/// automatically applies it to workers created from that client. Do not also register the plugin
+/// on [`WorkerOptions`], or its worker configuration will be applied twice.
+///
+/// ```
+/// # use temporalio_client::{ClientOptions, ClientPlugin};
+/// # use temporalio_sdk::{ClientAndWorkerPlugin, WorkerPlugin};
+/// # struct MyPlugin;
+/// # impl ClientPlugin for MyPlugin {
+/// #     fn name(&self) -> &str { "my-plugin" }
+/// # }
+/// # impl WorkerPlugin for MyPlugin {
+/// #     fn name(&self) -> &str { "my-plugin" }
+/// # }
+/// let plugin = ClientAndWorkerPlugin::new(MyPlugin);
+/// let client_options = ClientOptions::new("default").plugin(plugin).build();
+/// # let _ = client_options;
+/// ```
 ///
 /// **Experimental:** This API may change or be removed.
 #[derive(Clone)]
 pub struct ClientAndWorkerPlugin {
-    client: ClientPluginRegistration,
-    worker: WorkerPluginRegistration,
+    client: ErasedClientPlugin,
+    worker: ErasedWorkerPlugin,
 }
 
 impl ClientAndWorkerPlugin {
     /// Type-erase one plugin value for client registration, automatic worker propagation, and
     /// optional explicit worker registration.
-    ///
-    /// **Experimental:** This API may change or be removed.
     pub fn new<P>(plugin: P) -> Self
     where
         P: ClientPlugin + WorkerPlugin,
     {
         let plugin = Arc::new(plugin);
-        let mut client = ClientPluginRegistration::new(SharedClientPlugin(plugin.clone()));
-        let worker = WorkerPluginRegistration::with_instance_id(
-            SharedWorkerPlugin(plugin),
-            client.instance_id(),
-        );
+        let mut client = ErasedClientPlugin::new(SharedClientPlugin(plugin.clone()));
+        let worker = ErasedWorkerPlugin::new(SharedWorkerPlugin(plugin));
         client = client.with_worker_plugin(PropagatedWorkerPlugin(worker.clone()));
         Self { client, worker }
     }
 }
 
-impl From<ClientAndWorkerPlugin> for ClientPluginRegistration {
+impl From<ClientAndWorkerPlugin> for ErasedClientPlugin {
     fn from(plugin: ClientAndWorkerPlugin) -> Self {
         plugin.client
     }
 }
 
-impl From<ClientAndWorkerPlugin> for WorkerPluginRegistration {
+impl From<ClientAndWorkerPlugin> for ErasedWorkerPlugin {
     fn from(plugin: ClientAndWorkerPlugin) -> Self {
         plugin.worker
     }
@@ -143,7 +148,7 @@ pub struct SimplePlugin {
 }
 
 impl SimplePlugin {
-    /// Begin declaring a simple plugin with the name used in diagnostics and worker heartbeats.
+    /// Construct a new `SimplePluginBuilder` with a given name.
     ///
     /// **Experimental:** This API may change or be removed.
     #[allow(clippy::new_ret_no_self)]
@@ -157,22 +162,19 @@ impl SimplePlugin {
     }
 }
 
-impl From<SimplePlugin> for ClientPluginRegistration {
+impl From<SimplePlugin> for ErasedClientPlugin {
     fn from(plugin: SimplePlugin) -> Self {
         plugin.combined.into()
     }
 }
 
-impl From<SimplePlugin> for WorkerPluginRegistration {
+impl From<SimplePlugin> for ErasedWorkerPlugin {
     fn from(plugin: SimplePlugin) -> Self {
         plugin.combined.into()
     }
 }
 
-type ConnectionCustomizer =
-    Arc<dyn Fn(&mut ConnectionOptions) -> PluginResult + Send + Sync + 'static>;
-type ClientCustomizer = Arc<dyn Fn(&mut ClientOptions) -> PluginResult + Send + Sync + 'static>;
-type WorkerCustomizer = Arc<dyn Fn(&mut WorkerOptions) -> PluginResult + Send + Sync + 'static>;
+type Customizer<T> = Arc<dyn Fn(&mut T) -> Result<(), PluginError> + Send + Sync + 'static>;
 
 #[derive(Default)]
 struct SimplePluginDefinition {
@@ -186,9 +188,9 @@ struct SimplePluginDefinition {
     workflows: WorkflowDefinitions,
     #[cfg(feature = "wasm-workflows")]
     wasm_workflow_components: Vec<WasmWorkflowComponent>,
-    connection_customizers: Vec<ConnectionCustomizer>,
-    client_customizers: Vec<ClientCustomizer>,
-    worker_customizers: Vec<WorkerCustomizer>,
+    connection_customizers: Vec<Customizer<ConnectionOptions>>,
+    client_customizers: Vec<Customizer<ClientOptions>>,
+    worker_customizers: Vec<Customizer<WorkerOptions>>,
 }
 
 impl ClientPlugin for SimplePluginDefinition {
@@ -196,14 +198,17 @@ impl ClientPlugin for SimplePluginDefinition {
         &self.name
     }
 
-    fn configure_connection_options(&self, options: &mut ConnectionOptions) -> PluginResult {
+    fn configure_connection_options(
+        &self,
+        options: &mut ConnectionOptions,
+    ) -> Result<(), PluginError> {
         for configure in &self.connection_customizers {
             configure(options)?;
         }
         Ok(())
     }
 
-    fn configure_client_options(&self, options: &mut ClientOptions) -> PluginResult {
+    fn configure_client_options(&self, options: &mut ClientOptions) -> Result<(), PluginError> {
         if let Some(data_converter) = &self.data_converter {
             options.data_converter = data_converter.clone();
         }
@@ -222,7 +227,7 @@ impl WorkerPlugin for SimplePluginDefinition {
         &self.name
     }
 
-    fn configure_worker_options(&self, options: &mut WorkerOptions) -> PluginResult {
+    fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
         options.activities.extend(&self.activities);
         options
             .workflows
@@ -339,7 +344,7 @@ impl SimplePluginBuilder {
     /// **Experimental:** This API may change or be removed.
     pub fn configure_connection_options<F>(mut self, configure: F) -> Self
     where
-        F: Fn(&mut ConnectionOptions) -> PluginResult + Send + Sync + 'static,
+        F: Fn(&mut ConnectionOptions) -> Result<(), PluginError> + Send + Sync + 'static,
     {
         self.definition
             .connection_customizers
@@ -352,7 +357,7 @@ impl SimplePluginBuilder {
     /// **Experimental:** This API may change or be removed.
     pub fn configure_client_options<F>(mut self, configure: F) -> Self
     where
-        F: Fn(&mut ClientOptions) -> PluginResult + Send + Sync + 'static,
+        F: Fn(&mut ClientOptions) -> Result<(), PluginError> + Send + Sync + 'static,
     {
         self.definition.client_customizers.push(Arc::new(configure));
         self
@@ -363,7 +368,7 @@ impl SimplePluginBuilder {
     /// **Experimental:** This API may change or be removed.
     pub fn configure_worker_options<F>(mut self, configure: F) -> Self
     where
-        F: Fn(&mut WorkerOptions) -> PluginResult + Send + Sync + 'static,
+        F: Fn(&mut WorkerOptions) -> Result<(), PluginError> + Send + Sync + 'static,
     {
         self.definition.worker_customizers.push(Arc::new(configure));
         self
@@ -389,11 +394,14 @@ where
         ClientPlugin::name(self.0.as_ref())
     }
 
-    fn configure_connection_options(&self, options: &mut ConnectionOptions) -> PluginResult {
+    fn configure_connection_options(
+        &self,
+        options: &mut ConnectionOptions,
+    ) -> Result<(), PluginError> {
         self.0.configure_connection_options(options)
     }
 
-    fn configure_client_options(&self, options: &mut ClientOptions) -> PluginResult {
+    fn configure_client_options(&self, options: &mut ClientOptions) -> Result<(), PluginError> {
         self.0.configure_client_options(options)
     }
 }
@@ -408,9 +416,29 @@ where
         ClientPlugin::name(self.0.as_ref())
     }
 
-    fn configure_worker_options(&self, options: &mut WorkerOptions) -> PluginResult {
+    fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
         self.0.configure_worker_options(options)
     }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct WorkerPluginWarning<'a> {
+    plugin_name: &'a str,
+    message: &'static str,
+}
+
+fn worker_plugin_warnings(
+    plugins: &[ErasedWorkerPlugin],
+) -> impl Iterator<Item = WorkerPluginWarning<'_>> {
+    plugins.iter().enumerate().filter_map(|(index, plugin)| {
+        plugins[index + 1..]
+            .iter()
+            .any(|other| Arc::ptr_eq(&plugin.worker, &other.worker))
+            .then_some(WorkerPluginWarning {
+                plugin_name: plugin.plugin().name(),
+                message: "The same combined client and worker plugin was registered both through the client and directly on the worker",
+            })
+    })
 }
 
 pub(crate) fn apply_worker_plugins(
@@ -424,32 +452,22 @@ pub(crate) fn apply_worker_plugins(
     let mut plugins = client_options
         .plugins()
         .iter()
-        .flat_map(ClientPluginRegistration::worker_plugins)
-        .filter_map(|plugin| plugin.downcast_ref::<PropagatedWorkerPlugin>())
+        .flat_map(ErasedClientPlugin::worker_plugins)
+        .filter_map(|plugin| (plugin as &dyn Any).downcast_ref::<PropagatedWorkerPlugin>())
         .map(|plugin| plugin.0.clone())
         .collect::<Vec<_>>();
     plugins.append(&mut options.worker_plugins);
 
-    for (index, plugin) in plugins.iter().enumerate() {
-        if plugins[index + 1..]
-            .iter()
-            .any(|other| Arc::ptr_eq(&plugin.instance_id, &other.instance_id))
-        {
-            warn!(
-                plugin = plugin.plugin().name(),
-                "The same combined client and worker plugin was registered both through the client and directly on the worker"
-            );
-        }
+    for warning in worker_plugin_warnings(&plugins) {
+        warn!(plugin = warning.plugin_name, "{}", warning.message);
     }
 
     for registration in &plugins {
         registration
             .plugin()
             .configure_worker_options(options)
-            .map_err(|source| PluginApplyError {
-                plugin_name: registration.plugin().name().to_owned(),
-                target: PluginTarget::Worker,
-                source,
+            .map_err(|source| {
+                PluginApplyError::new(registration.plugin().name(), PluginTarget::Worker, source)
             })?;
     }
     options.worker_plugins = plugins;
@@ -478,7 +496,10 @@ mod tests {
             "combined"
         }
 
-        fn configure_worker_options(&self, _options: &mut WorkerOptions) -> PluginResult {
+        fn configure_worker_options(
+            &self,
+            _options: &mut WorkerOptions,
+        ) -> Result<(), PluginError> {
             self.order.lock().unwrap().push("propagated");
             Ok(())
         }
@@ -495,7 +516,10 @@ mod tests {
             self.name
         }
 
-        fn configure_worker_options(&self, _options: &mut WorkerOptions) -> PluginResult {
+        fn configure_worker_options(
+            &self,
+            _options: &mut WorkerOptions,
+        ) -> Result<(), PluginError> {
             self.order.lock().unwrap().push(self.value);
             Ok(())
         }
@@ -509,11 +533,11 @@ mod tests {
         });
         let client_options = ClientOptions::new("namespace").plugin(combined).build();
         let mut worker_options = WorkerOptions::new("queue")
-            .worker_plugin(WorkerPluginRegistration::new(RecordingWorkerPlugin {
+            .worker_plugin(RecordingWorkerPlugin {
                 name: "local",
                 value: "local",
                 order: order.clone(),
-            }))
+            })
             .build();
 
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
@@ -522,30 +546,25 @@ mod tests {
     }
 
     #[test]
-    fn explicitly_reusing_a_combined_registration_applies_both_registrations() {
+    fn explicitly_reusing_a_combined_registration_warns_and_applies_both() {
         let order = Arc::new(Mutex::new(Vec::new()));
         let combined = ClientAndWorkerPlugin::new(RecordingCombinedPlugin {
             order: order.clone(),
         });
-        let client_registration: ClientPluginRegistration = combined.clone().into();
-        let worker_registration: WorkerPluginRegistration = combined.into();
-        let propagated_registration = client_registration
-            .worker_plugins()
-            .find_map(|plugin| plugin.downcast_ref::<PropagatedWorkerPlugin>())
-            .unwrap();
-        assert!(Arc::ptr_eq(
-            &propagated_registration.0.instance_id,
-            &worker_registration.instance_id
-        ));
         let client_options = ClientOptions::new("namespace")
-            .plugin(client_registration)
+            .plugin(combined.clone())
             .build();
-        let mut worker_options = WorkerOptions::new("queue")
-            .worker_plugin(worker_registration)
-            .build();
+        let mut worker_options = WorkerOptions::new("queue").plugin(combined).build();
 
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
+        assert_eq!(
+            worker_plugin_warnings(&worker_options.worker_plugins).collect::<Vec<_>>(),
+            [WorkerPluginWarning {
+                plugin_name: "combined",
+                message: "The same combined client and worker plugin was registered both through the client and directly on the worker",
+            }]
+        );
         assert_eq!(*order.lock().unwrap(), ["propagated", "propagated"]);
     }
 
@@ -557,15 +576,24 @@ mod tests {
         }
     }
 
+    struct UnrecognizedWorkerPluginExtension {
+        _registration: ErasedWorkerPlugin,
+    }
+
+    impl WorkerPluginData for UnrecognizedWorkerPluginExtension {}
+
     #[test]
     fn arbitrary_opaque_data_cannot_impersonate_propagated_plugin() {
         let order = Arc::new(Mutex::new(Vec::new()));
-        let client_registration = ClientPluginRegistration::new(ClientOnlyPlugin)
-            .with_worker_plugin(WorkerPluginRegistration::new(RecordingWorkerPlugin {
-                name: "unrecognized",
-                value: "should-not-run",
-                order: order.clone(),
-            }));
+        let client_registration = ErasedClientPlugin::new(ClientOnlyPlugin).with_worker_plugin(
+            UnrecognizedWorkerPluginExtension {
+                _registration: ErasedWorkerPlugin::new(RecordingWorkerPlugin {
+                    name: "unrecognized",
+                    value: "should-not-run",
+                    order: order.clone(),
+                }),
+            },
+        );
         let client_options = ClientOptions::new("namespace")
             .plugin(client_registration)
             .build();
@@ -581,21 +609,23 @@ mod tests {
         let order = Arc::new(Mutex::new(Vec::new()));
         let client_options = ClientOptions::new("namespace").build();
         let mut worker_options = WorkerOptions::new("queue")
-            .worker_plugins([
-                WorkerPluginRegistration::new(RecordingWorkerPlugin {
-                    name: "same-name",
-                    value: "first",
-                    order: order.clone(),
-                }),
-                WorkerPluginRegistration::new(RecordingWorkerPlugin {
-                    name: "same-name",
-                    value: "second",
-                    order,
-                }),
-            ])
+            .worker_plugin(RecordingWorkerPlugin {
+                name: "same-name",
+                value: "first",
+                order: order.clone(),
+            })
+            .worker_plugin(RecordingWorkerPlugin {
+                name: "same-name",
+                value: "second",
+                order,
+            })
             .build();
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
+        assert_eq!(
+            worker_plugin_warnings(&worker_options.worker_plugins).count(),
+            0
+        );
         let core_options = worker_options
             .to_core_options("namespace".to_owned(), "identity".to_owned())
             .unwrap();
@@ -640,7 +670,7 @@ mod tests {
             })
             .build();
         let client_options = ClientOptions::new("namespace").build();
-        let mut worker_options = WorkerOptions::new("queue").worker_plugin(plugin).build();
+        let mut worker_options = WorkerOptions::new("queue").plugin(plugin).build();
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
         assert_eq!(worker_options.max_cached_workflows, 0);
@@ -654,8 +684,11 @@ mod tests {
             "failing-worker"
         }
 
-        fn configure_worker_options(&self, _options: &mut WorkerOptions) -> PluginResult {
-            Err(PluginError::message("worker failure"))
+        fn configure_worker_options(
+            &self,
+            _options: &mut WorkerOptions,
+        ) -> Result<(), PluginError> {
+            Err(PluginError::new("worker failure"))
         }
     }
 
@@ -663,7 +696,7 @@ mod tests {
     fn worker_application_errors_include_context() {
         let client_options = ClientOptions::new("namespace").build();
         let mut worker_options = WorkerOptions::new("queue")
-            .worker_plugin(WorkerPluginRegistration::new(FailingWorkerPlugin))
+            .worker_plugin(FailingWorkerPlugin)
             .build();
 
         let error = apply_worker_plugins(&client_options, &mut worker_options).unwrap_err();

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -333,10 +333,6 @@ pub(crate) fn apply_worker_plugins(
     client_options: &ClientOptions,
     options: &mut WorkerOptions,
 ) -> Result<(), PluginApplyError> {
-    if options.plugins_applied {
-        return Ok(());
-    }
-
     options.client_plugin_names = client_options
         .plugins()
         .iter()
@@ -363,7 +359,6 @@ pub(crate) fn apply_worker_plugins(
             })?;
     }
     options.worker_plugins = plugins;
-    options.plugins_applied = true;
     Ok(())
 }
 

--- a/crates/sdk/src/workflow_registry.rs
+++ b/crates/sdk/src/workflow_registry.rs
@@ -75,6 +75,13 @@ pub struct WorkflowDefinitions {
 }
 
 impl WorkflowDefinitions {
+    pub(crate) fn extend(&mut self, other: &Self) -> Result<(), WorkflowRegistrationError> {
+        for workflow in other.workflows.values() {
+            self.insert_workflow(workflow.definition.clone(), workflow.factory.clone())?;
+        }
+        Ok(())
+    }
+
     /// Creates a new empty `WorkflowDefinitions`.
     pub fn new() -> Self {
         Self::default()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
### Prefactors
- Added `Debug` implementations to `Client`/`Worker`
- Moving all interceptors to be registered via `WorkerOptions` instead of directly on the Worker. Allow multiple `WorkerInterceptor`s per Worker instead of only a single one. This is done in the first commit of the PR.

### Main Changes

Added `ClientPlugin` and `WorkerPlugin` traits which allows users to implement plugins. The stored types are `ErasedClientPlugin` and `ErasedWorkerPlugin`. The worker plugin is just a named `Arc<dyn WorkerPlugin>`, but `ErasedClientPlugin` carries `WorkerPluginData` which is essentially a named `Any` that carries worker plugins. This is needed since the client crate doesn't have access to the types necessary to define the worker plugin trait. On the actual worker plugin consumption side, we only respect the private `PropagatedWorkerPlugin`.

Client/worker only plugins will be registered via `ClientOptions::client_plugin(plugin: impl ClientPlugin)`/`WorkerOptions::worker_plugin(plugin: impl WorkerPlugin)`.

Dual plugins are registered using`ClientAndWorkerPlugin` struct which enabled propagating plugins that from a `Client` to any `Worker` that is constructed with that client. These plugins are used with `ClientOptions::plugin`.  e.g.
```
struct MyPlugin;
impl ClientPlugin for MyPlugin {..}
impl WorkerPlugin for MyPlugin {..}
let plugin = ClientAndWorkerPlugin::new(MyPlugin);
let client_options = ClientOptions::new("default").plugin(plugin).build();
let client = Client::connect(.., client_options)?;
// Worker will be configured with the worker plugin
let worker = Worker::new(client, ...)?;
```


## Why?
SDK Parity

I do not love the special type for dual plugins, but I didn't find a better solution that didn't encourage misuse.

We could get rid of the special `client_plugin`/`worker_plugin` constructors and force users to build the erased types themselves if we want to remove some surface area here. We could offer blanket implementation conversion for any plugin implementers into the erased type, but that opens the door for misuse of dual plugins e.g.
```
// Will not propagate worker plugins
ClientOptions::new(..).plugin(MyPlugin).build();
// Will propagate worker plugins
ClientOptions::new(..).plugin(ClientAndWorkerPlugin::new(MyPlugin)).build();
```

## Checklist
<!--- add/delete as needed --->

1. Closes #1356 
2. How was this tested:
Added unit tests around error propagation. Very basic integration tests just verifying plugin fields are respected.

3. Any docs updates needed?
Plugin docs can now be updated to include Rust samples once this is released.
