### PR TITLE
chore(sdk): mark remaining `Options` types as `non_exhaustive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ to docs, or any other relevant information.
   `ClientKeepAliveOptions::builder()` to construct keep-alive options.
 * `PayloadLimitsOptions` is now tagged with `#[non_exhaustive]`. Use
   `PayloadLimitsOptions::builder()` to construct payload limit options.
+* `RegisterNamespaceOptions` is now tagged with `#[non_exhaustive]`. Continue using
+  `RegisterNamespaceOptions::builder()` to construct namespace registration options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ to docs, or any other relevant information.
   construct client TLS options.
 * `ClientKeepAliveOptions` is now tagged with `#[non_exhaustive]`. Use
   `ClientKeepAliveOptions::builder()` to construct keep-alive options.
+* `PayloadLimitsOptions` is now tagged with `#[non_exhaustive]`. Use
+  `PayloadLimitsOptions::builder()` to construct payload limit options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to docs, or any other relevant information.
 
 ### Added
 * `RpcOptions::builder()` for constructing per-call RPC options.
+* `DnsLoadBalancingOptions::builder()` for configuring DNS re-resolution intervals.
 
 ### Breaking Changes :boom:
 * `CancellableFuture` and `CancellableFutureWithReason` now use the inherited `Future::Output`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ to docs, or any other relevant information.
   `LoadClientConfigProfileOptions::builder()` to construct profile loading options.
 * `ClientConfigFromTOMLOptions` is now tagged with `#[non_exhaustive]`. Use
   `ClientConfigFromTOMLOptions::builder()` to construct TOML parsing options.
+* `OtelCollectorOptions` is now tagged with `#[non_exhaustive]`. Use
+  `OtelCollectorOptions::builder()` to construct OpenTelemetry collector options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ to docs, or any other relevant information.
   `WorkflowContext::timer` remains supported.
 * `RetryOptions` is now tagged with `#[non_exhaustive]`. Use `RetryOptions::builder()` to
   construct retry options.
+* `HttpConnectProxyOptions` is now tagged with `#[non_exhaustive]`. Use
+  `HttpConnectProxyOptions::new(target_addr)` to construct proxy options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ to docs, or any other relevant information.
 * `TimerOptions` is now tagged with `#[non_exhaustive]`. Use
   `TimerOptions::builder(duration)` to construct timer options. Passing a `Duration` directly to
   `WorkflowContext::timer` remains supported.
+* `RetryOptions` is now tagged with `#[non_exhaustive]`. Use `RetryOptions::builder()` to
+  construct retry options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ to docs, or any other relevant information.
 ### Breaking Changes :boom:
 * `CancellableFuture` and `CancellableFutureWithReason` now use the inherited `Future::Output`
   associated type instead of a generic output parameter.
+* `TimerOptions` is now tagged with `#[non_exhaustive]`. Use
+  `TimerOptions::builder(duration)` to construct timer options. Passing a `Duration` directly to
+  `WorkflowContext::timer` remains supported.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ to docs, or any other relevant information.
   `RegisterNamespaceOptions::builder()` to construct namespace registration options.
 * `LoadClientConfigOptions` is now tagged with `#[non_exhaustive]`. Use
   `LoadClientConfigOptions::builder()` to construct client configuration loading options.
+* `LoadClientConfigProfileOptions` is now tagged with `#[non_exhaustive]`. Use
+  `LoadClientConfigProfileOptions::builder()` to construct profile loading options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ to docs, or any other relevant information.
   `LoadClientConfigOptions::builder()` to construct client configuration loading options.
 * `LoadClientConfigProfileOptions` is now tagged with `#[non_exhaustive]`. Use
   `LoadClientConfigProfileOptions::builder()` to construct profile loading options.
+* `ClientConfigFromTOMLOptions` is now tagged with `#[non_exhaustive]`. Use
+  `ClientConfigFromTOMLOptions::builder()` to construct TOML parsing options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ to docs, or any other relevant information.
   `HttpConnectProxyOptions::new(target_addr)` to construct proxy options.
 * `TlsOptions` is now tagged with `#[non_exhaustive]`. Use `TlsOptions::builder()` to construct
   TLS options.
+* `ClientTlsOptions` is now tagged with `#[non_exhaustive]`. Use `ClientTlsOptions::builder()` to
+  construct client TLS options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ to docs, or any other relevant information.
 
 ## Unreleased
 
+### Added
+* `RpcOptions::builder()` for constructing per-call RPC options.
+
 ### Breaking Changes :boom:
 * `CancellableFuture` and `CancellableFutureWithReason` now use the inherited `Future::Output`
   associated type instead of a generic output parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ to docs, or any other relevant information.
   `PollNexusOptions::builder()` to construct Nexus polling options.
 * `LocalActivityOptions` is now tagged with `#[non_exhaustive]`. Use
   `LocalActivityOptions::builder()` to construct local activity options.
+* `NexusOperationOptions` is now tagged with `#[non_exhaustive]`. Use
+  `NexusOperationOptions::builder()` to construct Nexus operation options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ to docs, or any other relevant information.
   `ClientConfigFromTOMLOptions::builder()` to construct TOML parsing options.
 * `OtelCollectorOptions` is now tagged with `#[non_exhaustive]`. Use
   `OtelCollectorOptions::builder()` to construct OpenTelemetry collector options.
+* `PrometheusExporterOptions` is now tagged with `#[non_exhaustive]`. Use
+  `PrometheusExporterOptions::builder()` to construct Prometheus exporter options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ to docs, or any other relevant information.
   `OtelCollectorOptions::builder()` to construct OpenTelemetry collector options.
 * `PrometheusExporterOptions` is now tagged with `#[non_exhaustive]`. Use
   `PrometheusExporterOptions::builder()` to construct Prometheus exporter options.
+* `WorkerDeploymentOptions` is now tagged with `#[non_exhaustive]`. Use
+  `WorkerDeploymentOptions::new(version)` to construct worker deployment options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ to docs, or any other relevant information.
   `PayloadLimitsOptions::builder()` to construct payload limit options.
 * `RegisterNamespaceOptions` is now tagged with `#[non_exhaustive]`. Continue using
   `RegisterNamespaceOptions::builder()` to construct namespace registration options.
+* `LoadClientConfigOptions` is now tagged with `#[non_exhaustive]`. Use
+  `LoadClientConfigOptions::builder()` to construct client configuration loading options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ to docs, or any other relevant information.
   construct retry options.
 * `HttpConnectProxyOptions` is now tagged with `#[non_exhaustive]`. Use
   `HttpConnectProxyOptions::new(target_addr)` to construct proxy options.
+* `TlsOptions` is now tagged with `#[non_exhaustive]`. Use `TlsOptions::builder()` to construct
+  TLS options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ to docs, or any other relevant information.
   TLS options.
 * `ClientTlsOptions` is now tagged with `#[non_exhaustive]`. Use `ClientTlsOptions::builder()` to
   construct client TLS options.
+* `ClientKeepAliveOptions` is now tagged with `#[non_exhaustive]`. Use
+  `ClientKeepAliveOptions::builder()` to construct keep-alive options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ to docs, or any other relevant information.
   `PrometheusExporterOptions::builder()` to construct Prometheus exporter options.
 * `WorkerDeploymentOptions` is now tagged with `#[non_exhaustive]`. Use
   `WorkerDeploymentOptions::new(version)` to construct worker deployment options.
+* `PollOptions` is now tagged with `#[non_exhaustive]`. Use `PollOptions::new(task_queue)` to
+  construct polling options.
+* `PollWorkflowOptions` is now tagged with `#[non_exhaustive]`. Use
+  `PollWorkflowOptions::builder()` to construct workflow polling options.
+* `PollActivityOptions` is now tagged with `#[non_exhaustive]`. Use
+  `PollActivityOptions::builder()` to construct activity polling options.
+* `PollNexusOptions` is now tagged with `#[non_exhaustive]`. Use
+  `PollNexusOptions::builder()` to construct Nexus polling options.
+* `LocalActivityOptions` is now tagged with `#[non_exhaustive]`. Use
+  `LocalActivityOptions::builder()` to construct local activity options.
 
 ## [0.6.0] - 2026-08-04
 

