### PR TITLE
feat(sdk): reexport core runtime from sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ to docs, or any other relevant information.
 ## [Unreleased]
 
 ### Added
+* `CoreRuntime` is now re-exported from `temporalio_sdk` as `Runtime`, with the remaining Core
+  runtime and worker configuration types under `temporalio_sdk::runtime`, so workers no
+  longer need a direct `temporalio-sdk-core` dependency. `Url` is also re-exported from
+  `temporalio_client`.
 * Workers can configure the maximum number of activity slots reserved for eager execution per
   workflow task with `WorkerOptions::max_eager_activity_reservations_per_workflow_task`.
 * `WorkflowInterceptor` for observing, transforming, or short-circuiting inbound workflow calls
@@ -141,6 +145,8 @@ to docs, or any other relevant information.
 * `PayloadCodec::{encode, decode}` now return `Result<_, PayloadConversionError>`, allowing codecs to fail.
 
 ### Fixed
+* `RuntimeOptions::default()` now uses the same 60-second worker heartbeat interval as the
+  builder default.
 * Workflow tasks no longer livelock when a burst of ready async operations exhausts Tokio's
   cooperative scheduling budget.
 * OTLP metric export failures are now logged through Core telemetry when OpenTelemetry's periodic

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -54,9 +54,8 @@ supported variables and the TOML file format.
 ```rust
 use temporalio_client::{
     Client, ClientOptions, Connection, ConnectionOptions,
-    WorkflowOptions, GetWorkflowResultOptions,
+    WorkflowOptions, GetWorkflowResultOptions, Url,
 };
-use temporalio_sdk_core::{Url, CoreRuntime, RuntimeOptions};
 use std::str::FromStr;
 
 #[tokio::main]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -64,6 +64,7 @@ pub use replaceable::SharedReplaceableClient;
 pub use retry::RetryOptions;
 pub use rpc_options::{RpcMetadata, RpcMetadataError, RpcOptions};
 pub use temporalio_common::{Memo, RetryPolicy};
+pub use url::Url;
 /// Potentially dangerous TLS related functionality.
 pub mod danger {
     /// Re-export the `ServerCertVerifier` trait so that users can implement custom TLS

--- a/crates/sdk-core/src/core_tests/mod.rs
+++ b/crates/sdk-core/src/core_tests/mod.rs
@@ -7,7 +7,7 @@ mod workflow_cancels;
 mod workflow_tasks;
 
 use crate::{
-    PollError, Worker,
+    PollError, RuntimeOptions, Worker,
     replay::{TestHistoryBuilder, canned_histories},
     test_help::{
         MockPollCfg, build_mock_pollers, mock_worker, single_hist_mock_sg, test_worker_cfg,

--- a/crates/sdk-core/src/core_tests/mod.rs
+++ b/crates/sdk-core/src/core_tests/mod.rs
@@ -7,7 +7,7 @@ mod workflow_cancels;
 mod workflow_tasks;
 
 use crate::{
-    PollError, RuntimeOptions, Worker,
+    PollError, Worker,
     replay::{TestHistoryBuilder, canned_histories},
     test_help::{
         MockPollCfg, build_mock_pollers, mock_worker, single_hist_mock_sg, test_worker_cfg,

--- a/crates/sdk-core/src/lib.rs
+++ b/crates/sdk-core/src/lib.rs
@@ -172,7 +172,7 @@ pub struct CoreRuntime {
 
 /// Holds telemetry options, as well as worker heartbeat_interval. Construct with
 /// [RuntimeOptions::builder]
-#[derive(Default, bon::Builder)]
+#[derive(bon::Builder)]
 #[builder(finish_fn(vis = "", name = build_internal))]
 #[non_exhaustive]
 pub struct RuntimeOptions {
@@ -185,6 +185,12 @@ pub struct RuntimeOptions {
     /// Interval must be between 1s and 60s, inclusive.
     #[builder(required, default = Some(Duration::from_secs(60)))]
     heartbeat_interval: Option<Duration>,
+}
+
+impl Default for RuntimeOptions {
+    fn default() -> Self {
+        Self::builder().build().expect("builder defaults are valid")
+    }
 }
 
 impl<S: runtime_options_builder::State> RuntimeOptionsBuilder<S> {
@@ -320,5 +326,16 @@ impl CoreRuntime {
 impl Drop for CoreRuntime {
     fn drop(&mut self) {
         remove_trace_subscriber_for_current_thread();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn runtime_options_default_matches_builder_default() {
+        let default = RuntimeOptions::default();
+        let built = RuntimeOptions::builder().build().unwrap();
+        assert_eq!(default.heartbeat_interval, built.heartbeat_interval);
     }
 }

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -84,18 +84,16 @@ the TOML format.
 
 ```rust
 use temporalio_client::{Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions};
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(RuntimeOptions::builder().build()?)?;
-
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_options, client_options) = ClientOptions::load_from_config(
         LoadClientConfigProfileOptions::default()
     )?;
     let connection = Connection::connect(conn_options).await?;
-    let client = Client::new(connection, client_options);
+    let client = Client::new(connection, client_options)?;
 
     let worker_options = WorkerOptions::new("my-task-queue")
         .register_activities(MyActivities { counter: Default::default() })

--- a/crates/sdk/examples/activity_heartbeating/worker.rs
+++ b/crates/sdk/examples/activity_heartbeating/worker.rs
@@ -3,18 +3,12 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{HeartbeatingActivities, HeartbeatingWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/activity_interceptor/worker.rs
+++ b/crates/sdk/examples/activity_interceptor/worker.rs
@@ -4,12 +4,10 @@ use futures_util::FutureExt;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
 use temporalio_sdk::{
-    Worker, WorkerOptions,
+    Runtime, Worker, WorkerOptions,
     interceptors::{ActivityInboundInterceptor, ExecuteActivityInput, ExecuteActivityOutput, Next},
 };
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
 use workflows::{
     ActivityInterceptorWorkflow, GreetingActivities, GreetingRequest, GreetingResponse,
 };
@@ -54,11 +52,7 @@ impl ActivityInboundInterceptor for LoggingActivityInterceptor {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/cancellation/worker.rs
+++ b/crates/sdk/examples/cancellation/worker.rs
@@ -3,18 +3,12 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{CancellationActivities, CancellationWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/child_workflows/worker.rs
+++ b/crates/sdk/examples/child_workflows/worker.rs
@@ -3,18 +3,13 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::{telemetry::TelemetryOptions, worker::WorkerTaskTypes};
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_common::worker::WorkerTaskTypes;
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{GreetingChildWorkflow, ParentWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/continue_as_new/worker.rs
+++ b/crates/sdk/examples/continue_as_new/worker.rs
@@ -3,18 +3,13 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::{telemetry::TelemetryOptions, worker::WorkerTaskTypes};
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_common::worker::WorkerTaskTypes;
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::ContinueAsNewWorkflow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/hello_world/worker.rs
+++ b/crates/sdk/examples/hello_world/worker.rs
@@ -3,18 +3,12 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{GreetingActivities, HelloWorldWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/local_activities/worker.rs
+++ b/crates/sdk/examples/local_activities/worker.rs
@@ -3,18 +3,12 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{GreetingActivities, LocalActivitiesWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/message_passing/worker.rs
+++ b/crates/sdk/examples/message_passing/worker.rs
@@ -3,18 +3,13 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::{telemetry::TelemetryOptions, worker::WorkerTaskTypes};
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_common::worker::WorkerTaskTypes;
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::MessagePassingWorkflow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/polling/worker.rs
+++ b/crates/sdk/examples/polling/worker.rs
@@ -3,18 +3,12 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{PollingActivities, PollingWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/saga/worker.rs
+++ b/crates/sdk/examples/saga/worker.rs
@@ -3,18 +3,12 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{BookingActivities, SagaWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/schedules/worker.rs
+++ b/crates/sdk/examples/schedules/worker.rs
@@ -3,18 +3,12 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{ScheduledActivities, ScheduledWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/search_attributes/worker.rs
+++ b/crates/sdk/examples/search_attributes/worker.rs
@@ -3,18 +3,13 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::{telemetry::TelemetryOptions, worker::WorkerTaskTypes};
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_common::worker::WorkerTaskTypes;
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::SearchAttributesWorkflow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/timer_examples/worker.rs
+++ b/crates/sdk/examples/timer_examples/worker.rs
@@ -3,18 +3,12 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::telemetry::TelemetryOptions;
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{TimerActivities, TimerWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/updatable_timer/worker.rs
+++ b/crates/sdk/examples/updatable_timer/worker.rs
@@ -3,18 +3,13 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::{telemetry::TelemetryOptions, worker::WorkerTaskTypes};
-use temporalio_sdk::{Worker, WorkerOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+use temporalio_common::worker::WorkerTaskTypes;
+use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::UpdatableTimerWorkflow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = CoreRuntime::new_assume_tokio(
-        RuntimeOptions::builder()
-            .telemetry_options(TelemetryOptions::builder().build())
-            .build()?,
-    )?;
+    let runtime = Runtime::new_assume_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -10,17 +10,15 @@
 //! An example of running an activity worker:
 //! ```no_run
 //! use std::str::FromStr;
-//! use temporalio_client::{Client, ClientOptions, Connection, ConnectionOptions};
-//! use temporalio_common::{
-//!     telemetry::TelemetryOptions,
-//!     worker::{WorkerDeploymentOptions, WorkerDeploymentVersion, WorkerTaskTypes},
+//! use temporalio_client::{Client, ClientOptions, Connection, ConnectionOptions, Url};
+//! use temporalio_common::worker::{
+//!     WorkerDeploymentOptions, WorkerDeploymentVersion, WorkerTaskTypes,
 //! };
 //! use temporalio_macros::activities;
 //! use temporalio_sdk::{
-//!     Worker, WorkerOptions,
+//!     Runtime, Worker, WorkerOptions,
 //!     activities::{ActivityContext, ActivityError},
 //! };
-//! use temporalio_sdk_core::{CoreRuntime, RuntimeOptions, Url};
 //!
 //! struct MyActivities;
 //!
@@ -39,12 +37,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let connection_options =
 //!         ConnectionOptions::new(Url::from_str("http://localhost:7233")?).build();
-//!     let telemetry_options = TelemetryOptions::builder().build();
-//!     let runtime_options = RuntimeOptions::builder()
-//!         .telemetry_options(telemetry_options)
-//!         .build()?;
-//!     let runtime = CoreRuntime::new_assume_tokio(runtime_options)?;
-//!
+//!     let runtime = Runtime::new_assume_tokio(Default::default())?;
 //!     let connection = Connection::connect(connection_options).await?;
 //!     let client = Client::new(connection, ClientOptions::new("my_namespace").build())?;
 //!
@@ -75,6 +68,24 @@ extern crate self as temporalio_sdk;
 pub mod activities;
 pub mod error;
 pub mod interceptors;
+/// Runtime configuration and low-level Core worker building blocks.
+///
+/// These types are grouped here to keep Core-specific configuration separate from the SDK's
+/// primary workflow and activity APIs. Create a [`crate::Runtime`] before connecting a client,
+/// then pass it to [`crate::Worker::new`].
+pub mod runtime {
+    pub use temporalio_sdk_core::{
+        ActivitySlotKind, FixedSizeSlotSupplier, LocalActivitySlotKind, NexusSlotKind,
+        PollerBehavior, ResourceBasedSlotsOptions, ResourceBasedSlotsOptionsBuilder,
+        ResourceBasedTuner, ResourceBasedTunerConfig, ResourceController, ResourceSlotOptions,
+        RuntimeOptions, RuntimeOptionsBuilder, SlotInfo, SlotInfoTrait, SlotKind, SlotKindType,
+        SlotMarkUsedContext, SlotReleaseContext, SlotReservationContext, SlotSupplier,
+        SlotSupplierOptions, SlotSupplierPermit, TokioRuntimeBuilder, TunerBuilder, TunerHolder,
+        TunerHolderOptions, TunerHolderOptionsBuilder, Worker as CoreWorker, WorkerConfig,
+        WorkerConfigBuilder, WorkerTuner, WorkerVersioningStrategy, WorkflowErrorType,
+        WorkflowSlotKind, init_replay_worker, replay,
+    };
+}
 mod workflow_executor;
 mod workflow_future;
 pub mod workflow_interceptors;
@@ -89,6 +100,7 @@ pub use crate::error::{
     RetryState, TimeoutType, WorkflowRegistrationError, WorkflowSignalError,
 };
 pub use temporalio_client::Namespace;
+pub use temporalio_sdk_core::CoreRuntime as Runtime;
 pub use temporalio_workflow::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
     CancellableFuture, CancellableFutureWithReason, ChildWorkflowCancellationType,
@@ -145,10 +157,7 @@ use temporalio_common::{
     },
     worker::{WorkerDeploymentOptions, WorkerTaskTypes, build_id_from_current_exe},
 };
-use temporalio_sdk_core::{
-    CoreRuntime, PollError, PollerBehavior, TunerBuilder, Worker as CoreWorker, WorkerConfig,
-    WorkerTuner, WorkerVersioningStrategy, WorkflowErrorType, init_worker,
-};
+use temporalio_sdk_core::{PollError, init_worker};
 use temporalio_workflow::runtime::entry::WorkflowImplementation;
 use tokio::sync::{
     Notify,
@@ -158,6 +167,11 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Span, field};
 use uuid::Uuid;
+
+use crate::runtime::{
+    CoreWorker, PollerBehavior, TunerBuilder, WorkerConfig, WorkerTuner, WorkerVersioningStrategy,
+    WorkflowErrorType,
+};
 
 /// Contains options for configuring a worker.
 #[derive(bon::Builder, Clone)]
@@ -627,7 +641,7 @@ async fn encode_activity_completion(
 impl Worker {
     /// Create a new worker from an existing client, and options.
     pub fn new(
-        runtime: &CoreRuntime,
+        runtime: &Runtime,
         client: Client,
         options: WorkerOptions,
     ) -> Result<Self, Box<dyn std::error::Error>> {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Rexport `Runtime` from SDK Core
- Rexport all types used in `RuntimeOptions` under a new `runtime` module to avoid polluting top level namespace
- Fixed `RuntimeOptions::default()` to match `RuntimeOptions::builder().build()` behavior
- Updated all examples to use new imports

## Why?
We generally don't want to users to take a direct dependency on core to use the Rust SDK.

`CoreRuntime` -> `Runtime` to match Typescript SDK naming convention. Not super strong opinions here

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added small 
3. Any docs updates needed?
Yes, can update imports/example Cargo.toml's once released.