--- a/crates/client/src/dns.rs
+++ b/crates/client/src/dns.rs
@@ -327,10 +327,11 @@ mod tests {
     #[test]
     fn zero_resolution_interval_is_error() {
         let opts = ConnectionOptions::new(Url::parse("http://temporal.example.com:7233").unwrap())
-            .dns_load_balancing(Some(DnsLoadBalancingOptions {
-                resolution_interval: Duration::ZERO,
-                ..Default::default()
-            }))
+            .dns_load_balancing(Some(
+                DnsLoadBalancingOptions::builder()
+                    .resolution_interval(Duration::ZERO)
+                    .build(),
+            ))
             .build();
         assert!(validate_and_get_dns_lb(&opts).is_err());
     }
@@ -338,10 +339,11 @@ mod tests {
     #[test]
     fn sub_minimum_resolution_interval_is_error() {
         let opts = ConnectionOptions::new(Url::parse("http://temporal.example.com:7233").unwrap())
-            .dns_load_balancing(Some(DnsLoadBalancingOptions {
-                resolution_interval: Duration::from_millis(500),
-                ..Default::default()
-            }))
+            .dns_load_balancing(Some(
+                DnsLoadBalancingOptions::builder()
+                    .resolution_interval(Duration::from_millis(500))
+                    .build(),
+            ))
             .build();
         assert!(validate_and_get_dns_lb(&opts).is_err());
     }

--- a/crates/client/src/envconfig.rs
+++ b/crates/client/src/envconfig.rs
@@ -66,10 +66,12 @@ fn build_tls_options(tls: ClientConfigTLS) -> Result<TlsOptions, ConfigError> {
                 resolve_datasource(cert).map_err(|e| ConfigError::LoadError(e.into()))?;
             let key_bytes =
                 resolve_datasource(key).map_err(|e| ConfigError::LoadError(e.into()))?;
-            Some(ClientTlsOptions {
-                client_cert: cert_bytes,
-                client_private_key: key_bytes,
-            })
+            Some(
+                ClientTlsOptions::builder()
+                    .client_cert(cert_bytes)
+                    .client_private_key(key_bytes)
+                    .build(),
+            )
         }
         (Some(_), None) | (None, Some(_)) => {
             return Err(ConfigError::InvalidConfig(

--- a/crates/client/src/envconfig.rs
+++ b/crates/client/src/envconfig.rs
@@ -85,12 +85,11 @@ fn build_tls_options(tls: ClientConfigTLS) -> Result<TlsOptions, ConfigError> {
         .transpose()
         .map_err(|e| ConfigError::LoadError(e.into()))?;
 
-    Ok(TlsOptions {
-        server_root_ca_cert,
-        domain: tls.server_name,
-        client_tls_options,
-        server_cert_verifier: None,
-    })
+    Ok(TlsOptions::builder()
+        .maybe_server_root_ca_cert(server_root_ca_cert)
+        .maybe_domain(tls.server_name)
+        .maybe_client_tls_options(client_tls_options)
+        .build())
 }
 
 /// Determine whether TLS should be enabled based on the profile's TLS config and API key.

--- a/crates/client/src/envconfig.rs
+++ b/crates/client/src/envconfig.rs
@@ -205,10 +205,9 @@ mod tests {
     #[test]
     fn empty_profile_defaults() {
         let env = HashMap::new();
-        let opts = LoadClientConfigProfileOptions {
-            disable_file: true,
-            ..Default::default()
-        };
+        let opts = LoadClientConfigProfileOptions::builder()
+            .disable_file(true)
+            .build();
         let (conn, client) = load_from_config_with_env(opts, Some(&env)).unwrap();
 
         assert_eq!(conn.target.as_str(), "http://localhost:7233/");
@@ -222,10 +221,9 @@ mod tests {
     fn namespace_override() {
         let mut env = HashMap::new();
         env.insert("TEMPORAL_NAMESPACE".to_string(), "my-namespace".to_string());
-        let opts = LoadClientConfigProfileOptions {
-            disable_file: true,
-            ..Default::default()
-        };
+        let opts = LoadClientConfigProfileOptions::builder()
+            .disable_file(true)
+            .build();
         let (_, client) = load_from_config_with_env(opts, Some(&env)).unwrap();
         assert_eq!(client.namespace, "my-namespace");
     }
@@ -383,11 +381,10 @@ namespace = "custom-ns"
         );
 
         // Default profile
-        let opts = LoadClientConfigProfileOptions {
-            config_source: Some(DataSource::Path(config_path.to_str().unwrap().to_string())),
-            disable_env: true,
-            ..Default::default()
-        };
+        let opts = LoadClientConfigProfileOptions::builder()
+            .config_source(DataSource::Path(config_path.to_str().unwrap().to_string()))
+            .disable_env(true)
+            .build();
         let (conn, client) = ClientOptions::load_from_config(opts).unwrap();
         assert_eq!(conn.target.as_str(), "https://toml-server:7233/");
         assert_eq!(client.namespace, "toml-ns");
@@ -399,12 +396,11 @@ namespace = "custom-ns"
         );
 
         // Custom profile
-        let opts = LoadClientConfigProfileOptions {
-            config_source: Some(DataSource::Path(config_path.to_str().unwrap().to_string())),
-            config_file_profile: Some("custom".to_string()),
-            disable_env: true,
-            ..Default::default()
-        };
+        let opts = LoadClientConfigProfileOptions::builder()
+            .config_source(DataSource::Path(config_path.to_str().unwrap().to_string()))
+            .config_file_profile("custom".to_string())
+            .disable_env(true)
+            .build();
         let (conn, client) = ClientOptions::load_from_config(opts).unwrap();
         assert_eq!(conn.target.as_str(), "http://custom-server:9090/");
         assert_eq!(client.namespace, "custom-ns");

--- a/crates/client/src/grpc.rs
+++ b/crates/client/src/grpc.rs
@@ -2288,14 +2288,12 @@ mod tests {
             }
         }
 
-        let deployment_opts = WorkerDeploymentOptions {
-            version: WorkerDeploymentVersion {
-                deployment_name: "test-deployment".to_string(),
-                build_id: "test-build-123".to_string(),
-            },
-            use_worker_versioning,
-            default_versioning_behavior: None,
-        };
+        let deployment_opts = WorkerDeploymentOptions::new(WorkerDeploymentVersion {
+            deployment_name: "test-deployment".to_string(),
+            build_id: "test-build-123".to_string(),
+        })
+        .use_worker_versioning(use_worker_versioning)
+        .build();
 
         let mut mock_provider = MockClientWorker::new();
         mock_provider

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -2440,19 +2440,18 @@ mod tests {
         #[tokio::test]
         async fn rpc_options_reach_the_request() {
             let (client, recorded) = mock_client(Vec::new(), Arc::new(AtomicUsize::new(0)));
-            let mut rpc_options = RpcOptions {
-                timeout: Some(Duration::from_millis(250)),
-                retry_options: Some(RetryOptions::no_retries()),
-                ..Default::default()
-            };
-            rpc_options
-                .metadata
+            let mut metadata = RpcMetadata::new();
+            metadata
                 .insert("call-meta", "call-value")
                 .unwrap();
-            rpc_options
-                .metadata
+            metadata
                 .insert_binary("call-meta-bin", vec![0, 255])
                 .unwrap();
+            let rpc_options = RpcOptions::builder()
+                .metadata(metadata)
+                .timeout(Duration::from_millis(250))
+                .retry_options(RetryOptions::no_retries())
+                .build();
             let mut options = WorkflowStartOptions::new("task-queue", "workflow-id").build();
             options.rpc_options = rpc_options.clone();
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -2438,9 +2438,7 @@ mod tests {
         async fn rpc_options_reach_the_request() {
             let (client, recorded) = mock_client(Vec::new(), Arc::new(AtomicUsize::new(0)));
             let mut metadata = RpcMetadata::new();
-            metadata
-                .insert("call-meta", "call-value")
-                .unwrap();
+            metadata.insert("call-meta", "call-value").unwrap();
             metadata
                 .insert_binary("call-meta-bin", vec![0, 255])
                 .unwrap();

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1915,11 +1915,10 @@ mod tests {
 
         #[tokio::test]
         async fn add_tls_to_channel_with_custom_verifier() {
-            let tls_opts = TlsOptions {
-                server_cert_verifier: Some(Arc::new(MockVerifier)),
-                domain: Some("test.temporal.io".to_string()),
-                ..Default::default()
-            };
+            let tls_opts = TlsOptions::builder()
+                .server_cert_verifier(Arc::new(MockVerifier))
+                .domain("test.temporal.io".to_string())
+                .build();
             let endpoint = tonic::transport::Channel::from_static("https://test.temporal.io:7233");
             let result = add_tls_to_channel(Some(&tls_opts), endpoint).await;
             assert!(
@@ -1933,12 +1932,11 @@ mod tests {
         async fn add_tls_to_channel_with_verifier_and_ca_cert_fails() {
             // When both server_cert_verifier and server_root_ca_cert are set,
             // add_tls_to_channel should fail with InvalidConfig.
-            let tls_opts = TlsOptions {
-                server_root_ca_cert: Some(b"some-ca-cert-bytes".to_vec()),
-                server_cert_verifier: Some(Arc::new(MockVerifier)),
-                domain: Some("test.temporal.io".to_string()),
-                ..Default::default()
-            };
+            let tls_opts = TlsOptions::builder()
+                .server_root_ca_cert(b"some-ca-cert-bytes".to_vec())
+                .server_cert_verifier(Arc::new(MockVerifier))
+                .domain("test.temporal.io".to_string())
+                .build();
             let endpoint = tonic::transport::Channel::from_static("https://test.temporal.io:7233");
             let result = add_tls_to_channel(Some(&tls_opts), endpoint).await;
             assert!(
@@ -1951,10 +1949,9 @@ mod tests {
         #[tokio::test]
         async fn add_tls_to_channel_without_verifier_still_works() {
             // Regression test: the original PEM path must still work.
-            let tls_opts = TlsOptions {
-                domain: Some("test.temporal.io".to_string()),
-                ..Default::default()
-            };
+            let tls_opts = TlsOptions::builder()
+                .domain("test.temporal.io".to_string())
+                .build();
             let endpoint = tonic::transport::Channel::from_static("https://test.temporal.io:7233");
             let result = add_tls_to_channel(Some(&tls_opts), endpoint).await;
             assert!(

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -270,13 +270,16 @@ impl Default for DnsLoadBalancingOptions {
 
 /// Payload size limit options for a connection.
 /// NOTE: Experimental
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, bon::Builder)]
+#[non_exhaustive]
 pub struct PayloadLimitsOptions {
     /// Warning threshold (bytes) for the size of an outbound payload-bearing field; over-threshold
     /// fields are logged but still sent to server. Defaults to 512 KiB. Set to `0` to disable.
+    #[builder(default = 512 * 1024)]
     pub payloads_warn_size: u64,
     /// Warning threshold (bytes) for outbound memo sizes; over-threshold memos are logged but still
     /// sent to server. Defaults to 2 KiB. Set to `0` to disable.
+    #[builder(default = 2 * 1024)]
     pub memo_warn_size: u64,
 }
 

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -247,10 +247,11 @@ impl Default for ClientKeepAliveOptions {
 }
 
 /// Options for DNS-based load balancing.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, bon::Builder)]
 #[non_exhaustive]
 pub struct DnsLoadBalancingOptions {
     /// How often to re-resolve DNS. Defaults to 30 seconds.
+    #[builder(default = Duration::from_secs(30))]
     pub resolution_interval: Duration,
 }
 

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -169,7 +169,8 @@ pub enum GrpcCompression {
 }
 
 /// Configuration options for TLS
-#[derive(Clone, Default)]
+#[derive(Clone, Default, bon::Builder)]
+#[non_exhaustive]
 pub struct TlsOptions {
     /// Bytes representing the root CA certificate used by the server. If not set, and the server's
     /// cert is issued by someone the operating system trusts, verification will still work (ex:

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -231,11 +231,14 @@ pub struct ClientTlsOptions {
 }
 
 /// Client keep alive configuration.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, bon::Builder)]
+#[non_exhaustive]
 pub struct ClientKeepAliveOptions {
     /// Interval to send HTTP2 keep alive pings.
+    #[builder(default = Duration::from_secs(30))]
     pub interval: Duration,
     /// Timeout that the keep alive must be responded to within or the connection will be closed.
+    #[builder(default = Duration::from_secs(15))]
     pub timeout: Duration,
 }
 

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -231,7 +231,7 @@ pub struct ClientTlsOptions {
 }
 
 /// Client keep alive configuration.
-#[derive(Clone, Debug, bon::Builder)]
+#[derive(Clone, Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct ClientKeepAliveOptions {
     /// Interval to send HTTP2 keep alive pings.
@@ -252,7 +252,7 @@ impl Default for ClientKeepAliveOptions {
 }
 
 /// Options for DNS-based load balancing.
-#[derive(Clone, Debug, bon::Builder)]
+#[derive(Clone, Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct DnsLoadBalancingOptions {
     /// How often to re-resolve DNS. Defaults to 30 seconds.
@@ -270,7 +270,7 @@ impl Default for DnsLoadBalancingOptions {
 
 /// Payload size limit options for a connection.
 /// NOTE: Experimental
-#[derive(Clone, Debug, bon::Builder)]
+#[derive(Clone, Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct PayloadLimitsOptions {
     /// Warning threshold (bytes) for the size of an outbound payload-bearing field; over-threshold
@@ -630,4 +630,61 @@ pub struct WorkflowCountOptions {
     /// Controls for the count RPC.
     #[builder(default)]
     pub rpc_options: RpcOptions,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tls_options_default_matches_builder_default() {
+        let TlsOptions {
+            server_root_ca_cert,
+            domain,
+            client_tls_options,
+            server_cert_verifier,
+        } = TlsOptions::default();
+        let TlsOptions {
+            server_root_ca_cert: built_server_root_ca_cert,
+            domain: built_domain,
+            client_tls_options: built_client_tls_options,
+            server_cert_verifier: built_server_cert_verifier,
+        } = TlsOptions::builder().build();
+
+        assert_eq!(server_root_ca_cert, built_server_root_ca_cert);
+        assert_eq!(domain, built_domain);
+        assert_eq!(
+            client_tls_options.map(|options| { (options.client_cert, options.client_private_key) }),
+            built_client_tls_options
+                .map(|options| { (options.client_cert, options.client_private_key) })
+        );
+        assert_eq!(
+            server_cert_verifier.is_some(),
+            built_server_cert_verifier.is_some()
+        );
+    }
+
+    #[test]
+    fn client_keep_alive_options_default_matches_builder_default() {
+        assert_eq!(
+            ClientKeepAliveOptions::default(),
+            ClientKeepAliveOptions::builder().build()
+        );
+    }
+
+    #[test]
+    fn dns_load_balancing_options_default_matches_builder_default() {
+        assert_eq!(
+            DnsLoadBalancingOptions::default(),
+            DnsLoadBalancingOptions::builder().build()
+        );
+    }
+
+    #[test]
+    fn payload_limits_options_default_matches_builder_default() {
+        assert_eq!(
+            PayloadLimitsOptions::default(),
+            PayloadLimitsOptions::builder().build()
+        );
+    }
 }

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -221,7 +221,8 @@ impl std::fmt::Debug for TlsOptions {
 }
 
 /// If using mTLS, both the client cert and private key must be specified, this contains them.
-#[derive(Clone)]
+#[derive(Clone, bon::Builder)]
+#[non_exhaustive]
 pub struct ClientTlsOptions {
     /// The certificate for this client, encoded as PEM
     pub client_cert: Vec<u8>,

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -169,7 +169,7 @@ pub enum GrpcCompression {
 }
 
 /// Configuration options for TLS
-#[derive(Clone, Default, bon::Builder)]
+#[derive(Clone, bon::Builder)]
 #[non_exhaustive]
 pub struct TlsOptions {
     /// Bytes representing the root CA certificate used by the server. If not set, and the server's
@@ -198,6 +198,12 @@ pub struct TlsOptions {
     /// Note that `domain` is still respected for the `:authority` header / origin override
     /// even when a custom verifier is set.
     pub server_cert_verifier: Option<Arc<dyn ServerCertVerifier>>,
+}
+
+impl Default for TlsOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
 }
 
 impl std::fmt::Debug for TlsOptions {
@@ -244,10 +250,7 @@ pub struct ClientKeepAliveOptions {
 
 impl Default for ClientKeepAliveOptions {
     fn default() -> Self {
-        Self {
-            interval: Duration::from_secs(30),
-            timeout: Duration::from_secs(15),
-        }
+        Self::builder().build()
     }
 }
 
@@ -262,9 +265,7 @@ pub struct DnsLoadBalancingOptions {
 
 impl Default for DnsLoadBalancingOptions {
     fn default() -> Self {
-        Self {
-            resolution_interval: Duration::from_secs(30),
-        }
+        Self::builder().build()
     }
 }
 
@@ -285,10 +286,7 @@ pub struct PayloadLimitsOptions {
 
 impl Default for PayloadLimitsOptions {
     fn default() -> Self {
-        Self {
-            payloads_warn_size: 512 * 1024,
-            memo_warn_size: 2 * 1024,
-        }
+        Self::builder().build()
     }
 }
 
@@ -630,61 +628,4 @@ pub struct WorkflowCountOptions {
     /// Controls for the count RPC.
     #[builder(default)]
     pub rpc_options: RpcOptions,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn tls_options_default_matches_builder_default() {
-        let TlsOptions {
-            server_root_ca_cert,
-            domain,
-            client_tls_options,
-            server_cert_verifier,
-        } = TlsOptions::default();
-        let TlsOptions {
-            server_root_ca_cert: built_server_root_ca_cert,
-            domain: built_domain,
-            client_tls_options: built_client_tls_options,
-            server_cert_verifier: built_server_cert_verifier,
-        } = TlsOptions::builder().build();
-
-        assert_eq!(server_root_ca_cert, built_server_root_ca_cert);
-        assert_eq!(domain, built_domain);
-        assert_eq!(
-            client_tls_options.map(|options| { (options.client_cert, options.client_private_key) }),
-            built_client_tls_options
-                .map(|options| { (options.client_cert, options.client_private_key) })
-        );
-        assert_eq!(
-            server_cert_verifier.is_some(),
-            built_server_cert_verifier.is_some()
-        );
-    }
-
-    #[test]
-    fn client_keep_alive_options_default_matches_builder_default() {
-        assert_eq!(
-            ClientKeepAliveOptions::default(),
-            ClientKeepAliveOptions::builder().build()
-        );
-    }
-
-    #[test]
-    fn dns_load_balancing_options_default_matches_builder_default() {
-        assert_eq!(
-            DnsLoadBalancingOptions::default(),
-            DnsLoadBalancingOptions::builder().build()
-        );
-    }
-
-    #[test]
-    fn payload_limits_options_default_matches_builder_default() {
-        assert_eq!(
-            PayloadLimitsOptions::default(),
-            PayloadLimitsOptions::builder().build()
-        );
-    }
 }

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -500,6 +500,7 @@ const DEFAULT_WORKFLOW_EXECUTION_RETENTION_PERIOD: Duration = Duration::from_sec
 /// Helper struct for `register_namespace`.
 #[derive(Clone, Debug, bon::Builder)]
 #[builder(on(String, into))]
+#[non_exhaustive]
 pub struct RegisterNamespaceOptions {
     /// Name (required)
     pub namespace: String,

--- a/crates/client/src/proxy.rs
+++ b/crates/client/src/proxy.rs
@@ -25,10 +25,13 @@ use tower::{Service, service_fn};
 use tokio::net::UnixStream;
 
 /// Options for HTTP CONNECT proxy.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, bon::Builder)]
+#[builder(start_fn = new, on(String, into))]
+#[non_exhaustive]
 pub struct HttpConnectProxyOptions {
     /// The host:port to proxy through for TCP, or unix:/path/to/unix.sock for
     /// Unix socket (which means it must start with "unix:/").
+    #[builder(start_fn)]
     pub target_addr: String,
     /// Optional HTTP basic auth for the proxy as user/pass tuple.
     pub basic_auth: Option<(String, String)>,
@@ -279,10 +282,7 @@ mod tests {
     #[tokio::test]
     async fn connect_request_line(#[case] uri: &str, #[case] expected: &str) {
         let (proxy_addr, handle) = mock_proxy().await;
-        let opts = HttpConnectProxyOptions {
-            target_addr: proxy_addr,
-            basic_auth: None,
-        };
+        let opts = HttpConnectProxyOptions::new(proxy_addr).build();
         let uri: tonic::transport::Uri = uri.parse().unwrap();
         let _ = opts.connect(uri).await;
 
@@ -293,10 +293,9 @@ mod tests {
     #[tokio::test]
     async fn connect_includes_basic_auth() {
         let (proxy_addr, handle) = mock_proxy().await;
-        let opts = HttpConnectProxyOptions {
-            target_addr: proxy_addr,
-            basic_auth: Some(("user".to_string(), "pass".to_string())),
-        };
+        let opts = HttpConnectProxyOptions::new(proxy_addr)
+            .basic_auth(("user".to_string(), "pass".to_string()))
+            .build();
         let uri: tonic::transport::Uri = "https://example.com:7233".parse().unwrap();
         let _ = opts.connect(uri).await;
 

--- a/crates/client/src/retry.rs
+++ b/crates/client/src/retry.rs
@@ -387,6 +387,11 @@ mod tests {
     };
     use tonic::{IntoRequest, Status};
 
+    #[test]
+    fn retry_options_default_matches_builder_default() {
+        assert_eq!(RetryOptions::default(), RetryOptions::builder().build());
+    }
+
     /// Predefined retry configs with low durations to make unit tests faster
     const TEST_RETRY_CONFIG: RetryOptions = RetryOptions {
         initial_interval: Duration::from_millis(1),

--- a/crates/client/src/retry.rs
+++ b/crates/client/src/retry.rs
@@ -54,14 +54,7 @@ pub struct RetryOptions {
 
 impl Default for RetryOptions {
     fn default() -> Self {
-        Self {
-            initial_interval: Duration::from_millis(100), // 100 ms wait by default.
-            randomization_factor: 0.2,                    // +-20% jitter.
-            multiplier: 1.7, // each next retry delay will increase by 70%
-            max_interval: Duration::from_secs(5), // until it reaches 5 seconds.
-            max_elapsed_time: Some(Duration::from_secs(10)), // 10 seconds total allocated time for all retries.
-            max_retries: 10,
-        }
+        Self::builder().build()
     }
 }
 
@@ -386,11 +379,6 @@ mod tests {
         PollActivityTaskQueueRequest, PollNexusTaskQueueRequest, PollWorkflowTaskQueueRequest,
     };
     use tonic::{IntoRequest, Status};
-
-    #[test]
-    fn retry_options_default_matches_builder_default() {
-        assert_eq!(RetryOptions::default(), RetryOptions::builder().build());
-    }
 
     /// Predefined retry configs with low durations to make unit tests faster
     const TEST_RETRY_CONFIG: RetryOptions = RetryOptions {

--- a/crates/client/src/retry.rs
+++ b/crates/client/src/retry.rs
@@ -27,21 +27,28 @@ pub const RETRYABLE_ERROR_CODES: [Code; 7] = [
 const LONG_POLL_FATAL_GRACE: Duration = Duration::from_secs(60);
 
 /// Configuration for retrying requests to the server
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, bon::Builder)]
+#[non_exhaustive]
 pub struct RetryOptions {
     /// initial wait time before the first retry.
+    #[builder(default = Duration::from_millis(100))]
     pub initial_interval: Duration,
     /// randomization jitter that is used as a multiplier for the current retry interval
     /// and is added or subtracted from the interval length.
+    #[builder(default = 0.2)]
     pub randomization_factor: f64,
     /// rate at which retry time should be increased, until it reaches max_interval.
+    #[builder(default = 1.7)]
     pub multiplier: f64,
     /// maximum amount of time to wait between retries.
+    #[builder(default = Duration::from_secs(5))]
     pub max_interval: Duration,
     /// maximum total amount of time requests should be retried for, if None is set then no limit
     /// will be used.
+    #[builder(required, default = Some(Duration::from_secs(10)))]
     pub max_elapsed_time: Option<Duration>,
     /// maximum number of retry attempts.
+    #[builder(default = 10)]
     pub max_retries: usize,
 }
 

--- a/crates/client/src/rpc_options.rs
+++ b/crates/client/src/rpc_options.rs
@@ -176,7 +176,7 @@ pub enum RpcMetadataError {
 }
 
 /// Controls applied to a single high-level client RPC.
-#[derive(Clone, Debug, Default, bon::Builder)]
+#[derive(Clone, Debug, Default, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct RpcOptions {
     /// Metadata attached to the RPC.
@@ -205,6 +205,11 @@ impl RpcOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rpc_options_default_matches_builder_default() {
+        assert_eq!(RpcOptions::default(), RpcOptions::builder().build());
+    }
 
     #[test]
     fn metadata_validates_and_exposes_values() {

--- a/crates/client/src/rpc_options.rs
+++ b/crates/client/src/rpc_options.rs
@@ -176,10 +176,11 @@ pub enum RpcMetadataError {
 }
 
 /// Controls applied to a single high-level client RPC.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, bon::Builder)]
 #[non_exhaustive]
 pub struct RpcOptions {
     /// Metadata attached to the RPC.
+    #[builder(default)]
     pub metadata: RpcMetadata,
     /// Timeout for the RPC, overriding the connection's default deadline.
     pub timeout: Option<Duration>,

--- a/crates/client/src/rpc_options.rs
+++ b/crates/client/src/rpc_options.rs
@@ -176,7 +176,7 @@ pub enum RpcMetadataError {
 }
 
 /// Controls applied to a single high-level client RPC.
-#[derive(Clone, Debug, Default, PartialEq, bon::Builder)]
+#[derive(Clone, Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct RpcOptions {
     /// Metadata attached to the RPC.
@@ -186,6 +186,12 @@ pub struct RpcOptions {
     pub timeout: Option<Duration>,
     /// Retry behavior for the RPC, overriding the connection's retry configuration.
     pub retry_options: Option<RetryOptions>,
+}
+
+impl Default for RpcOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
 }
 
 impl RpcOptions {
@@ -205,11 +211,6 @@ impl RpcOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn rpc_options_default_matches_builder_default() {
-        assert_eq!(RpcOptions::default(), RpcOptions::builder().build());
-    }
 
     #[test]
     fn metadata_validates_and_exposes_values() {

--- a/crates/client/src/worker.rs
+++ b/crates/client/src/worker.rs
@@ -672,16 +672,14 @@ mod tests {
         failing_worker
             .expect_task_queue()
             .return_const(task_queue.clone());
-        failing_worker
-            .expect_deployment_options()
-            .return_const(WorkerDeploymentOptions {
-                version: temporalio_common::worker::WorkerDeploymentVersion {
-                    deployment_name: "test-deployment".to_string(),
-                    build_id: "build-fail".to_string(),
-                },
-                use_worker_versioning: true,
-                default_versioning_behavior: None,
-            });
+        failing_worker.expect_deployment_options().return_const(
+            WorkerDeploymentOptions::new(temporalio_common::worker::WorkerDeploymentVersion {
+                deployment_name: "test-deployment".to_string(),
+                build_id: "build-fail".to_string(),
+            })
+            .use_worker_versioning(true)
+            .build(),
+        );
         failing_worker
             .expect_worker_instance_key()
             .return_const(failing_worker_id);
@@ -709,14 +707,13 @@ mod tests {
         succeeding_worker
             .expect_task_queue()
             .return_const(task_queue.clone());
-        let success_deployment_options = WorkerDeploymentOptions {
-            version: temporalio_common::worker::WorkerDeploymentVersion {
+        let success_deployment_options =
+            WorkerDeploymentOptions::new(temporalio_common::worker::WorkerDeploymentVersion {
                 deployment_name: "test-deployment".to_string(),
                 build_id: "build-success".to_string(),
-            },
-            use_worker_versioning: true,
-            default_versioning_behavior: None,
-        };
+            })
+            .use_worker_versioning(true)
+            .build();
         succeeding_worker
             .expect_deployment_options()
             .return_const(success_deployment_options.clone());
@@ -772,16 +769,14 @@ mod tests {
         failing_worker
             .expect_task_queue()
             .return_const(task_queue.clone());
-        failing_worker
-            .expect_deployment_options()
-            .return_const(WorkerDeploymentOptions {
-                version: temporalio_common::worker::WorkerDeploymentVersion {
-                    deployment_name: "test-deployment".to_string(),
-                    build_id: "build-fail".to_string(),
-                },
-                use_worker_versioning: true,
-                default_versioning_behavior: None,
-            });
+        failing_worker.expect_deployment_options().return_const(
+            WorkerDeploymentOptions::new(temporalio_common::worker::WorkerDeploymentVersion {
+                deployment_name: "test-deployment".to_string(),
+                build_id: "build-fail".to_string(),
+            })
+            .use_worker_versioning(true)
+            .build(),
+        );
         failing_worker
             .expect_worker_instance_key()
             .return_const(failing_worker_id);
@@ -984,16 +979,16 @@ mod tests {
         mock_provider
             .expect_deployment_options()
             .returning(move || {
-                build_id_for_closure
-                    .as_ref()
-                    .map(|build_id| WorkerDeploymentOptions {
-                        version: temporalio_common::worker::WorkerDeploymentVersion {
+                build_id_for_closure.as_ref().map(|build_id| {
+                    WorkerDeploymentOptions::new(
+                        temporalio_common::worker::WorkerDeploymentVersion {
                             deployment_name: deployment_name.clone(),
                             build_id: build_id.clone(),
                         },
-                        use_worker_versioning: true,
-                        default_versioning_behavior: None,
-                    })
+                    )
+                    .use_worker_versioning(true)
+                    .build()
+                })
             });
 
         if heartbeat_enabled {

--- a/crates/common/src/envconfig.rs
+++ b/crates/common/src/envconfig.rs
@@ -186,7 +186,8 @@ pub struct LoadClientConfigOptions {
 }
 
 /// Options for loading a client configuration profile
-#[derive(Debug, Default)]
+#[derive(Debug, Default, bon::Builder)]
+#[non_exhaustive]
 pub struct LoadClientConfigProfileOptions {
     /// Where to load config from. If unset, will try env vars then default path.
     pub config_source: Option<DataSource>,
@@ -195,12 +196,15 @@ pub struct LoadClientConfigProfileOptions {
     pub config_file_profile: Option<String>,
 
     /// If true, will error if there are unrecognized keys.
+    #[builder(default)]
     pub config_file_strict: bool,
 
     /// Disable loading from file
+    #[builder(default)]
     pub disable_file: bool,
 
     /// Disable loading from environment variables
+    #[builder(default)]
     pub disable_env: bool,
 }
 

--- a/crates/common/src/envconfig.rs
+++ b/crates/common/src/envconfig.rs
@@ -209,9 +209,11 @@ pub struct LoadClientConfigProfileOptions {
 }
 
 /// Options for parsing TOML configuration
-#[derive(Debug, Default)]
+#[derive(Debug, Default, bon::Builder)]
+#[non_exhaustive]
 pub struct ClientConfigFromTOMLOptions {
     /// If true, will error if there are unrecognized keys.
+    #[builder(default)]
     pub strict: bool,
 }
 
@@ -298,9 +300,9 @@ fn load_client_config_inner(
     if let Some(data) = toml_data {
         ClientConfig::from_toml(
             &data,
-            ClientConfigFromTOMLOptions {
-                strict: options.config_file_strict,
-            },
+            ClientConfigFromTOMLOptions::builder()
+                .strict(options.config_file_strict)
+                .build(),
         )
     } else {
         Ok(ClientConfig::default())
@@ -1418,7 +1420,9 @@ unrecognized_field = "is-bad"
 "#;
         let err = ClientConfig::from_toml(
             toml_str.as_bytes(),
-            ClientConfigFromTOMLOptions { strict: true },
+            ClientConfigFromTOMLOptions::builder()
+                .strict(true)
+                .build(),
         )
         .unwrap_err();
         let err_str = err.to_string();
@@ -1433,7 +1437,9 @@ foo = "bar"
 "#;
         let err = ClientConfig::from_toml(
             toml_str.as_bytes(),
-            ClientConfigFromTOMLOptions { strict: true },
+            ClientConfigFromTOMLOptions::builder()
+                .strict(true)
+                .build(),
         )
         .unwrap_err();
         let err_str = err.to_string();

--- a/crates/common/src/envconfig.rs
+++ b/crates/common/src/envconfig.rs
@@ -174,7 +174,7 @@ pub struct ClientConfigCodec {
 }
 
 /// Options for loading client configuration
-#[derive(Debug, Default, bon::Builder)]
+#[derive(Debug, Default, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct LoadClientConfigOptions {
     /// Where to load config from. If unset, will try env vars then default path.
@@ -186,7 +186,7 @@ pub struct LoadClientConfigOptions {
 }
 
 /// Options for loading a client configuration profile
-#[derive(Debug, Default, bon::Builder)]
+#[derive(Debug, Default, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct LoadClientConfigProfileOptions {
     /// Where to load config from. If unset, will try env vars then default path.
@@ -209,7 +209,7 @@ pub struct LoadClientConfigProfileOptions {
 }
 
 /// Options for parsing TOML configuration
-#[derive(Debug, Default, bon::Builder)]
+#[derive(Debug, Default, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct ClientConfigFromTOMLOptions {
     /// If true, will error if there are unrecognized keys.
@@ -1058,6 +1058,30 @@ mod tests {
     use tempfile::NamedTempFile;
 
     #[test]
+    fn load_client_config_options_default_matches_builder_default() {
+        assert_eq!(
+            LoadClientConfigOptions::default(),
+            LoadClientConfigOptions::builder().build()
+        );
+    }
+
+    #[test]
+    fn load_client_config_profile_options_default_matches_builder_default() {
+        assert_eq!(
+            LoadClientConfigProfileOptions::default(),
+            LoadClientConfigProfileOptions::builder().build()
+        );
+    }
+
+    #[test]
+    fn client_config_from_toml_options_default_matches_builder_default() {
+        assert_eq!(
+            ClientConfigFromTOMLOptions::default(),
+            ClientConfigFromTOMLOptions::builder().build()
+        );
+    }
+
+    #[test]
     fn test_client_config_toml_multiple_profiles() {
         let toml_str = r#"
 [profile.default]
@@ -1420,9 +1444,7 @@ unrecognized_field = "is-bad"
 "#;
         let err = ClientConfig::from_toml(
             toml_str.as_bytes(),
-            ClientConfigFromTOMLOptions::builder()
-                .strict(true)
-                .build(),
+            ClientConfigFromTOMLOptions::builder().strict(true).build(),
         )
         .unwrap_err();
         let err_str = err.to_string();
@@ -1437,9 +1459,7 @@ foo = "bar"
 "#;
         let err = ClientConfig::from_toml(
             toml_str.as_bytes(),
-            ClientConfigFromTOMLOptions::builder()
-                .strict(true)
-                .build(),
+            ClientConfigFromTOMLOptions::builder().strict(true).build(),
         )
         .unwrap_err();
         let err_str = err.to_string();

--- a/crates/common/src/envconfig.rs
+++ b/crates/common/src/envconfig.rs
@@ -174,12 +174,14 @@ pub struct ClientConfigCodec {
 }
 
 /// Options for loading client configuration
-#[derive(Debug, Default)]
+#[derive(Debug, Default, bon::Builder)]
+#[non_exhaustive]
 pub struct LoadClientConfigOptions {
     /// Where to load config from. If unset, will try env vars then default path.
     pub config_source: Option<DataSource>,
 
     /// If true, will error if there are unrecognized keys
+    #[builder(default)]
     pub config_file_strict: bool,
 }
 
@@ -339,10 +341,10 @@ pub fn load_client_config_profile(
     } else {
         // Load the full config
         let config = load_client_config(
-            LoadClientConfigOptions {
-                config_source: options.config_source,
-                config_file_strict: options.config_file_strict,
-            },
+            LoadClientConfigOptions::builder()
+                .maybe_config_source(options.config_source)
+                .config_file_strict(options.config_file_strict)
+                .build(),
             env_vars,
         )?;
 

--- a/crates/common/src/envconfig.rs
+++ b/crates/common/src/envconfig.rs
@@ -174,7 +174,7 @@ pub struct ClientConfigCodec {
 }
 
 /// Options for loading client configuration
-#[derive(Debug, Default, PartialEq, bon::Builder)]
+#[derive(Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct LoadClientConfigOptions {
     /// Where to load config from. If unset, will try env vars then default path.
@@ -185,8 +185,14 @@ pub struct LoadClientConfigOptions {
     pub config_file_strict: bool,
 }
 
+impl Default for LoadClientConfigOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
 /// Options for loading a client configuration profile
-#[derive(Debug, Default, PartialEq, bon::Builder)]
+#[derive(Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct LoadClientConfigProfileOptions {
     /// Where to load config from. If unset, will try env vars then default path.
@@ -208,13 +214,25 @@ pub struct LoadClientConfigProfileOptions {
     pub disable_env: bool,
 }
 
+impl Default for LoadClientConfigProfileOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
 /// Options for parsing TOML configuration
-#[derive(Debug, Default, PartialEq, bon::Builder)]
+#[derive(Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct ClientConfigFromTOMLOptions {
     /// If true, will error if there are unrecognized keys.
     #[builder(default)]
     pub strict: bool,
+}
+
+impl Default for ClientConfigFromTOMLOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
 }
 
 /// A source for environment variables, which can be either a provided HashMap or the system's
@@ -1056,30 +1074,6 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
-
-    #[test]
-    fn load_client_config_options_default_matches_builder_default() {
-        assert_eq!(
-            LoadClientConfigOptions::default(),
-            LoadClientConfigOptions::builder().build()
-        );
-    }
-
-    #[test]
-    fn load_client_config_profile_options_default_matches_builder_default() {
-        assert_eq!(
-            LoadClientConfigProfileOptions::default(),
-            LoadClientConfigProfileOptions::builder().build()
-        );
-    }
-
-    #[test]
-    fn client_config_from_toml_options_default_matches_builder_default() {
-        assert_eq!(
-            ClientConfigFromTOMLOptions::default(),
-            ClientConfigFromTOMLOptions::builder().build()
-        );
-    }
 
     #[test]
     fn test_client_config_toml_multiple_profiles() {

--- a/crates/common/src/telemetry.rs
+++ b/crates/common/src/telemetry.rs
@@ -127,6 +127,7 @@ pub enum TaskQueueLabelStrategy {
 
 /// Options for exporting to an OpenTelemetry Collector
 #[derive(Debug, Clone, bon::Builder)]
+#[non_exhaustive]
 pub struct OtelCollectorOptions {
     /// The url of the OTel collector to export telemetry and metrics to. Lang SDK should also
     /// export to this same collector.

--- a/crates/common/src/telemetry.rs
+++ b/crates/common/src/telemetry.rs
@@ -157,6 +157,7 @@ pub struct OtelCollectorOptions {
 
 /// Options for exporting metrics to Prometheus
 #[derive(Debug, Clone, bon::Builder)]
+#[non_exhaustive]
 pub struct PrometheusExporterOptions {
     /// The address the Prometheus exporter HTTP server will bind to.
     pub socket_addr: SocketAddr,

--- a/crates/common/src/worker.rs
+++ b/crates/common/src/worker.rs
@@ -116,12 +116,16 @@ impl WorkerTaskTypes {
 }
 
 /// Configuration for worker deployment versioning.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, bon::Builder)]
+#[builder(start_fn = new)]
+#[non_exhaustive]
 pub struct WorkerDeploymentOptions {
     /// The deployment version of this worker.
+    #[builder(start_fn)]
     pub version: WorkerDeploymentVersion,
     /// If set, opts in to the Worker Deployment Versioning feature, meaning this worker will only
     /// receive tasks for workflows it claims to be compatible with.
+    #[builder(default)]
     pub use_worker_versioning: bool,
     /// The default versioning behavior to use for workflows that do not pass one to Core.
     /// It is a startup-time error to specify `Some(Unspecified)` here.
@@ -131,14 +135,11 @@ pub struct WorkerDeploymentOptions {
 impl WorkerDeploymentOptions {
     /// Create deployment options from just a build ID, without opting into worker versioning.
     pub fn from_build_id(build_id: String) -> Self {
-        Self {
-            version: WorkerDeploymentVersion {
-                deployment_name: "".to_owned(),
-                build_id,
-            },
-            use_worker_versioning: false,
-            default_versioning_behavior: None,
-        }
+        Self::new(WorkerDeploymentVersion {
+            deployment_name: "".to_owned(),
+            build_id,
+        })
+        .build()
     }
 }
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -1537,9 +1537,9 @@ impl From<&ClientKeepAliveOptions> for temporalio_client::ClientKeepAliveOptions
 
 impl From<&ClientDnsLoadBalancingOptions> for temporalio_client::DnsLoadBalancingOptions {
     fn from(opts: &ClientDnsLoadBalancingOptions) -> Self {
-        let mut out = temporalio_client::DnsLoadBalancingOptions::default();
-        out.resolution_interval = Duration::from_millis(opts.resolution_interval_millis);
-        out
+        temporalio_client::DnsLoadBalancingOptions::builder()
+            .resolution_interval(Duration::from_millis(opts.resolution_interval_millis))
+            .build()
     }
 }
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -1528,10 +1528,10 @@ impl From<&ClientRetryOptions> for temporalio_client::RetryOptions {
 
 impl From<&ClientKeepAliveOptions> for temporalio_client::ClientKeepAliveOptions {
     fn from(opts: &ClientKeepAliveOptions) -> Self {
-        temporalio_client::ClientKeepAliveOptions {
-            interval: Duration::from_millis(opts.interval_millis),
-            timeout: Duration::from_millis(opts.timeout_millis),
-        }
+        temporalio_client::ClientKeepAliveOptions::builder()
+            .interval(Duration::from_millis(opts.interval_millis))
+            .timeout(Duration::from_millis(opts.timeout_millis))
+            .build()
     }
 }
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -1543,14 +1543,13 @@ impl From<&ClientDnsLoadBalancingOptions> for temporalio_client::DnsLoadBalancin
 
 impl From<&ClientHttpConnectProxyOptions> for temporalio_client::proxy::HttpConnectProxyOptions {
     fn from(opts: &ClientHttpConnectProxyOptions) -> Self {
-        temporalio_client::proxy::HttpConnectProxyOptions {
-            target_addr: opts.target_host.to_string(),
-            basic_auth: if opts.username.size != 0 && opts.password.size != 0 {
+        temporalio_client::proxy::HttpConnectProxyOptions::new(opts.target_host.to_string())
+            .maybe_basic_auth(if opts.username.size != 0 && opts.password.size != 0 {
                 Some((opts.username.to_string(), opts.password.to_string()))
             } else {
                 None
-            },
-        }
+            })
+            .build()
     }
 }
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -1511,18 +1511,16 @@ impl TryFrom<&ClientTlsOptions> for temporalio_client::TlsOptions {
 
 impl From<&ClientRetryOptions> for temporalio_client::RetryOptions {
     fn from(opts: &ClientRetryOptions) -> Self {
-        temporalio_client::RetryOptions {
-            initial_interval: Duration::from_millis(opts.initial_interval_millis),
-            randomization_factor: opts.randomization_factor,
-            multiplier: opts.multiplier,
-            max_interval: Duration::from_millis(opts.max_interval_millis),
-            max_elapsed_time: if opts.max_elapsed_time_millis == 0 {
-                None
-            } else {
-                Some(Duration::from_millis(opts.max_elapsed_time_millis))
-            },
-            max_retries: opts.max_retries,
-        }
+        temporalio_client::RetryOptions::builder()
+            .initial_interval(Duration::from_millis(opts.initial_interval_millis))
+            .randomization_factor(opts.randomization_factor)
+            .multiplier(opts.multiplier)
+            .max_interval(Duration::from_millis(opts.max_interval_millis))
+            .max_elapsed_time((opts.max_elapsed_time_millis != 0).then(|| {
+                Duration::from_millis(opts.max_elapsed_time_millis)
+            }))
+            .max_retries(opts.max_retries)
+            .build()
     }
 }
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -1484,28 +1484,28 @@ impl TryFrom<&ClientTlsOptions> for temporalio_client::TlsOptions {
     type Error = anyhow::Error;
 
     fn try_from(opts: &ClientTlsOptions) -> anyhow::Result<Self> {
-        Ok(temporalio_client::TlsOptions {
-            server_root_ca_cert: opts.server_root_ca_cert.to_option_vec(),
-            domain: opts.domain.to_option_string(),
-            client_tls_options: match (
-                opts.client_cert.to_option_vec(),
-                opts.client_private_key.to_option_vec(),
-            ) {
-                (None, None) => None,
-                (Some(client_cert), Some(client_private_key)) => {
-                    Some(temporalio_client::ClientTlsOptions {
-                        client_cert,
-                        client_private_key,
-                    })
-                }
-                _ => {
-                    return Err(anyhow::anyhow!(
-                        "Must have both client cert and private key or neither"
-                    ));
-                }
-            },
-            server_cert_verifier: None,
-        })
+        let client_tls_options = match (
+            opts.client_cert.to_option_vec(),
+            opts.client_private_key.to_option_vec(),
+        ) {
+            (None, None) => None,
+            (Some(client_cert), Some(client_private_key)) => {
+                Some(temporalio_client::ClientTlsOptions {
+                    client_cert,
+                    client_private_key,
+                })
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Must have both client cert and private key or neither"
+                ));
+            }
+        };
+        Ok(temporalio_client::TlsOptions::builder()
+            .maybe_server_root_ca_cert(opts.server_root_ca_cert.to_option_vec())
+            .maybe_domain(opts.domain.to_option_string())
+            .maybe_client_tls_options(client_tls_options)
+            .build())
     }
 }
 

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -1471,10 +1471,12 @@ impl TryFrom<&ConnectionOptions> for temporalio_client::ConnectionOptions {
                     ClientGrpcCompression::Gzip => temporalio_client::GrpcCompression::Gzip,
                     ClientGrpcCompression::None => temporalio_client::GrpcCompression::None,
                 })
-                .payload_limits(temporalio_client::PayloadLimitsOptions {
-                    payloads_warn_size: opts.payloads_warn_size,
-                    memo_warn_size: opts.memo_warn_size,
-                })
+                .payload_limits(
+                    temporalio_client::PayloadLimitsOptions::builder()
+                        .payloads_warn_size(opts.payloads_warn_size)
+                        .memo_warn_size(opts.memo_warn_size)
+                        .build(),
+                )
                 .build(),
         )
     }

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -1490,10 +1490,12 @@ impl TryFrom<&ClientTlsOptions> for temporalio_client::TlsOptions {
         ) {
             (None, None) => None,
             (Some(client_cert), Some(client_private_key)) => {
-                Some(temporalio_client::ClientTlsOptions {
-                    client_cert,
-                    client_private_key,
-                })
+                Some(
+                    temporalio_client::ClientTlsOptions::builder()
+                        .client_cert(client_cert)
+                        .client_private_key(client_private_key)
+                        .build(),
+                )
             }
             _ => {
                 return Err(anyhow::anyhow!(

--- a/crates/sdk-core-c-bridge/src/client.rs
+++ b/crates/sdk-core-c-bridge/src/client.rs
@@ -1491,14 +1491,12 @@ impl TryFrom<&ClientTlsOptions> for temporalio_client::TlsOptions {
             opts.client_private_key.to_option_vec(),
         ) {
             (None, None) => None,
-            (Some(client_cert), Some(client_private_key)) => {
-                Some(
-                    temporalio_client::ClientTlsOptions::builder()
-                        .client_cert(client_cert)
-                        .client_private_key(client_private_key)
-                        .build(),
-                )
-            }
+            (Some(client_cert), Some(client_private_key)) => Some(
+                temporalio_client::ClientTlsOptions::builder()
+                    .client_cert(client_cert)
+                    .client_private_key(client_private_key)
+                    .build(),
+            ),
             _ => {
                 return Err(anyhow::anyhow!(
                     "Must have both client cert and private key or neither"
@@ -1520,9 +1518,10 @@ impl From<&ClientRetryOptions> for temporalio_client::RetryOptions {
             .randomization_factor(opts.randomization_factor)
             .multiplier(opts.multiplier)
             .max_interval(Duration::from_millis(opts.max_interval_millis))
-            .max_elapsed_time((opts.max_elapsed_time_millis != 0).then(|| {
-                Duration::from_millis(opts.max_elapsed_time_millis)
-            }))
+            .max_elapsed_time(
+                (opts.max_elapsed_time_millis != 0)
+                    .then(|| Duration::from_millis(opts.max_elapsed_time_millis)),
+            )
             .max_retries(opts.max_retries)
             .build()
     }

--- a/crates/sdk-core-c-bridge/src/envconfig.rs
+++ b/crates/sdk-core-c-bridge/src/envconfig.rs
@@ -278,13 +278,13 @@ pub extern "C" fn temporal_core_client_env_config_profile_load(
         let config_source = parse_config_source(&opts.path, &opts.data)?;
         let env_vars_map = parse_env_vars(&opts.env_vars)?;
 
-        let load_options = LoadClientConfigProfileOptions {
-            config_source,
-            config_file_profile: profile_name,
-            config_file_strict: opts.config_file_strict,
-            disable_file: opts.disable_file,
-            disable_env: opts.disable_env,
-        };
+        let load_options = LoadClientConfigProfileOptions::builder()
+            .maybe_config_source(config_source)
+            .maybe_config_file_profile(profile_name)
+            .config_file_strict(opts.config_file_strict)
+            .disable_file(opts.disable_file)
+            .disable_env(opts.disable_env)
+            .build();
 
         let profile = envconfig::load_client_config_profile(load_options, env_vars_map.as_ref())
             .map_err(|e| e.to_string())?;

--- a/crates/sdk-core-c-bridge/src/envconfig.rs
+++ b/crates/sdk-core-c-bridge/src/envconfig.rs
@@ -219,10 +219,10 @@ pub extern "C" fn temporal_core_client_env_config_load(
         let opts = unsafe { &*options };
         let env_vars_map = parse_env_vars(&opts.env_vars)?;
 
-        let load_options = LoadClientConfigOptions {
-            config_source: parse_config_source(&opts.path, &opts.data)?,
-            config_file_strict: opts.config_file_strict,
-        };
+        let load_options = LoadClientConfigOptions::builder()
+            .maybe_config_source(parse_config_source(&opts.path, &opts.data)?)
+            .config_file_strict(opts.config_file_strict)
+            .build();
 
         let core_config = envconfig::load_client_config(load_options, env_vars_map.as_ref())
             .map_err(|e| e.to_string())?;

--- a/crates/sdk-core-c-bridge/src/worker.rs
+++ b/crates/sdk-core-c-bridge/src/worker.rs
@@ -1197,14 +1197,15 @@ impl TryFrom<&WorkerOptions> for temporalio_sdk_core::WorkerConfig {
                             }
                         };
                         temporalio_sdk_core::WorkerVersioningStrategy::WorkerDeploymentBased(
-                            temporalio_common::worker::WorkerDeploymentOptions {
-                                version: temporalio_common::worker::WorkerDeploymentVersion {
+                            temporalio_common::worker::WorkerDeploymentOptions::new(
+                                temporalio_common::worker::WorkerDeploymentVersion {
                                     deployment_name: dopts.version.deployment_name.to_string(),
                                     build_id: dopts.version.build_id.to_string(),
                                 },
-                                use_worker_versioning: dopts.use_worker_versioning,
-                                default_versioning_behavior: dvb,
-                            },
+                            )
+                            .use_worker_versioning(dopts.use_worker_versioning)
+                            .maybe_default_versioning_behavior(dvb)
+                            .build(),
                         )
                     }
                     WorkerVersioningStrategy::LegacyBuildIdBased(l) => {

--- a/crates/sdk-core/src/worker/client.rs
+++ b/crates/sdk-core/src/worker/client.rs
@@ -995,14 +995,14 @@ mod tests {
         let strategies = [
             (
                 "deployment",
-                WorkerVersioningStrategy::WorkerDeploymentBased(WorkerDeploymentOptions {
-                    version: WorkerDeploymentVersion {
+                WorkerVersioningStrategy::WorkerDeploymentBased(
+                    WorkerDeploymentOptions::new(WorkerDeploymentVersion {
                         deployment_name: "deployment".to_string(),
                         build_id: "deployment-build".to_string(),
-                    },
-                    use_worker_versioning: true,
-                    default_versioning_behavior: None,
-                }),
+                    })
+                    .use_worker_versioning(true)
+                    .build(),
+                ),
             ),
             (
                 "legacy",

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -2709,14 +2709,12 @@ mod tests {
             .namespace("default")
             .task_queue("test-queue")
             .versioning_strategy(WorkerVersioningStrategy::WorkerDeploymentBased(
-                WorkerDeploymentOptions {
-                    version: WorkerDeploymentVersion {
-                        deployment_name: "deployment".to_string(),
-                        build_id: "1.0".to_string(),
-                    },
-                    use_worker_versioning: false,
-                    default_versioning_behavior: Some(VersioningBehavior::AutoUpgrade.into()),
-                },
+                WorkerDeploymentOptions::new(WorkerDeploymentVersion {
+                    deployment_name: "deployment".to_string(),
+                    build_id: "1.0".to_string(),
+                })
+                .default_versioning_behavior(VersioningBehavior::AutoUpgrade.into())
+                .build(),
             ))
             .task_types(WorkerTaskTypes::all())
             .build();

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -227,10 +227,12 @@ async fn get_cloud_client_with_compression(compression: GrpcCompression) -> Clie
         .identity("sdk-test-client")
         .tls_options(
             TlsOptions::builder()
-                .client_tls_options(ClientTlsOptions {
-                    client_cert,
-                    client_private_key,
-                })
+                .client_tls_options(
+                    ClientTlsOptions::builder()
+                        .client_cert(client_cert)
+                        .client_private_key(client_private_key)
+                        .build(),
+                )
                 .build(),
         )
         .grpc_compression(compression)
@@ -850,10 +852,12 @@ pub(crate) fn get_integ_tls_config() -> Option<TlsOptions> {
         Some(
             TlsOptions::builder()
                 .server_root_ca_cert(root)
-                .client_tls_options(ClientTlsOptions {
-                    client_cert,
-                    client_private_key,
-                })
+                .client_tls_options(
+                    ClientTlsOptions::builder()
+                        .client_cert(client_cert)
+                        .client_private_key(client_private_key)
+                        .build(),
+                )
                 .build(),
         )
     } else {

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -225,13 +225,14 @@ async fn get_cloud_client_with_compression(compression: GrpcCompression) -> Clie
         .client_name("sdk-core-integ-tests")
         .client_version("clientver")
         .identity("sdk-test-client")
-        .tls_options(TlsOptions {
-            client_tls_options: Some(ClientTlsOptions {
-                client_cert,
-                client_private_key,
-            }),
-            ..Default::default()
-        })
+        .tls_options(
+            TlsOptions::builder()
+                .client_tls_options(ClientTlsOptions {
+                    client_cert,
+                    client_private_key,
+                })
+                .build(),
+        )
         .grpc_compression(compression)
         .build();
     let connection = Connection::connect(connection_opts).await.unwrap();
@@ -846,15 +847,15 @@ pub(crate) fn get_integ_tls_config() -> Option<TlsOptions> {
         let root = std::fs::read("../.cloud_certs/ca.pem").unwrap();
         let client_cert = std::fs::read("../.cloud_certs/client.pem").unwrap();
         let client_private_key = std::fs::read("../.cloud_certs/client.key").unwrap();
-        Some(TlsOptions {
-            server_root_ca_cert: Some(root),
-            domain: None,
-            client_tls_options: Some(ClientTlsOptions {
-                client_cert,
-                client_private_key,
-            }),
-            server_cert_verifier: None,
-        })
+        Some(
+            TlsOptions::builder()
+                .server_root_ca_cert(root)
+                .client_tls_options(ClientTlsOptions {
+                    client_cert,
+                    client_private_key,
+                })
+                .build(),
+        )
     } else {
         None
     }

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -125,14 +125,13 @@ pub(crate) fn integ_worker_config(tq: &str) -> WorkerConfig {
 
 pub(crate) fn integ_sdk_config(tq: &str) -> WorkerOptions {
     WorkerOptions::new(tq)
-        .deployment_options(WorkerDeploymentOptions {
-            version: WorkerDeploymentVersion {
+        .deployment_options(
+            WorkerDeploymentOptions::new(WorkerDeploymentVersion {
                 deployment_name: "".to_owned(),
                 build_id: "test_build_id".to_owned(),
-            },
-            use_worker_versioning: false,
-            default_versioning_behavior: None,
-        })
+            })
+            .build(),
+        )
         .build()
 }
 

--- a/crates/sdk-core/tests/common/workflows.rs
+++ b/crates/sdk-core/tests/common/workflows.rs
@@ -16,18 +16,19 @@ impl LaProblemWorkflow {
         ctx.execute_local_activity(
             StdActivities::delay,
             Duration::from_secs(15),
-            LocalActivityOptions {
-                retry_policy: RetryPolicy {
-                    initial_interval: Some(prost_dur!(from_micros(15))),
-                    backoff_coefficient: 1_000.,
-                    maximum_interval: Some(prost_dur!(from_millis(1500))),
-                    maximum_attempts: 4,
-                    non_retryable_error_types: vec![],
-                }
-                .into(),
-                timer_backoff_threshold: Some(Duration::from_secs(1)),
-                ..Default::default()
-            },
+            LocalActivityOptions::builder()
+                .retry_policy(
+                    RetryPolicy {
+                        initial_interval: Some(prost_dur!(from_micros(15))),
+                        backoff_coefficient: 1_000.,
+                        maximum_interval: Some(prost_dur!(from_millis(1500))),
+                        maximum_attempts: 4,
+                        non_retryable_error_types: vec![],
+                    }
+                    .into(),
+                )
+                .timer_backoff_threshold(Duration::from_secs(1))
+                .build(),
         )
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
+++ b/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
@@ -63,10 +63,9 @@ impl FuzzyWf {
                     .execute_local_activity(
                         StdActivities::echo,
                         "hi!".to_string(),
-                        LocalActivityOptions {
-                            start_to_close_timeout: Some(Duration::from_secs(5)),
-                            ..Default::default()
-                        },
+                        LocalActivityOptions::builder()
+                            .start_to_close_timeout(Duration::from_secs(5))
+                            .build(),
                     )
                     .await;
             }

--- a/crates/sdk-core/tests/integ_tests/client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/client_tests.rs
@@ -571,7 +571,8 @@ async fn http_proxy() {
     assert!(tcp_proxy.hit_count() == 0);
 
     // Connect client to proxy and make call and confirm reached
-    opts.http_connect_proxy = Some(HttpConnectProxyOptions::new(tcp_proxy_addr.to_string()).build());
+    opts.http_connect_proxy =
+        Some(HttpConnectProxyOptions::new(tcp_proxy_addr.to_string()).build());
     opts.dns_load_balancing = None;
     let connection = Connection::connect(opts.clone()).await.unwrap();
     let client_opts = temporalio_client::ClientOptions::new("my-namespace").build();

--- a/crates/sdk-core/tests/integ_tests/client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/client_tests.rs
@@ -571,10 +571,7 @@ async fn http_proxy() {
     assert!(tcp_proxy.hit_count() == 0);
 
     // Connect client to proxy and make call and confirm reached
-    opts.http_connect_proxy = Some(HttpConnectProxyOptions {
-        target_addr: tcp_proxy_addr.to_string(),
-        basic_auth: None,
-    });
+    opts.http_connect_proxy = Some(HttpConnectProxyOptions::new(tcp_proxy_addr.to_string()).build());
     opts.dns_load_balancing = None;
     let connection = Connection::connect(opts.clone()).await.unwrap();
     let client_opts = temporalio_client::ClientOptions::new("my-namespace").build();
@@ -600,10 +597,9 @@ async fn http_proxy() {
         let unix_proxy = HttpProxy::spawn_unix(UnixListener::bind(&sock_path).unwrap());
 
         // Connect client to proxy and make call and confirm reached
-        opts.http_connect_proxy = Some(HttpConnectProxyOptions {
-            target_addr: format!("unix:{}", sock_path.to_str().unwrap()),
-            basic_auth: None,
-        });
+        opts.http_connect_proxy = Some(
+            HttpConnectProxyOptions::new(format!("unix:{}", sock_path.to_str().unwrap())).build(),
+        );
         opts.dns_load_balancing = None;
         let connection = Connection::connect(opts.clone()).await.unwrap();
         let client_opts = temporalio_client::ClientOptions::new("my-namespace").build();

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -1177,12 +1177,11 @@ async fn nexus_metrics() {
     impl NexusMetricsWf {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>, endpoint: String) -> WorkflowResult<()> {
-            let partial_op = NexusOperationOptions {
-                endpoint: endpoint.clone(),
-                service: "mysvc".to_string(),
-                operation: "myop".to_string(),
-                ..Default::default()
-            };
+            let partial_op = NexusOperationOptions::builder()
+                .endpoint(endpoint.clone())
+                .service("mysvc")
+                .operation("myop")
+                .build();
             join!(
                 async {
                     ctx.start_nexus_operation(partial_op.clone())
@@ -1192,29 +1191,20 @@ async fn nexus_metrics() {
                         .await
                 },
                 async {
-                    let _ = ctx
-                        .start_nexus_operation(NexusOperationOptions {
-                            input: Some("fail".into()),
-                            ..partial_op.clone()
-                        })
-                        .await;
+                    let mut options = partial_op.clone();
+                    options.input = Some("fail".into());
+                    let _ = ctx.start_nexus_operation(options).await;
                 },
                 async {
-                    let _ = ctx
-                        .start_nexus_operation(NexusOperationOptions {
-                            input: Some("handler-fail".into()),
-                            ..partial_op.clone()
-                        })
-                        .await;
+                    let mut options = partial_op.clone();
+                    options.input = Some("handler-fail".into());
+                    let _ = ctx.start_nexus_operation(options).await;
                 },
                 async {
-                    let _ = ctx
-                        .start_nexus_operation(NexusOperationOptions {
-                            input: Some("timeout".into()),
-                            schedule_to_close_timeout: Some(Duration::from_secs(2)),
-                            ..partial_op.clone()
-                        })
-                        .await;
+                    let mut options = partial_op.clone();
+                    options.input = Some("timeout".into());
+                    options.schedule_to_close_timeout = Some(Duration::from_secs(2));
+                    let _ = ctx.start_nexus_operation(options).await;
                 }
             );
             Ok(())

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -1052,26 +1052,28 @@ async fn activity_metrics() {
             let local_act_fail = ctx.execute_local_activity(
                 PassFailActivities::pass_fail_act,
                 "fail".to_string(),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        maximum_attempts: 1,
-                        ..Default::default()
-                    }
-                    .into(),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        }
+                        .into(),
+                    )
+                    .build(),
             );
             let local_act_cancel = ctx.execute_local_activity(
                 PassFailActivities::pass_fail_act,
                 "cancel".to_string(),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        maximum_attempts: 1,
-                        ..Default::default()
-                    }
-                    .into(),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        }
+                        .into(),
+                    )
+                    .build(),
             );
             let _ = join!(local_act_pass, local_act_fail);
             // TODO: Currently takes a WFT b/c of https://github.com/temporalio/sdk-core/issues/856

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -541,10 +541,10 @@ async fn warn_band_payload_is_logged_and_completes() {
 
     let mut conn_opts = get_integ_server_options();
     conn_opts.metrics_meter = runtime.telemetry().get_temporal_metric_meter();
-    conn_opts.payload_limits = PayloadLimitsOptions {
-        payloads_warn_size: 1,
-        memo_warn_size: 1,
-    };
+    conn_opts.payload_limits = PayloadLimitsOptions::builder()
+        .payloads_warn_size(1)
+        .memo_warn_size(1)
+        .build();
     let connection = Connection::connect(conn_opts).await.unwrap();
     let client = Client::new(connection, ClientOptions::new(integ_namespace()).build()).unwrap();
 

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -1216,10 +1216,9 @@ async fn test_custom_slot_supplier_simple() {
                 .execute_local_activity(
                     StdActivities::no_op,
                     (),
-                    LocalActivityOptions {
-                        start_to_close_timeout: Some(Duration::from_secs(10)),
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .start_to_close_timeout(Duration::from_secs(10))
+                        .build(),
                 )
                 .await;
             Ok(())

--- a/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
@@ -42,11 +42,10 @@ async fn sets_deployment_info_on_task_responses(#[values(true, false)] use_defau
         deployment_name: deploy_name.clone(),
         build_id: "1.0".to_string(),
     };
-    starter.sdk_config.deployment_options = WorkerDeploymentOptions {
-        version: version.clone(),
-        use_worker_versioning: true,
-        default_versioning_behavior: Some(VersioningBehavior::AutoUpgrade),
-    };
+    starter.sdk_config.deployment_options = WorkerDeploymentOptions::new(version.clone())
+        .use_worker_versioning(true)
+        .default_versioning_behavior(VersioningBehavior::AutoUpgrade)
+        .build();
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let core = starter.get_worker().await;
     let client = starter.get_client().await;
@@ -173,14 +172,13 @@ async fn activity_has_deployment_stamp() {
     let wf_name = "activity_has_deployment_stamp";
     let mut starter = CoreWfStarter::new(wf_name);
     let deploy_name = format!("deployment-{}", starter.get_task_queue());
-    starter.sdk_config.deployment_options = WorkerDeploymentOptions {
-        version: WorkerDeploymentVersion {
-            deployment_name: deploy_name.clone(),
-            build_id: "1.0".to_string(),
-        },
-        use_worker_versioning: true,
-        default_versioning_behavior: Some(VersioningBehavior::AutoUpgrade),
-    };
+    starter.sdk_config.deployment_options = WorkerDeploymentOptions::new(WorkerDeploymentVersion {
+        deployment_name: deploy_name.clone(),
+        build_id: "1.0".to_string(),
+    })
+    .use_worker_versioning(true)
+    .default_versioning_behavior(VersioningBehavior::AutoUpgrade)
+    .build();
     starter.sdk_config.register_activities(StdActivities);
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
@@ -269,14 +267,11 @@ async fn versioning_off_with_custom_build_id() {
     let wf_type = "versioning_off_with_custom_build_id";
     let mut starter = CoreWfStarter::new(wf_type);
     let build_id = "my-custom-build-id-1.0";
-    starter.sdk_config.deployment_options = WorkerDeploymentOptions {
-        version: WorkerDeploymentVersion {
-            deployment_name: format!("deployment-{}", starter.get_task_queue()),
-            build_id: build_id.to_string(),
-        },
-        use_worker_versioning: false,
-        default_versioning_behavior: None,
-    };
+    starter.sdk_config.deployment_options = WorkerDeploymentOptions::new(WorkerDeploymentVersion {
+        deployment_name: format!("deployment-{}", starter.get_task_queue()),
+        build_id: build_id.to_string(),
+    })
+    .build();
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let core = starter.get_worker().await;
     starter.start_wf().await;
@@ -576,11 +571,10 @@ async fn continue_as_new_use_ramping_version_uses_ramping_deployment_version() {
 }
 
 fn versioned_worker_options(version: WorkerDeploymentVersion) -> WorkerDeploymentOptions {
-    WorkerDeploymentOptions {
-        version,
-        use_worker_versioning: true,
-        default_versioning_behavior: Some(VersioningBehavior::Pinned),
-    }
+    WorkerDeploymentOptions::new(version)
+        .use_worker_versioning(true)
+        .default_versioning_behavior(VersioningBehavior::Pinned)
+        .build()
 }
 
 async fn try_describe_worker_deployment(

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -1075,10 +1075,11 @@ async fn pass_timer_summary_to_metadata() {
     impl PassTimerSummaryWf {
         #[run(name = DEFAULT_WORKFLOW_TYPE)]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.timer(TimerOptions {
-                duration: Duration::from_secs(1),
-                summary: Some("timer summary".to_string()),
-            })
+            ctx.timer(
+                TimerOptions::builder(Duration::from_secs(1))
+                    .summary("timer summary".to_string())
+                    .build(),
+            )
             .await;
             Ok(())
         }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -941,10 +941,9 @@ async fn history_out_of_order_on_restart() {
             ctx.execute_local_activity(
                 StdActivities::echo,
                 "hi".to_string(),
-                LocalActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(5))
+                    .build(),
             )
             .await?;
             ctx.execute_activity(
@@ -970,10 +969,9 @@ async fn history_out_of_order_on_restart() {
             ctx.execute_local_activity(
                 StdActivities::echo,
                 "hi".to_string(),
-                LocalActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(5))
+                    .build(),
             )
             .await?;
             // Timer is added after restarting workflow

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -558,23 +558,17 @@ async fn deployment_version_correct_in_wf_info(#[values(true, false)] use_only_b
     let wf_type = "deployment_version_correct_in_wf_info";
     let mut starter = CoreWfStarter::new(wf_type);
     starter.sdk_config.deployment_options = if use_only_build_id {
-        WorkerDeploymentOptions {
-            version: WorkerDeploymentVersion {
-                deployment_name: "".to_string(),
-                build_id: "1.0".to_string(),
-            },
-            use_worker_versioning: false,
-            default_versioning_behavior: None,
-        }
+        WorkerDeploymentOptions::new(WorkerDeploymentVersion {
+            deployment_name: "".to_string(),
+            build_id: "1.0".to_string(),
+        })
+        .build()
     } else {
-        WorkerDeploymentOptions {
-            version: WorkerDeploymentVersion {
-                deployment_name: "deployment-1".to_string(),
-                build_id: "1.0".to_string(),
-            },
-            use_worker_versioning: false,
-            default_versioning_behavior: None,
-        }
+        WorkerDeploymentOptions::new(WorkerDeploymentVersion {
+            deployment_name: "deployment-1".to_string(),
+            build_id: "1.0".to_string(),
+        })
+        .build()
     };
     starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let core = starter.get_worker().await;
@@ -680,23 +674,17 @@ async fn deployment_version_correct_in_wf_info(#[values(true, false)] use_only_b
 
     let mut starter = starter.clone_no_worker();
     starter.sdk_config.deployment_options = if use_only_build_id {
-        WorkerDeploymentOptions {
-            version: WorkerDeploymentVersion {
-                deployment_name: "".to_string(),
-                build_id: "2.0".to_string(),
-            },
-            use_worker_versioning: false,
-            default_versioning_behavior: None,
-        }
+        WorkerDeploymentOptions::new(WorkerDeploymentVersion {
+            deployment_name: "".to_string(),
+            build_id: "2.0".to_string(),
+        })
+        .build()
     } else {
-        WorkerDeploymentOptions {
-            version: WorkerDeploymentVersion {
-                deployment_name: "deployment-1".to_string(),
-                build_id: "2.0".to_string(),
-            },
-            use_worker_versioning: false,
-            default_versioning_behavior: None,
-        }
+        WorkerDeploymentOptions::new(WorkerDeploymentVersion {
+            deployment_name: "deployment-1".to_string(),
+            build_id: "2.0".to_string(),
+        })
+        .build()
     };
 
     let core = starter.get_worker().await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -333,10 +333,9 @@ impl ActivityIdOrTypeChangeWf {
                 ctx.execute_local_activity(
                     StdActivities::default,
                     (),
-                    LocalActivityOptions {
-                        activity_id: Some("I'm bad and wrong!".to_string()),
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .activity_id("I'm bad and wrong!".to_string())
+                        .build(),
                 )
                 .await?;
             } else {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
@@ -1348,12 +1348,13 @@ fn assert_workflow_interceptor_context_outbound_api(ctx: &WorkflowInterceptorCon
         ChildWorkflowOptions::workflow_id("child".into()),
     );
     let _external = ctx.external_workflow("external", None);
-    let _nexus = ctx.start_nexus_operation(NexusOperationOptions {
-        endpoint: "endpoint".to_string(),
-        service: "service".to_string(),
-        operation: "operation".to_string(),
-        ..Default::default()
-    });
+    let _nexus = ctx.start_nexus_operation(
+        NexusOperationOptions::builder()
+            .endpoint("endpoint")
+            .service("service")
+            .operation("operation")
+            .build(),
+    );
 }
 
 #[workflow]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
@@ -1338,10 +1338,9 @@ fn assert_workflow_interceptor_context_outbound_api(ctx: &WorkflowInterceptorCon
     let _local_activity = ctx.execute_local_activity(
         StdActivities::echo,
         String::new(),
-        LocalActivityOptions {
-            start_to_close_timeout: Some(Duration::from_secs(1)),
-            ..Default::default()
-        },
+        LocalActivityOptions::builder()
+            .start_to_close_timeout(Duration::from_secs(1))
+            .build(),
     );
     let _child = ctx.start_child_workflow(
         OutboundChildInterceptorChild::run,
@@ -1378,10 +1377,9 @@ impl OutboundActivityInterceptorWorkflow {
             .execute_local_activity(
                 StdActivities::echo,
                 "local-original".to_string(),
-                LocalActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(5)),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(5))
+                    .build(),
             )
             .await?;
         assert_eq!(local_activity, "local-wrapped");

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -296,19 +296,20 @@ impl LocalActRetryTimerBackoff {
             .execute_local_activity(
                 StdActivities::always_fail,
                 (),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        initial_interval: Some(prost_dur!(from_micros(15))),
-                        // We want two local backoffs that are short. Third backoff will use timer
-                        backoff_coefficient: 1_000.,
-                        maximum_interval: Some(prost_dur!(from_millis(1500))),
-                        maximum_attempts: 4,
-                        non_retryable_error_types: vec![],
-                    }
-                    .into(),
-                    timer_backoff_threshold: Some(Duration::from_secs(1)),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            initial_interval: Some(prost_dur!(from_micros(15))),
+                            // We want two local backoffs that are short. Third backoff will use timer
+                            backoff_coefficient: 1_000.,
+                            maximum_interval: Some(prost_dur!(from_millis(1500))),
+                            maximum_attempts: 4,
+                            non_retryable_error_types: vec![],
+                        }
+                        .into(),
+                    )
+                    .timer_backoff_threshold(Duration::from_secs(1))
+                    .build(),
             )
             .await;
         assert!(matches!(res, Err(ActivityExecutionError::Failed(_))));
@@ -399,10 +400,9 @@ async fn cancel_immediate(#[case] cancel_type: ActivityCancellationType) {
             let la = ctx.execute_local_activity(
                 EchoWithManualCancel::echo,
                 "hi".to_string(),
-                LocalActivityOptions {
-                    cancel_type,
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .cancel_type(cancel_type)
+                    .build(),
             );
             la.cancel();
             let resolution = la.await;
@@ -540,19 +540,20 @@ async fn cancel_after_act_starts(
             let la = ctx.execute_local_activity(
                 EchoWithManualCancelAndBackoff::echo,
                 "hi".to_string(),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        initial_interval: Some(bo_dur.try_into().unwrap()),
-                        backoff_coefficient: 1.,
-                        maximum_interval: Some(bo_dur.try_into().unwrap()),
-                        // Retry forever until cancelled
-                        ..Default::default()
-                    }
-                    .into(),
-                    timer_backoff_threshold: Some(Duration::from_secs(1)),
-                    cancel_type,
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            initial_interval: Some(bo_dur.try_into().unwrap()),
+                            backoff_coefficient: 1.,
+                            maximum_interval: Some(bo_dur.try_into().unwrap()),
+                            // Retry forever until cancelled
+                            ..Default::default()
+                        }
+                        .into(),
+                    )
+                    .timer_backoff_threshold(Duration::from_secs(1))
+                    .cancel_type(cancel_type)
+                    .build(),
             );
             ctx.timer(Duration::from_secs(1)).await;
             // Note that this cancel can't go through for *two* WF tasks, because we do a full heartbeat
@@ -650,20 +651,21 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
                 .execute_local_activity(
                     LongRunningWithCancellation::go,
                     (),
-                    LocalActivityOptions {
-                        retry_policy: RetryPolicy {
-                            initial_interval: Some(prost_dur!(from_micros(15))),
-                            backoff_coefficient: 1_000.,
-                            maximum_interval: Some(prost_dur!(from_millis(1500))),
-                            maximum_attempts: 4,
-                            non_retryable_error_types: vec![],
-                        }
-                        .into(),
-                        timer_backoff_threshold: Some(Duration::from_secs(1)),
-                        schedule_to_close_timeout: sched,
-                        start_to_close_timeout: start,
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .retry_policy(
+                            RetryPolicy {
+                                initial_interval: Some(prost_dur!(from_micros(15))),
+                                backoff_coefficient: 1_000.,
+                                maximum_interval: Some(prost_dur!(from_millis(1500))),
+                                maximum_attempts: 4,
+                                non_retryable_error_types: vec![],
+                            }
+                            .into(),
+                        )
+                        .timer_backoff_threshold(Duration::from_secs(1))
+                        .maybe_schedule_to_close_timeout(sched)
+                        .maybe_start_to_close_timeout(start)
+                        .build(),
                 )
                 .await;
             let err = res.unwrap_err();
@@ -724,19 +726,20 @@ async fn schedule_to_close_timeout_across_timer_backoff(#[case] cached: bool) {
                 .execute_local_activity(
                     FailWithAtomicCounter::go,
                     "hi".to_string(),
-                    LocalActivityOptions {
-                        retry_policy: RetryPolicy {
-                            initial_interval: Some(prost_dur!(from_millis(15))),
-                            backoff_coefficient: 1_000.,
-                            maximum_interval: Some(prost_dur!(from_millis(1000))),
-                            maximum_attempts: 40,
-                            non_retryable_error_types: vec![],
-                        }
-                        .into(),
-                        timer_backoff_threshold: Some(Duration::from_millis(500)),
-                        schedule_to_close_timeout: Some(Duration::from_secs(2)),
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .retry_policy(
+                            RetryPolicy {
+                                initial_interval: Some(prost_dur!(from_millis(15))),
+                                backoff_coefficient: 1_000.,
+                                maximum_interval: Some(prost_dur!(from_millis(1000))),
+                                maximum_attempts: 40,
+                                non_retryable_error_types: vec![],
+                            }
+                            .into(),
+                        )
+                        .timer_backoff_threshold(Duration::from_millis(500))
+                        .schedule_to_close_timeout(Duration::from_secs(2))
+                        .build(),
                 )
                 .await;
             let err = res.unwrap_err();
@@ -806,34 +809,36 @@ async fn timer_backoff_concurrent_with_non_timer_backoff() {
             let r1 = ctx.execute_local_activity(
                 StdActivities::always_fail,
                 (),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        initial_interval: Some(prost_dur!(from_micros(15))),
-                        backoff_coefficient: 1_000.,
-                        maximum_interval: Some(prost_dur!(from_millis(1500))),
-                        maximum_attempts: 4,
-                        non_retryable_error_types: vec![],
-                    }
-                    .into(),
-                    timer_backoff_threshold: Some(Duration::from_secs(1)),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            initial_interval: Some(prost_dur!(from_micros(15))),
+                            backoff_coefficient: 1_000.,
+                            maximum_interval: Some(prost_dur!(from_millis(1500))),
+                            maximum_attempts: 4,
+                            non_retryable_error_types: vec![],
+                        }
+                        .into(),
+                    )
+                    .timer_backoff_threshold(Duration::from_secs(1))
+                    .build(),
             );
             let r2 = ctx.execute_local_activity(
                 StdActivities::always_fail,
                 (),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        initial_interval: Some(prost_dur!(from_millis(15))),
-                        backoff_coefficient: 10.,
-                        maximum_interval: Some(prost_dur!(from_millis(1500))),
-                        maximum_attempts: 4,
-                        non_retryable_error_types: vec![],
-                    }
-                    .into(),
-                    timer_backoff_threshold: Some(Duration::from_secs(10)),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            initial_interval: Some(prost_dur!(from_millis(15))),
+                            backoff_coefficient: 10.,
+                            maximum_interval: Some(prost_dur!(from_millis(1500))),
+                            maximum_attempts: 4,
+                            non_retryable_error_types: vec![],
+                        }
+                        .into(),
+                    )
+                    .timer_backoff_threshold(Duration::from_secs(10))
+                    .build(),
             );
             let (r1, r2) = temporalio_sdk::workflows::join!(r1, r2);
             assert!(matches!(r1, Err(ActivityExecutionError::Failed(_))));
@@ -877,18 +882,19 @@ async fn repro_nondeterminism_with_timer_bug() {
             let mut r1 = ctx.execute_local_activity(
                 StdActivities::delay,
                 Duration::from_secs(2),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        initial_interval: Some(prost_dur!(from_micros(15))),
-                        backoff_coefficient: 1_000.,
-                        maximum_interval: Some(prost_dur!(from_millis(1500))),
-                        maximum_attempts: 4,
-                        non_retryable_error_types: vec![],
-                    }
-                    .into(),
-                    timer_backoff_threshold: Some(Duration::from_secs(1)),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            initial_interval: Some(prost_dur!(from_micros(15))),
+                            backoff_coefficient: 1_000.,
+                            maximum_interval: Some(prost_dur!(from_millis(1500))),
+                            maximum_attempts: 4,
+                            non_retryable_error_types: vec![],
+                        }
+                        .into(),
+                    )
+                    .timer_backoff_threshold(Duration::from_secs(1))
+                    .build(),
             );
             temporalio_sdk::workflows::select! {
                 _ = t1 => {},
@@ -1044,9 +1050,7 @@ async fn la_resolve_same_time_as_other_cancel() {
             let mut local_act = ctx.execute_local_activity(
                 DelayWithCancellation::delay,
                 Duration::from_millis(100),
-                LocalActivityOptions {
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder().build(),
             );
             normal_act.cancel();
             // Race them, starting a timer if LA completes first
@@ -1272,10 +1276,9 @@ impl LocalActivityWithSummaryWf {
         ctx.execute_local_activity(
             StdActivities::echo,
             "hi".to_string(),
-            LocalActivityOptions {
-                summary: Some("Echo summary".to_string()),
-                ..Default::default()
-            },
+            LocalActivityOptions::builder()
+                .summary("Echo summary".to_string())
+                .build(),
         )
         .await?;
         Ok(())
@@ -1524,17 +1527,18 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
                 .execute_local_activity(
                     EventuallyPassingActivity::echo,
                     "hi".to_string(),
-                    LocalActivityOptions {
-                        retry_policy: RetryPolicy {
-                            initial_interval: Some(prost_dur!(from_millis(50))),
-                            backoff_coefficient: 1.2,
-                            maximum_interval: None,
-                            maximum_attempts: 5,
-                            non_retryable_error_types: vec![],
-                        }
-                        .into(),
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .retry_policy(
+                            RetryPolicy {
+                                initial_interval: Some(prost_dur!(from_millis(50))),
+                                backoff_coefficient: 1.2,
+                                maximum_interval: None,
+                                maximum_attempts: 5,
+                                non_retryable_error_types: vec![],
+                            }
+                            .into(),
+                        )
+                        .build(),
                 )
                 .await;
             if eventually_pass {
@@ -1626,17 +1630,18 @@ async fn local_act_retry_long_backoff_uses_timer() {
                 .execute_local_activity(
                     StdActivities::always_fail,
                     (),
-                    LocalActivityOptions {
-                        retry_policy: RetryPolicy {
-                            initial_interval: Some(prost_dur!(from_millis(65))),
-                            backoff_coefficient: 1_000.,
-                            maximum_interval: Some(prost_dur!(from_secs(600))),
-                            maximum_attempts: 3,
-                            non_retryable_error_types: vec![],
-                        }
-                        .into(),
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .retry_policy(
+                            RetryPolicy {
+                                initial_interval: Some(prost_dur!(from_millis(65))),
+                                backoff_coefficient: 1_000.,
+                                maximum_interval: Some(prost_dur!(from_secs(600))),
+                                maximum_attempts: 3,
+                                non_retryable_error_types: vec![],
+                            }
+                            .into(),
+                        )
+                        .build(),
                 )
                 .await;
             assert!(matches!(la_res, Err(ActivityExecutionError::Failed(_))));
@@ -2002,10 +2007,9 @@ async fn test_schedule_to_start_timeout() {
                 .execute_local_activity(
                     StdActivities::echo,
                     "hi".to_string(),
-                    LocalActivityOptions {
-                        schedule_to_start_timeout: prost_dur!(from_nanos(1)),
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .maybe_schedule_to_start_timeout(prost_dur!(from_nanos(1)))
+                        .build(),
                 )
                 .await;
             assert!(la_res.is_err());
@@ -2092,19 +2096,20 @@ async fn test_schedule_to_start_timeout_not_based_on_original_time(
                 .execute_local_activity(
                     StdActivities::echo,
                     "hi".to_string(),
-                    LocalActivityOptions {
-                        retry_policy: RetryPolicy {
-                            initial_interval: Some(prost_dur!(from_millis(50))),
-                            backoff_coefficient: 1.2,
-                            maximum_interval: None,
-                            maximum_attempts: 5,
-                            non_retryable_error_types: vec![],
-                        }
-                        .into(),
-                        schedule_to_start_timeout: Some(Duration::from_secs(60)),
-                        schedule_to_close_timeout,
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .retry_policy(
+                            RetryPolicy {
+                                initial_interval: Some(prost_dur!(from_millis(50))),
+                                backoff_coefficient: 1.2,
+                                maximum_interval: None,
+                                maximum_attempts: 5,
+                                non_retryable_error_types: vec![],
+                            }
+                            .into(),
+                        )
+                        .schedule_to_start_timeout(Duration::from_secs(60))
+                        .maybe_schedule_to_close_timeout(schedule_to_close_timeout)
+                        .build(),
                 )
                 .await;
             if is_sched_to_start {
@@ -2169,18 +2174,19 @@ async fn start_to_close_timeout_allows_retries(#[values(true, false)] la_complet
                 .execute_local_activity(
                     ActivityWithRetriesAndCancellation::go,
                     (),
-                    LocalActivityOptions {
-                        retry_policy: RetryPolicy {
-                            initial_interval: Some(prost_dur!(from_millis(20))),
-                            backoff_coefficient: 1.0,
-                            maximum_interval: None,
-                            maximum_attempts: 5,
-                            non_retryable_error_types: vec![],
-                        }
-                        .into(),
-                        start_to_close_timeout: Some(prost_dur!(from_millis(25))),
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .retry_policy(
+                            RetryPolicy {
+                                initial_interval: Some(prost_dur!(from_millis(20))),
+                                backoff_coefficient: 1.0,
+                                maximum_interval: None,
+                                maximum_attempts: 5,
+                                non_retryable_error_types: vec![],
+                            }
+                            .into(),
+                        )
+                        .start_to_close_timeout(prost_dur!(from_millis(25)))
+                        .build(),
                 )
                 .await;
             if la_completes {
@@ -2333,9 +2339,7 @@ async fn resolved_las_not_recorded_if_wft_fails_many_times() {
             ctx.execute_local_activity(
                 StdActivities::echo,
                 "hi".to_string(),
-                LocalActivityOptions {
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder().build(),
             )
             .await?;
             panic!()
@@ -2387,17 +2391,18 @@ async fn local_act_records_nonfirst_attempts_ok() {
             ctx.execute_local_activity(
                 StdActivities::always_fail,
                 (),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        initial_interval: Some(prost_dur!(from_millis(10))),
-                        backoff_coefficient: 1.0,
-                        maximum_interval: None,
-                        maximum_attempts: 0,
-                        non_retryable_error_types: vec![],
-                    }
-                    .into(),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            initial_interval: Some(prost_dur!(from_millis(10))),
+                            backoff_coefficient: 1.0,
+                            maximum_interval: None,
+                            maximum_attempts: 0,
+                            non_retryable_error_types: vec![],
+                        }
+                        .into(),
+                    )
+                    .build(),
             )
             .await
             .ok();
@@ -2707,16 +2712,17 @@ async fn local_act_retry_explicit_delay() {
                 .execute_local_activity(
                     ActivityWithExplicitBackoff::go,
                     (),
-                    LocalActivityOptions {
-                        retry_policy: RetryPolicy {
-                            initial_interval: Some(prost_dur!(from_millis(50))),
-                            backoff_coefficient: 1.0,
-                            maximum_attempts: 5,
-                            ..Default::default()
-                        }
-                        .into(),
-                        ..Default::default()
-                    },
+                    LocalActivityOptions::builder()
+                        .retry_policy(
+                            RetryPolicy {
+                                initial_interval: Some(prost_dur!(from_millis(50))),
+                                backoff_coefficient: 1.0,
+                                maximum_attempts: 5,
+                                ..Default::default()
+                            }
+                            .into(),
+                        )
+                        .build(),
                 )
                 .await;
             assert!(la_res.is_ok());
@@ -2774,14 +2780,15 @@ impl LaWf {
             .execute_local_activity(
                 StdActivities::default,
                 (),
-                LocalActivityOptions {
-                    retry_policy: RetryPolicy {
-                        maximum_attempts: 1,
-                        ..Default::default()
-                    }
-                    .into(),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .retry_policy(
+                        RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        }
+                        .into(),
+                    )
+                    .build(),
             )
             .await;
         Ok(())
@@ -3191,10 +3198,9 @@ async fn immediate_cancel(
             let la = ctx.execute_local_activity(
                 StdActivities::default,
                 (),
-                LocalActivityOptions {
-                    cancel_type,
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .cancel_type(cancel_type)
+                    .build(),
             );
             la.cancel();
             la.await.ok();
@@ -3308,10 +3314,9 @@ async fn cancel_after_act_starts_canned(
             let la = ctx.execute_local_activity(
                 ActivityWithConditionalCancelWait::echo,
                 (),
-                LocalActivityOptions {
-                    cancel_type,
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .cancel_type(cancel_type)
+                    .build(),
             );
             ctx.timer(Duration::from_secs(1)).await;
             la.cancel();

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
@@ -79,13 +79,14 @@ impl NexusBasicWf {
         ctx: &mut WorkflowContext<Self>,
     ) -> WorkflowResult<Result<NexusOperationResult, Failure>> {
         match ctx
-            .start_nexus_operation(NexusOperationOptions {
-                endpoint: ctx.state(|wf| wf.endpoint.clone()),
-                service: "svc".to_string(),
-                operation: "op".to_string(),
-                schedule_to_close_timeout: Some(Duration::from_secs(3)),
-                ..Default::default()
-            })
+            .start_nexus_operation(
+                NexusOperationOptions::builder()
+                    .endpoint(ctx.state(|wf| wf.endpoint.clone()))
+                    .service("svc")
+                    .operation("op")
+                    .schedule_to_close_timeout(Duration::from_secs(3))
+                    .build(),
+            )
             .await
         {
             Ok(started) => {
@@ -254,13 +255,14 @@ impl NexusAsyncWf {
     pub(crate) async fn run(
         ctx: &mut WorkflowContext<Self>,
     ) -> WorkflowResult<NexusOperationResult> {
-        let started = ctx.start_nexus_operation(NexusOperationOptions {
-            endpoint: ctx.state(|wf| wf.endpoint.clone()),
-            service: "svc".to_string(),
-            operation: "op".to_string(),
-            schedule_to_close_timeout: ctx.state(|wf| wf.schedule_to_close_timeout),
-            ..Default::default()
-        });
+        let started = ctx.start_nexus_operation(
+            NexusOperationOptions::builder()
+                .endpoint(ctx.state(|wf| wf.endpoint.clone()))
+                .service("svc")
+                .operation("op")
+                .maybe_schedule_to_close_timeout(ctx.state(|wf| wf.schedule_to_close_timeout))
+                .build(),
+        );
         if ctx.state(|wf| wf.outcome) == Outcome::CancelAfterRecordedBeforeStarted {
             ctx.timer(Duration::from_millis(1)).await;
             started.cancel();
@@ -537,12 +539,13 @@ impl NexusCancelBeforeStartWf {
 
     #[run]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        let started = ctx.start_nexus_operation(NexusOperationOptions {
-            endpoint: ctx.state(|wf| wf.endpoint.clone()),
-            service: "svc".to_string(),
-            operation: "op".to_string(),
-            ..Default::default()
-        });
+        let started = ctx.start_nexus_operation(
+            NexusOperationOptions::builder()
+                .endpoint(ctx.state(|wf| wf.endpoint.clone()))
+                .service("svc")
+                .operation("op")
+                .build(),
+        );
         started.cancel();
         let res = started.await.unwrap_err();
         assert_eq!(res.message, "Nexus Operation cancelled before scheduled");
@@ -607,12 +610,15 @@ impl NexusMustCompleteTaskWf {
     #[run]
     pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         // We just need to create the command, not await it.
-        drop(ctx.start_nexus_operation(NexusOperationOptions {
-            endpoint: ctx.state(|wf| wf.endpoint.clone()),
-            service: "svc".to_string(),
-            operation: "op".to_string(),
-            ..Default::default()
-        }));
+        drop(
+            ctx.start_nexus_operation(
+                NexusOperationOptions::builder()
+                    .endpoint(ctx.state(|wf| wf.endpoint.clone()))
+                    .service("svc")
+                    .operation("op")
+                    .build(),
+            ),
+        );
         // Workflow completes right away, only having scheduled the operation. We need a timer
         // to make sure the nexus task actually gets scheduled.
         ctx.timer(Duration::from_millis(1)).await;
@@ -719,14 +725,13 @@ struct NexusCancellationCallerWf {
 impl NexusCancellationCallerWf {
     #[run(name = "nexus_cancellation_types")]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<NexusOperationResult> {
-        let options = NexusOperationOptions {
-            endpoint: ctx.state(|wf| wf.endpoint.clone()),
-            service: "svc".to_string(),
-            operation: "op".to_string(),
-            schedule_to_close_timeout: ctx.state(|wf| wf.schedule_to_close_timeout),
-            cancellation_type: Some(ctx.state(|wf| wf.cancellation_type)),
-            ..Default::default()
-        };
+        let options = NexusOperationOptions::builder()
+            .endpoint(ctx.state(|wf| wf.endpoint.clone()))
+            .service("svc")
+            .operation("op")
+            .maybe_schedule_to_close_timeout(ctx.state(|wf| wf.schedule_to_close_timeout))
+            .cancellation_type(ctx.state(|wf| wf.cancellation_type))
+            .build();
         let started = ctx.start_nexus_operation(options);
         let started = started.await.unwrap();
         let result = started.result();

--- a/crates/sdk/examples/local_activities/workflows.rs
+++ b/crates/sdk/examples/local_activities/workflows.rs
@@ -39,10 +39,9 @@ impl LocalActivitiesWorkflow {
             .execute_local_activity(
                 GreetingActivities::greet,
                 name,
-                LocalActivityOptions {
-                    start_to_close_timeout: Some(Duration::from_secs(10)),
-                    ..Default::default()
-                },
+                LocalActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_secs(10))
+                    .build(),
             )
             .await?;
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -43,14 +43,13 @@
 //!
 //!     let worker_options = WorkerOptions::new("task_queue")
 //!         .task_types(WorkerTaskTypes::activity_only())
-//!         .deployment_options(WorkerDeploymentOptions {
-//!             version: WorkerDeploymentVersion {
+//!         .deployment_options(
+//!             WorkerDeploymentOptions::new(WorkerDeploymentVersion {
 //!                 deployment_name: "my_deployment".to_owned(),
 //!                 build_id: "my_build_id".to_owned(),
-//!             },
-//!             use_worker_versioning: false,
-//!             default_versioning_behavior: None,
-//!         })
+//!             })
+//!             .build(),
+//!         )
 //!         .register_activities(MyActivities)
 //!         .build();
 //!

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -3526,12 +3526,13 @@ mod tests {
             .continue_as_new(7, ContinueAsNewOptions::default())
             .expect_err("continue_as_new should terminate the workflow");
         let sync_ctx = ctx.sync_context();
-        let nexus = sync_ctx.start_nexus_operation(NexusOperationOptions {
-            endpoint: "original-endpoint".to_string(),
-            service: "original-service".to_string(),
-            operation: "original-operation".to_string(),
-            ..Default::default()
-        });
+        let nexus = sync_ctx.start_nexus_operation(
+            NexusOperationOptions::builder()
+                .endpoint("original-endpoint")
+                .service("original-service")
+                .operation("original-operation")
+                .build(),
+        );
         drop((signal, cancel, nexus));
 
         let WorkflowTermination::ContinueAsNew(continue_as_new) = termination else {

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -428,7 +428,7 @@ impl ActivityOptions {
 }
 
 /// Options for scheduling a local activity
-#[derive(Default, Debug, Clone, PartialEq, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct LocalActivityOptions {
     /// Identifier to use for tracking the activity in Workflow history.
@@ -468,6 +468,12 @@ pub struct LocalActivityOptions {
     pub start_to_close_timeout: Option<Duration>,
     /// Single-line summary for this activity that will appear in UI/CLI.
     pub summary: Option<String>,
+}
+
+impl Default for LocalActivityOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
 }
 
 impl LocalActivityOptions {
@@ -664,7 +670,7 @@ impl SignalData {
 }
 
 /// Options for timer
-#[derive(Default, Debug, Clone, PartialEq, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct TimerOptions {
     /// Duration for the timer
@@ -672,6 +678,12 @@ pub struct TimerOptions {
     pub duration: Duration,
     /// Summary of the timer
     pub summary: Option<String>,
+}
+
+impl Default for TimerOptions {
+    fn default() -> Self {
+        Self::builder(Duration::default()).build()
+    }
 }
 
 impl From<Duration> for TimerOptions {
@@ -933,22 +945,6 @@ fn string_user_metadata(summary: Option<String>, details: Option<String>) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn local_activity_options_default_matches_builder_default() {
-        assert_eq!(
-            LocalActivityOptions::default(),
-            LocalActivityOptions::builder().build()
-        );
-    }
-
-    #[test]
-    fn timer_options_default_matches_builder_default() {
-        assert_eq!(
-            TimerOptions::default(),
-            TimerOptions::builder(Duration::default()).build()
-        );
-    }
 
     #[test]
     fn activity_cancellation_default_preserves_sdk_behavior() {

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -428,7 +428,8 @@ impl ActivityOptions {
 }
 
 /// Options for scheduling a local activity
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, bon::Builder)]
+#[non_exhaustive]
 pub struct LocalActivityOptions {
     /// Identifier to use for tracking the activity in Workflow history.
     /// The `activityId` can be accessed by the activity function.
@@ -437,6 +438,7 @@ pub struct LocalActivityOptions {
     /// If `None` use the context's sequence number
     pub activity_id: Option<String>,
     /// Retry policy
+    #[builder(default)]
     pub retry_policy: RetryPolicy,
     /// Override attempt number rather than using 1.
     /// Ideally we would not expose this in a released Rust SDK, but it's needed for test.
@@ -447,6 +449,7 @@ pub struct LocalActivityOptions {
     /// Retry backoffs over this amount will use a timer rather than a local retry
     pub timer_backoff_threshold: Option<Duration>,
     /// How the activity will cancel
+    #[builder(default)]
     pub cancel_type: ActivityCancellationType,
     /// Indicates how long the caller is willing to wait for local activity completion. Limits how
     /// long retries will be attempted. When not specified defaults to the workflow execution

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -428,7 +428,7 @@ impl ActivityOptions {
 }
 
 /// Options for scheduling a local activity
-#[derive(Default, Debug, Clone, bon::Builder)]
+#[derive(Default, Debug, Clone, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct LocalActivityOptions {
     /// Identifier to use for tracking the activity in Workflow history.
@@ -664,7 +664,7 @@ impl SignalData {
 }
 
 /// Options for timer
-#[derive(Default, Debug, Clone, bon::Builder)]
+#[derive(Default, Debug, Clone, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct TimerOptions {
     /// Duration for the timer
@@ -701,7 +701,7 @@ impl TimerOptions {
 }
 
 /// Options for Nexus Operations
-#[derive(Default, Debug, Clone, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, bon::Builder)]
 #[builder(on(String, into))]
 #[non_exhaustive]
 pub struct NexusOperationOptions {
@@ -933,6 +933,22 @@ fn string_user_metadata(summary: Option<String>, details: Option<String>) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn local_activity_options_default_matches_builder_default() {
+        assert_eq!(
+            LocalActivityOptions::default(),
+            LocalActivityOptions::builder().build()
+        );
+    }
+
+    #[test]
+    fn timer_options_default_matches_builder_default() {
+        assert_eq!(
+            TimerOptions::default(),
+            TimerOptions::builder(Duration::default()).build()
+        );
+    }
 
     #[test]
     fn activity_cancellation_default_preserves_sdk_behavior() {

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -701,7 +701,9 @@ impl TimerOptions {
 }
 
 /// Options for Nexus Operations
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, bon::Builder)]
+#[builder(on(String, into))]
+#[non_exhaustive]
 pub struct NexusOperationOptions {
     /// Endpoint name, must exist in the endpoint registry or this command will fail.
     pub endpoint: String,
@@ -724,6 +726,7 @@ pub struct NexusOperationOptions {
     /// tracing information. Note these headers are not the same as Temporal headers on internal
     /// activities and child workflows, these are transmitted to Nexus operations that may be
     /// external and are not traditional payloads.
+    #[builder(default)]
     pub nexus_header: HashMap<String, String>,
     /// Cancellation type for the operation
     pub cancellation_type: Option<NexusOperationCancellationType>,

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -661,9 +661,11 @@ impl SignalData {
 }
 
 /// Options for timer
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, bon::Builder)]
+#[non_exhaustive]
 pub struct TimerOptions {
     /// Duration for the timer
+    #[builder(start_fn)]
     pub duration: Duration,
     /// Summary of the timer
     pub summary: Option<String>,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Go through remaining public `Options` structs and ensure they all:
 - are marked with `#[non_exhaustive]`
 - use `bon` to provide a builder
 - adding `PartialEq` implementations where applicable

Each commit is reviewable on its own.

## Why?
Without the `non_exhaustive` attribute, any expansion to these options would be a breaking change.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
👀, did add unit tests that `T::default() == T::builder().build()` to ensure those don't diverge. 

3. Any docs updates needed?
N/A
